### PR TITLE
Parse literal errors

### DIFF
--- a/packages/graphql-server-integration-testsuite/src/index.ts
+++ b/packages/graphql-server-integration-testsuite/src/index.ts
@@ -7,9 +7,11 @@ import {
     GraphQLSchema,
     GraphQLObjectType,
     GraphQLString,
+    GraphQLScalarType,
     GraphQLInt,
     GraphQLError,
     GraphQLNonNull,
+    Kind,
     introspectionQuery,
     BREAK,
 } from 'graphql';
@@ -20,6 +22,22 @@ const request = require('supertest-as-promised');
 import { GraphQLOptions } from 'graphql-server-core';
 import * as GraphiQL from 'graphql-server-module-graphiql';
 import { OperationStore } from 'graphql-server-module-operation-store';
+
+const ParseLiteralErrorScalar = new GraphQLScalarType({
+    name: 'ParseLiteralErrorScalar',
+    parseLiteral(ast){
+        if (ast.kind === Kind.STRING) {
+            throw new Error(ast.value);
+        }
+        throw new Error('Not a string')
+    },
+    parseValue(value){
+        return value;
+    },
+    serialize(value){
+        return value;
+    },
+});
 
 const queryType = new GraphQLObjectType({
     name: 'QueryType',
@@ -70,6 +88,15 @@ const queryType = new GraphQLObjectType({
                 throw new Error('Secret error message');
             },
         },
+        testParseLiteralError: {
+            type: GraphQLString,
+            resolve() {
+                return 'This never gets executed if things go according to plan';
+            },
+            args: {
+                arg: { type: ParseLiteralErrorScalar},
+            }
+        }
     },
 });
 
@@ -602,6 +629,22 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
               .post('/graphql')
               .send({
                   query: 'query test{ testError }',
+              });
+          return req.then((res) => {
+              expect(res.status).to.equal(200);
+              return expect(res.body.errors[0].message).to.equal(expected);
+          });
+      });
+
+      it('returns errors in parseLiteral', () => {
+          const expected = 'The Error';
+          app = createApp({graphqlOptions: {
+              schema,
+          }});
+          const req = request(app)
+              .post('/graphql')
+              .send({
+                  query: 'query test{ testParseLiteralError(arg: "The Error") }',
               });
           return req.then((res) => {
               expect(res.status).to.equal(200);

--- a/packages/graphql-server-integration-testsuite/src/index.ts
+++ b/packages/graphql-server-integration-testsuite/src/index.ts
@@ -23,18 +23,18 @@ import { GraphQLOptions } from 'graphql-server-core';
 import * as GraphiQL from 'graphql-server-module-graphiql';
 import { OperationStore } from 'graphql-server-module-operation-store';
 
-const ParseLiteralErrorScalar = new GraphQLScalarType({
+const parseLiteralErrorScalar = new GraphQLScalarType({
     name: 'ParseLiteralErrorScalar',
-    parseLiteral(ast){
+    parseLiteral(ast) {
         if (ast.kind === Kind.STRING) {
             throw new Error(ast.value);
         }
-        throw new Error('Not a string')
+        throw new Error('Not a string');
     },
-    parseValue(value){
+    parseValue(value) {
         return value;
     },
-    serialize(value){
+    serialize(value) {
         return value;
     },
 });
@@ -94,9 +94,9 @@ const queryType = new GraphQLObjectType({
                 return 'This never gets executed if things go according to plan';
             },
             args: {
-                arg: { type: ParseLiteralErrorScalar},
-            }
-        }
+                arg: { type: parseLiteralErrorScalar},
+            },
+        },
     },
 });
 


### PR DESCRIPTION
Failing test case for #381. Turns out this has to be fixed upstream as `graphql-js` is throwing these as uncaught errors.

Feel free to close this btw. Or re-run the tests when this is fixed upstream.