### PR TITLE
Update readme for the koa package

### DIFF
--- a/packages/apollo-server-koa/README.md
+++ b/packages/apollo-server-koa/README.md
@@ -54,7 +54,7 @@ router.get('/graphiql', graphiqlKoa({
 }));
 ```
 
-In case your GraphQL endpoint is protected via authentication, or if you need to pass other custom headers in the request that GraphiQL makes, you can use the `passHeader` option – a **string** that will be added to the request header object.
+In case your GraphQL endpoint is protected via authentication, or if you need to pass other custom headers in the request that GraphiQL makes, you can use the [`passHeader`](https://github.com/apollographql/apollo-server/blob/v1.0.2/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts#L17) option – a string that will be added to the request header object.
 
 For example:
 ```js

--- a/packages/apollo-server-koa/README.md
+++ b/packages/apollo-server-koa/README.md
@@ -22,8 +22,8 @@ Anyone is welcome to contribute to GraphQL Server, just read [CONTRIBUTING.md](.
 
 ```js
 import koa from 'koa'; // koa@2
-import koaRouter from 'koa-router'; // koa-router@next
-import koaBody from 'koa-bodyparser'; // koa-bodyparser@next
+import koaRouter from 'koa-router';
+import koaBody from 'koa-bodyparser';
 import { graphqlKoa } from 'apollo-server-koa';
 
 const app = new koa();

--- a/packages/apollo-server-koa/README.md
+++ b/packages/apollo-server-koa/README.md
@@ -40,3 +40,28 @@ app.use(router.routes());
 app.use(router.allowedMethods());
 app.listen(PORT);
 ```
+
+### GraphiQL
+
+You can also use `apollo-server-koa` for hosting the [GraphiQL](https://github.com/graphql/graphiql) in-browser IDE. Note the difference between `graphqlKoa` and `graphiqlKoa`.
+
+```js
+import { graphiqlKoa } from 'apollo-server-koa';
+
+// Setup the /graphiql route to show the GraphiQL UI
+router.get('/graphiql', graphiqlKoa({
+    endpointURL: '/graphql' // a POST endpoint that GraphiQL will make the actual requests to
+}));
+```
+
+In case your GraphQL endpoint is protected via authentication, or if you need to pass other custom headers in the request that GraphiQL makes, you can use the `passHeader` option – a **string** that will be added to the request header object.
+
+For example:
+```js
+import { graphiqlKoa } from 'apollo-server-koa';
+
+router.get('/graphiql', graphiqlKoa({
+    endpointURL: '/graphql',
+    passHeader: `'Authorization': 'Bearer lorem ipsum'`
+}));
+```


### PR DESCRIPTION
As koa@2 seems to now be the norm, the master/latest releases of both koa-bodyparser and koa-router support koa@2 . The `@next` tags/versions needn't be a thing any more.

I also added documentation for the `passHeader` functionality of `graphiqlKoa`. The lack of this almost made me write my own GraphiQL server.