### PR TITLE
Update GraphiQL version

### DIFF
--- a/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
@@ -29,7 +29,7 @@ export type GraphiQLData = {
 };
 
 // Current latest version of GraphiQL.
-const GRAPHIQL_VERSION = '0.10.2';
+const GRAPHIQL_VERSION = '0.11.2';
 const SUBSCRIPTIONS_TRANSPORT_VERSION = '0.7.0';
 
 // Ensures string values are safe to be used within a <script> tag.

--- a/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
@@ -65,11 +65,11 @@ export function renderGraphiQL(data: GraphiQLData): string {
       width: 100%;
     }
   </style>
-  <link href="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
+  <link href="//cdn.jsdelivr.net/npm/graphiql@${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.0.0/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.0.0/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphiql@${GRAPHIQL_VERSION}/graphiql.min.js"></script>
   ${usingSubscriptions ?
     `<script src="//unpkg.com/subscriptions-transport-ws@${SUBSCRIPTIONS_TRANSPORT_VERSION}/browser/client.js"></script>` +
     '<script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>'


### PR DESCRIPTION
Bumped the GraphiQL version to latest (0.11.2). Just changing the version would have broken the CDN link due to a change in jsDelivr (see [their docs](https://github.com/jsdelivr/jsdelivr/blob/master/README.md)), so I also updated the url structure.