### PR TITLE
Add tracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-### VNEXT
-* Updated restify lib ([@yucun](https://github.com/liyucun/)) in [#472](https://github.com/apollographql/apollo-server/issues/472)
-* Updated package apollo-server-micro, updated micro in devDependencies and peerDependencies to ^8.0.1
 ### v1.1.0
 
 * Added ability to provide custom default field resolvers [#482](https://github.com/apollographql/apollo-server/pull/482)
+* Add `tracing` option to collect and expose trace data in the [Apollo Tracing format](https://github.com/apollographql/apollo-tracing)
 * Add support for GraphiQL editor themes in [#484](https://github.com/apollographql/apollo-server/pull/484) as requested in [#444](https://github.com/apollographql/apollo-server/issues/444)
 * Add support for full websocket using GraphiQL [#491](https://github.com/apollographql/graphql-server/pull/491)
+* Updated restify lib ([@yucun](https://github.com/liyucun/)) in [#472](https://github.com/apollographql/apollo-server/issues/472)
+* Updated package apollo-server-micro, updated micro in devDependencies and peerDependencies to ^8.0.1
 
 ### v1.0.3
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Apollo Server can be configured with an options object with the following fields
 * **validationRules**: additional GraphQL validation rules to be applied to client-specified queries
 * **formatParams**: a function applied for each query in a batch to format parameters before execution
 * **formatResponse**: a function applied to each response after execution
+* **tracing**: when set to true, collect and expose trace data in the [Apollo Tracing format](https://github.com/apollographql/apollo-tracing)
 
 All options except for `schema` are optional.
 

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -39,6 +39,6 @@
     "definition": "dist/index.d.ts"
   },
   "dependencies": {
-    "apollo-tracing": "^0.0.6"
+    "apollo-tracing": "^0.0.7"
   }
 }

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -37,5 +37,8 @@
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"
+  },
+  "dependencies": {
+    "apollo-tracing": "^0.0.6"
   }
 }

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -24,15 +24,13 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "devDependencies": {
+    "@types/graphql": "^0.10.2",
     "@types/fibers": "0.0.29",
     "fibers": "1.0.15",
     "meteor-promise": "^0.8.2"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -27,6 +27,7 @@ export interface GraphQLServerOptions {
   formatResponse?: Function;
   fieldResolver?: GraphQLFieldResolver<any, any>;
   debug?: boolean;
+  tracing?: boolean;
 }
 
 export default GraphQLServerOptions;

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -118,6 +118,7 @@ export async function runHttpQuery(handlerArguments: Array<any>, request: HttpQu
         formatResponse: optionsObject.formatResponse,
         fieldResolver: optionsObject.fieldResolver,
         debug: optionsObject.debug,
+        tracing: optionsObject.tracing,
       };
 
       if (optionsObject.formatParams) {

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -30,6 +30,7 @@
     "apollo-server-module-graphiql": "^1.0.5"
   },
   "devDependencies": {
+    "@types/graphql": "^0.10.2",
     "@types/body-parser": "1.16.3",
     "@types/connect": "^3.4.30",
     "@types/express": "^4.0.35",
@@ -43,10 +44,6 @@
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/express": "^4.0.35",
-    "@types/graphql": "^0.10.1"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -30,18 +30,14 @@
     "boom": "^5.1.0"
   },
   "devDependencies": {
+    "@types/graphql": "^0.10.2",
     "@types/boom": "4.3.2",
-    "@types/graphql": "^0.10.1",
     "@types/hapi": "^16.1.4",
     "apollo-server-integration-testsuite": "^1.0.5",
     "hapi": "^16.4.3"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1",
-    "@types/hapi": "^16.1.2"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -27,13 +27,10 @@
     "supertest-as-promised": "^4.0.0"
   },
   "devDependencies": {
-    "@types/graphql": "^0.10.1"
+    "@types/graphql": "^0.10.2"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -29,6 +29,7 @@
     "apollo-server-module-graphiql": "^1.0.5"
   },
   "devDependencies": {
+     "@types/graphql": "^0.10.2",
     "@types/koa": "^2.0.39",
     "@types/koa-bodyparser": "^3.0.23",
     "@types/koa-router": "^7.0.22",
@@ -39,10 +40,6 @@
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1",
-    "@types/koa": "^2.0.39"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "0.0.10",
-    "@types/graphql": "^0.10.1",
+    "@types/graphql": "^0.10.2",
     "apollo-server-integration-testsuite": "^1.0.5"
   },
   "peerDependencies": {

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -29,6 +29,8 @@
     "apollo-server-module-graphiql": "^1.0.5"
   },
   "devDependencies": {
+    "@types/graphql": "^0.10.2",
+    "@types/micro": "^7.3.0",
     "apollo-server-integration-testsuite": "^1.0.5",
     "micro": "^8.0.1",
     "microrouter": "^2.1.1"
@@ -36,10 +38,6 @@
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1",
     "micro": "^8.0.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1",
-    "@types/micro": "^7.3.0"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-module-operation-store/package.json
+++ b/packages/apollo-server-module-operation-store/package.json
@@ -23,11 +23,11 @@
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
+  "devDependencies": {
+    "@types/graphql": "^0.10.2"
+  },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/apollo-server-restify/package.json
+++ b/packages/apollo-server-restify/package.json
@@ -29,16 +29,13 @@
     "apollo-server-module-graphiql": "^1.0.5"
   },
   "devDependencies": {
+    "@types/graphql": "^0.10.2",
     "@types/restify": "^5.0.1",
     "apollo-server-integration-testsuite": "^1.0.5",
     "restify": "^4.3.0"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1"
-  },
-  "optionalDependencies": {
-    "@types/graphql": "^0.10.1",
-    "@types/restify": "^5.0.1"
   },
   "typings": "dist/index.d.ts",
   "typescript": {


### PR DESCRIPTION
This PR adds a `tracing` option to Apollo Server to collect and expose trace data in the [Apollo Tracing format](https://github.com/apollographql/apollo-tracing).

When set to true, the server will include resolver timings and other execution information as part of the `extensions` field of the GraphQL response, and tools can extract this data from the response to give more insight into individual requests, and to track server performance and schema usage over time.

The format is work in progress. We're collaborating with others in the GraphQL community to make it available in different server environments, and to build awesome tools on top of it!

[Apollo Optics](https://www.apollodata.com/optics/) will use Apollo Tracing as a replacement for the current agent architecture.