### PR TITLE
Remove unnecessary route in Koa example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ const PORT = 3000;
 router.post('/graphql', koaBody(), graphqlKoa({ schema: myGraphQLSchema }));
 router.get('/graphql', graphqlKoa({ schema: myGraphQLSchema }));
 
-router.post('/graphiql', graphiqlKoa({ endpointURL: '/graphql' }));
 router.get('/graphiql', graphiqlKoa({ endpointURL: '/graphql' }));
 
 app.use(router.routes());


### PR DESCRIPTION
It is my understanding that `POST` to `/graphiql` will never occur since GraphiQL will talk to `/graphql` directly. Since this is not needed I suggest we to remove it to avoid confusion.
