### PR TITLE
fix default query case when query value null is provider

### DIFF
--- a/packages/apollo-server-module-graphiql/src/resolveGraphiQLString.ts
+++ b/packages/apollo-server-module-graphiql/src/resolveGraphiQLString.ts
@@ -22,11 +22,12 @@ async function resolveGraphiQLOptions(options: GraphiQLData | Function, ...args)
   }
 }
 
-function createGraphiQLParams(query: any = {}): GraphiQLParams {
+function createGraphiQLParams(query: any): GraphiQLParams {
+  const queryObject = query || {};
   return {
-    query: query.query || '',
-    variables: query.variables,
-    operationName: query.operationName || '',
+    query: queryObject.query || '',
+    variables: queryObject.variables,
+    operationName: queryObject.operationName || '',
   };
 }
 


### PR DESCRIPTION
I noticed when using in production the query will not be undefined, but null. This doesn't work with default arguments.

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
