### PR TITLE
Rollup / Webpack Tree Shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 * Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)
+* Added es2015 build for webpack and rollup tree-shaking ([@patrickheeney](https://github.com/patrickheeney)) on [#540](https://github.com/apollographql/apollo-server/pull/540)
 
 ### v1.1.2
 * Fixed bug with no URL query params with GraphiQL on Lambda [Issue #504](https://github.com/apollographql/apollo-server/issues/504) [PR #512](https://github.com/apollographql/apollo-server/pull/503)

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Node.js GraphQl server for Azure Functions",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-azure-functions/tsconfig.es.json
+++ b/packages/apollo-server-azure-functions/tsconfig.es.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+        "node_modules/@types"
+    ],
+    "types": [
+        "@types/node"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -21,7 +21,7 @@ import {
 // Make the global Promise constructor Fiber-aware to simulate a Meteor
 // environment.
 import { makeCompatible } from 'meteor-promise';
-import Fiber = require('fibers');
+const Fiber = require('fibers');
 makeCompatible(Promise, Fiber);
 
 const queryType = new GraphQLObjectType({

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -21,8 +21,9 @@ import {
 // Make the global Promise constructor Fiber-aware to simulate a Meteor
 // environment.
 import { makeCompatible } from 'meteor-promise';
-const Fiber = require('fibers');
-makeCompatible(Promise, Fiber);
+// tslint:disable-next-line
+const fiber = require('fibers');
+makeCompatible(Promise, fiber);
 
 const queryType = new GraphQLObjectType({
     name: 'QueryType',

--- a/packages/apollo-server-core/tsconfig.es.json
+++ b/packages/apollo-server-core/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-express/tsconfig.es.json
+++ b/packages/apollo-server-express/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-hapi/tsconfig.es.json
+++ b/packages/apollo-server-hapi/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -4,8 +4,11 @@
   "version": "1.1.2",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-integration-testsuite/tsconfig.es.json
+++ b/packages/apollo-server-integration-testsuite/tsconfig.es.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "lib": ["es6", "esnext.asynciterable"],
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-koa/tsconfig.es.json
+++ b/packages/apollo-server-koa/tsconfig.es.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "types": []
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-lambda/tsconfig.es.json
+++ b/packages/apollo-server-lambda/tsconfig.es.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+        "node_modules/@types"
+    ],
+    "types": [
+        "@types/node"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-micro/tsconfig.es.json
+++ b/packages/apollo-server-micro/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-module-graphiql/package.json
+++ b/packages/apollo-server-module-graphiql/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "GraphiQL renderer for Apollo GraphQL Server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-module-graphiql/tsconfig.es.json
+++ b/packages/apollo-server-module-graphiql/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-module-operation-store/package.json
+++ b/packages/apollo-server-module-operation-store/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Persisted operation store module for Apollo GraphQL Servers",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-module-operation-store/tsconfig.es.json
+++ b/packages/apollo-server-module-operation-store/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-restify/package.json
+++ b/packages/apollo-server-restify/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Restify",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-restify/tsconfig.es.json
+++ b/packages/apollo-server-restify/tsconfig.es.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "types": []
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-core/package.json
+++ b/packages/graphql-server-core/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-core/tsconfig.es.json
+++ b/packages/graphql-server-core/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-express/package.json
+++ b/packages/graphql-server-express/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-express/tsconfig.es.json
+++ b/packages/graphql-server-express/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-hapi/package.json
+++ b/packages/graphql-server-hapi/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-hapi/tsconfig.es.json
+++ b/packages/graphql-server-hapi/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-koa/package.json
+++ b/packages/graphql-server-koa/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-koa/tsconfig.es.json
+++ b/packages/graphql-server-koa/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-lambda/package.json
+++ b/packages/graphql-server-lambda/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-lambda/tsconfig.es.json
+++ b/packages/graphql-server-lambda/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-micro/package.json
+++ b/packages/graphql-server-micro/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-micro/tsconfig.es.json
+++ b/packages/graphql-server-micro/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-module-graphiql/package.json
+++ b/packages/graphql-server-module-graphiql/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "GraphiQL renderer for Apollo GraphQL Server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-module-graphiql/tsconfig.es.json
+++ b/packages/graphql-server-module-graphiql/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-module-operation-store/package.json
+++ b/packages/graphql-server-module-operation-store/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Persisted operation store module for Apollo GraphQL Servers",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-module-operation-store/tsconfig.es.json
+++ b/packages/graphql-server-module-operation-store/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-restify/package.json
+++ b/packages/graphql-server-restify/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Restify",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-restify/tsconfig.es.json
+++ b/packages/graphql-server-restify/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitAny": false,
+    "allowSyntheticDefaultImports": false,
+    "pretty": true,
+    "removeComments": true,
+    "lib": ["es6", "esnext.asynciterable"],
+    "types": [
+      "@types/node"
+    ]
+  }
+}


### PR DESCRIPTION
This mirrors the discussion and work on https://github.com/apollographql/graphql-tools/pull/344 . It creates a es2015 build for use in rollup and webpack and enables tree-shaking bundles. 

I ran `npm run compile` which `compiled` all builds I tested the resulting `dist/es` builds in my project locally with rollup. 

There were a few minor issues:

- I had to change `import Fiber = require('fibers')` because it resulted in this error for the `es2015` build: `Import assignment cannot be used when targeting ECMAScript 2015 modules`. This then caused linting errors: `lowerCamelCase or UPPER_CASE` and then `require statement not part of an import statement`. I disabled the line as it started a circular line of errors.

- All `tsconfig.es.json` are mirrors of `tsconfig.json` except for [this line in this module](https://github.com/apollographql/apollo-server/compare/master...patrickheeney:rollup?expand=1#diff-b21fd8a39953de473ea105fef64db978R6). Without it caused `Cannot find name 'AsyncIterator'`. 

Additional testing: I built https://github.com/apollographql/apollo-server/pull/543 to show how rollup can be used.

TODO:

- [X] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
