### PR TITLE
[Not For Merge] Rollup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 * Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)
+* Added es2015 build for webpack and rollup tree-shaking ([@patrickheeney](https://github.com/patrickheeney)) on [#540](https://github.com/apollographql/apollo-server/pull/540)
 
 ### v1.1.2
 * Fixed bug with no URL query params with GraphiQL on Lambda [Issue #504](https://github.com/apollographql/apollo-server/issues/504) [PR #512](https://github.com/apollographql/apollo-server/pull/503)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "travis": "istanbul cover -x \"*.test.js\" _mocha -- --timeout 5000 --full-trace ./test/tests.js",
     "posttravis": "npm run lint",
     "postcoverage": "remap-istanbul --input coverage/coverage.raw.json --type lcovonly --output coverage/lcov.info",
-    "release": "lerna publish"
+    "release": "lerna publish",
+    "rollup": "lerna exec -- rollup --config ../../rollup.config.js"
   },
   "devDependencies": {
     "@types/chai": "4.0.4",
@@ -33,6 +34,9 @@
     "mocha": "3.5.0",
     "npm-check-updates": "2.12.1",
     "remap-istanbul": "0.9.5",
+    "rollup": "^0.49.2",
+    "rollup-plugin-commonjs": "^8.2.0",
+    "rollup-plugin-node-resolve": "^3.0.0",
     "sinon": "3.2.1",
     "supertest": "3.0.0",
     "supertest-as-promised": "4.0.2",

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Node.js GraphQl server for Azure Functions",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-azure-functions/tsconfig.es.json
+++ b/packages/apollo-server-azure-functions/tsconfig.es.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+        "node_modules/@types"
+    ],
+    "types": [
+        "@types/node"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -21,7 +21,7 @@ import {
 // Make the global Promise constructor Fiber-aware to simulate a Meteor
 // environment.
 import { makeCompatible } from 'meteor-promise';
-import Fiber = require('fibers');
+const Fiber = require('fibers');
 makeCompatible(Promise, Fiber);
 
 const queryType = new GraphQLObjectType({

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -21,8 +21,9 @@ import {
 // Make the global Promise constructor Fiber-aware to simulate a Meteor
 // environment.
 import { makeCompatible } from 'meteor-promise';
-const Fiber = require('fibers');
-makeCompatible(Promise, Fiber);
+// tslint:disable-next-line
+const fiber = require('fibers');
+makeCompatible(Promise, fiber);
 
 const queryType = new GraphQLObjectType({
     name: 'QueryType',

--- a/packages/apollo-server-core/tsconfig.es.json
+++ b/packages/apollo-server-core/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-express/tsconfig.es.json
+++ b/packages/apollo-server-express/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-hapi/tsconfig.es.json
+++ b/packages/apollo-server-hapi/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -4,8 +4,11 @@
   "version": "1.1.2",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-integration-testsuite/tsconfig.es.json
+++ b/packages/apollo-server-integration-testsuite/tsconfig.es.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "lib": ["es6", "esnext.asynciterable"],
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-koa/tsconfig.es.json
+++ b/packages/apollo-server-koa/tsconfig.es.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "types": []
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-lambda/tsconfig.es.json
+++ b/packages/apollo-server-lambda/tsconfig.es.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+        "node_modules/@types"
+    ],
+    "types": [
+        "@types/node"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-micro/tsconfig.es.json
+++ b/packages/apollo-server-micro/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-module-graphiql/package.json
+++ b/packages/apollo-server-module-graphiql/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "GraphiQL renderer for Apollo GraphQL Server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-module-graphiql/tsconfig.es.json
+++ b/packages/apollo-server-module-graphiql/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-module-operation-store/package.json
+++ b/packages/apollo-server-module-operation-store/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Persisted operation store module for Apollo GraphQL Servers",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-module-operation-store/tsconfig.es.json
+++ b/packages/apollo-server-module-operation-store/tsconfig.es.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/apollo-server-restify/package.json
+++ b/packages/apollo-server-restify/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Restify",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/apollo-server-restify/tsconfig.es.json
+++ b/packages/apollo-server-restify/tsconfig.es.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "types": []
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-core/package.json
+++ b/packages/graphql-server-core/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-core/tsconfig.es.json
+++ b/packages/graphql-server-core/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-express/package.json
+++ b/packages/graphql-server-express/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-express/tsconfig.es.json
+++ b/packages/graphql-server-express/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-hapi/package.json
+++ b/packages/graphql-server-hapi/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-hapi/tsconfig.es.json
+++ b/packages/graphql-server-hapi/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-koa/package.json
+++ b/packages/graphql-server-koa/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-koa/tsconfig.es.json
+++ b/packages/graphql-server-koa/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-lambda/package.json
+++ b/packages/graphql-server-lambda/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-lambda/tsconfig.es.json
+++ b/packages/graphql-server-lambda/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-micro/package.json
+++ b/packages/graphql-server-micro/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-micro/tsconfig.es.json
+++ b/packages/graphql-server-micro/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-module-graphiql/package.json
+++ b/packages/graphql-server-module-graphiql/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "GraphiQL renderer for Apollo GraphQL Server",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-module-graphiql/tsconfig.es.json
+++ b/packages/graphql-server-module-graphiql/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-module-operation-store/package.json
+++ b/packages/graphql-server-module-operation-store/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.0",
   "description": "Persisted operation store module for Apollo GraphQL Servers",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-module-operation-store/tsconfig.es.json
+++ b/packages/graphql-server-module-operation-store/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/graphql-server-restify/package.json
+++ b/packages/graphql-server-restify/package.json
@@ -3,8 +3,11 @@
   "version": "1.1.2",
   "description": "Production-ready Node.js GraphQL server for Restify",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "jsnext:main": "dist/es/index.js",
   "scripts": {
-    "compile": "tsc",
+    "compile": "tsc && npm run compile-es",
+    "compile-es": "tsc -p tsconfig.es.json",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/packages/graphql-server-restify/tsconfig.es.json
+++ b/packages/graphql-server-restify/tsconfig.es.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.es",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,47 @@
+import path from 'path';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+const pkgName = path.basename(process.cwd());
+const pkg = require(path.resolve(process.cwd(), 'package.json'));
+const entry = pkg.module || pkg.main;
+
+let dependencies = ['crypto'].concat(Object.keys(pkg.peerDependencies || {}));
+
+// if this is graphql- forwarding package, treat as external due to real
+// dependencies (graphql) not being specific in package.json
+if (pkgName.substr(0, 8) === 'graphql-') {
+  dependencies = dependencies.concat(Object.keys(pkg.dependencies || {}));
+}
+
+// apollo-server-integration-testsuite doesn't have dependencies listed
+if (pkgName === 'apollo-server-integration-testsuite') {
+  dependencies = dependencies.concat(['chai', 'sinon', 'mocha']);
+}
+
+// console.log('DEBUG', pkgName, dependencies);
+
+// rollup.config.js
+export default {
+  input: entry,
+  external: dependencies,
+  plugins: [
+    nodeResolve({
+      module: true,
+      jsnext: true
+    }),
+    commonjs({
+      include: /node_modules/
+    })
+  ],
+  output: [
+    {
+      file: `dist/build/${pkgName}.cjs.js`,
+      format: 'cjs'
+    },
+    {
+      file: `dist/build/${pkgName}.es.js`,
+      format: 'es'
+    }
+  ]
+};

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitAny": false,
+    "allowSyntheticDefaultImports": false,
+    "pretty": true,
+    "removeComments": true,
+    "lib": ["es6", "esnext.asynciterable"],
+    "types": [
+      "@types/node"
+    ]
+  }
+}


### PR DESCRIPTION
**This is not for merging**

This PR is built on #540 to test the tree-shaking / rollup bundling and useful reference for how to utilize the `es2015` build and rollup. 

It successfully works on all current packages, although with a few `this` warnings. There is a `typescript` plugin for `rollup` to skip using a `es2015` build and build directly off `typescript` source, but as I built this for testing the `es2015` builds in PR #540, I did not utilize it. That plugin might have better support for how typescript compiles to get rid of the warnings.

TODO:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
