### PR TITLE
Added vhost option for Hapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+* Added support for the vhost option for Hapi [PR #611](https://github.com/apollographql/apollo-server/pull/611)
 
 ### v1.1.6
 * Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -14,6 +14,7 @@ export interface HapiOptionsFunction {
 
 export interface HapiPluginOptions {
   path: string;
+  vhost?: string;
   route?: any;
   graphqlOptions: GraphQLOptions | HapiOptionsFunction;
 }
@@ -58,6 +59,7 @@ const graphqlHapi: IRegister = function(server: Server, options: HapiPluginOptio
   server.route({
     method: ['GET', 'POST'],
     path: options.path || '/graphql',
+    vhost: options.vhost || undefined,
     config: options.route || {},
     handler: (request, reply) => runHttpQueryWrapper(options.graphqlOptions, request, reply),
   });


### PR DESCRIPTION
Hi there!

I've added the option to add a vhost to the endpoint, as it should be allowed by Hapi [route configuration](https://hapijs.com/api#route-configuration).

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
