### PR TITLE
Add debug to Hapi code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Now with the Hapi plugins `graphqlHapi` and `graphiqlHapi` you can pass a route 
 import hapi from 'hapi';
 import { graphqlHapi } from 'apollo-server-hapi';
 
-const server = new hapi.Server();
+const server = new hapi.Server({ debug: { request: "*" } });
 
 const HOST = 'localhost';
 const PORT = 3000;

--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -26,7 +26,7 @@ With the Hapi plugins `graphqlHapi` and `graphiqlHapi` you can pass a route obje
 import hapi from 'hapi';
 import { graphqlHapi } from 'apollo-server-hapi';
 
-const server = new hapi.Server();
+const server = new hapi.Server({ debug: { request: "*" } });
 
 const HOST = 'localhost';
 const PORT = 3000;


### PR DESCRIPTION
Thanks for sharing `apollo-server`, it's a great project.

I think it would be nice to add debug info to the `Hapi.server` call in the `README`, as people will be cutting and pasting this information from the docs and elsewhere whenever they start a new project (I know I do). Since there isn't an up-to-date and complete starter project, people are prone to making silly errors during setup. Adding this debug info is a very simple change that can cut debugging time (and potential frustration levels) down considerably. Especially for people who are new to development, or hapi, or graphql, or apollo in particular.

I am able to quickly figure things out on my own, but someone else may not be able to. Having debugging on "by default" will help get people up and going faster, and easier. It will also make it easier for a newbie to ask for help, since they will have an error message to show off, and more insight into what is wrong.