### PR TITLE
Send content length header.

### DIFF
--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -33,6 +33,7 @@ export function graphqlExpress(options: GraphQLOptions | ExpressGraphQLOptionsFu
       query: req.method === 'POST' ? req.body : req.query,
     }).then((gqlResponse) => {
       res.setHeader('Content-Type', 'application/json');
+      res.setHeader('Content-Length', Buffer.byteLength(gqlResponse, 'utf8'));
       res.write(gqlResponse);
       res.end();
     }, (error: HttpQueryError) => {


### PR DESCRIPTION
Sending a content-length header allows CloudFront to gzip compress the response.