### PR TITLE
Adding support for wss

### DIFF
--- a/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
@@ -44,7 +44,7 @@ function safeSerialize(data) {
 
 export function renderGraphiQL(data: GraphiQLData): string {
   const endpointURL = data.endpointURL;
-  const endpointWs = endpointURL.startsWith('ws://');
+  const endpointWs = endpointURL.startsWith('ws://') || endpointURL.startsWith('wss://');
   const subscriptionsEndpoint = data.subscriptionsEndpoint;
   const usingHttp = !endpointWs;
   const usingWs = endpointWs || !!subscriptionsEndpoint;


### PR DESCRIPTION
I found current `GraphiQL` is missing checking `wss` which is secure protocol for websocket. But mostly site is under `https` now, and cannot communicate with non-secure service. So it's very important to add this support.