### PR TITLE
Make only truthy values to be in URL in GraphiQL

### DIFF
--- a/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
@@ -184,7 +184,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
     }
     function updateURL() {
       var cleanParams = Object.keys(parameters).filter(function(v) {
-        return parameters[v] !== undefined;
+        return parameters[v];
       }).reduce(function(old, v) {
         old[v] = parameters[v];
         return old;


### PR DESCRIPTION
In current implementation of `apollo-server-module-graphiql`, it pushes useless `null` values of `variables` and `operationName` to URL string, so it usually becomes like

> example.com/graphiql?query=something&**operationName=null&variables=null**

This hasn't any useful value, and this behavior even causes [bugs like this](https://github.com/graphql/graphiql/issues/234) (filled under unrelated another repo, though) (read [this comment](https://github.com/graphql/graphiql/issues/234#issuecomment-312109591) about how to reproduce).

This PR fixes that.