### PR TITLE
fix: remove shallow cloning of object when executing a batch http req…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Include readme for npm packages
 * Update peerDependencies version for micro [PR #671](https://github.com/apollographql/apollo-server/pull/671)
 * Corrected the hapi example both in the README.md [PR #689] [Issue #689]
-* Remove context cloning when batching[PR #679](https://github.com/apollographql/apollo-server/pull/679)
+* Change GraphqlOptions to also accept context as a function[PR #679](https://github.com/apollographql/apollo-server/pull/679)
 
 ### v1.1.6
 * Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Include readme for npm packages
 * Update peerDependencies version for micro [PR #671](https://github.com/apollographql/apollo-server/pull/671)
 * Corrected the hapi example both in the README.md [PR #689] [Issue #689]
+* Remove context cloning when batching[PR #679](https://github.com/apollographql/apollo-server/pull/679)
 
 ### v1.1.6
 * Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -27,6 +27,10 @@ function isQueryOperation(query: DocumentNode, operationName: string) {
   return operationAST.operation === 'query';
 }
 
+export function isFunction(arg: any): arg is Function {
+  return typeof arg === 'function';
+}
+
 export async function runHttpQuery(handlerArguments: Array<any>, request: HttpQueryRequest): Promise<string> {
   let isGetRequest: boolean = false;
   let optionsObject: GraphQLOptions;
@@ -97,11 +101,18 @@ export async function runHttpQuery(handlerArguments: Array<any>, request: HttpQu
         }
       }
 
+      let context = optionsObject.context;
+      if (isFunction(context)) {
+        context = context();
+      } else if (isBatch) {
+        context = Object.assign({}, context || {});
+      }
+
       let params = {
         schema: optionsObject.schema,
         query: query,
         variables: variables,
-        context: optionsObject.context,
+        context,
         rootValue: optionsObject.rootValue,
         operationName: operationName,
         logFunction: optionsObject.logFunction,

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -97,19 +97,11 @@ export async function runHttpQuery(handlerArguments: Array<any>, request: HttpQu
         }
       }
 
-      // Shallow clone context for queries in batches. This allows
-      // users to distinguish multiple queries in the batch and to
-      // modify the context object without interfering with each other.
-      let context = optionsObject.context;
-      if (isBatch) {
-        context = Object.assign({},  context || {});
-      }
-
       let params = {
         schema: optionsObject.schema,
         query: query,
         variables: variables,
-        context: context,
+        context: optionsObject.context,
         rootValue: optionsObject.rootValue,
         operationName: operationName,
         logFunction: optionsObject.logFunction,

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -27,7 +27,7 @@ function isQueryOperation(query: DocumentNode, operationName: string) {
   return operationAST.operation === 'query';
 }
 
-export function isFunction(arg: any): arg is Function {
+function isFunction(arg: any): arg is Function {
   return typeof arg === 'function';
 }
 
@@ -101,11 +101,11 @@ export async function runHttpQuery(handlerArguments: Array<any>, request: HttpQu
         }
       }
 
-      let context = optionsObject.context;
+      let context = optionsObject.context || {};
       if (isFunction(context)) {
         context = context();
       } else if (isBatch) {
-        context = Object.assign({}, context || {});
+        context = Object.assign(Object.create(Object.getPrototypeOf(context)), context);
       }
 
       let params = {

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -522,9 +522,9 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           });
       });
 
-       it('executes batch context if it is a function', () => {
+       it('executes batch context if it is a function', async () => {
            let callCount = 0;
-           app = createApp({graphqlOptions: {
+           app = await createApp({graphqlOptions: {
                schema,
                context: () => {
                    callCount++;

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -522,6 +522,41 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           });
       });
 
+       it('executes batch context if it is a function', () => {
+           let callCount = 0;
+           app = createApp({graphqlOptions: {
+               schema,
+               context: () => {
+                   callCount++;
+                   return ({testField: 'expected'});
+               },
+           }});
+           const expected = [
+               {
+                   data: {
+                       testContext: 'expected',
+                   },
+               },
+               {
+                   data: {
+                       testContext: 'expected',
+                   },
+               },
+           ];
+           const req = request(app)
+               .post('/graphql')
+               .send([{
+                   query: 'query test{ testContext }',
+               }, {
+                   query: 'query test{ testContext }',
+               }]);
+           return req.then((res) => {
+               expect(callCount).to.equal(2);
+               expect(res.status).to.equal(200);
+               return expect(res.body).to.deep.equal(expected);
+           });
+       });
+
       it('can handle a request with a mutation', async () => {
           app = await createApp();
           const expected = {


### PR DESCRIPTION
Opened this to solve https://github.com/apollographql/apollo-server/issues/461, let me know if this change is appropriate and I'll clean up for merge

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
