### PR TITLE
Fix apollo-server-core runQuery breaks async_hook tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+* Fix apollo-server-core runQuery breaks async_hooks tracking [PR #733](https://github.com/apollographql/apollo-server/pull/733)
 
 ### v1.3.0
 * Added support for the vhost option for Hapi [PR #611](https://github.com/apollographql/apollo-server/pull/611)

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -62,11 +62,9 @@ export interface QueryOptions {
  cacheControl?: boolean;
 }
 
-const resolvedPromise = Promise.resolve();
-
 function runQuery(options: QueryOptions): Promise<GraphQLResponse> {
     // Fiber-aware Promises run their .then callbacks in Fibers.
-    return resolvedPromise.then(() => doRunQuery(options));
+    return Promise.resolve().then(() => doRunQuery(options));
 }
 
 function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {


### PR DESCRIPTION
By creating a promise out of the execution flow the ability to trace the
async call stack is lost.

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
