### PR TITLE
Use a named function for the middleware over an anonymous

### DIFF
--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -25,7 +25,8 @@ export function graphqlAdonis(
       `Apollo Server expects exactly one argument, got ${arguments.length}`,
     );
   }
-  return (ctx: AdonisContext): Promise<void> => {
+
+  const graphqlHandler = (ctx: AdonisContext): Promise<void> => {
     const { request, response } = ctx;
     const method = request.method();
     const query = method === 'POST' ? request.post() : request.get();
@@ -51,6 +52,8 @@ export function graphqlAdonis(
       },
     );
   };
+
+  return graphqlHandler;
 }
 
 export interface AdonisGraphiQLOptionsFunction {
@@ -60,7 +63,7 @@ export interface AdonisGraphiQLOptionsFunction {
 export function graphiqlAdonis(
   options: GraphiQL.GraphiQLData | AdonisGraphiQLOptionsFunction,
 ) {
-  return (ctx: AdonisContext): Promise<void> => {
+  const graphiqlHandler = (ctx: AdonisContext): Promise<void> => {
     const { request, response } = ctx;
     const query = request.get();
     return GraphiQL.resolveGraphiQLString(query, options, ctx).then(
@@ -72,4 +75,6 @@ export function graphiqlAdonis(
       },
     );
   };
+
+  return graphiqlHandler;
 }

--- a/packages/apollo-server-azure-functions/src/azureFunctionsApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionsApollo.ts
@@ -50,7 +50,10 @@ export function graphqlAzureFunctions(
     );
   }
 
-  return (httpContext: IHttpContext, request: IFunctionRequest) => {
+  const graphqlHandler = (
+    httpContext: IHttpContext,
+    request: IFunctionRequest,
+  ) => {
     const queryRequest = {
       method: request.method,
       options: options,
@@ -85,6 +88,8 @@ export function graphqlAzureFunctions(
         httpContext.done(null, result);
       });
   };
+
+  return graphqlHandler;
 }
 
 /* This Azure Functions Handler returns the html for the GraphiQL interactive query UI
@@ -101,7 +106,10 @@ export function graphqlAzureFunctions(
 export function graphiqlAzureFunctions(
   options: GraphiQLData | AzureFunctionsGraphiQLOptionsFunction,
 ) {
-  return (httpContext: IHttpContext, request: IFunctionRequest) => {
+  const graphiqlHandler = (
+    httpContext: IHttpContext,
+    request: IFunctionRequest,
+  ) => {
     const query = request.query;
 
     resolveGraphiQLString(query, options, httpContext, request).then(
@@ -127,4 +135,6 @@ export function graphiqlAzureFunctions(
       },
     );
   };
+
+  return graphiqlHandler;
 }

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -36,7 +36,7 @@ export function graphqlExpress(
     );
   }
 
-  return (req: express.Request, res: express.Response, next): void => {
+  return function graphql(req: express.Request, res: express.Response, next): void {
     runHttpQuery([req, res], {
       method: req.method,
       options: options,

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -36,7 +36,11 @@ export function graphqlExpress(
     );
   }
 
-  return function graphql(req: express.Request, res: express.Response, next): void {
+  const graphqlHandler = (
+    req: express.Request,
+    res: express.Response,
+    next,
+  ): void => {
     runHttpQuery([req, res], {
       method: req.method,
       options: options,
@@ -68,6 +72,8 @@ export function graphqlExpress(
       },
     );
   };
+
+  return graphqlHandler;
 }
 
 export interface ExpressGraphiQLOptionsFunction {
@@ -90,7 +96,11 @@ export interface ExpressGraphiQLOptionsFunction {
 export function graphiqlExpress(
   options: GraphiQL.GraphiQLData | ExpressGraphiQLOptionsFunction,
 ) {
-  return (req: express.Request, res: express.Response, next) => {
+  const graphiqlHandler = (
+    req: express.Request,
+    res: express.Response,
+    next,
+  ) => {
     const query = req.url && url.parse(req.url, true).query;
     GraphiQL.resolveGraphiQLString(query, options, req).then(
       graphiqlString => {
@@ -101,4 +111,6 @@ export function graphiqlExpress(
       error => next(error),
     );
   };
+
+  return graphiqlHandler;
 }

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -27,7 +27,7 @@ export function graphqlKoa(
     );
   }
 
-  return (ctx: koa.Context): Promise<void> => {
+  const graphqlHandler = (ctx: koa.Context): Promise<void> => {
     return runHttpQuery([ctx], {
       method: ctx.request.method,
       options: options,
@@ -54,6 +54,8 @@ export function graphqlKoa(
       },
     );
   };
+
+  return graphqlHandler;
 }
 
 export interface KoaGraphiQLOptionsFunction {
@@ -63,7 +65,7 @@ export interface KoaGraphiQLOptionsFunction {
 export function graphiqlKoa(
   options: GraphiQL.GraphiQLData | KoaGraphiQLOptionsFunction,
 ) {
-  return (ctx: koa.Context) => {
+  const graphiqlHandler = (ctx: koa.Context) => {
     const query = ctx.request.query;
     return GraphiQL.resolveGraphiQLString(query, options, ctx).then(
       graphiqlString => {
@@ -76,4 +78,6 @@ export function graphiqlKoa(
       },
     );
   };
+
+  return graphiqlHandler;
 }

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -34,7 +34,7 @@ export function graphqlLambda(
     );
   }
 
-  return async (
+  const graphqlHandler = async (
     event,
     lambdaContext: lambda.Context,
     callback: lambda.Callback,
@@ -73,6 +73,8 @@ export function graphqlLambda(
       });
     }
   };
+
+  return graphqlHandler;
 }
 
 export interface LambdaGraphiQLOptionsFunction {
@@ -95,7 +97,11 @@ export interface LambdaGraphiQLOptionsFunction {
 export function graphiqlLambda(
   options: GraphiQL.GraphiQLData | LambdaGraphiQLOptionsFunction,
 ) {
-  return (event, lambdaContext: lambda.Context, callback: lambda.Callback) => {
+  const graphiqlHandler = (
+    event,
+    lambdaContext: lambda.Context,
+    callback: lambda.Callback,
+  ) => {
     const query = event.queryStringParameters;
     GraphiQL.resolveGraphiQLString(query, options, event, lambdaContext).then(
       graphiqlString => {
@@ -115,4 +121,6 @@ export function graphiqlLambda(
       },
     );
   };
+
+  return graphiqlHandler;
 }

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -25,7 +25,7 @@ export function microGraphql(
     );
   }
 
-  return async function(req: IncomingMessage, res: ServerResponse) {
+  const graphqlHandler = async (req: IncomingMessage, res: ServerResponse) => {
     let query;
     if (req.method === 'POST') {
       try {
@@ -62,6 +62,8 @@ export function microGraphql(
       throw error;
     }
   };
+
+  return graphqlHandler;
 }
 
 export interface MicroGraphiQLOptionsFunction {
@@ -73,7 +75,7 @@ export interface MicroGraphiQLOptionsFunction {
 export function microGraphiql(
   options: GraphiQL.GraphiQLData | MicroGraphiQLOptionsFunction,
 ): RequestHandler {
-  return (req: IncomingMessage, res: ServerResponse) => {
+  const graphiqlHandler = (req: IncomingMessage, res: ServerResponse) => {
     const query = (req.url && url.parse(req.url, true).query) || {};
     return GraphiQL.resolveGraphiQLString(query, options, req).then(
       graphiqlString => {
@@ -88,4 +90,6 @@ export function microGraphiql(
       },
     );
   };
+
+  return graphiqlHandler;
 }

--- a/packages/apollo-server-restify/src/restifyApollo.ts
+++ b/packages/apollo-server-restify/src/restifyApollo.ts
@@ -35,7 +35,7 @@ export function graphqlRestify(
     );
   }
 
-  return (
+  const graphqlHandler = (
     req: restify.Request,
     res: restify.Response,
     next: restify.Next,
@@ -69,6 +69,8 @@ export function graphqlRestify(
       },
     );
   };
+
+  return graphqlHandler;
 }
 
 export interface RestifyGraphiQLOptionsFunction {
@@ -91,7 +93,11 @@ export interface RestifyGraphiQLOptionsFunction {
 export function graphiqlRestify(
   options: GraphiQL.GraphiQLData | RestifyGraphiQLOptionsFunction,
 ) {
-  return (req: restify.Request, res: restify.Response, next: restify.Next) => {
+  const graphiqlHandler = (
+    req: restify.Request,
+    res: restify.Response,
+    next: restify.Next,
+  ) => {
     const query = (req.url && url.parse(req.url, true).query) || {};
     GraphiQL.resolveGraphiQLString(query, options, req).then(
       graphiqlString => {
@@ -108,4 +114,6 @@ export function graphiqlRestify(
       },
     );
   };
+
+  return graphiqlHandler;
 }


### PR DESCRIPTION
It's making the investigation of performance issues easier.

**New Relic**
<img width="654" alt="capture d ecran 2018-02-09 a 18 16 21" src="https://user-images.githubusercontent.com/3165635/36040311-5de7b9c6-0dc5-11e8-8151-eb36d637f014.png">

**Chrome Dev Tool (express-graphql but I'm considering moving to apollo-server)**

<img width="247" alt="capture d ecran 2018-02-09 a 18 21 47" src="https://user-images.githubusercontent.com/3165635/36040570-2703d722-0dc6-11e8-9f94-f8a80938fe7f.png">

Related to:
- https://github.com/i18next/i18next-express-middleware/pull/144
- https://github.com/helmetjs/helmet/pull/165
- https://github.com/getsentry/raven-node/pull/424