### PR TITLE
add the debug attribute to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Apollo Server can be configured with an options object with the following fields
 * **formatParams**: a function applied for each query in a batch to format parameters before execution
 * **formatResponse**: a function applied to each response after execution
 * **tracing**: when set to true, collect and expose trace data in the [Apollo Tracing format](https://github.com/apollographql/apollo-tracing)
+* **debug**: when set to true, stack trace for errors gets logged and output to the console
 
 All options except for `schema` are optional.
 


### PR DESCRIPTION
The debug attribute isn't present in the documentation so I added it. Also didn't know if I should update the CHANGELOG.md because the PR is concerning the documentation only.