### PR TITLE
[docs] Use package-based Hexo theme, rather than a Git submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/themes/meteor"]
-	path = docs/themes/meteor
-	url = https://github.com/meteor/hexo-theme-meteor.git

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,3 +7,4 @@ public/*
 !public/_redirects
 .deploy*/
 docs.json
+_multiconfig.yml

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,6 @@ Read the docs at [apollographql.com/docs/apollo-server](https://www.apollographq
 To run the docs app locally:
 
 ```bash
-git submodule update && git submodule init
 npm install
 npm start
 ```

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,9 +7,6 @@ title: Apollo Server
 propertytitle: Using Apollo Server
 subtitle: Apollo Server
 description: A guide to using Apollo Server.
-author:
-language:
-timezone:
 versions:
   - '1'
 sidebar_categories:
@@ -48,80 +45,13 @@ content_root: docs/source
 typescript_api_box:
   data_file: docs.json
 
-social_links:
-  github: 'https://github.com/apollographql'
-  twitter: '@apollographql'
-  slackInvitePage: 'https://www.apollographql.com/#slack'
-
 # API keys
 apis:
-  segment: wgrIo8Bul0Ujl8USETG3DB6hONdy4kTg
   docsearch:
     apiKey: 768e823959d35bbd51e4b2439be13fb7
     indexName: apollodata
-  gtm: GTM-PNFDVBB
 
-logo:
-  nav_mobile: images/logo-apollo-space-left.svg
-  title: Apollo
-  url: https://www.apollographql.com/
-
-# URL
-## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
 url: https://www.apollographql.com/docs/apollo-server/
 root: /docs/apollo-server/
-permalink: :year/:month/:day/:title/
-permalink_defaults:
 
-# Directory
-source_dir: source
 public_dir: public/docs/apollo-server
-tag_dir: tags
-archive_dir: archives
-category_dir: categories
-code_dir: downloads/code
-i18n_dir: :lang
-skip_render:
-
-# Writing
-new_post_name: :title.md # File name of new posts
-default_layout: post
-titlecase: false # Transform title into titlecase
-external_link: true # Open external links in new tab
-filename_case: 0
-render_drafts: false
-post_asset_folder: false
-relative_link: false
-future: true
-highlight:
-  enable: true
-  line_number: true
-  auto_detect: true
-  tab_replace:
-
-# Category & Tag
-default_category: uncategorized
-category_map:
-tag_map:
-
-# Date / Time format
-## Hexo uses Moment.js to parse and display date
-## You can customize the date format as defined in
-## http://momentjs.com/docs/#/displaying/format/
-date_format: YYYY-MM-DD
-time_format: HH:mm:ss
-
-# Pagination
-## Set per_page to 0 to disable pagination
-per_page: 10
-pagination_dir: page
-
-# Extensions
-## Plugins: http://hexo.io/plugins/
-## Themes: http://hexo.io/themes/
-theme: meteor
-
-# Deployment
-## Docs: http://hexo.io/docs/deployment.html
-deploy:
-  type:

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "hexo-renderer-marked": "0.3.2",
     "hexo-server": "0.3.1",
     "lodash": "^4.13.1",
+    "meteor-theme-hexo": "1.0.1",
     "nodemon": "^1.14.12",
     "showdown": "^1.4.2"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,11 +11,11 @@
     "handlebars": "^4.0.5",
     "hexo": "3.6.0",
     "hexo-generator-archive": "0.1.5",
-    "hexo-generator-category": "^0.1.2",
+    "hexo-generator-category": "0.1.3",
     "hexo-generator-index": "0.2.1",
     "hexo-generator-tag": "0.2.0",
     "hexo-renderer-ejs": "0.3.1",
-    "hexo-renderer-less": "^0.2.0",
+    "hexo-renderer-less": "0.2.0",
     "hexo-renderer-marked": "0.3.2",
     "hexo-server": "0.3.1",
     "lodash": "^4.13.1",
@@ -29,5 +29,8 @@
       "nodemon -x 'rm db.json; hexo serve' -w assets/ -w code/ -w source/ -w themes/ -w scripts/",
     "clean": "hexo clean",
     "test": "npm run clean; npm run build"
+  },
+  "renovate": {
+    "extends": ["apollo-docs"]
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "hexo": {
     "version": "3.6.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "handlebars": "^4.0.5",
     "hexo": "3.6.0",
     "hexo-generator-archive": "0.1.5",
@@ -17,6 +17,7 @@
     "hexo-renderer-marked": "0.3.2",
     "hexo-server": "0.3.1",
     "lodash": "^4.13.1",
+    "nodemon": "^1.14.12",
     "showdown": "^1.4.2"
   },
   "scripts": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,8 @@
     "version": "3.6.0"
   },
   "devDependencies": {
+    "apollo-hexo-config": "^1.0.2",
+    "chexo": "^1.0.4",
     "handlebars": "^4.0.5",
     "hexo": "3.6.0",
     "hexo-generator-archive": "0.1.5",
@@ -21,8 +23,8 @@
     "showdown": "^1.4.2"
   },
   "scripts": {
-    "start": "hexo serve",
-    "build": "hexo generate",
+    "start": "npm run build && chexo apollo-hexo-config -- server",
+    "build": "chexo apollo-hexo-config -- generate",
     "develop-theme":
       "nodemon -x 'rm db.json; hexo serve' -w assets/ -w code/ -w source/ -w themes/ -w scripts/",
     "clean": "hexo clean",


### PR DESCRIPTION
This PR is part of a series of mostly-automated PRs whose primary goal is to replace the Hexo theme, which has historically been provided with a Git submodule to the [theme repository](https://github.com/meteor/hexo-theme-meteor), with a theme installed via the [`meteor-theme-hexo`](https://github.com/hexo-theme-meteor) package ([npm](https://npm.im/meteor-theme-hexo)) which was created after the re-convergence of the (previously-separated) Apollo and Meteor themes which took place in https://github.com/meteor/hexo-theme-meteor/pull/51. 

I (@abernix) will check each of these automated PRs' Netlify deploy previews and comment on the PR once it is ready to be merged.

**Please do not merge this until I've updated with confirmation.**

The Apollo repositories which are receiving this PR are those listed at:

   https://github.com/meteor/hexo-theme-meteor/#readme

Most of these changes have been incrementally added to other repositories for testing and, now that they've been validated, are now ready (hopefully!) for all repositories.

While this package-based theme could be used by using Hexo's (recently added) inherited config file through the use of comma-delimited `--config` parameters (one of which would be pointing to the `node_modules` directory; e.g.  `hexo --config ../node_modules/module/,_config.yml`), a newly-created [`chexo`](https://npm.im/chexo) ("config hexo") package allows this to be, only: 

    chexo apollo-hexo-config -- start

...where everything after the `--` will be passed directly to `hexo` and interpreted as usual.

Like other automated commits of this type, this also aims to update other Hexo dependencies to their latest stable versions and align all of Apollo's [Hexo](https://hexo.io/)-based doc configurations with the same patterns.

This PR also introduces [Renovate](https://renovateapp.com/) configuration within the docs' `package.json` (i.e. for repositories which have nested docs or have previously configured Renovate, it does _not_ affect the top-level `package.json` or `renovate.json`) in order to accommodate the auto-updating of these dependencies (and the theme!) in the future.  If a repository is not configured for Renovate app, it will not be affected by this change, however those that _do_ will automatically have their Hexo-related PRs merged by this new Renovate configuration.

In the event that the repository wishes to setup Renovate to update docs dependencies (recommended!), but does not wish to use Renovate for the rest of the repository, it will be necessary to have a [Renovate `packageFiles` configuration](https://renovateapp.com/docs/configuration-reference/configuration-options#packagefiles) which points to _just_ the docs' `package.json` (e.g. `"packageFiles": ["docs/package.json"]`) in either the `renovate.json` or the `package.json`'s `renovate` object.

Lastly, please `@mention` me below if you have any questions about this PR!