### PR TITLE
Stop `prettier`-ing JSON files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "compile": "lerna exec -- npm run compile",
     "lint":
-      "prettier-check --ignore-path .gitignore \"{docs/{,source/**},.,packages/**,test}/{*.{j,t}s*,*.md,*.json}\"",
+      "prettier-check --ignore-path .gitignore \"{docs/{,source/**},.,packages/**,test}/{*.{j,t}s*,*.md}\"",
     "lint-fix":
-      "prettier --write --ignore-path .gitignore \"{docs/{,source/**},.,packages/**,test}/{*.{j,t}s*,*.md,*.json}\"",
+      "prettier --write --ignore-path .gitignore \"{docs/{,source/**},.,packages/**,test}/{*.{j,t}s*,*.md}\"",
     "prebootstrap": "npm install",
     "postinstall": "lerna bootstrap",
     "pretest": "npm run compile",


### PR DESCRIPTION
With a lack of comments and a fairly strict structure, it's arguable if JSON
files were ever meant to be pretty, but the method we're using right now is
a bit futile, especially considering that tools that we use to automatically
update JSON (specifically, package.json) don't run prettier themselves.

The most problematic rule is the 80 characters line limit.

Lines in JSON can be wrapped in, at most, one place: after the colon in the
key.  This means that as soon as a single npm-script declaration exceeds the
line-length rule a second time, it can't be wrapped again, resulting in a
violation of the very rule being enforced.

Clearly, I've always thought that prettying JSON is a bit silly, but the
straw that broke the camel's back here is automated package.json changes by
bots which update the repository via their automated PRs.

Perhaps in a day where the JavaScript package manifest finds a new file
extension (.js?, .yaml, .toml?), it will be able to reap the glitz and glamour
of being eloquently formatted, but until then we'll have to use long-line
wrapping in our editors.

...or shorten our npm scripts.