### PR TITLE
FIX: Incorrect Content-Type for apollo-server-adonis

### DIFF
--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -35,7 +35,8 @@ export function graphqlAdonis(
       query,
     }).then(
       gqlResponse => {
-        response.json(gqlResponse);
+        response.header('Content-Type', 'application/json');
+        response.send(gqlResponse);
       },
       (error: HttpQueryError) => {
         if ('HttpQueryError' !== error.name) {


### PR DESCRIPTION
# Issue #867 

# Intended outcome
Responses from apollo-server-adonis shall have a Content-Type: application/json header set.

# Actual outcome
Responses have Content-Type: text/plain; charset=utf-8 header set.

# Analysis
The module apollo-server-adonis calls response.json(gqlResponse) after it gets the output from runHttpQuery.

However, gqlResponse is already stringified (see link 1). The only reason .json method works, is because it is an "alias" to .send and uses heuristics to determine the content type in the end, regardless of the response method used. Adonis has it's own response object, with a similar interface to Express but a different implementation.

# Proposed Solutions
Continue returning gqlResponse as-is, but use send method and manually set the content type header to application/json. The easiest to implement.