### PR TITLE
FIX: Incorrect Content-Type for apollo-server-adonis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All of the packages in the `apollo-server` repo are released with the same version numbers, so a new version of a particular package might not represent an actual change to that package. We generally try to mark changes that affect only one web server integration package with that package name, and don't specify package names for changes that affect most of the packages or which affect shared core packages.
 
+### vNEXT
+
+* `apollo-server-adonis`: The `Content-type` of an operation response will now be correctly set to `application/json`.
+
 ### v1.3.4
 
 * Upgrade to `apollo-cache-control@0.1.0` and allow you to specify options to it (such as the new `defaultMaxAge`) by passing `cacheControl: {defaultMaxAge: 5}` instead of `cacheControl: true`.

--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -35,7 +35,7 @@ export function graphqlAdonis(
       query,
     }).then(
       gqlResponse => {
-        response.header('Content-Type', 'application/json');
+        response.type('application/json');
         response.send(gqlResponse);
       },
       (error: HttpQueryError) => {

--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -35,7 +35,8 @@ export function graphqlAdonis(
       query,
     }).then(
       gqlResponse => {
-        response.json(gqlResponse);
+        response.header('Content-Type', 'application/json');
+        response.send(gqlResponse);
       },
       (error: HttpQueryError) => {
         if ('HttpQueryError' !== error.name) {


### PR DESCRIPTION
#Issue #867

## Intended outcome
Responses from apollo-server-adonis shall have a Content-Type: application/json header set.

## Actual outcome
Responses have Content-Type: text/plain; charset=utf-8 header set.

## Analysis
The module apollo-server-adonis calls response.json(gqlResponse) after it gets the output from runHttpQuery.

However, gqlResponse is already stringified (see link 1). The only reason .json method works, is because it is an "alias" to .send and uses heuristics to determine the content type in the end, regardless of the response method used. Adonis has it's own response object, with a similar interface to Express but a different implementation.

## Proposed Solutions
Continue returning gqlResponse as-is, but use send method and manually set the content type header to application/json. The easiest to implement.