### PR TITLE
GRAPHIQL_VERSION 0.11.2 → 0.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix apollo-server-core runQuery breaks `async_hooks` tracking [PR #733](https://github.com/apollographql/apollo-server/pull/733)
 * Optimize one-time functions [PR# 821](https://github.com/apollographql/apollo-server/pull/821)
 * The `GraphQLOptions` type is now exported from `apollo-server-express` in order to facilitate type checking when utilizing `graphqlExpress`, `graphiqlExpress`, `graphqlConnect` or `graphiqlConnect`. [PR #871](https://github.com/apollographql/apollo-server/pull/871)
+* Update GRAPHIQL_VERSION 0.11.2 → 0.11.11
 
 ### v1.3.2
 

--- a/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
@@ -33,7 +33,7 @@ export type GraphiQLData = {
 };
 
 // Current latest version of GraphiQL.
-const GRAPHIQL_VERSION = '0.11.2';
+const GRAPHIQL_VERSION = '0.11.11';
 const SUBSCRIPTIONS_TRANSPORT_VERSION = '0.8.2';
 
 // Ensures string values are safe to be used within a <script> tag.


### PR DESCRIPTION
This just bumps the version of of GraphiQL to the latest bugfix release.

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

/label dependencies

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->