### PR TITLE
Update CHANGELOG for all releases back to v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,54 @@
 # Changelog
 
+All of the packages in the `apollo-server` repo are released with the same version numbers, so a new version of a particular package might not represent an actual change to that package. We generally try to mark changes that affect only one web server integration package with that package name, and don't specify package names for changes that affect most of the packages or which affect shared core packages.
+
 ### v1.3.3
 
-* Update peer dependencies to support `graphql@0.13.x`.
-* Fix issue where `apollo-server-core`'s `runQuery` method broke `async_hooks` call stack. [PR #733](https://github.com/apollographql/apollo-server/pull/733)
-* Hoist declarations of rarely used functions out of `doRunQuery` to improve performance. [PR# 821](https://github.com/apollographql/apollo-server/pull/821)
-* The `GraphQLOptions` type is now exported from `apollo-server-express` in order to facilitate type checking when utilizing `graphqlExpress`, `graphiqlExpress`, `graphqlConnect` or `graphiqlConnect`. [PR #871](https://github.com/apollographql/apollo-server/pull/871)
+* Updated peer dependencies to support `graphql@0.13.x`.
+* `apollo-server-express`: The `GraphQLOptions` type is now exported from `apollo-server-express` in order to facilitate type checking when utilizing `graphqlExpress`, `graphiqlExpress`, `graphqlConnect` and `graphiqlConnect`. [PR #871](https://github.com/apollographql/apollo-server/pull/871)
 * Update GraphiQL version to 0.11.11. [PR #914](https://github.com/apollographql/apollo-server/pull/914)
 
 ### v1.3.2
 
 * Updated peer dependencies and tests to support `graphql@0.12`.
+* Fix issue where the core `runQuery` method broke the ability to use the Node `async_hooks` feature's call stack. [PR #733](https://github.com/apollographql/apollo-server/pull/733)
+* Hoist declarations of rarely used functions out of `doRunQuery` to improve performance. [PR# 821](https://github.com/apollographql/apollo-server/pull/821)
 
 ### v1.3.1
 
-* Fixed execution fatal error with `graphql@0.12`.
+* Fixed a fatal execution error with the new `graphql@0.12`.
 
 ### v1.3.0
 
+* **Breaking:** `apollo-server-hapi`: now supports Hapi v17, and no longer supports Hapi v16. (We intend to release a new `apollo-server-hapi16` for users still on Hapi v16.)
+* **New package**: `apollo-server-adonis` supporting the Adonis framework!
+* The `graphqlOptions` parameter to server GraphQL integration functions now accepts context as a function and as an object with a prototype. [PR #679](https://github.com/apollographql/apollo-server/pull/679)
+* `apollo-server-express`: Send Content-Length header.
+* `apollo-server-micro`: Allow Micro 9 in `peerDependencies`. [PR #671](https://github.com/apollographql/apollo-server/pull/671)
+* GraphiQL integration:
+  * Recognize Websocket endpoints with secure `wss://` URLs.
+  * Only include truthy values in GraphiQL URL.
+
+### v1.2.0
+
+* **New feature**: Add support for Apollo Cache Control. Enable `apollo-cache-control` by passing `cacheControl: true` to your server's GraphQL integration function.
+* Include README.md in published npm packages.
+
+### v1.1.7
+
 * Added support for the vhost option for Hapi [PR #611](https://github.com/apollographql/apollo-server/pull/611)
-* Include readme for npm packages
-* Update peerDependencies version for micro [PR #671](https://github.com/apollographql/apollo-server/pull/671)
-* Corrected the hapi example both in the README.md [PR #689][issue #689]
-* Change GraphqlOptions to also accept context as a function [PR #679](https://github.com/apollographql/apollo-server/pull/679)
+* Fix dependency on `apollo-tracing` to be less strict.
 
 ### v1.1.6
 
-* Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)
-* Update apollo-server-lambda README to reflect new package name.
-* Add support for connectionParams in GraphiQL plugin options [#452](https://github.com/apollographql/apollo-server/issues/452) [PR 548](https://github.com/apollographql/apollo-server/pull/548)
+* GraphiQL integration: add support for `websocketConnectionParams` for subscriptions. [#452](https://github.com/apollographql/apollo-server/issues/452) [PR 548](https://github.com/apollographql/apollo-server/pull/548)
+
+(v1.1.4 had a major bug and was immediately unpublished. v1.1.5 was identical to v1.1.6.)
+
+### v1.1.3
+
+* GraphiQL integration: Fixes bug where CORS would not allow `Access-Control-Allow-Origin: *` with credential 'include', changed to 'same-origin' [Issue #514](https://github.com/apollographql/apollo-server/issues/514)
+* Updated peer dependencies to support `graphql@0.11`.
 
 ### v1.1.2
 

--- a/packages/apollo-server-adonis/README.md
+++ b/packages/apollo-server-adonis/README.md
@@ -5,7 +5,7 @@ description: Setting up Apollo Server with Adonis
 
 [![npm version](https://badge.fury.io/js/apollo-server-core.svg)](https://badge.fury.io/js/apollo-server-core) [![Build Status](https://travis-ci.org/apollographql/apollo-server.svg?branch=master)](https://travis-ci.org/apollographql/apollo-server) [![Coverage Status](https://coveralls.io/repos/github/apollographql/apollo-server/badge.svg?branch=master)](https://coveralls.io/github/apollographql/apollo-server?branch=master) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://www.apollographql.com/#slack)
 
-This is the Adonis Framework integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa, Adonis Framework, and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/).
+This is the Adonis Framework integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa, Adonis Framework, and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
 npm install apollo-server-adonis

--- a/packages/apollo-server-azure-functions/README.md
+++ b/packages/apollo-server-azure-functions/README.md
@@ -52,3 +52,5 @@ module.exports = function run(context, request) {
   }
 };
 ```
+
+[Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)

--- a/packages/apollo-server-core/README.md
+++ b/packages/apollo-server-core/README.md
@@ -1,3 +1,4 @@
 # apollo-server-core
 
 This is the core module of the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/)
+[Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)

--- a/packages/apollo-server-express/README.md
+++ b/packages/apollo-server-express/README.md
@@ -5,7 +5,7 @@ description: Setting up Apollo Server with Express.js or Connect
 
 [![npm version](https://badge.fury.io/js/apollo-server-core.svg)](https://badge.fury.io/js/apollo-server-core) [![Build Status](https://travis-ci.org/apollographql/apollo-server.svg?branch=master)](https://travis-ci.org/apollographql/apollo-server) [![Coverage Status](https://coveralls.io/repos/github/apollographql/apollo-server/badge.svg?branch=master)](https://coveralls.io/github/apollographql/apollo-server?branch=master) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://www.apollographql.com/#slack)
 
-This is the Express and Connect integration of GraphQL Server. Apollo Server is a community-maintained open-source GraphQL server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/).
+This is the Express and Connect integration of GraphQL Server. Apollo Server is a community-maintained open-source GraphQL server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
 npm install apollo-server-express

--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -5,7 +5,7 @@ description: Setting up Apollo Server with Hapi
 
 [![npm version](https://badge.fury.io/js/apollo-server-core.svg)](https://badge.fury.io/js/apollo-server-core) [![Build Status](https://travis-ci.org/apollographql/apollo-server.svg?branch=master)](https://travis-ci.org/apollographql/apollo-server) [![Coverage Status](https://coveralls.io/repos/github/apollographql/apollo-server/badge.svg?branch=master)](https://coveralls.io/github/apollographql/apollo-server?branch=master) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://www.apollographql.com/#slack)
 
-This is the Hapi integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/).
+This is the Hapi integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
 npm install apollo-server-hapi

--- a/packages/apollo-server-koa/README.md
+++ b/packages/apollo-server-koa/README.md
@@ -5,7 +5,7 @@ description: Setting up Apollo Server with Koa
 
 [![npm version](https://badge.fury.io/js/apollo-server-core.svg)](https://badge.fury.io/js/apollo-server-core) [![Build Status](https://travis-ci.org/apollographql/apollo-server.svg?branch=master)](https://travis-ci.org/apollographql/apollo-server) [![Coverage Status](https://coveralls.io/repos/github/apollographql/apollo-server/badge.svg?branch=master)](https://coveralls.io/github/apollographql/apollo-server?branch=master) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://www.apollographql.com/#slack)
 
-This is the Koa integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/).
+This is the Koa integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
 npm install apollo-server-koa

--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -5,7 +5,7 @@ description: Setting up Apollo Server with Lambda
 
 [![npm version](https://badge.fury.io/js/apollo-server-core.svg)](https://badge.fury.io/js/apollo-server-core) [![Build Status](https://travis-ci.org/apollographql/apollo-server.svg?branch=master)](https://travis-ci.org/apollographql/apollo-server) [![Coverage Status](https://coveralls.io/repos/github/apollographql/apollo-server/badge.svg?branch=master)](https://coveralls.io/github/apollographql/apollo-server?branch=master) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://www.apollographql.com/#slack)
 
-This is the AWS Lambda integration for the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/)
+This is the AWS Lambda integration for the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/) [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
 npm install apollo-server-lambda

--- a/packages/apollo-server-micro/README.md
+++ b/packages/apollo-server-micro/README.md
@@ -5,7 +5,7 @@ description: Setting up Apollo Server with Micro
 
 [![npm version](https://badge.fury.io/js/apollo-server-core.svg)](https://badge.fury.io/js/apollo-server-core) [![Build Status](https://travis-ci.org/apollographql/apollo-server.svg?branch=master)](https://travis-ci.org/apollographql/apollo-server) [![Coverage Status](https://coveralls.io/repos/github/apollographql/apollo-server/badge.svg?branch=master)](https://coveralls.io/github/apollographql/apollo-server?branch=master) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://www.apollographql.com/#slack)
 
-This is the [Micro](https://github.com/zeit/micro) integration for the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/)
+This is the [Micro](https://github.com/zeit/micro) integration for the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/) [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
 npm install apollo-server-micro

--- a/packages/apollo-server-module-graphiql/README.md
+++ b/packages/apollo-server-module-graphiql/README.md
@@ -1,3 +1,4 @@
 # apollo-server-module-graphiql
 
 This is the GraphiQL rendering implementation for the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/)
+[Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)

--- a/packages/apollo-server-module-operation-store/README.md
+++ b/packages/apollo-server-module-operation-store/README.md
@@ -1,3 +1,4 @@
 # apollo-server-module-operation-store
 
 This is the persisted query store implementation for the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/)
+[Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)

--- a/packages/apollo-server-restify/README.md
+++ b/packages/apollo-server-restify/README.md
@@ -45,3 +45,4 @@ Apollo Server is built with the following principles in mind:
 * **Performance**: Apollo Server is well-tested and production-ready - no modifications needed
 
 Anyone is welcome to contribute to Apollo Server, just read [CONTRIBUTING.md](https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md), take a look at the [roadmap](https://github.com/apollographql/apollo-server/blob/master/ROADMAP.md) and make your first PR!
+[Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)

--- a/packages/graphql-server-core/README.md
+++ b/packages/graphql-server-core/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-core` package is now called [`apollo-server-core`](https://www.npmjs.com/package/apollo-server-core). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-express/README.md
+++ b/packages/graphql-server-express/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-express` package is now called [`apollo-server-express`](https://www.npmjs.com/package/apollo-server-express). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-hapi/README.md
+++ b/packages/graphql-server-hapi/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-hapi` package is now called [`apollo-server-hapi`](https://www.npmjs.com/package/apollo-server-hapi). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-koa/README.md
+++ b/packages/graphql-server-koa/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-koa` package is now called [`apollo-server-koa`](https://www.npmjs.com/package/apollo-server-koa). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-lambda/README.md
+++ b/packages/graphql-server-lambda/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-lambda` package is now called [`apollo-server-lambda`](https://www.npmjs.com/package/apollo-server-lambda). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-micro/README.md
+++ b/packages/graphql-server-micro/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-micro` package is now called [`apollo-server-micro`](https://www.npmjs.com/package/apollo-server-micro). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-module-graphiql/README.md
+++ b/packages/graphql-server-module-graphiql/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-module-graphiql` package is now called [`apollo-server-module-graphiql`](https://www.npmjs.com/package/apollo-server-module-graphiql). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-module-operation-store/README.md
+++ b/packages/graphql-server-module-operation-store/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-module-operation-store` package is now called [`apollo-server-module-operation-store`](https://www.npmjs.com/package/apollo-server-module-operation-store). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.

--- a/packages/graphql-server-restify/README.md
+++ b/packages/graphql-server-restify/README.md
@@ -1,0 +1,1 @@
+The `graphql-server-restify` package is now called [`apollo-server-restify`](https://www.npmjs.com/package/apollo-server-restify). We are continuing to release matching versions of the package under the old name, but we recommend you switch to using the new name. The API is identical.


### PR DESCRIPTION
There were many missing releases and bullet points as well as inaccurate
ones. For example, it was impossible to figure out that users of Hapi 16 who
want to use Apollo Cache Control needed to use precisely version 1.2.0 of
apollo-server-hapi (which wasn't even mentioned).

Link to CHANGELOG from all READMEs. Add READMEs for the graphql-server-*
packages. Add an explanation of our versioning system to the top of
CHANGELOG.md.
