### PR TITLE
Tighter context typing for GraphQLServerOptions

### DIFF
--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -21,16 +21,16 @@ import { GraphQLExtension } from 'graphql-extensions';
  * - (optional) debug: a boolean that will print additional debug logging if execution errors occur
  *
  */
-export interface GraphQLServerOptions {
+ export interface GraphQLServerOptions<TContext = any> {
   schema: GraphQLSchema;
   formatError?: Function;
   rootValue?: any;
-  context?: any;
+  context?: TContext;
   logFunction?: LogFunction;
   formatParams?: Function;
   validationRules?: Array<(context: ValidationContext) => any>;
   formatResponse?: Function;
-  fieldResolver?: GraphQLFieldResolver<any, any>;
+  fieldResolver?: GraphQLFieldResolver<any, TContext>;
   debug?: boolean;
   tracing?: boolean;
   cacheControl?: boolean;


### PR DESCRIPTION
This small patch adds optional support for tighter typing on the context of GraphQLServerOptions, to match the equivalent ones in graphql-tools. There's still a gap as `GraphQLSchemaConfig`, `GraphQLObjectType` and `getFields` are all still typed as `any`, but it at least allows a demonstration of consistency between the resolvers passed to makeExecutableSchema and the context that will be supplied by parameterising them both with a common type. The param defaults to any and is backwards compatible.

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

/label types