### PR TITLE
Additional extensions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All of the packages in the `apollo-server` repo are released with the same version numbers, so a new version of a particular package might not represent an actual change to that package. We generally try to mark changes that affect only one web server integration package with that package name, and don't specify package names for changes that affect most of the packages or which affect shared core packages.
 
+### v1.3.5
+
+* **New feature**: Add support for additional [GraphQL extensions](https://github.com/apollographql/graphql-extensions) by passing the option `extensions: [CustomExtension]` to your server's GraphQL integration function. [PR #934](https://github.com/apollographql/apollo-server/pull/934)
+
 ### v1.3.4
 
 * Upgrade to `apollo-cache-control@0.1.0` and allow you to specify options to it (such as the new `defaultMaxAge`) by passing `cacheControl: {defaultMaxAge: 5}` instead of `cacheControl: true`.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -48,6 +48,7 @@ At the end of the day, Apollo Server is a simple, production-ready solution with
 * Support HTTP query batching
 * Support Apollo Tracing to get performance information about your server
 * Support Apollo Cache Control to inform caching gateways such as Apollo Engine
+* Support additional [graphql-extensions](https://github.com/apollographql/graphql-extensions) (other than Apollo Tracing or Cache Control)
 
 <h2 id="principles">Principles</h2>
 

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -107,13 +107,16 @@ const GraphQLOptions = {
   validationRules?: Array<ValidationRule>,
 
   // a function applied to each graphQL execution result
-  formatResponse?: Function
+  formatResponse?: Function,
 
   // a custom default field resolver
-  fieldResolver?: Function
+  fieldResolver?: Function,
 
   // a boolean that will print additional debug logging if execution errors occur
-  debug?: boolean
+  debug?: boolean,
+
+  // (optional) extra GraphQL extensions from graphql-extensions
+  extensions?: Array<GraphQLExtension>
 }
 ```
 

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -20,6 +20,7 @@ import { CacheControlExtensionOptions } from 'apollo-cache-control';
  * - (optional) formatResponse: a function applied to each graphQL execution result
  * - (optional) fieldResolver: a custom default field resolver
  * - (optional) debug: a boolean that will print additional debug logging if execution errors occur
+ * - (optional) extensions: an array of GraphQLExtension
  *
  */
 export interface GraphQLServerOptions {
@@ -35,6 +36,7 @@ export interface GraphQLServerOptions {
   debug?: boolean;
   tracing?: boolean;
   cacheControl?: boolean | CacheControlExtensionOptions;
+  extensions?: Array<typeof GraphQLExtension | GraphQLExtension>;
 }
 
 export default GraphQLServerOptions;

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -155,6 +155,7 @@ export async function runHttpQuery(
         debug: optionsObject.debug,
         tracing: optionsObject.tracing,
         cacheControl: optionsObject.cacheControl,
+        extensions: optionsObject.extensions,
       };
 
       if (optionsObject.formatParams) {

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -18,6 +18,7 @@ import { runQuery, LogAction, LogStep } from './runQuery';
 // environment.
 import { makeCompatible } from 'meteor-promise';
 import Fiber = require('fibers');
+import { GraphQLExtensionStack, GraphQLExtension } from 'graphql-extensions';
 makeCompatible(Promise, Fiber);
 
 const queryType = new GraphQLObjectType({
@@ -327,6 +328,53 @@ describe('runQuery', () => {
       testObject: {
         testString: 'a very testful field resolver string',
       },
+    });
+  });
+
+  describe('graphql extensions', () => {
+    class CustomExtension implements GraphQLExtension<any> {
+      format(): [string, any] {
+        return ['customExtension', { foo: 'bar' }];
+      }
+    }
+
+    it('creates the extension stack', async () => {
+      const query = `{ testString }`;
+      const expected = { testString: 'it works' };
+      const extensions = [CustomExtension];
+      return runQuery({
+        schema: new GraphQLSchema({
+          query: new GraphQLObjectType({
+            name: 'QueryType',
+            fields: {
+              testString: {
+                type: GraphQLString,
+                resolve(root, args, context) {
+                  expect(context._extensionStack).to.be.instanceof(
+                    GraphQLExtensionStack,
+                  );
+                  expect(
+                    context._extensionStack.extensions[0],
+                  ).to.be.instanceof(CustomExtension);
+                },
+              },
+            },
+          }),
+        }),
+        query,
+        extensions,
+      });
+    });
+
+    it('runs format response from extensions', async () => {
+      const query = `{ testString }`;
+      const expected = { testString: 'it works' };
+      const extensions = [CustomExtension];
+      return runQuery({ schema, query: query, extensions }).then(res => {
+        return expect(res.extensions).to.deep.equal({
+          customExtension: { foo: 'bar' },
+        });
+      });
     });
   });
 

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -72,6 +72,7 @@ export interface QueryOptions {
   debug?: boolean;
   tracing?: boolean;
   cacheControl?: boolean | CacheControlExtensionOptions;
+  extensions?: Array<typeof GraphQLExtension | GraphQLExtension>;
 }
 
 export function runQuery(options: QueryOptions): Promise<GraphQLResponse> {
@@ -114,7 +115,7 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
   logFunction({ action: LogAction.request, step: LogStep.start });
 
   const context = options.context || {};
-  let extensions = [];
+  let extensions = options.extensions !== undefined ? options.extensions : [];
   if (options.tracing) {
     extensions.push(TracingExtension);
   }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Passing additional extensions (other than the default Tracing and Cache Control) seems to be a need (https://github.com/apollographql/apollo-server/issues/657) which could open the door to new and interesting extensions.

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->