### PR TITLE
chore(renovate): disable pinning for peerDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "pinVersions": true,
+  "extends": [":pinAllExceptPeerDependencies"],
   "semanticCommits": true,
   "depTypes": [{ "depType": "dependencies", "pinVersions": false }],
   "timezone": "America/Los_Angeles",


### PR DESCRIPTION
Renovate v12 introduces a default of `pinVersions=false` and removes the hardcoded `peerDependencies.pinVersions=false` setting. This repository's root level `pinVersions=true` therefore then trickles down to `peerDependencies` as well. This PR updates Renovate config to use a preset that pins everything except `peerDependencies`.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->