### PR TITLE
Convert `Buffer.byteLength` to string before assigning to `Content-Length`.

### DIFF
--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -44,7 +44,10 @@ export function graphqlExpress(
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Content-Length', Buffer.byteLength(gqlResponse, 'utf8'));
+        res.setHeader(
+          'Content-Length',
+          Buffer.byteLength(gqlResponse, 'utf8').toString(),
+        );
         res.write(gqlResponse);
         res.end();
       },


### PR DESCRIPTION
This change seems necessary in order to meet the new type definitions for
`res.setHeader` which mandate that the argument be a string, or an array of
strings.  Those type definitions were introduced via the `@types/node@9`
series of typing updates provided in ([0]), ([1]), ([2]).

With any luck, this will fix the failures being exhibited in CircleCI
tests ([3]) after we landed those typing updates.

[0]: https://github.com/apollographql/apollo-server/pull/907
[1]: https://github.com/apollographql/apollo-server/pull/927
[2]: https://github.com/apollographql/apollo-server/pull/939
[3]: https://circleci.com/gh/apollographql/apollo-server/1587