### PR TITLE
core: return PersistedQueryNotSupported for Apollo Persisted Queries

### DIFF
--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -403,6 +403,48 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
         });
       });
 
+      it('returns PersistedQueryNotSupported to a GET request', async () => {
+        app = await createApp();
+        const req = request(app)
+          .get('/graphql')
+          .query({
+            extensions: JSON.stringify({
+              persistedQuery: {
+                version: 1,
+                sha256Hash:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              },
+            }),
+          });
+        return req.then(res => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.deep.equal({
+            errors: [{ message: 'PersistedQueryNotSupported' }],
+          });
+        });
+      });
+
+      it('returns PersistedQueryNotSupported to a POST request', async () => {
+        app = await createApp();
+        const req = request(app)
+          .post('/graphql')
+          .send({
+            extensions: {
+              persistedQuery: {
+                version: 1,
+                sha256Hash:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              },
+            },
+          });
+        return req.then(res => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.deep.equal({
+            errors: [{ message: 'PersistedQueryNotSupported' }],
+          });
+        });
+      });
+
       it('can handle a request with variables', async () => {
         app = await createApp();
         const expected = {


### PR DESCRIPTION
Apollo Persisted Queries is a standard for sending queries as short hashes
instead of full strings, designed to work well with GET requests. It is
implemented by servers including the Apollo Engine Proxy, and by the
apollo-link-persisted-query client.

A common configuration is to set up persisted queries on production servers but
not in development. It is still convenient to leave apollo-link-persisted-query
always on, though. While apollo-link-persisted-query can detect that servers
don't support PQs, it works better if the server actually says it doesn't
support the PQ, instead of trying to process a request without a query and
potentially printing a confusing stack trace.  This commit makes apollo-server
directly return PersistedQueryNotSupported instead of allowing confusing stack
traces to occur.
