### PR TITLE
bump version of subscriptions-transport-ws for graphiql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All of the packages in the `apollo-server` repo are released with the same versi
 
 ### vNEXT
 
+* Upgrade `subscription-transport-ws` to 0.9.9 for Graphiql
+
 ### v1.3.6
 
 * Recognize requests with Apollo Persisted Queries and return `PersistedQueryNotSupported` to the client instead of a confusing error. [PR #982](https://github.com/apollographql/apollo-server/pull/982)

--- a/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
+++ b/packages/apollo-server-module-graphiql/src/renderGraphiQL.ts
@@ -34,7 +34,7 @@ export type GraphiQLData = {
 
 // Current latest version of GraphiQL.
 const GRAPHIQL_VERSION = '0.11.11';
-const SUBSCRIPTIONS_TRANSPORT_VERSION = '0.8.2';
+const SUBSCRIPTIONS_TRANSPORT_VERSION = '0.9.9';
 
 // Ensures string values are safe to be used within a <script> tag.
 // TODO: I don't think that's the right escape function


### PR DESCRIPTION
The newer subscription client has a more forgiving default ka timeout

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->