### PR TITLE
Pin npm to 5, at least for the time-being.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ run_install_desired_npm: &run_install_desired_npm
     # use that to work-around the issue.  It's possible that npm cleanup might
     # prevent this from being necessary, but this can be removed once Node 6 is
     # no longer being built below.
-    name: Install npm@latest, but with yarn.
-    command: sudo yarn global add npm@latest
+    name: Install npm@5, but with yarn.
+    command: sudo yarn global add npm@5
 
 # These are the steps used for each version of Node which we're testing
 # against.  Thanks to YAMLs inability to merge arrays (though it is able


### PR DESCRIPTION
npm 6 deprecates support for Node.js 4, which is still LTS until the end of the week.

It's probably best to take a moment and ensure that npm@6 is actually working as we desire too, so this is just to make sure that we don't end up with a bunch of PRs that need to be re-based/re-tested, which seems to already be happening.