### PR TITLE
Enable version support via Netlify redirects.

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,7 +4,6 @@ db.json
 *.log
 node_modules/
 public/*
-!public/_redirects
 .deploy*/
 docs.json
 _multiconfig.yml

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,3 +45,6 @@ url: https://www.apollographql.com/docs/apollo-server/
 root: /docs/apollo-server/
 
 public_dir: public/docs/apollo-server
+
+versioned-netlify-redirects:
+  netlify_site_id: apollo-server-docs

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,7 @@ subtitle: Apollo Server
 description: A guide to using Apollo Server.
 versions:
   - '1'
+  - '2'
 sidebar_categories:
   null:
     - index

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,6 @@
     "test": "npm run clean; npm run build"
   },
   "dependencies": {
-    "hexo-versioned-netlify-redirects": "^1.0.6"
+    "hexo-versioned-netlify-redirects": "^1.0.7"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,6 @@
     "test": "npm run clean; npm run build"
   },
   "dependencies": {
-    "hexo-versioned-netlify-redirects": "^1.0.5"
+    "hexo-versioned-netlify-redirects": "^1.0.6"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,6 @@
     "test": "npm run clean; npm run build"
   },
   "dependencies": {
-    "hexo-versioned-netlify-redirects": "^1.0.3"
+    "hexo-versioned-netlify-redirects": "^1.0.4"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,5 +21,8 @@
     "build": "chexo apollo-hexo-config -- generate",
     "clean": "hexo clean",
     "test": "npm run clean; npm run build"
+  },
+  "dependencies": {
+    "hexo-versioned-netlify-redirects": "^1.0.2"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,6 @@
     "test": "npm run clean; npm run build"
   },
   "dependencies": {
-    "hexo-versioned-netlify-redirects": "^1.0.2"
+    "hexo-versioned-netlify-redirects": "^1.0.3"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,6 @@
     "test": "npm run clean; npm run build"
   },
   "dependencies": {
-    "hexo-versioned-netlify-redirects": "^1.0.4"
+    "hexo-versioned-netlify-redirects": "^1.0.5"
   }
 }

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,1 +1,0 @@
-/ /docs/apollo-server/


### PR DESCRIPTION
This uses `hexo-versioned-netlify-redirects`[0], a package I wrote just for this purpose (on Meteor) a few months back.

With any luck, this will do the trick for Apollo too.

[0]: https://github.com/meteor/hexo-versioned-netlify-redirects