### PR TITLE
Add mocking to base server constructor

### DIFF
--- a/packages/apollo-server/CHANGELOG.md
+++ b/packages/apollo-server/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ### vNEXT
 
+* `apollo-server`: add `mocks` paramter to the base constructor(applies to all variants) [PR#1006](https://github.com/apollographql/apollo-server/pull/1006)
 * `apollo-server`: add `/.well-known/apollo/server-health` endpoint with async callback for additional checks, ie database poke [PR#992](https://github.com/apollographql/apollo-server/pull/992)
 * `apollo-server`: collocate graphql gui with endpoint and provide gui when accessed from browser [PR#987](https://github.com/apollographql/apollo-server/pull/987)

--- a/packages/apollo-server/src/utils/ApolloServer.ts
+++ b/packages/apollo-server/src/utils/ApolloServer.ts
@@ -1,4 +1,4 @@
-import { makeExecutableSchema } from 'graphql-tools';
+import { makeExecutableSchema, addMockFunctionsToSchema } from 'graphql-tools';
 import { Server as HttpServer } from 'http';
 import {
   execute,
@@ -89,6 +89,7 @@ export class ApolloServerBase<
       subscriptions,
       typeDefs,
       enableIntrospection,
+      mocks,
       ...requestOptions
     } = config;
 
@@ -119,6 +120,14 @@ export class ApolloServerBase<
           schemaDirectives,
           resolvers,
         });
+
+    if (mocks) {
+      addMockFunctionsToSchema({
+        schema: this.schema,
+        preserveResolvers: true,
+        mocks: typeof mocks === 'boolean' ? {} : mocks,
+      });
+    }
 
     this.subscriptions = subscriptions;
     this.cors = cors;

--- a/packages/apollo-server/src/utils/types.ts
+++ b/packages/apollo-server/src/utils/types.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema } from 'graphql';
 import { CorsOptions } from 'cors';
-import { SchemaDirectiveVisitor, IResolvers } from 'graphql-tools';
+import { SchemaDirectiveVisitor, IResolvers, IMocks } from 'graphql-tools';
 import { ConnectionContext } from 'subscriptions-transport-ws';
 import { GraphQLOptions } from 'apollo-server-core';
 export { CacheControlExtensionOptions } from 'apollo-cache-control';
@@ -43,6 +43,7 @@ export interface Config<Server, ContextShape = any, Cors = CorsOptions>
   engineInRequestPath?: boolean;
   engine?: boolean | Object;
   enableIntrospection?: boolean;
+  mocks?: boolean | IMocks;
 }
 
 // XXX export these directly from apollo-engine-js


### PR DESCRIPTION
This PR adds mocking to the new apollo server by adding a parameter to the constructor. The parameter, `mock` allows a user to specify a boolean or an object containing mocks for types/objects. The default is to preserve the resolvers. If a user would like to remove the resolvers, then they must comment out the resolvers passed to the constructor, which I believe to be a better alternative to the `preserveResolvers` parameter currently found in `addMockFunctionToSchema`.

The changes apply directly to the Base server implementation, so all variants receive the changes.

Documentation to come in #1007.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->