### PR TITLE
Add mocking to apollo server core 2 refactor

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import { makeExecutableSchema } from 'graphql-tools';
+import { makeExecutableSchema, addMockFunctionsToSchema } from 'graphql-tools';
 import { Server as HttpServer } from 'http';
 import {
   execute,
@@ -40,8 +40,8 @@ const NoIntrospection = (context: ValidationContext) => ({
       context.reportError(
         new GraphQLError(
           'GraphQL introspection is not allowed by Apollo Server, but the query containted __schema or __type. To enable introspection, pass introspection: true to ApolloServer in production',
-          [node]
-        )
+          [node],
+        ),
       );
     }
   },
@@ -70,6 +70,7 @@ export class ApolloServerBase<Request = RequestInit> {
       subscriptions,
       typeDefs,
       enableIntrospection,
+      mocks,
       ...requestOptions
     } = config;
 
@@ -99,6 +100,14 @@ export class ApolloServerBase<Request = RequestInit> {
           schemaDirectives,
           resolvers,
         });
+
+    if (mocks) {
+      addMockFunctionsToSchema({
+        schema: this.schema,
+        preserveResolvers: true,
+        mocks: typeof mocks === 'boolean' ? {} : mocks,
+      });
+    }
 
     this.subscriptions = subscriptions;
   }
@@ -140,10 +149,10 @@ export class ApolloServerBase<Request = RequestInit> {
           () => {
             this.engine.engineListeningAddress.url = require('url').resolve(
               this.engine.engineListeningAddress.url,
-              this.graphqlPath
+              this.graphqlPath,
             );
             success(this.engine.engineListeningAddress);
-          }
+          },
         );
         this.engine.on('error', fail);
         return;
@@ -179,7 +188,7 @@ export class ApolloServerBase<Request = RequestInit> {
           });
 
           success(la);
-        }
+        },
       );
     });
   }
@@ -225,7 +234,7 @@ export class ApolloServerBase<Request = RequestInit> {
       {
         server,
         path: this.graphqlPath,
-      }
+      },
     );
   }
 
@@ -234,7 +243,7 @@ export class ApolloServerBase<Request = RequestInit> {
     const { ENGINE_API_KEY, ENGINE_CONFIG } = process.env;
     if (engine === false && (ENGINE_API_KEY || ENGINE_CONFIG)) {
       console.warn(
-        'engine is set to false when creating ApolloServer but either ENGINE_CONFIG or ENGINE_API_KEY was found in the environment'
+        'engine is set to false when creating ApolloServer but either ENGINE_CONFIG or ENGINE_API_KEY was found in the environment',
       );
     }
     let ApolloEngine;
@@ -250,7 +259,7 @@ export class ApolloServerBase<Request = RequestInit> {
       }
 
       this.engine = new ApolloEngine(
-        typeof engine === 'boolean' ? undefined : engine
+        typeof engine === 'boolean' ? undefined : engine,
       );
     }
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema } from 'graphql';
-import { SchemaDirectiveVisitor, IResolvers } from 'graphql-tools';
+import { SchemaDirectiveVisitor, IResolvers, IMocks } from 'graphql-tools';
 import { ConnectionContext } from 'subscriptions-transport-ws';
 import { Server as HttpServer } from 'http';
 
@@ -7,7 +7,7 @@ import { GraphQLServerOptions as GraphQLOptions } from './graphqlOptions';
 
 export type Context<T = any> = T;
 export type ContextFunction<T = any> = (
-  context: Context<T>
+  context: Context<T>,
 ) => Promise<Context<T>>;
 
 export interface SubscriptionServerOptions {
@@ -39,6 +39,7 @@ export interface Config<Server>
   context?: Context<any> | ContextFunction<any>;
   subscriptions?: SubscriptionServerOptions | string | false;
   enableIntrospection?: boolean;
+  mocks?: boolean | IMocks;
 }
 
 // XXX export these directly from apollo-engine-js
@@ -68,7 +69,7 @@ export interface ListenOptions {
   onConnect?: (
     connectionParams: Object,
     websocket: WebSocket,
-    context: ConnectionContext
+    context: ConnectionContext,
   ) => any;
   onDisconnect?: (websocket: WebSocket, context: ConnectionContext) => any;
 }


### PR DESCRIPTION
This PR adds mocking to the apollo server core by adding a parameter to the constructor. The parameter, mock allows a user to specify a boolean or an object containing mocks for types/objects. The default is to preserve the resolvers. If a user would like to remove the resolvers, then they must comment out the resolvers passed to the constructor, which I believe to be a better alternative to the preserveResolvers parameter currently found in addMockFunctionToSchema.

The changes apply directly to the Base server implementation, so all variants receive the changes.

Documentation to come in #1007.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->