### PR TITLE
Remove stack traces print and include response in logging function

### DIFF
--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -1,5 +1,7 @@
+<<<<<<< HEAD
 # Changelog
 
 ### vNEXT
 
 * `apollo-server-core`: add `mocks` parameter to the base constructor(applies to all variants) [PR#1017](https://github.com/apollographql/apollo-server/pull/1017)
+* `apollo-server-core`: Remove printing of stack traces with `debug` option and include response in logging function[PR#1018](https://github.com/apollographql/apollo-server/pull/1018)

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -118,9 +118,8 @@ describe('runQuery', () => {
     });
   });
 
-  it('sends stack trace to error if in an error occurs and debug mode is set', () => {
+  it('does not call console.error if in an error occurs and debug mode is set', () => {
     const query = `query { testError }`;
-    const expected = /at resolveFieldValueOrError/;
     const logStub = stub(console, 'error');
     return runQuery({
       schema,
@@ -128,12 +127,11 @@ describe('runQuery', () => {
       debug: true,
     }).then(res => {
       logStub.restore();
-      expect(logStub.callCount).to.equal(1);
-      expect(logStub.getCall(0).args[0]).to.match(expected);
+      expect(logStub.callCount).to.equal(0);
     });
   });
 
-  it('does not send stack trace if in an error occurs and not in debug mode', () => {
+  it('does not call console.error if in an error occurs and not in debug mode', () => {
     const query = `query { testError }`;
     const logStub = stub(console, 'error');
     return runQuery({
@@ -291,6 +289,10 @@ describe('runQuery', () => {
       expect(logs[10]).to.deep.equals({
         action: LogAction.request,
         step: LogStep.end,
+        key: 'response',
+        data: {
+          data: expected,
+        },
       });
     });
   });

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -83,10 +83,6 @@ export function runQuery(options: QueryOptions): Promise<GraphQLResponse> {
   return Promise.resolve().then(() => doRunQuery(options));
 }
 
-function printStackTrace(error: Error) {
-  console.error(error.stack);
-}
-
 function format(
   errors: Array<Error>,
   options?: {

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -50,7 +50,7 @@ export interface LogMessage {
   action: LogAction;
   step: LogStep;
   key?: string;
-  data?: Object;
+  data?: any;
 }
 
 export interface LogFunction {
@@ -234,7 +234,6 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
       ),
     ).then(result => {
       logFunction({ action: LogAction.execute, step: LogStep.end });
-      logFunction({ action: LogAction.request, step: LogStep.end });
 
       let response: GraphQLResponse = {
         data: result.data,
@@ -245,9 +244,6 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
           formatter: options.formatError,
           debug,
         });
-        if (debug) {
-          result.errors.map(printStackTrace);
-        }
       }
 
       if (extensionStack) {
@@ -259,6 +255,13 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
       if (options.formatResponse) {
         response = options.formatResponse(response, options);
       }
+
+      logFunction({
+        action: LogAction.request,
+        step: LogStep.end,
+        key: 'response',
+        data: response,
+      });
 
       return response;
     });


### PR DESCRIPTION
Removes stack trace printing coupling to `debug` option and include response in the log function. 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->