### PR TITLE
Enables context creation to be async and capture errors with opt-in logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ jobs:
   # Platform tests, each with the same tests but different platform or version.
   # The docker tag represents the Node.js version and the full list is available
   # at https://hub.docker.com/r/circleci/node/.
-  Node.js 4:
-    docker: [ { image: 'circleci/node:4' } ]
-    <<: *common_test_steps
-
   Node.js 6:
     docker: [ { image: 'circleci/node:6' } ]
     <<: *common_test_steps
@@ -73,7 +69,6 @@ workflows:
   version: 2
   Build and Test:
     jobs:
-      - Node.js 4
       - Node.js 6
       - Node.js 8
       - Node.js 9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All of the packages in the `apollo-server` repo are released with the same versi
 
 ### vNEXT
 
+* Remove tests and guaranteed support for Node 4 [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
+
 ### v1.3.6
 
 * Recognize requests with Apollo Persisted Queries and return `PersistedQueryNotSupported` to the client instead of a confusing error. [PR #982](https://github.com/apollographql/apollo-server/pull/982)

--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -3,6 +3,6 @@
 ### vNEXT
 
 * `apollo-server-core`: Replace console.error with logFunction for opt-in logging [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
-* `apollo-server-core`: errors in context creation can be async and is formatted to include error code [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
+* `apollo-server-core`: context creation can be async and errors are formatted to include error code [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
 * `apollo-server-core`: add `mocks` parameter to the base constructor(applies to all variants) [PR#1017](https://github.com/apollographql/apollo-server/pull/1017)
 * `apollo-server-core`: Remove printing of stack traces with `debug` option and include response in logging function[PR#1018](https://github.com/apollographql/apollo-server/pull/1018)

--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server-core`: Replace console.error with logFunction for opt-in logging [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
+* `apollo-server-core`: errors in context creation can be async and is formatted to include error code [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
 * `apollo-server-core`: add `mocks` parameter to the base constructor(applies to all variants) [PR#1017](https://github.com/apollographql/apollo-server/pull/1017)
 * `apollo-server-core`: Remove printing of stack traces with `debug` option and include response in logging function[PR#1018](https://github.com/apollographql/apollo-server/pull/1018)

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -17,7 +17,7 @@ import {
   ExecutionParams,
 } from 'subscriptions-transport-ws';
 
-import { internalFormatError } from './errors';
+import { formatApolloErrors } from './errors';
 import { GraphQLServerOptions as GraphQLOptions } from './graphqlOptions';
 import { LogFunction } from './logging';
 
@@ -212,8 +212,7 @@ export class ApolloServerBase<Request = RequestInit> {
         onOperation: async (_: string, connection: ExecutionParams) => {
           connection.formatResponse = (value: ExecutionResult) => ({
             ...value,
-            errors:
-              value.errors && value.errors.map(err => internalFormatError(err)),
+            errors: value.errors && formatApolloErrors(value.errors),
           });
           let context: Context = this.context ? this.context : { connection };
 
@@ -279,8 +278,6 @@ export class ApolloServerBase<Request = RequestInit> {
       schema: this.schema,
       tracing: Boolean(this.engineEnabled),
       cacheControl: Boolean(this.engineEnabled),
-      formatError: (e: GraphQLError) =>
-        internalFormatError(e, this.requestOptions.debug),
       context,
       // allow overrides from options
       ...this.requestOptions,

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -275,13 +275,13 @@ export class ApolloServerBase<Request = RequestInit> {
     if (this.engine || engineInRequestPath) this.engineEnabled = true;
   }
 
-  async request(request: Request) {
+  request(request: Request) {
     let context: Context = this.context ? this.context : { request };
 
-    //Differ context resolution to inside of runQuery
+    //Defer context resolution to inside of runQuery
     context =
       typeof this.context === 'function'
-        ? async () => this.context({ req: request })
+        ? () => this.context({ req: request })
         : context;
 
     return {

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -278,9 +278,10 @@ export class ApolloServerBase<Request = RequestInit> {
   async request(request: Request) {
     let context: Context = this.context ? this.context : { request };
 
+    //Differ context resolution to inside of runQuery
     context =
       typeof this.context === 'function'
-        ? await this.context({ req: request })
+        ? async () => this.context({ req: request })
         : context;
 
     return {

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -19,7 +19,7 @@ import {
 
 import { internalFormatError } from './errors';
 import { GraphQLServerOptions as GraphQLOptions } from './graphqlOptions';
-import { LogFunction } from './runQuery';
+import { LogFunction } from './logging';
 
 import {
   Config,

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -10,9 +10,12 @@ export class ApolloError extends Error {
   ) {
     super(message);
 
-    Object.keys(properties).forEach(key => {
-      this[key] = properties[key];
-    });
+    if (properties) {
+      Object.keys(properties).forEach(key => {
+        this[key] = properties[key];
+      });
+    }
+
     //extensions are flattened to be included in the root of GraphQLError's, so
     //don't add properties to extensions
     this.extensions = { code };

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -9,7 +9,13 @@ export class ApolloError extends Error {
     properties?: Record<string, any>,
   ) {
     super(message);
-    this.extensions = { ...properties, code };
+
+    Object.keys(properties).forEach(key => {
+      this[key] = properties[key];
+    });
+    //extensions are flattened to be included in the root of GraphQLError's, so
+    //don't add properties to extensions
+    this.extensions = { code };
   }
 }
 

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql';
+import { LogStep, LogAction, LogMessage, LogFunction } from './logging';
 
 export class ApolloError extends Error {
   public extensions;

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -102,7 +102,7 @@ export function fromGraphQLError(error: GraphQLError, options?: ErrorOptions) {
   //copy the original error, while keeping all values non-enumerable, so they
   //are not printed unless directly referenced
   Object.defineProperty(copy, 'originalError', { value: {} });
-  Reflect.ownKeys(error).forEach(key => {
+  Object.getOwnPropertyNames(error).forEach(key => {
     Object.defineProperty(copy.originalError, key, { value: error[key] });
   });
 

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -21,7 +21,11 @@ import { GraphQLExtension } from 'graphql-extensions';
  * - (optional) debug: a boolean that will print additional debug logging if execution errors occur
  *
  */
-export interface GraphQLServerOptions<TContext = any> {
+export interface GraphQLServerOptions<
+  TContext =
+    | (() => Promise<Record<string, any>> | Record<string, any>)
+    | Record<string, any>
+> {
   schema: GraphQLSchema;
   formatError?: Function;
   rootValue?: any;
@@ -40,8 +44,12 @@ export interface GraphQLServerOptions<TContext = any> {
 export default GraphQLServerOptions;
 
 export async function resolveGraphqlOptions(
-  options: GraphQLServerOptions | Function,
-  ...args
+  options:
+    | GraphQLServerOptions
+    | ((
+        ...args: Array<any>
+      ) => Promise<GraphQLServerOptions> | GraphQLServerOptions),
+  ...args: Array<any>
 ): Promise<GraphQLServerOptions> {
   if (typeof options === 'function') {
     return await options(...args);

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -3,7 +3,7 @@ import {
   ValidationContext,
   GraphQLFieldResolver,
 } from 'graphql';
-import { LogFunction } from './runQuery';
+import { LogFunction } from './logging';
 import { GraphQLExtension } from 'graphql-extensions';
 
 /*

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -44,11 +44,7 @@ export async function resolveGraphqlOptions(
   ...args
 ): Promise<GraphQLServerOptions> {
   if (typeof options === 'function') {
-    try {
-      return await options(...args);
-    } catch (e) {
-      throw new Error(`Invalid options provided to ApolloServer: ${e.message}`);
-    }
+    return await options(...args);
   } else {
     return options;
   }

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -12,7 +12,7 @@ export {
   ValidationError,
   AuthenticationError,
   ForbiddenError,
-  internalFormatError,
+  formatApolloErrors,
 } from './errors';
 
 // ApolloServer Base class

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -1,10 +1,5 @@
-export {
-  runQuery,
-  LogFunction,
-  LogMessage,
-  LogStep,
-  LogAction,
-} from './runQuery';
+export { runQuery } from './runQuery';
+export { LogFunction, LogMessage, LogStep, LogAction } from './logging';
 export { runHttpQuery, HttpQueryRequest, HttpQueryError } from './runHttpQuery';
 export {
   default as GraphQLOptions,

--- a/packages/apollo-server-core/src/logging.ts
+++ b/packages/apollo-server-core/src/logging.ts
@@ -1,0 +1,25 @@
+export enum LogAction {
+  request,
+  parse,
+  validation,
+  execute,
+  setup,
+  cleanup,
+}
+
+export enum LogStep {
+  start,
+  end,
+  status,
+}
+
+export interface LogMessage {
+  action: LogAction;
+  step: LogStep;
+  key?: string;
+  data?: any;
+}
+
+export interface LogFunction {
+  (message: LogMessage);
+}

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -250,16 +250,17 @@ export async function runHttpQuery(
       // Populate any HttpQueryError to our handler which should
       // convert it to Http Error.
       if (e.name === 'HttpQueryError') {
-        return Promise.reject(e);
+        //async function wraps this in a Promise
+        throw e;
       }
 
-      return Promise.resolve({
+      return {
         errors: formatApolloErrors([e], {
           formatter: optionsObject.formatError,
           debug,
           logFunction: optionsObject.logFunction,
         }),
-      });
+      };
     }
   }) as Array<Promise<ExecutionResult>>;
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -9,7 +9,7 @@ import { formatApolloErrors } from './errors';
 export interface HttpQueryRequest {
   method: string;
   query: Record<string, any>;
-  options: GraphQLOptions | Function;
+  options: GraphQLOptions | (() => Promise<GraphQLOptions> | GraphQLOptions);
 }
 
 export class HttpQueryError extends Error {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -195,7 +195,25 @@ export async function runHttpQuery(
         //appease typescript compiler, otherwise could use || {}
         context = {};
       } else if (typeof context === 'function') {
-        context = await context();
+        try {
+          context = await context();
+        } catch (e) {
+          e.message = `Context creation failed: ${e.message}`;
+          throw new HttpQueryError(
+            500,
+            JSON.stringify({
+              errors: formatApolloErrors([e], {
+                formatter: optionsObject.formatError,
+                debug,
+                logFunction: optionsObject.logFunction,
+              }),
+            }),
+            true,
+            {
+              'Content-Type': 'application/json',
+            },
+          );
+        }
       } else if (isBatch) {
         context = Object.assign(
           Object.create(Object.getPrototypeOf(context)),

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -8,7 +8,7 @@ import { formatApolloErrors } from './errors';
 
 export interface HttpQueryRequest {
   method: string;
-  query: Record<string, any>;
+  query: Record<string, any> | Array<Record<string, any>>;
   options: GraphQLOptions | (() => Promise<GraphQLOptions> | GraphQLOptions);
 }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -4,7 +4,7 @@ import {
   default as GraphQLOptions,
   resolveGraphqlOptions,
 } from './graphqlOptions';
-import { internalFormatError } from './errors';
+import { formatApolloErrors } from './errors';
 
 export interface HttpQueryRequest {
   method: string;
@@ -198,7 +198,7 @@ export async function runHttpQuery(
         operationName: operationName,
         logFunction: optionsObject.logFunction,
         validationRules: optionsObject.validationRules,
-        formatError: formatErrorFn,
+        formatError: optionsObject.formatError,
         formatResponse: optionsObject.formatResponse,
         fieldResolver: optionsObject.fieldResolver,
         debug: optionsObject.debug,
@@ -218,7 +218,13 @@ export async function runHttpQuery(
         return Promise.reject(e);
       }
 
-      return Promise.resolve({ errors: [formatErrorFn(e)] });
+      return Promise.resolve({
+        errors: formatApolloErrors([e], {
+          formatter: optionsObject.formatError,
+          debug,
+          logFunction: optionsObject.logFunction,
+        }),
+      });
     }
   });
   const responses = await Promise.all(requests);

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -56,6 +56,9 @@ export async function runHttpQuery(
     // logFunction, debug. Therefore, we need to do some unnatural things, such
     // as use NODE_ENV to determine the debug settings
     e.message = `Invalid options provided to ApolloServer: ${e.message}`;
+    if (!debugDefault) {
+      e.warning = `To remove the stacktrace, set the NODE_ENV environment variable to production if the options creation can fail`;
+    }
     throw new HttpQueryError(
       500,
       JSON.stringify({

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -12,7 +12,8 @@ import {
   parse,
 } from 'graphql';
 
-import { runQuery, LogAction, LogStep } from './runQuery';
+import { runQuery } from './runQuery';
+import { LogAction, LogStep } from './logging';
 
 // Make the global Promise constructor Fiber-aware to simulate a Meteor
 // environment.

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -27,34 +27,12 @@ import {
   SyntaxError,
 } from './errors';
 
+import { LogStep, LogAction, LogMessage, LogFunction } from './logging';
+
 export interface GraphQLResponse {
   data?: object;
   errors?: Array<GraphQLError & object>;
   extensions?: object;
-}
-
-export enum LogAction {
-  request,
-  parse,
-  validation,
-  execute,
-}
-
-export enum LogStep {
-  start,
-  end,
-  status,
-}
-
-export interface LogMessage {
-  action: LogAction;
-  step: LogStep;
-  key?: string;
-  data?: any;
-}
-
-export interface LogFunction {
-  (message: LogMessage);
 }
 
 export interface QueryOptions {

--- a/packages/apollo-server-express/src/apolloServerHttp.test.ts
+++ b/packages/apollo-server-express/src/apolloServerHttp.test.ts
@@ -330,6 +330,9 @@ describe(`GraphQL-HTTP (apolloServer) tests for ${version} express`, () => {
         data: null,
         errors: [
           {
+            extensions: {
+              code: 'INTERNAL_SERVER_ERROR',
+            },
             message: 'Throws!',
             locations: [{ line: 1, column: 2 }],
             path: ['thrower'],
@@ -359,6 +362,9 @@ describe(`GraphQL-HTTP (apolloServer) tests for ${version} express`, () => {
       expect(JSON.parse(response.text)).to.deep.equal({
         errors: [
           {
+            extensions: {
+              code: 'GRAPHQL_VALIDATION_FAILED',
+            },
             message: 'Cannot query field "notExists" on type "QueryRoot".',
             locations: [{ line: 1, column: 2 }],
           },
@@ -385,6 +391,9 @@ describe(`GraphQL-HTTP (apolloServer) tests for ${version} express`, () => {
       expect(JSON.parse(response.text)).to.deep.equal({
         errors: [
           {
+            extensions: {
+              code: 'GRAPHQL_VALIDATION_FAILED',
+            },
             message: 'Cannot query field "notExists" on type "QueryRoot".',
             locations: [{ line: 1, column: 2 }],
           },
@@ -532,6 +541,9 @@ describe(`GraphQL-HTTP (apolloServer) tests for ${version} express`, () => {
       expect(JSON.parse(response.text)).to.deep.equal({
         errors: [
           {
+            extensions: {
+              code: 'GRAPHQL_VALIDATION_FAILED',
+            },
             message: 'AlwaysInvalidRule was really invalid!',
           },
         ],

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -33,6 +33,7 @@
     "@types/koa": "2.0.45",
     "@types/koa-bodyparser": "4.2.0",
     "@types/koa-router": "7.0.28",
+    "@types/node": "^8.10.12",
     "apollo-server-integration-testsuite": "^1.3.6",
     "koa": "2.5.1",
     "koa-bodyparser": "4.2.0",


### PR DESCRIPTION
This PR allows the context option in apollo-server-core's runQuery/runHttpQuery to be an async function, which would be common in authentication fetching scenarios.

Additionally, this PR increases the capture and formatting of errors during the creation of the options and context.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->