### PR TITLE
tests: Update Node.js testing versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ jobs:
   # Platform tests, each with the same tests but different platform or version.
   # The docker tag represents the Node.js version and the full list is available
   # at https://hub.docker.com/r/circleci/node/.
-  Node.js 4:
-    docker: [ { image: 'circleci/node:4' } ]
-    <<: *common_test_steps
-
   Node.js 6:
     docker: [ { image: 'circleci/node:6' } ]
     <<: *common_test_steps
@@ -73,7 +69,6 @@ workflows:
   version: 2
   Build and Test:
     jobs:
-      - Node.js 4
       - Node.js 6
       - Node.js 8
       - Node.js 9


### PR DESCRIPTION
Node.js 9, as with odd numbered Node.js versions, is no longer longer being
actively maintained with the release of (even numbered) Node.js 10.

Node.js 4 will no longer be receiving any additional updates from the
Node.js foundation.

For more details see the LTS schedule and Node.js blog posts:

Ref: https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742
Ref: https://github.com/nodejs/LTS