### PR TITLE
engine -> engineProxy in listen, fix engineLauncherOptions, and make unrequired parameters optional

### DIFF
--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -40,7 +40,6 @@ export interface Config<Server>
   subscriptions?: SubscriptionServerOptions | string | false;
   enableIntrospection?: boolean;
   mocks?: boolean | IMocks;
-  engineProxy?: boolean | EngineLauncherOptions;
 }
 
 // XXX export these directly from apollo-engine-js
@@ -60,6 +59,7 @@ export interface ListenOptions {
   path?: string;
   backlog?: number;
   exclusive?: boolean;
+  engineProxy?: boolean | EngineLauncherOptions;
   // WebSocket options
   keepAlive?: number;
   onConnect?: (

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -59,7 +59,11 @@ export interface ListenOptions {
   path?: string;
   backlog?: number;
   exclusive?: boolean;
-  engineProxy?: boolean | EngineLauncherOptions;
+  // XXX clean this up
+  engineInRequestPath?: boolean;
+  engineProxy?: boolean | Record<string, any>;
+  // engine launcher options
+  engineLauncherOptions?: EngineLauncherOptions;
   // WebSocket options
   keepAlive?: number;
   onConnect?: (

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -35,11 +35,12 @@ export interface Config<Server>
   typeDefs?: string | [string];
   resolvers?: IResolvers;
   schema?: GraphQLSchema;
-  schemaDirectives: Record<string, typeof SchemaDirectiveVisitor>;
+  schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>;
   context?: Context<any> | ContextFunction<any>;
   subscriptions?: SubscriptionServerOptions | string | false;
   enableIntrospection?: boolean;
   mocks?: boolean | IMocks;
+  engineProxy?: boolean | EngineLauncherOptions;
 }
 
 // XXX export these directly from apollo-engine-js
@@ -59,11 +60,6 @@ export interface ListenOptions {
   path?: string;
   backlog?: number;
   exclusive?: boolean;
-  // XXX clean this up
-  engineInRequestPath?: boolean;
-  engine?: boolean | Object;
-  // engine launcher options
-  engineLauncherOptions?: EngineLauncherOptions;
   // WebSocket options
   keepAlive?: number;
   onConnect?: (

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -19,8 +19,8 @@ export class ApolloServer extends ApolloServerBase<express.Request> {
     onHealthCheck,
     ...opts
   }: Config<express.Request> & {
-    onHealthCheck: (req: express.Request) => Promise<any>;
-    disableHealthCheck: boolean;
+    onHealthCheck?: (req: express.Request) => Promise<any>;
+    disableHealthCheck?: boolean;
   }) {
     super(opts);
     if (disableHealthCheck) this.disableHealthCheck = true;


### PR DESCRIPTION
This renames the engine parameter in listen to engineProxy and overloads the parameter as the launch options. If true, the server assumes that the proxy is already in place. Otherwise if an object is passed as engineProxy, then the proxy is launched as a parallel process.

The PR also makes the schemaDirectives parameter optional in addition to the healthcheck parameters.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->