### PR TITLE
Apollo Server 2 for Edge Environments

### DIFF
--- a/packages/apollo-server-edge/package.json
+++ b/packages/apollo-server-edge/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "apollo-server-edge",
+  "version": "1.0.0-beta.3",
+  "description": "Production-ready Node.js GraphQL server for edge environments",
+  "main": "dist/index.js",
+  "scripts": {
+    "compile": "tsc",
+    "prepublish": "npm run compile"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-edge"
+  },
+  "keywords": [
+    "GraphQL",
+    "Apollo",
+    "Server",
+    "Cloudflare",
+    "Fly.io",
+    "Javascript"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/apollographql/apollo-server/issues"
+  },
+  "homepage": "https://github.com/apollographql/apollo-server#readme",
+  "dependencies": {
+    "apollo-server-core": "2.0.0-beta.0",
+    "apollo-server-module-graphiql": "^1.3.4"
+  },
+  "devDependencies": {
+    "@types/graphql": "0.12.7"
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  }
+}

--- a/packages/apollo-server-edge/src/ApolloServer.ts
+++ b/packages/apollo-server-edge/src/ApolloServer.ts
@@ -2,17 +2,12 @@ import { graphqlEdge } from './edgeApollo';
 
 import { ApolloServerBase } from 'apollo-server-core';
 
-interface FetchEvent extends Event {
-  respondWith: (result: Promise<ResponseInit>) => void;
-  request: RequestInit;
-}
-
 export class ApolloServer extends ApolloServerBase {
   public async listen() {
     const graphql = this.request.bind(this);
     addEventListener('fetch', (event: FetchEvent) => {
       event.respondWith(graphqlEdge(graphql)(event.request));
     });
-    return await { url: '', port: null };
+    return { url: '', port: null };
   }
 }

--- a/packages/apollo-server-edge/src/ApolloServer.ts
+++ b/packages/apollo-server-edge/src/ApolloServer.ts
@@ -1,0 +1,18 @@
+import { graphqlEdge } from './edgeApollo';
+
+import { ApolloServerBase } from 'apollo-server-core';
+
+interface FetchEvent extends Event {
+  respondWith: (result: Promise<ResponseInit>) => void;
+  request: RequestInit;
+}
+
+export class ApolloServer extends ApolloServerBase {
+  public async listen() {
+    const graphql = this.request.bind(this);
+    addEventListener('fetch', (event: FetchEvent) => {
+      event.respondWith(graphqlEdge(graphql)(event.request));
+    });
+    return await { url: '', port: null };
+  }
+}

--- a/packages/apollo-server-edge/src/edgeApollo.ts
+++ b/packages/apollo-server-edge/src/edgeApollo.ts
@@ -1,4 +1,3 @@
-import * as url from 'url';
 import {
   GraphQLOptions,
   HttpQueryError,
@@ -22,7 +21,7 @@ export function graphqlEdge(options: GraphQLOptions) {
     );
   }
 
-  const graphqlHandler = async (req: RequestInit): Promise<Response> => {
+  const graphqlHandler = async (req: Request): Promise<Response> => {
     if (req.method === 'OPTIONS') {
       return Promise.resolve(
         new Response('', {
@@ -37,10 +36,10 @@ export function graphqlEdge(options: GraphQLOptions) {
         }),
       );
     }
-    const url = new URL((req as Request).url);
+    const url = new URL(req.url);
     const query =
       req.method === 'POST'
-        ? await (req as Request).json()
+        ? await req.json()
         : {
             query: url.searchParams.get('query'),
             variables: url.searchParams.get('variables'),

--- a/packages/apollo-server-edge/src/edgeApollo.ts
+++ b/packages/apollo-server-edge/src/edgeApollo.ts
@@ -1,0 +1,87 @@
+import * as url from 'url';
+import {
+  GraphQLOptions,
+  HttpQueryError,
+  runHttpQuery,
+} from 'apollo-server-core';
+// import * as GraphiQL from 'apollo-server-module-graphiql';
+
+// Design principles:
+// - You can issue a GET or POST with your query.
+// - simple, fast and secure
+//
+
+export function graphqlEdge(options: GraphQLOptions) {
+  if (!options) {
+    throw new Error('Apollo Server requires options.');
+  }
+
+  if (arguments.length > 1) {
+    throw new Error(
+      `Apollo Server expects exactly one argument, got ${arguments.length}`,
+    );
+  }
+
+  const graphqlHandler = async (req: RequestInit): Promise<Response> => {
+    if (req.method === 'OPTIONS') {
+      return Promise.resolve(
+        new Response('', {
+          status: 204,
+          headers: {
+            'content-type': 'application/json',
+            'access-control-allow-origin': '*',
+            'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+            'access-control-allow-headers': 'content-type',
+            vary: 'Access-Control-Request-Headers',
+          },
+        }),
+      );
+    }
+    const url = new URL((req as Request).url);
+    const query =
+      req.method === 'POST'
+        ? await (req as Request).json()
+        : {
+            query: url.searchParams.get('query'),
+            variables: url.searchParams.get('variables'),
+            operationName: url.searchParams.get('operationName'),
+            extensions: url.searchParams.get('extensions'),
+          };
+
+    return runHttpQuery([req], {
+      method: req.method,
+      options: options,
+      query,
+    }).then(
+      gqlResponse =>
+        new Response(gqlResponse, {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'access-control-allow-origin': '*',
+          },
+        }),
+      (error: HttpQueryError) => {
+        if ('HttpQueryError' !== error.name) throw error;
+
+        const res = new Response(error.message, {
+          status: error.statusCode,
+          headers: {
+            'content-type': 'application/json',
+            'access-control-allow-origin': '*',
+          },
+        });
+
+        if (error.headers) {
+          Object.keys(error.headers).forEach(header => {
+            res.headers[header] = error.headers[header];
+          });
+        }
+
+        return res;
+      },
+    );
+  };
+
+  return graphqlHandler;
+}

--- a/packages/apollo-server-edge/src/index.ts
+++ b/packages/apollo-server-edge/src/index.ts
@@ -1,0 +1,2 @@
+export { graphqlEdge } from './edgeApollo';
+export { ApolloServer } from './ApolloServer';

--- a/packages/apollo-server-edge/tsconfig.json
+++ b/packages/apollo-server-edge/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["es6", "esnext.asynciterable", "dom"],
+    "types": ["@types/node"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/apollo-server-edge/tsconfig.json
+++ b/packages/apollo-server-edge/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "target": "es2017",
     "rootDir": "./src",
     "outDir": "./dist",
-    "lib": ["es6", "esnext.asynciterable", "dom"],
+    "lib": ["es2017", "esnext.asynciterable", "webworker"],
     "types": ["@types/node"]
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This is an implementation of Apollo server that is compatible with edge environments, including fly.io and cloudflare.

We could remove apollo-server-cloudflare, since it won't be in the release. It's just around because of https://www.meetup.com/Cloudflare-Meetups/events/249647260/

For now we are going to keep server-cloudflare, since there may be different implementations of the cache api

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->