### PR TITLE
AS2: Move default options into listen function and add bodyParserConfig

### DIFF
--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server-core`: move subscriptions options into listen [PR#1059](https://github.com/apollographql/apollo-server/pull/1059)
 * `apollo-server-core`: Replace console.error with logFunction for opt-in logging [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
 * `apollo-server-core`: context creation can be async and errors are formatted to include error code [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
 * `apollo-server-core`: add `mocks` parameter to the base constructor(applies to all variants) [PR#1017](https://github.com/apollographql/apollo-server/pull/1017)

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -141,15 +141,12 @@ export class ApolloServerBase<Request = RequestInit> {
     return new Promise((success, fail) => {
       if (this.engineProxy) {
         this.engineProxy.listen(
-          Object.assign(
-            {},
-            {
-              graphqlPaths: [this.graphqlPath],
-              port: options.port,
-              httpServer: this.http,
-              launcherOptions: options.engineLauncherOptions,
-            },
-          ),
+          {
+            graphqlPaths: [this.graphqlPath],
+            port: options.port,
+            httpServer: this.http,
+            launcherOptions: options.engineLauncherOptions,
+          },
           () => {
             this.engineProxy.engineListeningAddress.url = require('url').resolve(
               this.engineProxy.engineListeningAddress.url,

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -48,8 +48,8 @@ const NoIntrospection = (context: ValidationContext) => ({
 });
 
 export class ApolloServerBase<Request = RequestInit> {
-  public subscriptions: Config<Request>['subscriptions'];
   public disableTools: boolean = !isDev;
+  public subscriptionsEnabled: boolean = false;
 
   private schema: GraphQLSchema;
   private context?: Context | ContextFunction;
@@ -67,7 +67,6 @@ export class ApolloServerBase<Request = RequestInit> {
       resolvers,
       schema,
       schemaDirectives,
-      subscriptions,
       typeDefs,
       enableIntrospection,
       mocks,
@@ -108,8 +107,6 @@ export class ApolloServerBase<Request = RequestInit> {
         mocks: typeof mocks === 'boolean' ? {} : mocks,
       });
     }
-
-    this.subscriptions = subscriptions;
   }
 
   public use({ getHttp, path }: RegistrationOptions) {
@@ -121,18 +118,20 @@ export class ApolloServerBase<Request = RequestInit> {
 
   public listen(opts: ListenOptions = {}): Promise<ServerInfo> {
     this.http = this.getHttp();
+
     const options = {
       port: process.env.PORT || 4000,
       ...opts,
     };
 
-    if (this.subscriptions !== false) {
+    if (opts.subscriptions !== false) {
       const config: any =
-        this.subscriptions === true || typeof this.subscriptions === 'undefined'
+        opts.subscriptions === true || typeof opts.subscriptions === 'undefined'
           ? {
               path: this.graphqlPath,
             }
-          : this.subscriptions;
+          : opts.subscriptions;
+      this.subscriptionsEnabled = true;
       this.createSubscriptionServer(this.http, config);
     }
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -37,7 +37,6 @@ export interface Config<Server>
   schema?: GraphQLSchema;
   schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>;
   context?: Context<any> | ContextFunction<any>;
-  subscriptions?: SubscriptionServerOptions | string | false;
   enableIntrospection?: boolean;
   mocks?: boolean | IMocks;
 }
@@ -66,6 +65,7 @@ export interface ListenOptions {
   engineLauncherOptions?: EngineLauncherOptions;
   // WebSocket options
   keepAlive?: number;
+  subscriptions?: SubscriptionServerOptions | string | false;
   onConnect?: (
     connectionParams: Object,
     websocket: WebSocket,
@@ -82,7 +82,6 @@ export interface MiddlewareOptions {
 
 export interface RegistrationOptions {
   path: string;
-  // subscriptions?: boolean;
   getHttp: () => HttpServer;
 }
 

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -12,7 +12,6 @@ export interface ServerRegistration {
   app: express.Application;
   server: ApolloServerBase<express.Request>;
   path?: string;
-  subscriptions?: boolean;
   cors?: corsMiddleware.CorsOptions;
   bodyParserConfig?: OptionsJson;
 }
@@ -50,7 +49,7 @@ export const registerServer = async ({
         if (prefersHTML) {
           return gui({
             endpoint: path,
-            subscriptionsEndpoint: server.subscriptions && path,
+            subscriptionsEndpoint: server.subscriptionsEnabled && path,
           })(req, res, next);
         }
       }

--- a/packages/apollo-server/CHANGELOG.md
+++ b/packages/apollo-server/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server`: move non-schema related options into listen [PR#1059](https://github.com/apollographql/apollo-server/pull/1059)
+* `apollo-server`: add `bodyParserConfig` options [PR#1059](https://github.com/apollographql/apollo-server/pull/1059)
 * `apollo-server`: add `/.well-known/apollo/server-health` endpoint with async callback for additional checks, ie database poke [PR#992](https://github.com/apollographql/apollo-server/pull/992)
 * `apollo-server`: collocate graphql gui with endpoint and provide gui when accessed from browser [PR#987](https://github.com/apollographql/apollo-server/pull/987)

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "devDependencies": {
+    "@types/body-parser": "^1.17.0",
     "@types/express": "^4.11.1",
     "@types/graphql": "^0.13.0",
     "typescript": "2.8.1"

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -53,9 +53,9 @@ export class ApolloServer extends ApolloServerBase<express.Request> {
             res.json({ status: 'pass' });
           }
         });
-
-        await registerServer({ app, path: '/', server: this });
       }
+
+      await registerServer({ app, path: '/', server: this });
     }
 
     return super.listen(opts);

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -1,5 +1,6 @@
 import * as express from 'express';
 import { registerServer } from 'apollo-server-express';
+import { OptionsJson } from 'body-parser';
 
 import {
   ApolloServerBase,
@@ -17,6 +18,7 @@ export class ApolloServer extends ApolloServerBase<express.Request> {
     opts: ListenOptions & {
       onHealthCheck?: (req: express.Request) => Promise<any>;
       disableHealthCheck?: boolean;
+      bodyParserConfig?: OptionsJson;
     } = {},
   ): Promise<ServerInfo> {
     //defensive copy


### PR DESCRIPTION
This moves the options for the default apollo-server from the constructor into the listen function. The goals is to keep the server constructor the same across all environments. Additional functionality is added in other function, such as `listen` or `registerServer`.

Additionally, @thepwagner found a bug, where `registerServer` was not called when `disableHealthCheck` was true on [this line](https://github.com/apollographql/apollo-server/compare/refactor-2.0...server-2.0/default-impl-params?expand=1#diff-c635668124bc43d28885aa7d04c99342R52) and requested the ability to configure the body parser of express.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->