### PR TITLE
apollo-server-core: move http options under own key in listenOptions

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -396,9 +396,11 @@ describe('ApolloServerBase', () => {
             level: 'ERROR',
           },
         },
-        port: 4000,
+        http: {
+          port: 4242,
+        },
       });
-      expect(enginePort).to.equal(4000);
+      expect(enginePort).to.equal(4242);
 
       //Check engine responding
       const engineApolloFetch = createApolloFetch({ uri: engineUri });

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -59,11 +59,7 @@ export interface ListenOptions {
   // node http listen options
   // https://nodejs.org/api/net.html#net_server_listen_options_callback
   // https://github.com/apollographql/apollo-server/pull/979#discussion_r184483094
-  port?: string | number;
-  host?: string;
-  path?: string;
-  backlog?: number;
-  exclusive?: boolean;
+  http?: HttpListenOptions | any | { handle: any; backlog?: number };
   // XXX clean this up
   engineInRequestPath?: boolean;
   engineProxy?: boolean | Record<string, any>;


### PR DESCRIPTION
Moves http options, such as `port` and `host`, under key in `listenOptions`.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->