### PR TITLE
tests: Switch from testing Node.js 9 to Node.js 10.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
     docker: [ { image: 'circleci/node:8' } ]
     <<: *common_test_steps
 
-  Node.js 9:
-    docker: [ { image: 'circleci/node:9' } ]
+  Node.js 10:
+    docker: [ { image: 'circleci/node:10' } ]
     <<: *common_test_steps
 
   # Other tests, unrelated to typical code tests.
@@ -71,6 +71,6 @@ workflows:
     jobs:
       - Node.js 6
       - Node.js 8
-      - Node.js 9
+      - Node.js 10
       - Linting
       - Docs


### PR DESCRIPTION
> This follows-up on #1026, which had previously included this commit but is now broken out separately for better clarity.

In the same way as other odd numbered Node.js versions, Node.js 9 is no longer longer being actively maintained since the release of (the even numbered) Node.js 10.

Node.js 9 will not be receiving additional updates, and Node.js 10 will transition to LTS status sometime around October 2018.

For more information see the blog post from Node.js and check the LTS timeline:

Ref: https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742
Ref: https://github.com/nodejs/LTS