### PR TITLE
apollo-server-hapi: add cors option

### DIFF
--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -12,6 +12,7 @@ export interface ServerRegistration {
   options?: hapi.ServerOptions;
   server: ApolloServerBase<hapi.Request>;
   path?: string;
+  cors?: boolean;
 }
 
 export interface HapiListenOptions {
@@ -27,6 +28,7 @@ export const registerServer = async ({
   app,
   options,
   server,
+  cors,
   path,
 }: ServerRegistration) => {
   if (!path) path = '/graphql';
@@ -96,7 +98,7 @@ server.listen({ http: { port: YOUR_PORT_HERE } });
       path: path,
       graphqlOptions: server.request.bind(server),
       route: {
-        cors: true,
+        cors: typeof cors === 'boolean' ? cors : true,
       },
     },
   });


### PR DESCRIPTION
Adds cors configuration option to hapi variant

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->