### PR TITLE
Move health check into the server variants

### DIFF
--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -44,6 +44,7 @@ export class ApolloServer extends ApolloServerBase<Request> {
         disableHealthCheck,
         bodyParserConfig,
         onHealthCheck,
+        cors,
       });
     }
 

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -1,6 +1,8 @@
 import * as express from 'express';
+import { Application, Request } from 'express';
 import { registerServer } from 'apollo-server-express';
 import { OptionsJson } from 'body-parser';
+import { CorsOptions } from 'cors';
 
 import {
   ApolloServerBase,
@@ -11,47 +13,40 @@ import {
 
 export * from './exports';
 
-export class ApolloServer extends ApolloServerBase<express.Request> {
+export class ApolloServer extends ApolloServerBase<Request> {
   // here we overwrite the underlying listen to configure
   // the fallback / default server implementation
   async listen(
     opts: ListenOptions & {
-      onHealthCheck?: (req: express.Request) => Promise<any>;
+      onHealthCheck?: (req: Request) => Promise<any>;
       disableHealthCheck?: boolean;
       bodyParserConfig?: OptionsJson;
+      cors?: CorsOptions;
     } = {},
   ): Promise<ServerInfo> {
-    //defensive copy
-    const { onHealthCheck } = opts;
+    const {
+      disableHealthCheck,
+      bodyParserConfig,
+      onHealthCheck,
+      cors,
+      ...listenOpts
+    } = opts;
 
     // we haven't configured a server yet so lets build the default one
     // using express
     if (!this.getHttp) {
       const app = express();
 
-      if (!opts.disableHealthCheck) {
-        //uses same path as engine
-        app.use('/.well-known/apollo/server-health', (req, res, next) => {
-          //Response follows https://tools.ietf.org/html/draft-inadarei-api-health-check-01
-          res.type('application/health+json');
-
-          if (onHealthCheck) {
-            onHealthCheck(req)
-              .then(() => {
-                res.json({ status: 'pass' });
-              })
-              .catch(() => {
-                res.status(503).json({ status: 'fail' });
-              });
-          } else {
-            res.json({ status: 'pass' });
-          }
-        });
-      }
-
-      await registerServer({ app, path: '/', server: this });
+      await registerServer({
+        app,
+        path: '/',
+        server: this,
+        disableHealthCheck,
+        bodyParserConfig,
+        onHealthCheck,
+      });
     }
 
-    return super.listen(opts);
+    return super.listen(listenOpts);
   }
 }


### PR DESCRIPTION
Moves health check into the server variants from default apollo-server. Adds support for health check in apollo-server-hapi. 

Additionally adds the cors option to apollo-server default's listen function.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->