### PR TITLE
apollo-server: remove extra configuration of registerServer from listen

### DIFF
--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -16,38 +16,24 @@ export * from './exports';
 export class ApolloServer extends ApolloServerBase<Request> {
   // here we overwrite the underlying listen to configure
   // the fallback / default server implementation
-  async listen(
-    opts: ListenOptions & {
-      onHealthCheck?: (req: Request) => Promise<any>;
-      disableHealthCheck?: boolean;
-      bodyParserConfig?: OptionsJson;
-      cors?: CorsOptions;
-    } = {},
-  ): Promise<ServerInfo> {
-    const {
-      disableHealthCheck,
-      bodyParserConfig,
-      onHealthCheck,
-      cors,
-      ...listenOpts
-    } = opts;
-
+  async listen(opts: ListenOptions = {}): Promise<ServerInfo> {
     // we haven't configured a server yet so lets build the default one
     // using express
     if (!this.getHttp) {
       const app = express();
 
+      //provide generous values for the getting started experience
       await registerServer({
         app,
         path: '/',
         server: this,
-        disableHealthCheck,
-        bodyParserConfig,
-        onHealthCheck,
-        cors,
+        bodyParserConfig: { limit: '50mb' },
+        cors: {
+          origin: '*',
+        },
       });
     }
 
-    return super.listen(listenOpts);
+    return super.listen(opts);
   }
 }


### PR DESCRIPTION
This removes the healthcheck, body parser, and cors from the `listen` configurations in the default apollo-server. Since the `listen` interface is shared across all standalone node integrations, it was quite important to make the listen interface cleaner. The defaults are generous, with cors set to * and body parser limit to 50mb to allow large file uploads.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->