### PR TITLE
Basic apollo-server and express integration tests

### DIFF
--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -41,7 +41,6 @@
     "@types/express": "4.11.1",
     "@types/multer": "1.3.6",
     "@types/node": "^10.1.2",
-    "apollo-server": "2.0.0-beta.2",
     "apollo-server-integration-testsuite": "^1.3.6",
     "connect": "3.6.6",
     "connect-query": "1.0.0",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -41,6 +41,7 @@
     "@types/express": "4.11.1",
     "@types/multer": "1.3.6",
     "@types/node": "^10.1.2",
+    "apollo-server": "2.0.0-beta.2",
     "apollo-server-integration-testsuite": "^1.3.6",
     "connect": "3.6.6",
     "connect-query": "1.0.0",

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -6,7 +6,8 @@ import * as express from 'express';
 import * as request from 'request';
 import { createApolloFetch } from 'apollo-fetch';
 
-import { gql, ApolloServer } from 'apollo-server';
+//to remove the circular dependency, we reference it directly
+import { gql, ApolloServer } from '../../apollo-server/dist/index';
 import { registerServer } from './ApolloServer';
 
 const typeDefs = gql`

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -1,0 +1,252 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import 'mocha';
+import * as express from 'express';
+
+import * as request from 'request';
+import { createApolloFetch } from 'apollo-fetch';
+
+import { gql, ApolloServer } from 'apollo-server';
+import { registerServer } from './ApolloServer';
+
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`;
+
+const resolvers = {
+  Query: {
+    hello: () => 'hi',
+  },
+};
+
+describe('apollo-server-express', () => {
+  describe('', () => {
+    it('accepts typeDefs and resolvers', () => {
+      const app = express();
+      const server = new ApolloServer({ typeDefs, resolvers });
+      expect(() => registerServer({ app, server })).not.to.throw;
+    });
+
+    it('accepts typeDefs and mocks', () => {
+      const app = express();
+      const server = new ApolloServer({ typeDefs, resolvers });
+      expect(() => registerServer({ app, server })).not.to.throw;
+    });
+  });
+
+  describe('registerServer', () => {
+    let server: ApolloServer;
+    let app: express.Application;
+    afterEach(async () => {
+      await server.stop();
+    });
+
+    it('can be queried', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+      app = express();
+
+      registerServer({ app, server });
+
+      const { url: uri } = await server.listen();
+      const apolloFetch = createApolloFetch({ uri });
+      const result = await apolloFetch({ query: '{hello}' });
+
+      expect(result.data).to.deep.equal({ hello: 'hi' });
+      expect(result.errors, 'errors should exist').not.to.exist;
+    });
+
+    it('renders GraphQL playground when browser requests', async () => {
+      const nodeEnv = process.env.NODE_ENV;
+      delete process.env.NODE_ENV;
+
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+      app = express();
+
+      registerServer({ app, server });
+
+      const { url } = await server.listen();
+      return new Promise((resolve, reject) => {
+        request(
+          {
+            url,
+            method: 'GET',
+            headers: {
+              accept:
+                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+            },
+          },
+          (error, response, body) => {
+            process.env.NODE_ENV = nodeEnv;
+            if (error) {
+              reject(error);
+            } else {
+              expect(body).to.contain('GraphQLPlayground');
+              expect(response.statusCode).to.equal(200);
+              resolve();
+            }
+          },
+        );
+      });
+    });
+
+    it('accepts cors configuration', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+      app = express();
+
+      registerServer({ app, server, cors: { origin: 'apollographql.com' } });
+
+      const { url: uri } = await server.listen({});
+
+      const apolloFetch = createApolloFetch({ uri }).useAfter(
+        (response, next) => {
+          expect(
+            response.response.headers.get('access-control-allow-origin'),
+          ).to.equal('apollographql.com');
+          next();
+        },
+      );
+      await apolloFetch({ query: '{hello}' });
+    });
+
+    it('accepts body parser configuration', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+      app = express();
+
+      registerServer({ app, server, bodyParserConfig: { limit: 0 } });
+
+      const { url: uri } = await server.listen({});
+
+      const apolloFetch = createApolloFetch({ uri });
+
+      return new Promise((resolve, reject) => {
+        apolloFetch({ query: '{hello}' })
+          .then(reject)
+          .catch(error => {
+            expect(error.response).to.exist;
+            expect(error.response.status).to.equal(413);
+            expect(error.toString()).to.contain('Payload Too Large');
+            resolve();
+          });
+      });
+    });
+
+    describe('healthchecks', () => {
+      let server: ApolloServer;
+
+      afterEach(async () => {
+        await server.stop();
+      });
+
+      it('creates a healthcheck endpoint', async () => {
+        server = new ApolloServer({
+          typeDefs,
+          resolvers,
+        });
+        app = express();
+
+        registerServer({ app, server, bodyParserConfig: { limit: 0 } });
+
+        const { port } = await server.listen();
+        return new Promise((resolve, reject) => {
+          request(
+            {
+              url: `http://localhost:${port}/.well-known/apollo/server-health`,
+              method: 'GET',
+            },
+            (error, response, body) => {
+              if (error) {
+                reject(error);
+              } else {
+                expect(body).to.equal(JSON.stringify({ status: 'pass' }));
+                expect(response.statusCode).to.equal(200);
+                resolve();
+              }
+            },
+          );
+        });
+      });
+
+      it('provides a callback for the healthcheck', async () => {
+        server = new ApolloServer({
+          typeDefs,
+          resolvers,
+        });
+        app = express();
+
+        registerServer({
+          app,
+          server,
+          onHealthCheck: async () => {
+            throw Error("can't connect to DB");
+          },
+        });
+
+        const { port } = await server.listen({});
+
+        return new Promise((resolve, reject) => {
+          request(
+            {
+              url: `http://localhost:${port}/.well-known/apollo/server-health`,
+              method: 'GET',
+            },
+            (error, response, body) => {
+              if (error) {
+                reject(error);
+              } else {
+                expect(body).to.equal(JSON.stringify({ status: 'fail' }));
+                expect(response.statusCode).to.equal(503);
+                resolve();
+              }
+            },
+          );
+        });
+      });
+
+      it('can disable the healthCheck', async () => {
+        server = new ApolloServer({
+          typeDefs,
+          resolvers,
+        });
+        app = express();
+        registerServer({
+          app,
+          server,
+          disableHealthCheck: true,
+        });
+
+        const { port } = await server.listen({});
+
+        return new Promise((resolve, reject) => {
+          request(
+            {
+              url: `http://localhost:${port}/.well-known/apollo/server-health`,
+              method: 'GET',
+            },
+            (error, response, body) => {
+              if (error) {
+                reject(error);
+              } else {
+                expect(response.statusCode).to.equal(404);
+                resolve();
+              }
+            },
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -6,9 +6,10 @@ import * as express from 'express';
 import * as request from 'request';
 import { createApolloFetch } from 'apollo-fetch';
 
-//to remove the circular dependency, we reference it directly
-import { gql, ApolloServer } from '../../apollo-server/dist/index';
+import { ApolloServerBase } from 'apollo-server-core';
 import { registerServer } from './ApolloServer';
+
+const gql = String.raw;
 
 const typeDefs = gql`
   type Query {
@@ -23,6 +24,9 @@ const resolvers = {
 };
 
 describe('apollo-server-express', () => {
+  //to remove the circular dependency, we reference it directly
+  const ApolloServer = require('../../apollo-server/dist/index').ApolloServer;
+
   describe('', () => {
     it('accepts typeDefs and resolvers', () => {
       const app = express();
@@ -38,7 +42,7 @@ describe('apollo-server-express', () => {
   });
 
   describe('registerServer', () => {
-    let server: ApolloServer;
+    let server: ApolloServerBase<express.Request>;
     let app: express.Application;
     afterEach(async () => {
       await server.stop();
@@ -146,7 +150,7 @@ describe('apollo-server-express', () => {
     });
 
     describe('healthchecks', () => {
-      let server: ApolloServer;
+      let server: ApolloServerBase<express.Request>;
 
       afterEach(async () => {
         await server.stop();

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -27,6 +27,8 @@
   "devDependencies": {
     "@types/body-parser": "^1.17.0",
     "@types/express": "^4.11.1",
+    "@types/request": "^2.47.0",
+    "request": "^2.87.0",
     "typescript": "2.8.1"
   },
   "peerDependencies": {

--- a/packages/apollo-server/src/index.test.ts
+++ b/packages/apollo-server/src/index.test.ts
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+import 'mocha';
+
+import * as request from 'request';
+import { createApolloFetch } from 'apollo-fetch';
+
+import { gql, ApolloServer } from './index';
+
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`;
+
+const resolvers = {
+  Query: {
+    hello: () => 'hi',
+  },
+};
+
+describe('apollo-server', () => {
+  describe('constructor', () => {
+    it('accepts typeDefs and resolvers', () => {
+      expect(() => new ApolloServer({ typeDefs, resolvers })).not.to.throw;
+    });
+
+    it('accepts typeDefs and mocks', () => {
+      expect(() => new ApolloServer({ typeDefs, mocks: true })).not.to.throw;
+    });
+  });
+
+  describe('without registerServer', () => {
+    let server: ApolloServer;
+    afterEach(async () => {
+      await server.stop();
+    });
+
+    it('can be queried', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+
+      const { url: uri } = await server.listen();
+      const apolloFetch = createApolloFetch({ uri });
+      const result = await apolloFetch({ query: '{hello}' });
+
+      expect(result.data).to.deep.equal({ hello: 'hi' });
+      expect(result.errors, 'errors should exist').not.to.exist;
+    });
+
+    it('renders GraphQL playground when browser requests', async () => {
+      const nodeEnv = process.env.NODE_ENV;
+      delete process.env.NODE_ENV;
+
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+
+      const { url } = await server.listen();
+      return new Promise((resolve, reject) => {
+        request(
+          {
+            url,
+            method: 'GET',
+            headers: {
+              accept:
+                'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
+            },
+          },
+          (error, response, body) => {
+            process.env.NODE_ENV = nodeEnv;
+            if (error) {
+              reject(error);
+            } else {
+              expect(body).to.contain('GraphQLPlayground');
+              expect(response.statusCode).to.equal(200);
+              resolve();
+            }
+          },
+        );
+      });
+    });
+
+    it('configures cors', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+
+      const { url: uri } = await server.listen({});
+
+      const apolloFetch = createApolloFetch({ uri }).useAfter(
+        (response, next) => {
+          expect(
+            response.response.headers.get('access-control-allow-origin'),
+          ).to.equal('*');
+          next();
+        },
+      );
+      await apolloFetch({ query: '{hello}' });
+    });
+
+    it('creates a healthcheck endpoint', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+
+      const { port } = await server.listen();
+      return new Promise((resolve, reject) => {
+        request(
+          {
+            url: `http://localhost:${port}/.well-known/apollo/server-health`,
+            method: 'GET',
+          },
+          (error, response, body) => {
+            if (error) {
+              reject(error);
+            } else {
+              expect(body).to.equal(JSON.stringify({ status: 'pass' }));
+              expect(response.statusCode).to.equal(200);
+              resolve();
+            }
+          },
+        );
+      });
+    });
+  });
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -14,6 +14,15 @@ require('../packages/apollo-server-core/dist/runHttpQuery.test.js');
 require('../packages/apollo-server-core/dist/errors.test.js');
 require('../packages/apollo-server-core/dist/ApolloServer.test.js');
 
+//Apollo server 2 tests
+
+//apollo-server
+require('../packages/apollo-server/dist/index.test.js');
+
+//apollo-server-express
+require('../packages/apollo-server-express/dist/ApolloServer.test.js');
+
+//Apollo server 1 tests
 require('../packages/apollo-server-module-operation-store/dist/operationStore.test');
 
 NODE_MAJOR_VERSION >= 7 &&


### PR DESCRIPTION
Adds basic apollo-server and express integration tests. Including the constructor, registerServer, healthchecks, and basic querying

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->