### PR TITLE
apollo-server-core: add request to runHttpQuery for access to headers

### DIFF
--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -34,6 +34,7 @@ export function graphqlAdonis(
       method,
       options,
       query,
+      request,
     }).then(
       gqlResponse => {
         response.type('application/json');

--- a/packages/apollo-server-azure-functions/src/azureFunctionsApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionsApollo.ts
@@ -58,6 +58,7 @@ export function graphqlAzureFunctions(
       method: request.method,
       options: options,
       query: request.method === 'POST' ? request.body : request.query,
+      request,
     };
 
     if (queryRequest.query && typeof queryRequest.query === 'string') {

--- a/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
+++ b/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
@@ -38,6 +38,7 @@ export function graphqlCloudflare(options: GraphQLOptions) {
       method: req.method,
       options: options,
       query,
+      request: req as Request,
     }).then(
       gqlResponse =>
         new Response(gqlResponse, {

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -34,6 +34,7 @@
     "fibers": "1.0.15",
     "graphql-tag": "^2.9.2",
     "meteor-promise": "0.8.6",
+    "mock-req": "^0.2.0",
     "typescript": "2.8.3"
   },
   "peerDependencies": {

--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -78,6 +78,7 @@ function createHttpServer(server) {
           method: req.method,
           options: server.request(req as any),
           query: JSON.parse(body),
+          request: req,
         })
           .then(gqlResponse => {
             res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-core/src/runHttpQuery.test.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.test.ts
@@ -2,6 +2,7 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import 'mocha';
+import * as MockReq from 'mock-req';
 
 import {
   GraphQLSchema,
@@ -38,6 +39,7 @@ describe('runHttpQuery', () => {
       options: {
         schema,
       },
+      request: new MockReq(),
     };
 
     it('raises a 400 error if the query is missing', () => {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -5,6 +5,7 @@ import {
   resolveGraphqlOptions,
 } from './graphqlOptions';
 import { formatApolloErrors } from './errors';
+import { IncomingMessage } from 'http';
 
 export interface HttpQueryRequest {
   method: string;
@@ -12,6 +13,7 @@ export interface HttpQueryRequest {
   options:
     | GraphQLOptions
     | ((...args: Array<any>) => Promise<GraphQLOptions> | GraphQLOptions);
+  request: IncomingMessage | Request;
 }
 
 export class HttpQueryError extends Error {

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -45,6 +45,7 @@ export function graphqlExpress(
       method: req.method,
       options: options,
       query: req.method === 'POST' ? req.body : req.query,
+      request: req,
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -6,6 +6,7 @@ import {
   runHttpQuery,
   HttpQueryError,
 } from 'apollo-server-core';
+import { IncomingMessage } from 'http';
 
 export interface IRegister {
   (server: Server, options: any): void;
@@ -50,6 +51,7 @@ const graphqlHapi: IPlugin = {
                 ? //TODO type payload as string or Record
                   (request.payload as any)
                 : request.query,
+            request: request.raw.req,
           });
 
           const response = h.response(gqlResponse);

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -33,6 +33,7 @@ export function graphqlKoa(
       options: options,
       query:
         ctx.request.method === 'POST' ? ctx.request.body : ctx.request.query,
+      request: ctx.req,
     }).then(
       gqlResponse => {
         ctx.set('Content-Type', 'application/json');

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -54,6 +54,7 @@ export function graphqlLambda(
         method: event.httpMethod,
         options: options,
         query: query,
+        request: event,
       });
       headers['Content-Type'] = 'application/json';
       statusCode = 200;

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -42,6 +42,7 @@ export function microGraphql(
         method: req.method,
         options: options,
         query: query,
+        request: req,
       });
 
       res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-restify/src/restifyApollo.ts
+++ b/packages/apollo-server-restify/src/restifyApollo.ts
@@ -44,6 +44,7 @@ export function graphqlRestify(
       method: req.method,
       options: options,
       query: req.method === 'POST' ? req.body : req.query,
+      request: req,
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
This adds the request as an argument to runHttpQuery, so that we have access to it in reporting.

This is a breaking change for `apollo-server-core`

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->