### PR TITLE
Always only parse query in runQuery and don't accept AST over the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ store.put('query testquery{ testString }');
 graphqlOptions = {
   schema: Schema,
   formatParams(params) {
-    params['query'] = store.get(params.operationName);
+    params['parsedQuery'] = store.get(params.operationName);
+    delete params['queryString'];  // Or throw if this is provided.
     return params;
   },
 };

--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server-core`: move query parse into runQuery and no longer accept GraphQL AST over the wire [PR#1097](https://github.com/apollographql/apollo-server/pull/1097)
 * `apollo-server-core`: custom errors allow instanceof checks [PR#1074](https://github.com/apollographql/apollo-server/pull/1074)
 * `apollo-server-core`: move subscriptions options into listen [PR#1059](https://github.com/apollographql/apollo-server/pull/1059)
 * `apollo-server-core`: Replace console.error with logFunction for opt-in logging [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -1,5 +1,5 @@
 import { parse, DocumentNode, ExecutionResult } from 'graphql';
-import { runQuery } from './runQuery';
+import { runQuery, QueryOptions } from './runQuery';
 import {
   default as GraphQLOptions,
   resolveGraphqlOptions,
@@ -158,11 +158,8 @@ export async function runHttpQuery(
         );
       }
 
-      if (typeof queryString !== 'string') {
-        if (!queryString) {
-          // Note that we've already thrown a different error if it looks like APQ.
-          throw new HttpQueryError(400, 'Must provide query string.');
-        }
+      //We ensure that there is a queryString or parsedQuery after formatParams
+      if (queryString && typeof queryString !== 'string') {
         // Check for a common error first.
         if (queryString && (queryString as any).kind === 'Document') {
           throw new HttpQueryError(
@@ -239,7 +236,7 @@ export async function runHttpQuery(
         );
       }
 
-      let params = {
+      let params: QueryOptions = {
         schema: optionsObject.schema,
         queryString,
         nonQueryError,
@@ -259,6 +256,11 @@ export async function runHttpQuery(
 
       if (optionsObject.formatParams) {
         params = optionsObject.formatParams(params);
+      }
+
+      if (!params.queryString && !params.parsedQuery) {
+        // Note that we've already thrown a different error if it looks like APQ.
+        throw new HttpQueryError(400, 'Must provide query string.');
       }
 
       return runQuery(params);

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -179,6 +179,7 @@ export async function runHttpQuery(
       // a particular HTTP error in that case, but we don't actually parse the
       // query until we're in runQuery, so we declare the error we want to throw
       // here and pass it into runQuery.
+      // TODO this could/should be added as a validation rule rather than an ad hoc error
       let nonQueryError;
       if (isGetRequest) {
         nonQueryError = new HttpQueryError(

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -92,7 +92,7 @@ describe('runQuery', () => {
   it('returns the right result when query is a string', () => {
     const query = `{ testString }`;
     const expected = { testString: 'it works' };
-    return runQuery({ schema, query: query }).then(res => {
+    return runQuery({ schema, queryString: query }).then(res => {
       expect(res.data).to.deep.equal(expected);
     });
   });
@@ -100,7 +100,7 @@ describe('runQuery', () => {
   it('returns the right result when query is a document', () => {
     const query = parse(`{ testString }`);
     const expected = { testString: 'it works' };
-    return runQuery({ schema, query: query }).then(res => {
+    return runQuery({ schema, parsedQuery: query }).then(res => {
       expect(res.data).to.deep.equal(expected);
     });
   });
@@ -110,7 +110,7 @@ describe('runQuery', () => {
     const expected = /Syntax Error/;
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       variables: { base: 1 },
     }).then(res => {
       expect(res.data).to.be.undefined;
@@ -124,7 +124,7 @@ describe('runQuery', () => {
     const logStub = stub(console, 'error');
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       debug: true,
     }).then(res => {
       logStub.restore();
@@ -137,7 +137,7 @@ describe('runQuery', () => {
     const logStub = stub(console, 'error');
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       debug: false,
     }).then(res => {
       logStub.restore();
@@ -151,7 +151,7 @@ describe('runQuery', () => {
       'Variable "$base" of type "String" used in position expecting type "Int!".';
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       variables: { base: 1 },
     }).then(res => {
       expect(res.data).to.be.undefined;
@@ -163,7 +163,7 @@ describe('runQuery', () => {
   it('correctly passes in the rootValue', () => {
     const query = `{ testRootValue }`;
     const expected = { testRootValue: 'it also works' };
-    return runQuery({ schema, query: query, rootValue: 'it also' }).then(
+    return runQuery({ schema, queryString: query, rootValue: 'it also' }).then(
       res => {
         expect(res.data).to.deep.equal(expected);
       },
@@ -173,9 +173,11 @@ describe('runQuery', () => {
   it('correctly passes in the context', () => {
     const query = `{ testContextValue }`;
     const expected = { testContextValue: 'it still works' };
-    return runQuery({ schema, query: query, context: 'it still' }).then(res => {
-      expect(res.data).to.deep.equal(expected);
-    });
+    return runQuery({ schema, queryString: query, context: 'it still' }).then(
+      res => {
+        expect(res.data).to.deep.equal(expected);
+      },
+    );
   });
 
   it('passes the options to formatResponse', () => {
@@ -183,7 +185,7 @@ describe('runQuery', () => {
     const expected = { testContextValue: 'it still works' };
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       context: 'it still',
       formatResponse: (response, { context }) => {
         response['extensions'] = context;
@@ -200,7 +202,7 @@ describe('runQuery', () => {
     const expected = { testArgumentValue: 6 };
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       variables: { base: 1 },
     }).then(res => {
       expect(res.data).to.deep.equal(expected);
@@ -213,7 +215,7 @@ describe('runQuery', () => {
       'Variable "$base" of required type "Int!" was not provided.';
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
     }).then(res => {
       expect(res.errors[0].message).to.deep.equal(expected);
     });
@@ -222,7 +224,7 @@ describe('runQuery', () => {
   it('supports yielding resolver functions', () => {
     return runQuery({
       schema,
-      query: `{ testAwaitedValue }`,
+      queryString: `{ testAwaitedValue }`,
     }).then(res => {
       expect(res.data).to.deep.equal({
         testAwaitedValue: 'it works',
@@ -241,9 +243,11 @@ describe('runQuery', () => {
     const expected = {
       testString: 'it works',
     };
-    return runQuery({ schema, query: query, operationName: 'Q1' }).then(res => {
-      expect(res.data).to.deep.equal(expected);
-    });
+    return runQuery({ schema, queryString: query, operationName: 'Q1' }).then(
+      res => {
+        expect(res.data).to.deep.equal(expected);
+      },
+    );
   });
 
   it('calls logFunction', () => {
@@ -258,7 +262,7 @@ describe('runQuery', () => {
     };
     return runQuery({
       schema,
-      query: query,
+      queryString: query,
       operationName: 'Q1',
       variables: { test: 123 },
       logFunction: logFn,
@@ -309,7 +313,7 @@ describe('runQuery', () => {
 
     const result1 = await runQuery({
       schema,
-      query: query,
+      queryString: query,
       operationName: 'Q1',
     });
 
@@ -321,7 +325,7 @@ describe('runQuery', () => {
 
     const result2 = await runQuery({
       schema,
-      query: query,
+      queryString: query,
       operationName: 'Q1',
       fieldResolver: () => 'a very testful field resolver string',
     });
@@ -364,7 +368,7 @@ describe('runQuery', () => {
 
       await runQuery({
         schema,
-        query: query,
+        queryString: query,
         operationName: 'Q1',
       });
 

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -30,6 +30,7 @@
     "definition": "dist/index.d.ts"
   },
   "devDependencies": {
-    "@types/node": "^10.1.2"
+    "@types/node": "^10.1.2",
+    "graphql-tag": "^2.9.2"
   }
 }

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "^1.3.6",
+    "apollo-server-core": "2.0.0-beta.0",
     "apollo-server-module-graphiql": "^1.3.4",
     "apollo-server-module-operation-store": "^1.3.5",
     "supertest": "^3.1.0"

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -998,7 +998,8 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           graphqlOptions: {
             schema,
             formatParams(params) {
-              params['query'] = store.get(params.operationName);
+              params['parsedQuery'] = store.get(params.operationName);
+              delete params['queryString'];
               return params;
             },
           },
@@ -1022,10 +1023,10 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           graphqlOptions: {
             schema,
             formatParams(params) {
-              if (params.query) {
+              if (params.queryString) {
                 throw new Error('Must not provide query, only operationName');
               }
-              params['query'] = store.get(params.operationName);
+              params['parsedQuery'] = store.get(params.operationName);
               return params;
             },
           },

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -19,6 +19,7 @@ const request = require('supertest');
 import { GraphQLOptions } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 import { OperationStore } from 'apollo-server-module-operation-store';
+import gql from 'graphql-tag';
 
 const personType = new GraphQLObjectType({
   name: 'PersonType',
@@ -523,6 +524,26 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           expect(res.body.data.__schema.types[0].fields[0].name).to.equal(
             'testString',
           );
+        });
+      });
+
+      it('does not accept a query AST', async () => {
+        app = await createApp();
+        const expected = {
+          testString: 'it works',
+        };
+        const req = request(app)
+          .post('/graphql')
+          .send({
+            query: gql`
+              query test {
+                testString
+              }
+            `,
+          });
+        return req.then(res => {
+          expect(res.status).to.equal(400);
+          expect(res.text).to.contain('GraphQL queries must be strings');
         });
       });
 


### PR DESCRIPTION
This places the parsing of the AST into runQuery and removes the ability to send an AST to the server. The removal of this functionality is a breaking change considered a bug fix. It fits with Apollo Server 2's theme of enforcing best practices with sensible defaults. Sending an AST over the wire is certainly not recommended.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->