### PR TITLE
Allow user-defined GraphQLExtensions, add apollo-engine-reporting

### DIFF
--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -107,13 +107,16 @@ const GraphQLOptions = {
   validationRules?: Array<ValidationRule>,
 
   // a function applied to each graphQL execution result
-  formatResponse?: Function
+  formatResponse?: Function,
 
   // a custom default field resolver
-  fieldResolver?: Function
+  fieldResolver?: Function,
 
   // a boolean that will print additional debug logging if execution errors occur
-  debug?: boolean
+  debug?: boolean,
+
+  // (optional) extra GraphQL extensions from graphql-extensions
+  extensions?: Array<GraphQLExtension>
 }
 ```
 

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -116,7 +116,7 @@ const GraphQLOptions = {
   debug?: boolean,
 
   // (optional) extra GraphQL extensions from graphql-extensions
-  extensions?: Array<GraphQLExtension>
+  extensions?: Array<() => GraphQLExtension>
 }
 ```
 

--- a/packages/apollo-server-adonis/package.json
+++ b/packages/apollo-server-adonis/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "devDependencies": {

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "devDependencies": {

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "typings": "dist/index.d.ts",

--- a/packages/apollo-server-cloudflare/src/ApolloServer.ts
+++ b/packages/apollo-server-cloudflare/src/ApolloServer.ts
@@ -9,7 +9,7 @@ interface FetchEvent extends Event {
 
 export class ApolloServer extends ApolloServerBase {
   public async listen() {
-    const graphql = this.request.bind(this);
+    const graphql = this.graphQLServerOptionsForRequest.bind(this);
     addEventListener('fetch', (event: FetchEvent) => {
       event.respondWith(graphqlCloudflare(graphql)(event.request));
     });

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -47,8 +47,8 @@
   },
   "dependencies": {
     "apollo-cache-control": "^0.1.1",
-    "apollo-tracing": "^0.1.0",
-    "graphql-extensions": "^0.0.x",
+    "apollo-tracing": "^0.2.0-beta.0",
+    "graphql-extensions": "0.1.0-beta.7",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.2",
     "subscriptions-transport-ws": "^0.9.9",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -47,10 +47,12 @@
   },
   "dependencies": {
     "apollo-cache-control": "^0.1.1",
+    "apollo-engine-reporting": "0.0.0-beta.8",
     "apollo-tracing": "^0.2.0-beta.0",
     "graphql-extensions": "0.1.0-beta.7",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.2",
+    "node-fetch": "^2.1.2",
     "subscriptions-transport-ws": "^0.9.9",
     "ws": "^5.1.1"
   }

--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -78,7 +78,7 @@ function createHttpServer(server) {
 
         runHttpQuery([req, res], {
           method: req.method,
-          options: server.request(req as any),
+          options: server.graphQLServerOptionsForRequest(req as any),
           query: JSON.parse(body),
           request: new MockReq(),
         })

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -340,7 +340,7 @@ export class ApolloServerBase<Request = RequestInit> {
     }
   }
 
-  request(request: Request) {
+  graphQLServerOptionsForRequest(request: Request) {
     let context: Context = this.context ? this.context : { request };
 
     try {

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -19,6 +19,7 @@ import { GraphQLExtension } from 'graphql-extensions';
  * - (optional) formatResponse: a function applied to each graphQL execution result
  * - (optional) fieldResolver: a custom default field resolver
  * - (optional) debug: a boolean that will print additional debug logging if execution errors occur
+ * - (optional) extensions: an array of GraphQLExtension
  *
  */
 export interface GraphQLServerOptions<
@@ -39,6 +40,7 @@ export interface GraphQLServerOptions<
   tracing?: boolean;
   // cacheControl?: boolean | CacheControlExtensionOptions;
   cacheControl?: boolean | any;
+  extensions?: Array<typeof GraphQLExtension | GraphQLExtension>;
 }
 
 export default GraphQLServerOptions;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -19,7 +19,7 @@ import { GraphQLExtension } from 'graphql-extensions';
  * - (optional) formatResponse: a function applied to each graphQL execution result
  * - (optional) fieldResolver: a custom default field resolver
  * - (optional) debug: a boolean that will print additional debug logging if execution errors occur
- * - (optional) extensions: an array of GraphQLExtension
+ * - (optional) extensions: an array of functions which create GraphQLExtensions (each GraphQLExtension object is used for one request)
  *
  */
 export interface GraphQLServerOptions<
@@ -40,7 +40,7 @@ export interface GraphQLServerOptions<
   tracing?: boolean;
   // cacheControl?: boolean | CacheControlExtensionOptions;
   cacheControl?: boolean | any;
-  extensions?: Array<typeof GraphQLExtension | GraphQLExtension>;
+  extensions?: Array<() => GraphQLExtension>;
 }
 
 export default GraphQLServerOptions;

--- a/packages/apollo-server-core/src/nodeHttpToRequest.ts
+++ b/packages/apollo-server-core/src/nodeHttpToRequest.ts
@@ -1,4 +1,5 @@
 import { IncomingMessage } from 'http';
+import { Request, Headers } from 'node-fetch';
 
 export function convertNodeHttpToRequest(req: IncomingMessage): Request {
   const headers = new Headers();

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -17,7 +17,7 @@ export interface HttpQueryRequest {
   options:
     | GraphQLOptions
     | ((...args: Array<any>) => Promise<GraphQLOptions> | GraphQLOptions);
-  request: Request;
+  request: Pick<Request, 'url' | 'method' | 'headers'>;
 }
 
 export class HttpQueryError extends Error {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -255,6 +255,7 @@ export async function runHttpQuery(
         tracing: optionsObject.tracing,
         cacheControl: optionsObject.cacheControl,
         request: request.request,
+        extensions: optionsObject.extensions,
       };
 
       if (optionsObject.formatParams) {

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -20,6 +20,7 @@ import { LogAction, LogStep } from './logging';
 // environment.
 import { makeCompatible } from 'meteor-promise';
 import Fiber = require('fibers');
+import { GraphQLExtensionStack, GraphQLExtension } from 'graphql-extensions';
 makeCompatible(Promise, Fiber);
 
 const queryType = new GraphQLObjectType({
@@ -363,6 +364,53 @@ describe('runQuery', () => {
       testObject: {
         testString: 'a very testful field resolver string',
       },
+    });
+  });
+
+  describe('graphql extensions', () => {
+    class CustomExtension implements GraphQLExtension<any> {
+      format(): [string, any] {
+        return ['customExtension', { foo: 'bar' }];
+      }
+    }
+
+    it('creates the extension stack', async () => {
+      const query = `{ testString }`;
+      const expected = { testString: 'it works' };
+      const extensions = [CustomExtension];
+      return runQuery({
+        schema: new GraphQLSchema({
+          query: new GraphQLObjectType({
+            name: 'QueryType',
+            fields: {
+              testString: {
+                type: GraphQLString,
+                resolve(root, args, context) {
+                  expect(context._extensionStack).to.be.instanceof(
+                    GraphQLExtensionStack,
+                  );
+                  expect(
+                    context._extensionStack.extensions[0],
+                  ).to.be.instanceof(CustomExtension);
+                },
+              },
+            },
+          }),
+        }),
+        query,
+        extensions,
+      });
+    });
+
+    it('runs format response from extensions', async () => {
+      const query = `{ testString }`;
+      const expected = { testString: 'it works' };
+      const extensions = [CustomExtension];
+      return runQuery({ schema, query: query, extensions }).then(res => {
+        return expect(res.extensions).to.deep.equal({
+          customExtension: { foo: 'bar' },
+        });
+      });
     });
   });
 

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -375,9 +375,9 @@ describe('runQuery', () => {
     }
 
     it('creates the extension stack', async () => {
-      const query = `{ testString }`;
+      const queryString = `{ testString }`;
       const expected = { testString: 'it works' };
-      const extensions = [CustomExtension];
+      const extensions = [() => new CustomExtension()];
       return runQuery({
         schema: new GraphQLSchema({
           query: new GraphQLObjectType({
@@ -397,16 +397,22 @@ describe('runQuery', () => {
             },
           }),
         }),
-        query,
+        queryString,
         extensions,
+        request: new MockReq(),
       });
     });
 
     it('runs format response from extensions', async () => {
-      const query = `{ testString }`;
+      const queryString = `{ testString }`;
       const expected = { testString: 'it works' };
-      const extensions = [CustomExtension];
-      return runQuery({ schema, query: query, extensions }).then(res => {
+      const extensions = [() => new CustomExtension()];
+      return runQuery({
+        schema,
+        queryString,
+        extensions,
+        request: new MockReq(),
+      }).then(res => {
         return expect(res.extensions).to.deep.equal({
           customExtension: { foo: 'bar' },
         });

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -64,6 +64,7 @@ export interface QueryOptions {
   // cacheControl?: boolean | CacheControlExtensionOptions;
   cacheControl?: boolean | any;
   request: Request;
+  extensions?: Array<typeof GraphQLExtension | GraphQLExtension>;
 }
 
 function isQueryOperation(query: DocumentNode, operationName: string) {
@@ -98,7 +99,7 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
   logFunction({ action: LogAction.request, step: LogStep.start });
 
   const context = options.context || {};
-  let extensions = [];
+  let extensions = options.extensions !== undefined ? options.extensions : [];
   if (options.tracing) {
     extensions.push(TracingExtension);
   }

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -66,7 +66,7 @@ export interface QueryOptions {
   tracing?: boolean;
   // cacheControl?: boolean | CacheControlExtensionOptions;
   cacheControl?: boolean | any;
-  request: Request;
+  request: Pick<Request, 'url' | 'method' | 'headers'>;
   extensions?: Array<() => GraphQLExtension>;
 }
 
@@ -126,7 +126,11 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
   }
 
   const requestDidEnd = extensionStack.requestDidStart({
-    request: options.request,
+    // Since the Request interfacess are not the same between node-fetch and
+    // typescript's lib dom, we should limit the fields that need to be passed
+    // into requestDidStart to only the ones we need, currently just the
+    // headers, method, and url
+    request: options.request as any,
   });
   return Promise.resolve()
     .then(() => {

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -7,6 +7,7 @@ import {
   print,
   validate,
   execute,
+  ExecutionArgs,
   getOperationAST,
   GraphQLError,
   specifiedRules,
@@ -17,6 +18,7 @@ import {
   enableGraphQLExtensions,
   GraphQLExtension,
   GraphQLExtensionStack,
+  EndHandler,
 } from 'graphql-extensions';
 import { TracingExtension } from 'apollo-tracing';
 import { CacheControlExtension } from 'apollo-cache-control';
@@ -29,6 +31,7 @@ import {
 } from './errors';
 
 import { LogStep, LogAction, LogMessage, LogFunction } from './logging';
+import { GraphQLRequest } from 'apollo-fetch';
 
 export interface GraphQLResponse {
   data?: object;
@@ -64,7 +67,7 @@ export interface QueryOptions {
   // cacheControl?: boolean | CacheControlExtensionOptions;
   cacheControl?: boolean | any;
   request: Request;
-  extensions?: Array<typeof GraphQLExtension | GraphQLExtension>;
+  extensions?: Array<() => GraphQLExtension>;
 }
 
 function isQueryOperation(query: DocumentNode, operationName: string) {
@@ -78,8 +81,6 @@ export function runQuery(options: QueryOptions): Promise<GraphQLResponse> {
 }
 
 function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
-  let documentAST: DocumentNode;
-
   if (options.queryString && options.parsedQuery) {
     throw new Error('Only supply one of queryString and parsedQuery');
   }
@@ -99,166 +100,212 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
   logFunction({ action: LogAction.request, step: LogStep.start });
 
   const context = options.context || {};
-  let extensions = options.extensions !== undefined ? options.extensions : [];
+
+  // If custom extension factories were provided, create per-request extension objects.
+  const extensions = options.extensions ? options.extensions.map(f => f()) : [];
+
+  // Legacy hard-coded extension factories. The ApolloServer class doesn't use
+  // this code path, but older APIs did.
   if (options.tracing) {
-    extensions.push(TracingExtension);
+    extensions.push(new TracingExtension());
   }
   if (options.cacheControl === true) {
-    extensions.push(CacheControlExtension);
+    extensions.push(new CacheControlExtension());
   } else if (options.cacheControl) {
     extensions.push(new CacheControlExtension(options.cacheControl));
   }
-  const extensionStack =
-    extensions.length > 0 && new GraphQLExtensionStack(extensions);
 
-  if (extensionStack) {
+  const extensionStack = new GraphQLExtensionStack(extensions);
+
+  // We unconditionally create an extensionStack (so that we don't have to
+  // litter the rest of this function with `if (extensionStack)`, but we don't
+  // instrument the schema unless there actually are extensions.
+  if (extensions.length > 0) {
     context._extensionStack = extensionStack;
     enableGraphQLExtensions(options.schema);
-
-    extensionStack.requestDidStart();
   }
 
-  const loggedQuery = options.queryString || print(options.parsedQuery);
-  logFunction({
-    action: LogAction.request,
-    step: LogStep.status,
-    key: 'query',
-    data: loggedQuery,
+  const requestDidEnd = extensionStack.requestDidStart({
+    request: options.request,
   });
-  logFunction({
-    action: LogAction.request,
-    step: LogStep.status,
-    key: 'variables',
-    data: options.variables,
-  });
-  logFunction({
-    action: LogAction.request,
-    step: LogStep.status,
-    key: 'operationName',
-    data: options.operationName,
-  });
-
-  // Parse and validate the query, unless it is already an AST (eg, if using
-  // OperationStore with formatParams).
-  if (options.queryString) {
-    try {
-      logFunction({ action: LogAction.parse, step: LogStep.start });
-      documentAST = parse(options.queryString);
-      logFunction({ action: LogAction.parse, step: LogStep.end });
-    } catch (syntaxError) {
-      logFunction({ action: LogAction.parse, step: LogStep.end });
-      return Promise.resolve({
-        errors: formatApolloErrors(
-          [
-            fromGraphQLError(syntaxError, {
-              errorClass: SyntaxError,
-            }),
-          ],
-          {
-            formatter: options.formatError,
-            debug,
-          },
-        ),
+  return Promise.resolve()
+    .then(() => {
+      const loggedQuery = options.queryString || print(options.parsedQuery);
+      logFunction({
+        action: LogAction.request,
+        step: LogStep.status,
+        key: 'query',
+        data: loggedQuery,
       });
-    }
-  } else {
-    documentAST = options.parsedQuery;
-  }
+      logFunction({
+        action: LogAction.request,
+        step: LogStep.status,
+        key: 'variables',
+        data: options.variables,
+      });
+      logFunction({
+        action: LogAction.request,
+        step: LogStep.status,
+        key: 'operationName',
+        data: options.operationName,
+      });
 
-  if (
-    options.nonQueryError &&
-    !isQueryOperation(documentAST, options.operationName)
-  ) {
-    throw options.nonQueryError;
-  }
-
-  let rules = specifiedRules;
-  if (options.validationRules) {
-    rules = rules.concat(options.validationRules);
-  }
-  logFunction({ action: LogAction.validation, step: LogStep.start });
-  const validationErrors = validate(options.schema, documentAST, rules);
-  logFunction({ action: LogAction.validation, step: LogStep.end });
-
-  if (validationErrors.length) {
-    return Promise.resolve({
-      errors: formatApolloErrors(
-        validationErrors.map(err =>
-          fromGraphQLError(err, { errorClass: ValidationError }),
-        ),
-        {
-          formatter: options.formatError,
-          logFunction,
-          debug,
-        },
-      ),
-    });
-  }
-
-  if (extensionStack) {
-    extensionStack.executionDidStart();
-  }
-
-  try {
-    logFunction({ action: LogAction.execute, step: LogStep.start });
-    return Promise.resolve(
-      execute(
-        options.schema,
-        documentAST,
-        options.rootValue,
-        context,
-        options.variables,
-        options.operationName,
-        options.fieldResolver,
-      ),
-    ).then(result => {
-      logFunction({ action: LogAction.execute, step: LogStep.end });
-
-      let response: GraphQLResponse = {
-        data: result.data,
-      };
-
-      if (result.errors) {
-        response.errors = formatApolloErrors([...result.errors], {
-          formatter: options.formatError,
-          logFunction,
-          debug,
+      // Parse the document.
+      let documentAST: DocumentNode;
+      if (options.parsedQuery) {
+        documentAST = options.parsedQuery;
+      } else if (!options.queryString) {
+        throw new Error('Must supply one of queryString and parsedQuery');
+      } else {
+        logFunction({ action: LogAction.parse, step: LogStep.start });
+        const parsingDidEnd = extensionStack.parsingDidStart({
+          queryString: options.queryString,
         });
+        let graphqlParseErrors;
+        try {
+          documentAST = parse(options.queryString);
+        } catch (syntaxError) {
+          graphqlParseErrors = formatApolloErrors(
+            [
+              fromGraphQLError(syntaxError, {
+                errorClass: SyntaxError,
+              }),
+            ],
+            {
+              formatter: options.formatError,
+              debug,
+            },
+          );
+        } finally {
+          parsingDidEnd(...(graphqlParseErrors || []));
+          logFunction({ action: LogAction.parse, step: LogStep.end });
+          if (graphqlParseErrors) {
+            return Promise.resolve({ errors: graphqlParseErrors });
+          }
+        }
       }
 
-      if (extensionStack) {
-        extensionStack.executionDidEnd();
-        extensionStack.requestDidEnd();
-        response.extensions = extensionStack.format();
+      if (
+        options.nonQueryError &&
+        !isQueryOperation(documentAST, options.operationName)
+      ) {
+        // XXX this goes to requestDidEnd, is that correct or should it be
+        // validation?
+        throw options.nonQueryError;
       }
 
-      if (options.formatResponse) {
-        response = options.formatResponse(response, options);
+      let rules = specifiedRules;
+      if (options.validationRules) {
+        rules = rules.concat(options.validationRules);
+      }
+      logFunction({ action: LogAction.validation, step: LogStep.start });
+      const validationDidEnd = extensionStack.validationDidStart();
+      let validationErrors;
+      try {
+        validationErrors = validate(options.schema, documentAST, rules);
+      } catch (validationThrewError) {
+        // Catch errors thrown by validate, not just those returned by it.
+        validationErrors = [validationThrewError];
+      } finally {
+        try {
+          if (validationErrors) {
+            validationErrors = formatApolloErrors(
+              validationErrors.map(err =>
+                fromGraphQLError(err, { errorClass: ValidationError }),
+              ),
+              {
+                formatter: options.formatError,
+                logFunction,
+                debug,
+              },
+            );
+          }
+        } finally {
+          validationDidEnd(...(validationErrors || []));
+          logFunction({ action: LogAction.validation, step: LogStep.end });
+
+          if (validationErrors && validationErrors.length) {
+            return Promise.resolve({
+              errors: validationErrors,
+            });
+          }
+        }
       }
 
+      const executionArgs: ExecutionArgs = {
+        schema: options.schema,
+        document: documentAST,
+        rootValue: options.rootValue,
+        contextValue: context,
+        variableValues: options.variables,
+        operationName: options.operationName,
+        fieldResolver: options.fieldResolver,
+      };
+      logFunction({ action: LogAction.execute, step: LogStep.start });
+      const executionDidEnd = extensionStack.executionDidStart({
+        executionArgs,
+      });
+      return Promise.resolve()
+        .then(() => execute(executionArgs))
+        .catch(executionError => {
+          return {
+            // These errors will get passed through formatApolloErrors in the
+            // `then` below.
+            // TODO accurate code for this error, which describes this error, which
+            // can occur when:
+            // * variables incorrectly typed/null when nonnullable
+            // * unknown operation/operation name invalid
+            // * operation type is unsupported
+            // Options: PREPROCESSING_FAILED, GRAPHQL_RUNTIME_CHECK_FAILED
+
+            errors: [fromGraphQLError(executionError)],
+          } as ExecutionResult;
+        })
+        .then(result => {
+          let response: GraphQLResponse = {
+            data: result.data,
+          };
+
+          if (result.errors) {
+            response.errors = formatApolloErrors([...result.errors], {
+              formatter: options.formatError,
+              logFunction,
+              debug,
+            });
+          }
+
+          executionDidEnd(...result.errors);
+          logFunction({ action: LogAction.execute, step: LogStep.end });
+
+          const formattedExtensions = extensionStack.format();
+          if (Object.keys(formattedExtensions).length > 0) {
+            response.extensions = formattedExtensions;
+          }
+
+          if (options.formatResponse) {
+            response = options.formatResponse(response, options);
+          }
+
+          return response;
+        });
+    })
+    .catch(err => {
+      // Handle the case of an internal server failure (or nonQueryError) ---
+      // we're not returning a GraphQL response so we don't call
+      // willSendResponse.
+      requestDidEnd(err);
+      logFunction({ action: LogAction.request, step: LogStep.end });
+      throw err;
+    })
+    .then(graphqlResponse => {
+      extensionStack.willSendResponse({ graphqlResponse });
+      requestDidEnd();
       logFunction({
         action: LogAction.request,
         step: LogStep.end,
         key: 'response',
-        data: response,
+        data: graphqlResponse,
       });
-
-      return response;
+      return graphqlResponse;
     });
-  } catch (executionError) {
-    logFunction({ action: LogAction.execute, step: LogStep.end });
-    logFunction({ action: LogAction.request, step: LogStep.end });
-    return Promise.resolve({
-      //TODO accurate code for this error, which describes this error, which
-      // can occur when:
-      // * variables incorrectly typed/null when nonnullable
-      // * unknown operation/operation name invalid
-      // * operation type is unsupported
-      // Options: PREPROCESSING_FAILED, GRAPHQL_RUNTIME_CHECK_FAILED
-      errors: formatApolloErrors([fromGraphQLError(executionError)], {
-        formatter: options.formatError,
-        debug,
-      }),
-    });
-  }
 }

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -3,6 +3,7 @@ import { SchemaDirectiveVisitor, IResolvers, IMocks } from 'graphql-tools';
 import { ConnectionContext } from 'subscriptions-transport-ws';
 import { Server as HttpServer } from 'http';
 import { ListenOptions as HttpListenOptions } from 'net';
+import { GraphQLExtension } from 'graphql-extensions';
 
 import { GraphQLServerOptions as GraphQLOptions } from './graphqlOptions';
 
@@ -44,6 +45,7 @@ export interface Config<Server>
   context?: Context<any> | ContextFunction<any>;
   introspection?: boolean;
   mocks?: boolean | IMocks;
+  extensions?: Array<() => GraphQLExtension>;
 }
 
 // XXX export these directly from apollo-engine-js

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -4,6 +4,7 @@ import { ConnectionContext } from 'subscriptions-transport-ws';
 import { Server as HttpServer } from 'http';
 import { ListenOptions as HttpListenOptions } from 'net';
 import { GraphQLExtension } from 'graphql-extensions';
+import { EngineReportingOptions } from 'apollo-engine-reporting';
 
 import { GraphQLServerOptions as GraphQLOptions } from './graphqlOptions';
 
@@ -45,6 +46,7 @@ export interface Config<Server>
   context?: Context<any> | ContextFunction<any>;
   introspection?: boolean;
   mocks?: boolean | IMocks;
+  engine?: boolean | EngineReportingOptions;
   extensions?: Array<() => GraphQLExtension>;
 }
 

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/accepts": "^1.3.5",
     "accepts": "^1.3.5",
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4",
     "apollo-upload-server": "^5.0.0",
     "body-parser": "^1.18.3",

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -129,7 +129,7 @@ export const registerServer = async ({
         if (prefersHTML) {
           return gui({
             endpoint: path,
-            subscriptionsEndpoint: server.subscriptionsPath,
+            subscriptionEndpoint: server.subscriptionsPath,
           })(req, res, next);
         }
       }

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -133,7 +133,11 @@ export const registerServer = async ({
           })(req, res, next);
         }
       }
-      return graphqlExpress(server.request.bind(server))(req, res, next);
+      return graphqlExpress(server.graphQLServerOptionsForRequest.bind(server))(
+        req,
+        res,
+        next,
+      );
     },
   );
 };

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
     "accept": "^3.0.2",
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4",
     "apollo-upload-server": "^5.0.0",
     "boom": "^7.1.0",

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -119,7 +119,7 @@ server.listen({ http: { port: YOUR_PORT_HERE } });
           return h
             .response(
               renderPlaygroundPage({
-                subscriptionsEndpoint: server.subscriptionsPath,
+                subscriptionEndpoint: server.subscriptionsPath,
                 endpoint: path,
                 version: '1.4.0',
               }),

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -161,7 +161,7 @@ server.listen({ http: { port: YOUR_PORT_HERE } });
     plugin: graphqlHapi,
     options: {
       path: path,
-      graphqlOptions: server.request.bind(server),
+      graphqlOptions: server.graphQLServerOptionsForRequest.bind(server),
       route: {
         cors: typeof cors === 'boolean' ? cors : true,
       },

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.0",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4",
     "apollo-server-module-operation-store": "^1.3.5",
     "supertest": "^3.1.0"

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "devDependencies": {

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "devDependencies": {

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "devDependencies": {

--- a/packages/apollo-server-restify/package.json
+++ b/packages/apollo-server-restify/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
     "apollo-server-module-graphiql": "^1.3.4"
   },
   "devDependencies": {

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Production ready GraphQL Server",
   "author": "opensource@apollographql.com",
   "main": "dist/index.js",
@@ -36,8 +36,8 @@
   },
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "apollo-server-core": "2.0.0-beta.1",
-    "apollo-server-express": "2.0.0-beta.1",
+    "apollo-server-core": "2.0.0-beta.2",
+    "apollo-server-express": "2.0.0-beta.2",
     "express": "^4.16.3",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.1"


### PR DESCRIPTION
I started with #934 by @sebas5384 (which allows you to pass in your own extensions) and updated it for a new graphql-extensions API.

- Actually call validationDidStart and parsingDidStart.

- Use new graphql-extensions API which:
  - replaces fooDidEnd with a handler returned by fooDidStart
  - adds options to various methods
  - has a new willSendResponse method
  - requires you to construct the extension objects yourself

- Make a better effort at consistently calling end handlers even on error

