### PR TITLE
runQuery accepts Request object that variants create 

### DIFF
--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -35,7 +35,7 @@ export function graphqlAdonis(
       method,
       options,
       query,
-      request: convertHttpMessageToRequest(request),
+      request: convertHttpMessageToRequest(request.request),
     }).then(
       gqlResponse => {
         response.type('application/json');

--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -3,6 +3,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
+  convertHttpMessageToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -34,7 +35,7 @@ export function graphqlAdonis(
       method,
       options,
       query,
-      request,
+      request: convertHttpMessageToRequest(request),
     }).then(
       gqlResponse => {
         response.type('application/json');

--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -3,7 +3,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
-  convertHttpMessageToRequest,
+  convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -35,7 +35,7 @@ export function graphqlAdonis(
       method,
       options,
       query,
-      request: convertHttpMessageToRequest(request.request),
+      request: convertNodeHttpToRequest(request.request),
     }).then(
       gqlResponse => {
         response.type('application/json');

--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server-core`: accept `Request` object in `runQuery` [PR#1108](https://github.com/apollographql/apollo-server/pull/1108)
 * `apollo-server-core`: move query parse into runQuery and no longer accept GraphQL AST over the wire [PR#1097](https://github.com/apollographql/apollo-server/pull/1097)
 * `apollo-server-core`: custom errors allow instanceof checks [PR#1074](https://github.com/apollographql/apollo-server/pull/1074)
 * `apollo-server-core`: move subscriptions options into listen [PR#1059](https://github.com/apollographql/apollo-server/pull/1059)

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -28,6 +28,7 @@
     "@types/fibers": "0.0.30",
     "@types/graphql": "^0.13.1",
     "@types/node": "^10.1.2",
+    "@types/node-fetch": "^1.6.9",
     "@types/ws": "^4.0.2",
     "apollo-engine": "^1.1.1",
     "apollo-fetch": "^0.7.0",

--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 import * as http from 'http';
 import * as net from 'net';
+import * as MockReq from 'mock-req';
 import 'mocha';
 
 import {
@@ -78,7 +79,7 @@ function createHttpServer(server) {
           method: req.method,
           options: server.request(req as any),
           query: JSON.parse(body),
-          request: req,
+          request: new MockReq(),
         })
           .then(gqlResponse => {
             res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -15,6 +15,8 @@ export {
   formatApolloErrors,
 } from './errors';
 
+export { convertHttpMessageToRequest } from './nodeHttpToRequest';
+
 // ApolloServer Base class
 export { ApolloServerBase } from './ApolloServer';
 export * from './types';

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -15,7 +15,7 @@ export {
   formatApolloErrors,
 } from './errors';
 
-export { convertHttpMessageToRequest } from './nodeHttpToRequest';
+export { convertNodeHttpToRequest } from './nodeHttpToRequest';
 
 // ApolloServer Base class
 export { ApolloServerBase } from './ApolloServer';

--- a/packages/apollo-server-core/src/nodeHttpToRequest.ts
+++ b/packages/apollo-server-core/src/nodeHttpToRequest.ts
@@ -1,0 +1,18 @@
+import { IncomingMessage } from 'http';
+
+export function convertHttpMessageToRequest(req: IncomingMessage): Request {
+  const headers = new Headers();
+  Object.keys(req.headers).forEach(key => {
+    const values = req.headers[key];
+    if (Array.isArray(values)) {
+      values.forEach(value => headers.append(key, value));
+    } else {
+      headers.append(key, values);
+    }
+  });
+
+  return new Request(req.url, {
+    headers,
+    method: req.method,
+  });
+}

--- a/packages/apollo-server-core/src/nodeHttpToRequest.ts
+++ b/packages/apollo-server-core/src/nodeHttpToRequest.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage } from 'http';
 
-export function convertHttpMessageToRequest(req: IncomingMessage): Request {
+export function convertNodeHttpToRequest(req: IncomingMessage): Request {
   const headers = new Headers();
   Object.keys(req.headers).forEach(key => {
     const values = req.headers[key];

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -5,7 +5,6 @@ import {
   resolveGraphqlOptions,
 } from './graphqlOptions';
 import { formatApolloErrors } from './errors';
-import { IncomingMessage } from 'http';
 
 export interface HttpQueryRequest {
   method: string;
@@ -18,7 +17,7 @@ export interface HttpQueryRequest {
   options:
     | GraphQLOptions
     | ((...args: Array<any>) => Promise<GraphQLOptions> | GraphQLOptions);
-  request: IncomingMessage | Request;
+  request: Request;
 }
 
 export class HttpQueryError extends Error {
@@ -255,6 +254,7 @@ export async function runHttpQuery(
         debug: optionsObject.debug,
         tracing: optionsObject.tracing,
         cacheControl: optionsObject.cacheControl,
+        request: request.request,
       };
 
       if (optionsObject.formatParams) {

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import { stub } from 'sinon';
+import * as MockReq from 'mock-req';
 import 'mocha';
 
 import {
@@ -92,7 +93,11 @@ describe('runQuery', () => {
   it('returns the right result when query is a string', () => {
     const query = `{ testString }`;
     const expected = { testString: 'it works' };
-    return runQuery({ schema, queryString: query }).then(res => {
+    return runQuery({
+      schema,
+      queryString: query,
+      request: new MockReq(),
+    }).then(res => {
       expect(res.data).to.deep.equal(expected);
     });
   });
@@ -100,7 +105,11 @@ describe('runQuery', () => {
   it('returns the right result when query is a document', () => {
     const query = parse(`{ testString }`);
     const expected = { testString: 'it works' };
-    return runQuery({ schema, parsedQuery: query }).then(res => {
+    return runQuery({
+      schema,
+      parsedQuery: query,
+      request: new MockReq(),
+    }).then(res => {
       expect(res.data).to.deep.equal(expected);
     });
   });
@@ -112,6 +121,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       variables: { base: 1 },
+      request: new MockReq(),
     }).then(res => {
       expect(res.data).to.be.undefined;
       expect(res.errors.length).to.equal(1);
@@ -126,6 +136,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       debug: true,
+      request: new MockReq(),
     }).then(res => {
       logStub.restore();
       expect(logStub.callCount).to.equal(0);
@@ -139,6 +150,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       debug: false,
+      request: new MockReq(),
     }).then(res => {
       logStub.restore();
       expect(logStub.callCount).to.equal(0);
@@ -153,6 +165,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       variables: { base: 1 },
+      request: new MockReq(),
     }).then(res => {
       expect(res.data).to.be.undefined;
       expect(res.errors.length).to.equal(1);
@@ -163,21 +176,27 @@ describe('runQuery', () => {
   it('correctly passes in the rootValue', () => {
     const query = `{ testRootValue }`;
     const expected = { testRootValue: 'it also works' };
-    return runQuery({ schema, queryString: query, rootValue: 'it also' }).then(
-      res => {
-        expect(res.data).to.deep.equal(expected);
-      },
-    );
+    return runQuery({
+      schema,
+      queryString: query,
+      rootValue: 'it also',
+      request: new MockReq(),
+    }).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
   });
 
   it('correctly passes in the context', () => {
     const query = `{ testContextValue }`;
     const expected = { testContextValue: 'it still works' };
-    return runQuery({ schema, queryString: query, context: 'it still' }).then(
-      res => {
-        expect(res.data).to.deep.equal(expected);
-      },
-    );
+    return runQuery({
+      schema,
+      queryString: query,
+      context: 'it still',
+      request: new MockReq(),
+    }).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
   });
 
   it('passes the options to formatResponse', () => {
@@ -191,6 +210,7 @@ describe('runQuery', () => {
         response['extensions'] = context;
         return response;
       },
+      request: new MockReq(),
     }).then(res => {
       expect(res.data).to.deep.equal(expected);
       expect(res['extensions']).to.equal('it still');
@@ -204,6 +224,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       variables: { base: 1 },
+      request: new MockReq(),
     }).then(res => {
       expect(res.data).to.deep.equal(expected);
     });
@@ -216,6 +237,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: query,
+      request: new MockReq(),
     }).then(res => {
       expect(res.errors[0].message).to.deep.equal(expected);
     });
@@ -225,6 +247,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: `{ testAwaitedValue }`,
+      request: new MockReq(),
     }).then(res => {
       expect(res.data).to.deep.equal({
         testAwaitedValue: 'it works',
@@ -243,11 +266,14 @@ describe('runQuery', () => {
     const expected = {
       testString: 'it works',
     };
-    return runQuery({ schema, queryString: query, operationName: 'Q1' }).then(
-      res => {
-        expect(res.data).to.deep.equal(expected);
-      },
-    );
+    return runQuery({
+      schema,
+      queryString: query,
+      operationName: 'Q1',
+      request: new MockReq(),
+    }).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
   });
 
   it('calls logFunction', () => {
@@ -266,6 +292,7 @@ describe('runQuery', () => {
       operationName: 'Q1',
       variables: { test: 123 },
       logFunction: logFn,
+      request: new MockReq(),
     }).then(res => {
       expect(res.data).to.deep.equal(expected);
       expect(logs.length).to.equals(11);
@@ -315,6 +342,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       operationName: 'Q1',
+      request: new MockReq(),
     });
 
     expect(result1.data).to.deep.equal({
@@ -328,6 +356,7 @@ describe('runQuery', () => {
       queryString: query,
       operationName: 'Q1',
       fieldResolver: () => 'a very testful field resolver string',
+      request: new MockReq(),
     });
 
     expect(result2.data).to.deep.equal({
@@ -370,6 +399,7 @@ describe('runQuery', () => {
         schema,
         queryString: query,
         operationName: 'Q1',
+        request: new MockReq(),
       });
 
       // this is the only async process so we expect the async ids to be a sequence

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -63,6 +63,7 @@ export interface QueryOptions {
   tracing?: boolean;
   // cacheControl?: boolean | CacheControlExtensionOptions;
   cacheControl?: boolean | any;
+  request: Request;
 }
 
 function isQueryOperation(query: DocumentNode, operationName: string) {

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -6,7 +6,7 @@ import * as express from 'express';
 import * as request from 'request';
 import * as FormData from 'form-data';
 import * as fs from 'fs';
-import * as fetch from 'node-fetch';
+import fetch from 'node-fetch';
 import { createApolloFetch } from 'apollo-fetch';
 
 import { ApolloServerBase } from 'apollo-server-core';

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -4,6 +4,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
+  convertHttpMessageToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -45,7 +46,7 @@ export function graphqlExpress(
       method: req.method,
       options: options,
       query: req.method === 'POST' ? req.body : req.query,
-      request: req,
+      request: convertHttpMessageToRequest(req),
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -4,7 +4,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
-  convertHttpMessageToRequest,
+  convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -46,7 +46,7 @@ export function graphqlExpress(
       method: req.method,
       options: options,
       query: req.method === 'POST' ? req.body : req.query,
-      request: convertHttpMessageToRequest(req),
+      request: convertNodeHttpToRequest(req),
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -5,6 +5,7 @@ import {
   GraphQLOptions,
   runHttpQuery,
   HttpQueryError,
+  convertHttpMessageToRequest,
 } from 'apollo-server-core';
 import { IncomingMessage } from 'http';
 
@@ -51,7 +52,7 @@ const graphqlHapi: IPlugin = {
                 ? //TODO type payload as string or Record
                   (request.payload as any)
                 : request.query,
-            request: request.raw.req,
+            request: convertHttpMessageToRequest(request.raw.req),
           });
 
           const response = h.response(gqlResponse);

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -5,7 +5,7 @@ import {
   GraphQLOptions,
   runHttpQuery,
   HttpQueryError,
-  convertHttpMessageToRequest,
+  convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import { IncomingMessage } from 'http';
 
@@ -52,7 +52,7 @@ const graphqlHapi: IPlugin = {
                 ? //TODO type payload as string or Record
                   (request.payload as any)
                 : request.query,
-            request: convertHttpMessageToRequest(request.raw.req),
+            request: convertNodeHttpToRequest(request.raw.req),
           });
 
           const response = h.response(gqlResponse);

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -3,7 +3,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
-  convertHttpMessageToRequest,
+  convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -34,7 +34,7 @@ export function graphqlKoa(
       options: options,
       query:
         ctx.request.method === 'POST' ? ctx.request.body : ctx.request.query,
-      request: convertHttpMessageToRequest(ctx.req),
+      request: convertNodeHttpToRequest(ctx.req),
     }).then(
       gqlResponse => {
         ctx.set('Content-Type', 'application/json');

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -3,6 +3,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
+  convertHttpMessageToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -33,7 +34,7 @@ export function graphqlKoa(
       options: options,
       query:
         ctx.request.method === 'POST' ? ctx.request.body : ctx.request.query,
-      request: ctx.req,
+      request: convertHttpMessageToRequest(ctx.req),
     }).then(
       gqlResponse => {
         ctx.set('Content-Type', 'application/json');

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -2,6 +2,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
+  convertHttpMessageToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 import { createError, json, RequestHandler } from 'micro';
@@ -42,7 +43,7 @@ export function microGraphql(
         method: req.method,
         options: options,
         query: query,
-        request: req,
+        request: convertHttpMessageToRequest(req),
       });
 
       res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -2,7 +2,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
-  convertHttpMessageToRequest,
+  convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 import { createError, json, RequestHandler } from 'micro';
@@ -43,7 +43,7 @@ export function microGraphql(
         method: req.method,
         options: options,
         query: query,
-        request: convertHttpMessageToRequest(req),
+        request: convertNodeHttpToRequest(req),
       });
 
       res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-restify/src/restifyApollo.ts
+++ b/packages/apollo-server-restify/src/restifyApollo.ts
@@ -4,6 +4,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
+  convertHttpMessageToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -44,7 +45,7 @@ export function graphqlRestify(
       method: req.method,
       options: options,
       query: req.method === 'POST' ? req.body : req.query,
-      request: req,
+      request: convertHttpMessageToRequest(req),
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');

--- a/packages/apollo-server-restify/src/restifyApollo.ts
+++ b/packages/apollo-server-restify/src/restifyApollo.ts
@@ -4,7 +4,7 @@ import {
   GraphQLOptions,
   HttpQueryError,
   runHttpQuery,
-  convertHttpMessageToRequest,
+  convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import * as GraphiQL from 'apollo-server-module-graphiql';
 
@@ -45,7 +45,7 @@ export function graphqlRestify(
       method: req.method,
       options: options,
       query: req.method === 'POST' ? req.body : req.query,
-      request: convertHttpMessageToRequest(req),
+      request: convertNodeHttpToRequest(req),
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
**breaking change** to apollo-server-core that adds a request object into runQuery, so that the extensions have access to the headers, url, and http method.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->