### PR TITLE
AS2: Fix handling errors from context constructor and merged schemas

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -370,6 +370,8 @@ describe('ApolloServerBase', () => {
     });
 
     it('returns thrown context error as a valid graphql result', async () => {
+      const nodeEnv = process.env.NODE_ENV;
+      delete process.env.NODE_ENV;
       const typeDefs = gql`
         type Query {
           hello: String
@@ -407,6 +409,87 @@ describe('ApolloServerBase', () => {
       expect(e.extensions).to.exist;
       expect(e.extensions.code).to.equal('UNAUTHENTICATED');
       expect(e.extensions.exception.stacktrace).to.exist;
+
+      process.env.NODE_ENV = nodeEnv;
+      await server.stop();
+    });
+
+    it('propogates error codes in production', async () => {
+      const nodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      const server = new ApolloServerBase({
+        typeDefs: gql`
+          type Query {
+            error: String
+          }
+        `,
+        resolvers: {
+          Query: {
+            error: () => {
+              throw new AuthenticationError('we the best music');
+            },
+          },
+        },
+      });
+      const httpServer = createHttpServer(server);
+
+      server.use({
+        getHttp: () => httpServer,
+        path: '/graphql',
+      });
+      const { url: uri } = await server.listen();
+      const apolloFetch = createApolloFetch({ uri });
+
+      const result = await apolloFetch({ query: `{error}` });
+      expect(result.data).to.exist;
+      expect(result.data).to.deep.equal({ error: null });
+
+      expect(result.errors, 'errors should exist').to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].extensions.code).to.equal('UNAUTHENTICATED');
+      expect(result.errors[0].extensions.exception).not.to.exist;
+
+      process.env.NODE_ENV = nodeEnv;
+      await server.stop();
+    });
+
+    it('propogates error codes with null response in production', async () => {
+      const nodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      const server = new ApolloServerBase({
+        typeDefs: gql`
+          type Query {
+            error: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            error: () => {
+              throw new AuthenticationError('we the best music');
+            },
+          },
+        },
+      });
+      const httpServer = createHttpServer(server);
+
+      server.use({
+        getHttp: () => httpServer,
+        path: '/graphql',
+      });
+      const { url: uri } = await server.listen();
+      const apolloFetch = createApolloFetch({ uri });
+
+      const result = await apolloFetch({ query: `{error}` });
+      expect(result.data).null;
+
+      expect(result.errors, 'errors should exist').to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].extensions.code).to.equal('UNAUTHENTICATED');
+      expect(result.errors[0].extensions.exception).not.to.exist;
+
+      process.env.NODE_ENV = nodeEnv;
       await server.stop();
     });
   });
@@ -471,7 +554,7 @@ describe('ApolloServerBase', () => {
     });
   });
 
-  describe('subscriptions', () => {
+  describe('subscritptions', () => {
     const SOMETHING_CHANGED_TOPIC = 'something_changed';
     const pubsub = new PubSub();
     let server: ApolloServerBase;

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -330,11 +330,17 @@ export class ApolloServerBase<Request = RequestInit> {
   request(request: Request) {
     let context: Context = this.context ? this.context : { request };
 
-    //Defer context resolution to inside of runQuery
-    context =
-      typeof this.context === 'function'
-        ? () => this.context({ req: request })
-        : context;
+    try {
+      context =
+        typeof this.context === 'function'
+          ? this.context({ req: request })
+          : context;
+    } catch (error) {
+      //Defer context error resolution to inside of runQuery
+      context = () => {
+        throw error;
+      };
+    }
 
     return {
       schema: this.schema,

--- a/packages/apollo-server-core/src/errors.test.ts
+++ b/packages/apollo-server-core/src/errors.test.ts
@@ -3,13 +3,7 @@ import { expect } from 'chai';
 import { stub, spy } from 'sinon';
 import 'mocha';
 
-import {
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLString,
-  GraphQLInt,
-  GraphQLError,
-} from 'graphql';
+import { GraphQLError } from 'graphql';
 
 import {
   ApolloError,
@@ -19,22 +13,6 @@ import {
   ValidationError,
   SyntaxError,
 } from './errors';
-
-const queryType = new GraphQLObjectType({
-  name: 'QueryType',
-  fields: {
-    testString: {
-      type: GraphQLString,
-      resolve() {
-        return 'it works';
-      },
-    },
-  },
-});
-
-const schema = new GraphQLSchema({
-  query: queryType,
-});
 
 describe('Errors', () => {
   describe('ApolloError', () => {
@@ -172,7 +150,6 @@ describe('Errors', () => {
       });
     });
     it('provides a forbidden error', () => {
-      debugger;
       verifyError(new ForbiddenError(message), {
         code: 'FORBIDDEN',
         errorClass: ForbiddenError,

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -3,7 +3,7 @@ import { LogStep, LogAction, LogMessage, LogFunction } from './logging';
 
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
-  readonly name = 'ApolloError';
+  readonly name;
   readonly locations;
   readonly path;
   readonly source;
@@ -27,6 +27,11 @@ export class ApolloError extends Error implements GraphQLError {
       Object.keys(properties).forEach(key => {
         this[key] = properties[key];
       });
+    }
+
+    //if no name provided, use the default. defineProperty ensures that it stays non-enumerable
+    if (!this.name) {
+      Object.defineProperty(this, 'name', { value: 'ApolloError' });
     }
 
     //extensions are flattened to be included in the root of GraphQLError's, so

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -212,7 +212,30 @@ export function formatApolloErrors(
   }
   const { formatter, debug, logFunction } = options;
 
-  const enrichedErrors = errors.map(error => enrichError(error, debug));
+  const flattenedErrors = [];
+  errors.forEach(error => {
+    // Errors that occur in graphql-tools can contain an errors array that contains the errors thrown in a merged schema
+    // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L104-L107
+    //
+    // They are are wrapped in an extra GraphQL error
+    // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L109-L113
+    // which calls:
+    // https://github.com/graphql/graphql-js/blob/0a30b62964/src/error/locatedError.js#L18-L37
+    if (Array.isArray((error as any).errors)) {
+      (error as any).errors.forEach(e => flattenedErrors.push(e));
+    } else if (
+      (error as any).originalError &&
+      Array.isArray((error as any).originalError.errors)
+    ) {
+      (error as any).originalError.errors.forEach(e => flattenedErrors.push(e));
+    } else {
+      flattenedErrors.push(error);
+    }
+  });
+
+  const enrichedErrors = flattenedErrors.map(error =>
+    enrichError(error, debug),
+  );
 
   if (!formatter) {
     return enrichedErrors;

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -114,7 +114,7 @@ export const registerServer = async ({
     path,
     corsMiddleware(cors),
     json(bodyParserConfig),
-    uploadsMiddleware,
+    uploadsMiddleware ? uploadsMiddleware : (req, res, next) => next(),
     (req, res, next) => {
       // make sure we check to see if graphql gui should be on
       if (!server.disableTools && req.method === 'GET') {

--- a/packages/apollo-server-express/src/apolloServerHttp.test.ts
+++ b/packages/apollo-server-express/src/apolloServerHttp.test.ts
@@ -324,7 +324,6 @@ describe(`GraphQL-HTTP (apolloServer) tests for ${version} express`, () => {
           query: '{thrower}',
         });
 
-      // console.log(response.text);
       expect(response.status).to.equal(200);
       expect(JSON.parse(response.text)).to.deep.equal({
         data: null,


### PR DESCRIPTION
Defers throwing of an error during context creation until the thunk containing the result of `context` as a function is called in `runQuery`.

Additionally handles errors that are returned by merged schema, surfacing errors that are hidden by CombinedError in `graphql-tools`.

Fixes #1100 
Related to #1077 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->