### PR TITLE
readme: remove dist names about koa

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ StartServer();
 ### Koa
 
 ```js
-import koa from 'koa'; // koa@2
-import koaRouter from 'koa-router'; // koa-router@next
-import koaBody from 'koa-bodyparser'; // koa-bodyparser@next
+import koa from 'koa';
+import koaRouter from 'koa-router';
+import koaBody from 'koa-bodyparser';
 import { graphqlKoa, graphiqlKoa } from 'apollo-server-koa';
 
 const app = new koa();


### PR DESCRIPTION
Since koa@2 has been published for a long time, and almost all the middlewares migrated to koa@2.
It's no need to add extra dist names for koa and koa middlewares.

- [x] docs
