### PR TITLE
Factor out runQuery's use of logFunction into an extension

### DIFF
--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -49,7 +49,7 @@
     "apollo-cache-control": "^0.1.1",
     "apollo-engine-reporting": "0.0.0-beta.8",
     "apollo-tracing": "^0.2.0-beta.0",
-    "graphql-extensions": "0.1.0-beta.7",
+    "graphql-extensions": "0.1.0-beta.12",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.2",
     "node-fetch": "^2.1.2",

--- a/packages/apollo-server-core/src/errors.ts
+++ b/packages/apollo-server-core/src/errors.ts
@@ -245,12 +245,13 @@ export function formatApolloErrors(
     try {
       return formatter(error);
     } catch (err) {
-      logFunction({
-        action: LogAction.cleanup,
-        step: LogStep.status,
-        data: err,
-        key: 'error',
-      });
+      logFunction &&
+        logFunction({
+          action: LogAction.cleanup,
+          step: LogStep.status,
+          data: err,
+          key: 'error',
+        });
 
       if (debug) {
         return enrichError(err, debug);

--- a/packages/apollo-server-core/src/logging.ts
+++ b/packages/apollo-server-core/src/logging.ts
@@ -1,3 +1,6 @@
+import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
+import { print, DocumentNode } from 'graphql';
+
 export enum LogAction {
   request,
   parse,
@@ -22,4 +25,82 @@ export interface LogMessage {
 
 export interface LogFunction {
   (message: LogMessage);
+}
+
+// A GraphQLExtension that implements the existing logFunction interface. Note
+// that now that custom extensions are supported, you may just want to do your
+// logging as a GraphQLExtension rather than write a LogFunction.
+
+export class LogFunctionExtension<TContext = any>
+  implements GraphQLExtension<TContext> {
+  private logFunction: LogFunction;
+  public constructor(logFunction: LogFunction) {
+    this.logFunction = logFunction;
+  }
+
+  public requestDidStart(options: {
+    request: Request;
+    queryString?: string;
+    parsedQuery?: DocumentNode;
+    operationName?: string;
+    variables?: { [key: string]: any };
+  }) {
+    this.logFunction({ action: LogAction.request, step: LogStep.start });
+    const loggedQuery = options.queryString || print(options.parsedQuery);
+    this.logFunction({
+      action: LogAction.request,
+      step: LogStep.status,
+      key: 'query',
+      data: loggedQuery,
+    });
+    this.logFunction({
+      action: LogAction.request,
+      step: LogStep.status,
+      key: 'variables',
+      data: options.variables,
+    });
+    this.logFunction({
+      action: LogAction.request,
+      step: LogStep.status,
+      key: 'operationName',
+      data: options.operationName,
+    });
+
+    return (...errors: Array<Error>) => {
+      // If there are no errors, we log in willSendResponse instead.
+      if (errors.length) {
+        this.logFunction({ action: LogAction.request, step: LogStep.end });
+      }
+    };
+  }
+
+  public parsingDidStart() {
+    this.logFunction({ action: LogAction.parse, step: LogStep.start });
+    return () => {
+      this.logFunction({ action: LogAction.parse, step: LogStep.end });
+    };
+  }
+
+  public validationDidStart() {
+    this.logFunction({ action: LogAction.validation, step: LogStep.start });
+    return () => {
+      this.logFunction({ action: LogAction.validation, step: LogStep.end });
+    };
+  }
+
+  public executionDidStart() {
+    this.logFunction({ action: LogAction.execute, step: LogStep.start });
+    return () => {
+      this.logFunction({ action: LogAction.execute, step: LogStep.end });
+    };
+  }
+
+  public willSendResponse(o: { graphqlResponse: GraphQLResponse }) {
+    this.logFunction({
+      action: LogAction.request,
+      step: LogStep.end,
+      key: 'response',
+      data: o.graphqlResponse,
+    });
+  }
 }

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -56,7 +56,7 @@ const queryType = new GraphQLObjectType({
     testContextValue: {
       type: GraphQLString,
       resolve(_root, _args, context) {
-        return context + ' works';
+        return context.s + ' works';
       },
     },
     testArgumentValue: {
@@ -193,7 +193,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: query,
-      context: 'it still',
+      context: { s: 'it still' },
       request: new MockReq(),
     }).then(res => {
       expect(res.data).to.deep.equal(expected);
@@ -206,9 +206,9 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: query,
-      context: 'it still',
+      context: { s: 'it still' },
       formatResponse: (response, { context }) => {
-        response['extensions'] = context;
+        response['extensions'] = context.s;
         return response;
       },
       request: new MockReq(),


### PR DESCRIPTION
This requires a slightly newer graphql-extensions beta which has more arguments
to requestDidStart.

Also make it ok to not pass logFunction to formatApolloErrors.
