### PR TITLE
Enable Apollo Server 2 to have async context + test

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import { stub } from 'sinon';
 import * as http from 'http';
 import * as net from 'net';
-import * as MockReq from 'mock-req';
 import 'mocha';
 
 import {
@@ -25,6 +24,7 @@ Object.assign(global, {
 import { createApolloFetch } from 'apollo-fetch';
 import { ApolloServerBase } from './ApolloServer';
 import { AuthenticationError } from './errors';
+import { convertNodeHttpToRequest } from './nodeHttpToRequest';
 import { runHttpQuery } from './runHttpQuery';
 import gqlTag from 'graphql-tag';
 
@@ -78,7 +78,7 @@ function createHttpServer(server) {
           method: req.method,
           options: server.graphQLServerOptionsForRequest(req as any),
           query: JSON.parse(body),
-          request: new MockReq(),
+          request: convertNodeHttpToRequest(req),
         })
           .then(gqlResponse => {
             res.setHeader('Content-Type', 'application/json');
@@ -398,10 +398,8 @@ describe('ApolloServerBase', () => {
       const apolloFetch = createApolloFetch({ uri });
 
       expect(spy.notCalled).true;
-      const result = await apolloFetch({ query: '{hello}' });
+      await apolloFetch({ query: '{hello}' });
       expect(spy.calledOnce).true;
-      expect(result.data).to.deep.equal({ hello: 'hi' });
-      expect(result.errors).not.to.exist;
       await server.stop();
     });
 

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -354,13 +354,13 @@ export class ApolloServerBase<Request = RequestInit> {
     }
   }
 
-  graphQLServerOptionsForRequest(request: Request) {
+  async graphQLServerOptionsForRequest(request: Request) {
     let context: Context = this.context ? this.context : { request };
 
     try {
       context =
         typeof this.context === 'function'
-          ? this.context({ req: request })
+          ? await this.context({ req: request })
           : context;
     } catch (error) {
       //Defer context error resolution to inside of runQuery

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -28,6 +28,12 @@ const resolvers = {
 describe('apollo-server-express', () => {
   //to remove the circular dependency, we reference it directly
   const ApolloServer = require('../../apollo-server/dist/index').ApolloServer;
+  let server: ApolloServerBase<express.Request>;
+  let app: express.Application;
+
+  afterEach(async () => {
+    if (server) await server.stop();
+  });
 
   describe('', () => {
     it('accepts typeDefs and resolvers', () => {
@@ -44,12 +50,6 @@ describe('apollo-server-express', () => {
   });
 
   describe('registerServer', () => {
-    let server: ApolloServerBase<express.Request>;
-    let app: express.Application;
-    afterEach(async () => {
-      await server.stop();
-    });
-
     it('can be queried', async () => {
       server = new ApolloServer({
         typeDefs,
@@ -377,14 +377,13 @@ describe('apollo-server-express', () => {
         expect(e.extensions.exception.stacktrace).to.exist;
 
         process.env.NODE_ENV = nodeEnv;
-        await server.stop();
       });
 
       it('propogates error codes in dev mode', async () => {
         const nodeEnv = process.env.NODE_ENV;
         delete process.env.NODE_ENV;
 
-        const server = new ApolloServer({
+        server = new ApolloServer({
           typeDefs: gql`
             type Query {
               error: String
@@ -416,7 +415,6 @@ describe('apollo-server-express', () => {
         expect(result.errors[0].extensions.exception.stacktrace).to.exist;
 
         process.env.NODE_ENV = nodeEnv;
-        await server.stop();
       });
 
       it('propogates error codes in production', async () => {
@@ -454,14 +452,13 @@ describe('apollo-server-express', () => {
         expect(result.errors[0].extensions.exception).not.to.exist;
 
         process.env.NODE_ENV = nodeEnv;
-        await server.stop();
       });
 
       it('propogates error codes with null response in production', async () => {
         const nodeEnv = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';
 
-        const server = new ApolloServer({
+        server = new ApolloServer({
           typeDefs: gql`
             type Query {
               error: String!
@@ -491,7 +488,6 @@ describe('apollo-server-express', () => {
         expect(result.errors[0].extensions.exception).not.to.exist;
 
         process.env.NODE_ENV = nodeEnv;
-        await server.stop();
       });
     });
   });


### PR DESCRIPTION
Ensures that Apollo Server 2's context can be async

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->