### PR TITLE
Move the JSON.stringify from core to framework shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All of the packages in the `apollo-server` repo are released with the same versi
 ### vNEXT
 
 * Upgrade `subscription-transport-ws` to 0.9.9 for Graphiql
+* Move `JSON.stringify` into framework shims, rather than core [PR #1144](https://github.com/apollographql/apollo-server/pull/1144)
 
 ### v1.3.6
 

--- a/packages/apollo-server-adonis/src/adonisApollo.ts
+++ b/packages/apollo-server-adonis/src/adonisApollo.ts
@@ -37,7 +37,7 @@ export function graphqlAdonis(
     }).then(
       gqlResponse => {
         response.type('application/json');
-        response.json(gqlResponse);
+        response.json(JSON.stringify(gqlResponse));
       },
       (error: HttpQueryError) => {
         if ('HttpQueryError' !== error.name) {

--- a/packages/apollo-server-azure-functions/src/azureFunctionsApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionsApollo.ts
@@ -71,7 +71,7 @@ export function graphqlAzureFunctions(
           headers: {
             'Content-Type': 'application/json',
           },
-          body: gqlResponse,
+          body: JSON.stringify(gqlResponse),
           isRaw: true,
         };
         httpContext.res = result;

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -11,6 +11,9 @@ import {
   resolveGraphqlOptions,
 } from './graphqlOptions';
 
+export type Dict<T> = { [key: string]: T };
+export type QueryResult = Dict<any> | Dict<any>[];
+
 export interface HttpQueryRequest {
   method: string;
   query: Record<string, any>;
@@ -44,7 +47,7 @@ function isQueryOperation(query: DocumentNode, operationName: string) {
 export async function runHttpQuery(
   handlerArguments: Array<any>,
   request: HttpQueryRequest,
-): Promise<string> {
+): Promise<QueryResult> {
   let isGetRequest: boolean = false;
   let optionsObject: GraphQLOptions;
 
@@ -229,8 +232,8 @@ export async function runHttpQuery(
         'Content-Type': 'application/json',
       });
     }
-    return JSON.stringify(gqlResponse);
+    return gqlResponse;
   }
 
-  return JSON.stringify(responses);
+  return responses;
 }

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -47,12 +47,13 @@ export function graphqlExpress(
       query: req.method === 'POST' ? req.body : req.query,
     }).then(
       gqlResponse => {
+        let jsonResponse = JSON.stringify(gqlResponse);
         res.setHeader('Content-Type', 'application/json');
         res.setHeader(
           'Content-Length',
-          Buffer.byteLength(gqlResponse, 'utf8').toString(),
+          Buffer.byteLength(jsonResponse, 'utf8').toString(),
         );
-        res.write(gqlResponse);
+        res.write(jsonResponse);
         res.end();
       },
       (error: HttpQueryError) => {

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -48,7 +48,7 @@ const graphqlHapi: IPlugin = {
             query: request.method === 'post' ? request.payload : request.query,
           });
 
-          const response = h.response(gqlResponse);
+          const response = h.response(JSON.stringify(gqlResponse));
           response.type('application/json');
           return response;
         } catch (error) {

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -36,7 +36,7 @@ export function graphqlKoa(
     }).then(
       gqlResponse => {
         ctx.set('Content-Type', 'application/json');
-        ctx.body = gqlResponse;
+        ctx.body = JSON.stringify(gqlResponse);
       },
       (error: HttpQueryError) => {
         if ('HttpQueryError' !== error.name) {

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -50,11 +50,13 @@ export function graphqlLambda(
     }
 
     try {
-      gqlResponse = await runHttpQuery([event, lambdaContext], {
-        method: event.httpMethod,
-        options: options,
-        query: query,
-      });
+      gqlResponse = JSON.stringify(
+        await runHttpQuery([event, lambdaContext], {
+          method: event.httpMethod,
+          options: options,
+          query: query,
+        }),
+      );
       headers['Content-Type'] = 'application/json';
       statusCode = 200;
     } catch (error) {

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -45,7 +45,7 @@ export function microGraphql(
       });
 
       res.setHeader('Content-Type', 'application/json');
-      return gqlResponse;
+      return JSON.stringify(gqlResponse);
     } catch (error) {
       if ('HttpQueryError' === error.name) {
         if (error.headers) {

--- a/packages/apollo-server-restify/src/restifyApollo.ts
+++ b/packages/apollo-server-restify/src/restifyApollo.ts
@@ -47,7 +47,7 @@ export function graphqlRestify(
     }).then(
       gqlResponse => {
         res.setHeader('Content-Type', 'application/json');
-        res.write(gqlResponse);
+        res.write(JSON.stringify(gqlResponse));
         res.end();
         next();
       },


### PR DESCRIPTION
See #1139 for the background on the motivation here.

Basically, because the core library was `JSON.stringify`ing the query result before returning it to the framework shim, that means that any frameworks that support some kind of "after" middleware (i.e. Koa) are unable to inspect the result without re-parsing from the JSON string (obviously not good for perf reasons).

This PR moves the responsibility of `JSON.stringify`ing the result onto the framework shims. While this doesn't have any immediate impact on the API, if we can get this merged in, I'll follow up with another PR to at least the Koa shim to take advantage of this (i.e. allow the user to supply a `serializeResponse` method to override the default `ctx.body = JSON.stringify(result)` behavior). This would allow users to do things like save a copy of the query result onto `ctx` for later inspection. Or even leverage a streaming JSON stringifier, for example.

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass