### PR TITLE
Docs: Convert import to requires

### DIFF
--- a/docs/source/features/scalars-enums.md
+++ b/docs/source/features/scalars-enums.md
@@ -32,8 +32,8 @@ $ npm install --save graphql-type-json
 In code, require the type defined by in the npm package and use it :
 
 ```js
-import { ApolloServer, gql } from 'apollo-server';
-import GraphQLJSON from 'graphql-type-json';
+const { ApolloServer, gql } = require('apollo-server');
+const GraphQLJSON = require('graphql-type-json');
 
 const schemaString = gql`
 
@@ -67,8 +67,8 @@ Remark : `GraphQLJSON` is a [`GraphQLScalarType`](http://graphql.org/graphql-js/
 Defining a [GraphQLScalarType](http://graphql.org/graphql-js/type/#graphqlscalartype) instance provides more control over the custom scalar and can be added to Apollo server in the following way:
 
 ```js
-import { ApolloServer, gql } from 'apollo-server';
-import { GraphQLScalarType, Kind } from 'graphql';
+const { ApolloServer, gql } = require('apollo-server');
+const { GraphQLScalarType, Kind } = require('graphql');
 
 const myCustomScalarType = new GraphQLScalarType({
   name: 'MyCustomScalar',
@@ -138,8 +138,8 @@ type MyType {
 Next, the resolver:
 
 ```js
-import { GraphQLScalarType } from 'graphql';
-import { Kind } from 'graphql/language';
+const { GraphQLScalarType } = require('graphql');
+const { Kind } = require('graphql/language');
 
 const resolvers = {
   Date: new GraphQLScalarType({
@@ -183,9 +183,9 @@ type MyType {
 Next, the resolver:
 
 ```js
-import { ApolloServer, gql } from 'apollo-server';
-import { GraphQLScalarType } from 'graphql';
-import { Kind } from 'graphql/language';
+const { ApolloServer, gql } = require('apollo-server');
+const { GraphQLScalarType } = require('graphql');
+const { Kind } = require('graphql/language');
 
 function oddValue(value) {
   return value % 2 === 1 ? value : null;
@@ -261,7 +261,7 @@ query MyAvatar($color: AllowedColor) {
 Putting it all together:
 
 ```js
-import { ApolloServer, gql } from 'apollo-server';
+const { ApolloServer, gql } = require('apollo-server');
 
 const typeDefs = gql`
   enum AllowedColor {


### PR DESCRIPTION
The previous custom scalar section used to use import and should instead use requires, which is supported without a build step in node

@rgbkrk if you feel more documentation is necessary, please PR it in

Fixes #1145 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->