### PR TITLE
Integrations export their own ApolloServer

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -115,7 +115,7 @@ new ApolloServer({
 
 ## registerServer
 
-The `registerServer` method is from `apollo-server-express`. Middleware registration has been greatly simplified with this new method.
+The `registerServer` method providec by all integrations. Middleware registration has been greatly simplified with this new method.
 
 ### Parameters
 
@@ -133,9 +133,13 @@ The `registerServer` method is from `apollo-server-express`. Middleware registra
 
     Specify a custom path. It defaults to `/graphql` if no path is specified.
 
-  * `cors`: <`Object`>
+  * `cors`: <`Object`> (express, hapi)
 
-    Pass the cors options.
+    Pass the integration specific cors options.
+
+  * `bodyParser`: <`Object`> (express)
+
+    Pass the body parser options.
 
 ### Usage
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -115,7 +115,7 @@ new ApolloServer({
 
 ## registerServer
 
-The `registerServer` method providec by all integrations. Middleware registration has been greatly simplified with this new method.
+The `registerServer` method is provided by all the `apollo-server-{integration}` packages. This function connects ApolloServer to a specific framework. Use it instead of the `listen` method to customize the app's web behavior.
 
 ### Parameters
 
@@ -123,7 +123,7 @@ The `registerServer` method providec by all integrations. Middleware registratio
 
   * `app`: <`HttpServer`> _(required)_
 
-    Pass the handle to your nexpress server here.
+    Pass an instance of an integrationed server here.
 
   * `server`: <`ApolloServer`> _(required)_
 
@@ -133,17 +133,16 @@ The `registerServer` method providec by all integrations. Middleware registratio
 
     Specify a custom path. It defaults to `/graphql` if no path is specified.
 
-  * `cors`: <`Object`> (express, hapi)
+  * `cors`: <`Object`> ([express](https://github.com/expressjs/cors#cors), [hapi](https://hapijs.com/api#-routeoptionscors))
+    Pass the integration-specific cors options.
 
-    Pass the integration specific cors options.
+  * `bodyParser`: <`Object`> ([express](https://github.com/expressjs/body-parser#body-parser))
 
-  * `bodyParser`: <`Object`> (express)
-
-    Pass the body parser options.
+    Pass the body-parser options.
 
 ### Usage
 
-The `registerServer` method from `apollo-server-express` allows you to easily register your middleware as shown in the example below:
+The `registerServer` method from `apollo-server-express` registration of middleware as shown in the example below:
 
 ```js
 const { ApolloServer } = require('apollo-server');
@@ -170,7 +169,7 @@ In the case of GraphQL, the `gql` tag is used to surround GraphQL operation and 
 
 ### Usage
 
-Import the `gql` template literal tag into the current context from the `apollo-server` module:
+Import the `gql` template literal tag into the current context from the `apollo-server` or `apollo-server-{integration}` modules:
 
 ```js
 const { gql } = require('apollo-server');

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -123,7 +123,7 @@ The `registerServer` method is provided by all the `apollo-server-{integration}`
 
   * `app`: <`HttpServer`> _(required)_
 
-    Pass an instance of an integrationed server here.
+    Pass an instance of the server integration here.
 
   * `server`: <`ApolloServer`> _(required)_
 

--- a/docs/source/essentials/server.md
+++ b/docs/source/essentials/server.md
@@ -128,8 +128,7 @@ For existing applications, we'll pass it into the `registerServer` method as `ap
 > The existing application is frequently already named `app`, especially when using Express.  If the application is identified by a different variable, pass the existing variable in place of `app`.
 
 ```js
-const { ApolloServer, gql } = require('apollo-server');
-const { registerServer } = require('apollo-server-express');
+const { ApolloServer, gql, registerServer } = require('apollo-server-express');
 const { typeDefs, resolvers } = require('./schema');
 
 const server = new ApolloServer({

--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -103,8 +103,7 @@ Now, you can just do this instead:
 
 ```js
 const express = require('express');
-const { ApolloServer, gql } = require('apollo-server');
-const { registerServer } = require('apollo-server-express');
+const { ApolloServer, gql, registerServer } = require('apollo-server-express');
 
 const app = express();
 
@@ -131,7 +130,7 @@ server.listen().then(({ url }) => {
 
 <h2 id="Stand-alone">Stand-alone</h2>
 
-If you are simply focused on running a production-ready GraphQL server quickly, Apollo Server 2.0 ships with a built-in server and starting your own server (e.g. Express, Koa, etc.) is no longer necessary.
+For starting a production-ready GraphQL server quickly, Apollo Server 2.0 ships with a built-in server, so starting a server (e.g. Express, Koa, etc.) is no longer necessary.
 
 For these cases, it's possible to remove the existing `apollo-server-{integrations}` package and add the new `apollo-server` beta.  If using Express, this can be done by running:
 
@@ -166,14 +165,14 @@ server.listen().then(({ url }) => {
 });
 ```
 
+
 <h2 id="add-middleware">Adding Additional Middleware to Apollo Server 2</h2>
 
 For middleware that is collocated with the GraphQL endpoint, Apollo Server 2 allows middleware mounted on the same path before `registerServer` is called. For example, this server runs an authentication middleware before GraphQL execution.
 
 ```js
 const express = require('express');
-const { ApolloServer, gql } = require('apollo-server');
-const { registerServer } = require('apollo-server-express');
+const { ApolloServer, gql, registerServer } = require('apollo-server-express');
 
 const app = express();
 const path = '/graphql';

--- a/packages/apollo-server-cloudflare/src/ApolloServer.ts
+++ b/packages/apollo-server-cloudflare/src/ApolloServer.ts
@@ -5,8 +5,11 @@ export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
 import { GraphQLOptions } from 'apollo-server-core';
 
 export class ApolloServer extends ApolloServerBase {
-  async createGraphQLServerOptions(req: Request): Promise<GraphQLOptions> {
-    return super.graphQLServerOptions({ req });
+  //This translates the arguments from the middleware into graphQL options It
+  //provides typings for the integration specific behavior, ideally this would
+  //be propagated with a generic to the super class
+  async createGraphQLServerOptions(request: Request): Promise<GraphQLOptions> {
+    return super.graphQLServerOptions({ request });
   }
 
   public async listen() {

--- a/packages/apollo-server-cloudflare/src/ApolloServer.ts
+++ b/packages/apollo-server-cloudflare/src/ApolloServer.ts
@@ -1,10 +1,16 @@
 import { graphqlCloudflare } from './cloudflareApollo';
 
 import { ApolloServerBase } from 'apollo-server-core';
+export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
+import { GraphQLOptions } from 'apollo-server-core';
 
 export class ApolloServer extends ApolloServerBase {
+  async createGraphQLServerOptions(req: Request): Promise<GraphQLOptions> {
+    return super.graphQLServerOptions({ req });
+  }
+
   public async listen() {
-    const graphql = this.graphQLServerOptionsForRequest.bind(this);
+    const graphql = this.createGraphQLServerOptions.bind(this);
     addEventListener('fetch', (event: FetchEvent) => {
       event.respondWith(graphqlCloudflare(graphql)(event.request));
     });

--- a/packages/apollo-server-cloudflare/src/index.ts
+++ b/packages/apollo-server-cloudflare/src/index.ts
@@ -1,2 +1,3 @@
 export { graphqlCloudflare } from './cloudflareApollo';
 export { ApolloServer } from './ApolloServer';
+export { gql } from 'apollo-server-core';

--- a/packages/apollo-server-core/src/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/ApolloServer.test.ts
@@ -66,7 +66,7 @@ const schema = new GraphQLSchema({
   query: queryType,
 });
 
-function createHttpServer(server) {
+function createHttpServer(server: ApolloServerBase) {
   return http.createServer(async (req, res) => {
     let body: any = [];
     req
@@ -79,7 +79,7 @@ function createHttpServer(server) {
         // do whatever we need to in order to respond to this request.
         runHttpQuery([req, res], {
           method: req.method,
-          options: server.graphQLServerOptionsForRequest(req as any),
+          options: (server as any).graphQLServerOptions({ req, res }),
           query:
             req.method.toUpperCase() === 'GET'
               ? url.parse(req.url, true)

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -61,7 +61,7 @@ const NoIntrospection = (context: ValidationContext) => ({
   },
 });
 
-export class ApolloServerBase<Request = RequestInit> {
+export class ApolloServerBase {
   public disableTools: boolean;
   // set in the listen function if subscriptions are enabled
   public subscriptionsPath: string;
@@ -78,6 +78,7 @@ export class ApolloServerBase<Request = RequestInit> {
   private subscriptionServer?: SubscriptionServer;
   protected getHttp: () => HttpServer;
 
+  //The constructor should be universal across all environments. All environment specific behavior should be set in an exported registerServer or in by overriding listen
   constructor(config: Config) {
     const {
       context,
@@ -400,15 +401,15 @@ const typeDefs = gql\`${startSchema}\`
     }
   }
 
-  async graphQLServerOptionsForRequest(request: Request) {
-    let context: Context = this.context ? this.context : { request };
+  protected async graphQLServerOptions(
+    integrationContextArgument?: Record<string, any>,
+  ) {
+    let context: Context = this.context ? this.context : {};
 
     try {
       context =
         typeof this.context === 'function'
-          ? await this.context({
-              req: request,
-            })
+          ? await this.context(integrationContextArgument || {})
           : context;
     } catch (error) {
       //Defer context error resolution to inside of runQuery
@@ -432,6 +433,6 @@ const typeDefs = gql\`${startSchema}\`
         any
       >,
       ...this.requestOptions,
-    };
+    } as GraphQLOptions;
   }
 }

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -401,6 +401,9 @@ const typeDefs = gql\`${startSchema}\`
     }
   }
 
+  //This function is used by the integrations to generate the graphQLOptions
+  //from an object containing the request and other integration specific
+  //options
   protected async graphQLServerOptions(
     integrationContextArgument?: Record<string, any>,
   ) {

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -5,6 +5,7 @@ import { Server as HttpServer } from 'http';
 import { ListenOptions as HttpListenOptions } from 'net';
 import { GraphQLExtension } from 'graphql-extensions';
 import { EngineReportingOptions } from 'apollo-engine-reporting';
+export { GraphQLExtension } from 'graphql-extensions';
 
 import {
   GraphQLServerOptions as GraphQLOptions,

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -29,7 +29,12 @@ const resolvers = {
 describe('apollo-server-express', () => {
   //to remove the circular dependency, we reference it directly
   const ApolloServer = require('../../apollo-server/dist/index').ApolloServer;
-  let server: ApolloServerBase<express.Request>;
+  let server: ApolloServerBase & {
+    createGraphQLServerOptions: (
+      req: express.Request,
+      res: express.Response,
+    ) => any;
+  };
   let app: express.Application;
 
   afterEach(async () => {
@@ -153,8 +158,6 @@ describe('apollo-server-express', () => {
     });
 
     describe('healthchecks', () => {
-      let server: ApolloServerBase<express.Request>;
-
       afterEach(async () => {
         await server.stop();
       });

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -19,6 +19,9 @@ import { GraphQLOptions } from 'apollo-server-core';
 const gql = String.raw;
 
 export class ApolloServer extends ApolloServerBase {
+  //This translates the arguments from the middleware into graphQL options It
+  //provides typings for the integration specific behavior, ideally this would
+  //be propagated with a generic to the super class
   async createGraphQLServerOptions(
     req: express.Request,
     res: express.Response,

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -13,11 +13,23 @@ import {
   GraphQLUpload,
 } from 'apollo-upload-server';
 
+export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
+import { GraphQLOptions } from 'apollo-server-core';
+
 const gql = String.raw;
+
+export class ApolloServer extends ApolloServerBase {
+  async createGraphQLServerOptions(
+    req: express.Request,
+    res: express.Response,
+  ): Promise<GraphQLOptions> {
+    return super.graphQLServerOptions({ req, res });
+  }
+}
 
 export interface ServerRegistration {
   app: express.Application;
-  server: ApolloServerBase<express.Request>;
+  server: ApolloServer;
   path?: string;
   cors?: corsMiddleware.CorsOptions;
   bodyParserConfig?: OptionsJson;
@@ -29,7 +41,7 @@ export interface ServerRegistration {
 
 const fileUploadMiddleware = (
   uploadsConfig: Record<string, any>,
-  server: ApolloServerBase<express.Request>,
+  server: ApolloServerBase,
 ) => (
   req: express.Request,
   res: express.Response,
@@ -133,7 +145,7 @@ export const registerServer = async ({
           })(req, res, next);
         }
       }
-      return graphqlExpress(server.graphQLServerOptionsForRequest.bind(server))(
+      return graphqlExpress(server.createGraphQLServerOptions.bind(server))(
         req,
         res,
         next,

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -1,5 +1,5 @@
 // Expose types which can be used by both middleware flavors.
-export { GraphQLOptions } from 'apollo-server-core';
+export { GraphQLOptions, gql } from 'apollo-server-core';
 export {
   ApolloError,
   toApolloError,

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -22,4 +22,4 @@ export {
 export { graphqlConnect, graphiqlConnect } from './connectApollo';
 
 // ApolloServer integration
-export { registerServer } from './ApolloServer';
+export { registerServer, ServerRegistration } from './ApolloServer';

--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -83,13 +83,13 @@ StartServer().catch(error => console.log(error));
 
 ### Context
 
-The context is created for each request. The following code snippet shows the creation of a context. The arguments are the `req`, the request, and `h`, the response toolkit.
+The context is created for each request. The following code snippet shows the creation of a context. The arguments are the `request`, the request, and `h`, the response toolkit.
 
 ```js
 new ApolloServer({
   typeDefs,
   resolvers,
-  context: async ({ req, h }) => {
+  context: async ({ request, h }) => {
     return { ... };
   },
 })

--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -8,7 +8,7 @@ description: Setting up Apollo Server with Hapi
 This is the Hapi integration of Apollo Server. Apollo Server is a community-maintained open-source Apollo Server that works with all Node.js HTTP server frameworks: Express, Connect, Hapi, Koa and Restify. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
-npm install apollo-server@beta apollo-server-hapi@beta
+npm install apollo-server-hapi@beta
 ```
 
 ## Usage
@@ -18,8 +18,7 @@ After constructing Apollo server, a hapi server can be enabled with a call to `r
 The code below requires Hapi 17 or higher.
 
 ```js
-const { ApolloServer, gql } = require('apollo-server');
-const { registerServer } = require('apollo-server-hapi');
+const { registerServer, ApolloServer, gql } = require('apollo-server-hapi');
 
 const HOST = 'localhost';
 
@@ -57,8 +56,7 @@ StartServer().catch(error => console.log(error));
 For more advanced use cases or migrating from 1.x, a Hapi server can be constructed and passed into `registerServer`.
 
 ```js
-const { ApolloServer, gql } = require('apollo-server');
-const { registerServer } = require('apollo-server-hapi');
+const { ApolloServer, gql, registerServer } = require('apollo-server-hapi');
 const Hapi = require('hapi');
 
 async function StartServer() {
@@ -81,6 +79,20 @@ async function StartServer() {
 }
 
 StartServer().catch(error => console.log(error));
+```
+
+### Context
+
+The context is created for each request. The following code snippet shows the creation of a context. The arguments are the `req`, the request, and `h`, the response toolkit.
+
+```js
+new ApolloServer({
+  typeDefs,
+  resolvers,
+  context: async ({ req, h }) => {
+    return { ... };
+  },
+})
 ```
 
 ## Principles

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -9,13 +9,25 @@ import {
 
 import { graphqlHapi } from './hapiApollo';
 
+export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
+import { GraphQLOptions } from 'apollo-server-core';
+
 const gql = String.raw;
+
+export class ApolloServer extends ApolloServerBase {
+  async createGraphQLServerOptions(
+    req: hapi.Request,
+    h: hapi.ResponseToolkit,
+  ): Promise<GraphQLOptions> {
+    return super.graphQLServerOptions({ req, h });
+  }
+}
 
 export interface ServerRegistration {
   app?: hapi.Server;
   //The options type should exclude port
   options?: hapi.ServerOptions;
-  server: ApolloServerBase<hapi.Request>;
+  server: ApolloServer;
   path?: string;
   cors?: boolean;
   onHealthCheck?: (req: hapi.Request) => Promise<any>;
@@ -158,7 +170,7 @@ server.listen({ http: { port: YOUR_PORT_HERE } });
     plugin: graphqlHapi,
     options: {
       path: path,
-      graphqlOptions: server.graphQLServerOptionsForRequest.bind(server),
+      graphqlOptions: server.createGraphQLServerOptions.bind(server),
       route: {
         cors: typeof cors === 'boolean' ? cors : true,
       },

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -15,11 +15,14 @@ import { GraphQLOptions } from 'apollo-server-core';
 const gql = String.raw;
 
 export class ApolloServer extends ApolloServerBase {
+  //This translates the arguments from the middleware into graphQL options It
+  //provides typings for the integration specific behavior, ideally this would
+  //be propagated with a generic to the super class
   async createGraphQLServerOptions(
-    req: hapi.Request,
+    request: hapi.Request,
     h: hapi.ResponseToolkit,
   ): Promise<GraphQLOptions> {
-    return super.graphQLServerOptions({ req, h });
+    return super.graphQLServerOptions({ request, h });
   }
 }
 
@@ -30,7 +33,7 @@ export interface ServerRegistration {
   server: ApolloServer;
   path?: string;
   cors?: boolean;
-  onHealthCheck?: (req: hapi.Request) => Promise<any>;
+  onHealthCheck?: (request: hapi.Request) => Promise<any>;
   disableHealthCheck?: boolean;
   uploads?: boolean | Record<string, any>;
 }
@@ -45,11 +48,11 @@ export interface HapiListenOptions {
 }
 
 const handleFileUploads = (uploadsConfig: Record<string, any>) => async (
-  req: hapi.Request,
+  request: hapi.Request,
 ) => {
-  if (req.mime === 'multipart/form-data') {
-    Object.defineProperty(req, 'payload', {
-      value: await processFileUploads(req, uploadsConfig),
+  if (request.mime === 'multipart/form-data') {
+    Object.defineProperty(request, 'payload', {
+      value: await processFileUploads(request, uploadsConfig),
       writable: false,
     });
   }

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -18,7 +18,7 @@ export interface IPlugin {
 }
 
 export interface HapiOptionsFunction {
-  (req?: Request): GraphQLOptions | Promise<GraphQLOptions>;
+  (request?: Request): GraphQLOptions | Promise<GraphQLOptions>;
 }
 
 export interface HapiPluginOptions {
@@ -84,7 +84,7 @@ const graphqlHapi: IPlugin = {
 };
 
 export interface HapiGraphiQLOptionsFunction {
-  (req?: Request): GraphiQL.GraphiQLData | Promise<GraphiQL.GraphiQLData>;
+  (request?: Request): GraphiQL.GraphiQLData | Promise<GraphiQL.GraphiQLData>;
 }
 
 export interface HapiGraphiQLPluginOptions {

--- a/packages/apollo-server-hapi/src/index.ts
+++ b/packages/apollo-server-hapi/src/index.ts
@@ -1,5 +1,5 @@
 // Expose types which can be used by both middleware flavors.
-export { GraphQLOptions } from 'apollo-server-core';
+export { GraphQLOptions, gql } from 'apollo-server-core';
 export {
   ApolloError,
   toApolloError,

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -3,8 +3,11 @@
 // use with express). The dependency is unused otherwise, so don't worry if
 // you're not using express or your version doesn't quite match up.
 import express from 'express';
-import { Request } from 'express';
 import { registerServer } from 'apollo-server-express';
+export {
+  registerServer as registerExpressServer,
+  ServerRegistration,
+} from 'apollo-server-express';
 
 import {
   ApolloServerBase,
@@ -12,9 +15,19 @@ import {
   ServerInfo,
 } from 'apollo-server-core';
 
+export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
+import { GraphQLOptions } from 'apollo-server-core';
+
 export * from './exports';
 
-export class ApolloServer extends ApolloServerBase<Request> {
+export class ApolloServer extends ApolloServerBase {
+  async createGraphQLServerOptions(
+    req: express.Request,
+    res: express.Response,
+  ): Promise<GraphQLOptions> {
+    return super.graphQLServerOptions({ req, res });
+  }
+
   // here we overwrite the underlying listen to configure
   // the fallback / default server implementation
   async listen(opts: ListenOptions = {}): Promise<ServerInfo> {

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -17,6 +17,9 @@ import { GraphQLOptions } from 'apollo-server-core';
 export * from './exports';
 
 export class ApolloServer extends ApolloServerBase {
+  //This translates the arguments from the middleware into graphQL options It
+  //provides typings for the integration specific behavior, ideally this would
+  //be propagated with a generic to the super class
   async createGraphQLServerOptions(
     req: express.Request,
     res: express.Response,

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -4,10 +4,6 @@
 // you're not using express or your version doesn't quite match up.
 import express from 'express';
 import { registerServer } from 'apollo-server-express';
-export {
-  registerServer as registerExpressServer,
-  ServerRegistration,
-} from 'apollo-server-express';
 
 import {
   ApolloServerBase,

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -15,7 +15,7 @@ import {
   ServerInfo,
 } from 'apollo-server-core';
 
-export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
+export { GraphQLOptions, GraphQLExtension, gql } from 'apollo-server-core';
 import { GraphQLOptions } from 'apollo-server-core';
 
 export * from './exports';


### PR DESCRIPTION
This PR creates ApolloServer classes for the hapi, express, and cloudflare integrations. The constructor will continue to stay the same across all environments(ideally there would be a way to programmatically enforce this). The reasons to do this are the ApolloServer class in apollo-server brings the extra dependency on express, which does not work for serverless environments. The presumably more common path is going to be to use apollo-server-{variant}, so that should be equally as understandable/easy as the getting started experience. The arguments the context creation function will be set by the variant and be type safe, see #1110. The new typings should also solve #1140

The downside is that we won't be using the apollo-server package everywhere. I'm unconvinced this will be possible.

This PR stays backwards compatible with the dual import of apollo-server and apollo-server-express(below), however the documentation should be updated to reflect these changes.

The old way:

```js
const express = require('express');
const { registerServer } = require('apollo-server-express');
const { ApolloServer, gql } = require('apollo-server');

const server = new ApolloServer({ typeDefs, resolvers });

const app = express();
registerServer({ server, app });

server.listen().then(({ url }) => {
  console.log(`🚀 Server ready at ${url}`);
});
```

The new way of importing would be as follows:

**apollo-server**

```js
const { ApolloServer, gql } = require('apollo-server');
// There could be a possibility to import registerExpressServer, however I don't think we need it

const server = new ApolloServer({ typeDefs, resolvers });

server.listen().then(({ url }) => {
  console.log(`🚀 Server ready at ${url}`);
});
```

**apollo-server-express**

```js
const express = require('express');
const { ApolloServer, gql, registerServer } = require('apollo-server-express');

const server = new ApolloServer({ typeDefs, resolvers });

const app = express();
registerServer({ server, app });

server.listen().then(({ url }) => {
  console.log(`🚀 Server ready at ${url}`);
});
```

**apollo-server-hapi**

```js
const { registerServer, ApolloServer, gql } = require('apollo-server-hapi');

async function StartServer() {
  const server = new ApolloServer({ typeDefs, resolvers });

  await registerServer({
    server,
    //Hapi Server constructor options
    options: {
      host: 'localhost',
    },
  });

  server.listen().then(({ url }) => {
    console.log(`🚀  Server ready at ${url}`);
  });
}

StartServer().catch(error => console.log(error));
```


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->