### PR TITLE
Resupport Node 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ version: 2
 run_install_desired_npm: &run_install_desired_npm
   run:
     name: Install npm@6
-    command: sudo npm install -g npm@6
+    # we use yarn, since Node 6 does not support the latest npm by default, so
+    # use 5
+    command: sudo yarn global add npm@5
 
 # These are the steps used for each version of Node which we're testing
 # against.  Thanks to YAMLs inability to merge arrays (though it is able
@@ -29,6 +31,10 @@ jobs:
   # Platform tests, each with the same tests but different platform or version.
   # The docker tag represents the Node.js version and the full list is available
   # at https://hub.docker.com/r/circleci/node/.
+  Node.js 6:
+    docker: [ { image: 'circleci/node:6' } ]
+    <<: *common_test_steps
+
   Node.js 8:
     docker: [ { image: 'circleci/node:8' } ]
     <<: *common_test_steps
@@ -64,6 +70,8 @@ workflows:
   version: 2
   Build and Test:
     jobs:
+      - Node.js 6:
+          <<: *ignore_doc_branches
       - Node.js 8:
           <<: *ignore_doc_branches
       - Node.js 10:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "devDependencies": {
     "@types/chai": "4.1.3",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "devDependencies": {
     "@types/fibers": "0.0.30",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "dependencies": {
     "@types/accepts": "^1.3.5",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "dependencies": {
     "accept": "^3.0.2",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "dependencies": {
     "apollo-server-core": "^2.0.0-beta.9",

--- a/packages/apollo-server-module-operation-store/package.json
+++ b/packages/apollo-server-module-operation-store/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=8"
+    "node": ">=6"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.1 || ^0.11.0 || ^0.12.0 || ^0.13.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2016",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -10,6 +10,6 @@
     "removeComments": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "lib": ["es2017", "esnext.asynciterable", "webworker"],
+    "lib": ["es2016", "esnext.asynciterable", "webworker"]
   }
 }


### PR DESCRIPTION
This readds support for Node 6, since there are still environments that require Node 6, such as GCF. It is also LTS until April 2019

Fixes #1167 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->