### PR TITLE
[docs] server.applyMiddleware with app

### DIFF
--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -120,7 +120,7 @@ const resolvers = {
 };
 
 const server = new ApolloServer({ typeDefs, resolvers });
-server.applyMiddleware({ server });
+server.applyMiddleware({ app });
 
 app.listen({ port: 4000 }, () =>
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`)


### PR DESCRIPTION
`applyMiddleware` accepts `app` instead of `server`:

https://github.com/apollographql/apollo-server/blob/b6f88d59ef3293e0e23044fdee0a566a46cfa19f/packages/apollo-server-express/src/ApolloServer.ts#L84-L93