### PR TITLE
remove extra '/' from docs

### DIFF
--- a/docs/source/whats-new.md
+++ b/docs/source/whats-new.md
@@ -136,7 +136,7 @@ const server = new ApolloServer({
 
 server.listen().then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`);
-  console.log(`Try your health check at: ${url}/.well-known/apollo/server-health`);
+  console.log(`Try your health check at: ${url}.well-known/apollo/server-health`);
 });
 ```
 


### PR DESCRIPTION
the url is incorrect: example.com//.well-known/apollo/server-health

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->