### PR TITLE
Apollo server 2.0 - DatasourceREST - Improve types

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -1,6 +1,11 @@
 import { HTTPCache } from './HTTPCache';
 
-export type Params = { [name: string]: any };
+export type Params =
+  | URLSearchParams
+  | string
+  | { [key: string]: string | string[] | undefined }
+  | Iterable<[string, string]>
+  | Array<[string, string]>;
 
 export abstract class RESTDataSource<TContext = any> {
   abstract baseURL: string;
@@ -18,47 +23,59 @@ export abstract class RESTDataSource<TContext = any> {
     this.context = context;
   }
 
-  protected async get(
+  protected async get<TResponse>(
     path: string,
     params?: Params,
     options?: RequestInit,
-  ): Promise<any> {
-    return this.fetch(path, params, Object.assign({ method: 'GET' }, options));
+  ): Promise<TResponse> {
+    return this.fetch<TResponse>(
+      path,
+      params,
+      Object.assign({ method: 'GET' }, options),
+    );
   }
 
-  protected async post(
+  protected async post<TResponse>(
     path: string,
     params?: Params,
     options?: RequestInit,
-  ): Promise<any> {
-    return this.fetch(path, params, Object.assign({ method: 'POST' }, options));
+  ): Promise<TResponse> {
+    return this.fetch<TResponse>(
+      path,
+      params,
+      Object.assign({ method: 'POST' }, options),
+    );
   }
 
-  protected async put(
+  protected async put<TResponse>(
     path: string,
     params?: Params,
     options?: RequestInit,
-  ): Promise<any> {
-    return this.fetch(path, params, Object.assign({ method: 'PUT' }, options));
+  ): Promise<TResponse> {
+    return this.fetch<TResponse>(
+      path,
+      params,
+      Object.assign({ method: 'PUT' }, options),
+    );
   }
 
-  protected async delete(
+  protected async delete<TResponse>(
     path: string,
     params?: Params,
     options?: RequestInit,
-  ): Promise<any> {
-    return this.fetch(
+  ): Promise<TResponse> {
+    return this.fetch<TResponse>(
       path,
       params,
       Object.assign({ method: 'DELETE' }, options),
     );
   }
 
-  private async fetch(
+  private async fetch<TResponse>(
     path: string,
     params?: Params,
     init?: RequestInit,
-  ): Promise<any> {
+  ): Promise<TResponse> {
     const url = new URL(path, this.baseURL);
 
     if (params && Object.keys(params).length > 0) {

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -47,6 +47,18 @@ export abstract class RESTDataSource<TContext = any> {
     );
   }
 
+  protected async patch<TResponse>(
+    path: string,
+    params?: Params,
+    options?: RequestInit,
+  ): Promise<TResponse> {
+    return this.fetch<TResponse>(
+      path,
+      params,
+      Object.assign({ method: 'PATCH' }, options),
+    );
+  }
+
   protected async put<TResponse>(
     path: string,
     params?: Params,

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -101,7 +101,7 @@ describe('RESTDataSource', () => {
     );
   });
 
-  for (const method of ['GET', 'POST', 'PUT', 'DELETE']) {
+  for (const method of ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']) {
     const dataSource = new class extends RESTDataSource {
       baseURL = 'https://api.example.com';
 
@@ -111,6 +111,10 @@ describe('RESTDataSource', () => {
 
       postFoo() {
         return this.post('foo');
+      }
+
+      patchFoo() {
+        return this.patch('foo');
       }
 
       putFoo() {


### PR DESCRIPTION
Hello,

I'm just begining to play a little bit with Apollo server 2.0, datasourceRest and typescript.

This PR include some little improvements:

- Use generics instead of `any` to permit to type the response easily
- Use the full type from `URLSearchParams` to be more precise about the possibilities of the API
- Add `PATCH` method


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->