### PR TITLE
Error handling for data sources

### DIFF
--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -1,4 +1,9 @@
 import 'apollo-server-env';
+import {
+  ApolloError,
+  AuthenticationError,
+  ForbiddenError,
+} from 'apollo-server-core';
 import { RESTDataSource } from '../RESTDataSource';
 
 import fetch, { mockFetch, unmockFetch } from '../../../../__mocks__/fetch';
@@ -178,4 +183,52 @@ describe('RESTDataSource', () => {
       expect(fetch.mock.calls[0][0].method).toEqual(method);
     });
   }
+
+  it('throws an AuthenticationError when the response status is 401', async () => {
+    const dataSource = new class extends RESTDataSource {
+      baseURL = 'https://api.example.com';
+
+      getFoo() {
+        return this.get('foo');
+      }
+    }();
+
+    dataSource.httpCache = httpCache;
+
+    fetch.mockResponseOnce('Invalid token', undefined, 401);
+
+    await expect(dataSource.getFoo()).rejects.toThrow(AuthenticationError);
+  });
+
+  it('throws a ForbiddenError when the response status is 403', async () => {
+    const dataSource = new class extends RESTDataSource {
+      baseURL = 'https://api.example.com';
+
+      getFoo() {
+        return this.get('foo');
+      }
+    }();
+
+    dataSource.httpCache = httpCache;
+
+    fetch.mockResponseOnce('No access', undefined, 403);
+
+    await expect(dataSource.getFoo()).rejects.toThrow(ForbiddenError);
+  });
+
+  it('throws an ApolloError when the response status is 500', async () => {
+    const dataSource = new class extends RESTDataSource {
+      baseURL = 'https://api.example.com';
+
+      getFoo() {
+        return this.get('foo');
+      }
+    }();
+
+    dataSource.httpCache = httpCache;
+
+    fetch.mockResponseOnce('Oops', undefined, 500);
+
+    await expect(dataSource.getFoo()).rejects.toThrow(ApolloError);
+  });
 });

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -55,6 +55,7 @@
     "apollo-datasource-rest": "^2.0.0-rc.0",
     "apollo-engine-reporting": "0.0.0-beta.12",
     "apollo-server-env": "^2.0.0-rc.0",
+    "apollo-server-errors": "^2.0.0-rc.0",
     "apollo-tracing": "^0.2.0-beta.1",
     "graphql-extensions": "0.1.0-beta.13",
     "graphql-subscriptions": "^0.5.8",

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -27,7 +27,7 @@ import {
 import Keyv = require('keyv');
 import QuickLru = require('quick-lru');
 
-import { formatApolloErrors } from './errors';
+import { formatApolloErrors } from 'apollo-server-errors';
 import {
   GraphQLServerOptions as GraphQLOptions,
   PersistedQueryOptions,

--- a/packages/apollo-server-core/src/errors.test.ts
+++ b/packages/apollo-server-core/src/errors.test.ts
@@ -13,7 +13,7 @@ import {
   ValidationError,
   UserInputError,
   SyntaxError,
-} from './errors';
+} from 'apollo-server-errors';
 
 describe('Errors', () => {
   describe('ApolloError', () => {

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -16,7 +16,7 @@ export {
   ForbiddenError,
   UserInputError,
   formatApolloErrors,
-} from './errors';
+} from 'apollo-server-errors';
 
 export { convertNodeHttpToRequest } from './nodeHttpToRequest';
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -10,7 +10,7 @@ import {
   formatApolloErrors,
   PersistedQueryNotSupportedError,
   PersistedQueryNotFoundError,
-} from './errors';
+} from 'apollo-server-errors';
 import { LogAction, LogStep } from './logging';
 import { HTTPCache } from 'apollo-datasource-rest';
 

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -26,7 +26,7 @@ import {
   formatApolloErrors,
   ValidationError,
   SyntaxError,
-} from './errors';
+} from 'apollo-server-errors';
 
 import { LogFunction, LogFunctionExtension } from './logging';
 

--- a/packages/apollo-server-errors/.npmignore
+++ b/packages/apollo-server-errors/.npmignore
@@ -1,0 +1,6 @@
+*
+!src/**/*
+!dist/**/*
+dist/**/*.test.*
+!package.json
+!README.md

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "apollo-datasource-rest",
+  "name": "apollo-server-errors",
   "version": "2.0.0-rc.0",
   "author": "opensource@apollographql.com",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-datasource-rest"
+    "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-errors"
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "bugs": {
@@ -14,24 +14,19 @@
   "scripts": {
     "clean": "rm -rf lib",
     "compile": "tsc",
-    "prepublish": "npm run clean && npm run compile",
-    "test": "jest --verbose"
+    "prepublish": "npm run clean && npm run compile"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
     "node": ">=6"
   },
-  "dependencies": {
-    "apollo-server-caching": "^2.0.0-rc.0",
-    "apollo-server-env": "^2.0.0-rc.0",
-    "apollo-server-errors": "^2.0.0-rc.0",
-    "http-cache-semantics": "^4.0.0",
-    "lru-cache": "^4.1.3"
+  "dependencies": {},
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "devDependencies": {
     "@types/jest": "^23.0.0",
-    "@types/lru-cache": "^4.1.1",
     "jest": "^23.1.0",
     "ts-jest": "^22.4.6"
   },

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -1,5 +1,5 @@
 import { GraphQLError } from 'graphql';
-import { LogStep, LogAction, LogFunction } from './logging';
+// import { LogStep, LogAction, LogFunction } from './logging';
 
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
@@ -216,16 +216,16 @@ export function formatApolloErrors(
   errors: Array<Error>,
   options?: {
     formatter?: Function;
-    logFunction?: LogFunction;
+    logFunction?: any; // LogFunction;
     debug?: boolean;
   },
 ): Array<ApolloError> {
   if (!options) {
     return errors.map(error => enrichError(error));
   }
-  const { formatter, debug, logFunction } = options;
+  const { formatter, debug } = options;
 
-  const flattenedErrors = [];
+  const flattenedErrors: Error[] = [];
   errors.forEach(error => {
     // Errors that occur in graphql-tools can contain an errors array that contains the errors thrown in a merged schema
     // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L104-L107
@@ -258,13 +258,13 @@ export function formatApolloErrors(
     try {
       return formatter(error);
     } catch (err) {
-      logFunction &&
-        logFunction({
-          action: LogAction.cleanup,
-          step: LogStep.status,
-          data: err,
-          key: 'error',
-        });
+      // logFunction &&
+      //   logFunction({
+      //     action: LogAction.cleanup,
+      //     step: LogStep.status,
+      //     data: err,
+      //     key: 'error',
+      //   });
 
       if (debug) {
         return enrichError(err, debug);

--- a/packages/apollo-server-errors/tsconfig.json
+++ b/packages/apollo-server-errors/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "removeComments": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/__tests__/*", "**/__mocks__/*"]
+}


### PR DESCRIPTION
This PR introduces better error handling for data sources in Apollo Server 2.0.

Fetch methods will call the `didReceiveErrorResponse` lifecycle method on the datasource for non-success responses, which can either throw an error or return a response itself. That opens the door for custom fallbacks and retries.

```typescript
protected async didReceiveErrorResponse<TResult = any>(
    response: Response,
  ): Promise<TResult>
```

The default implementation in `RESTDataSource` throws specific errors based on the status code.
- An `AuthenticationError` for a 401
- A `ForbiddenError` for a 403
- An `ApolloError` as a fallback

We may want to introduce a more specific error type for backend errors, like a `SERVICE_UNAVAILABLE`.

In order to get this working, I had to extract errors from core into their own `apollo-server-errors` package. Because `apollo-server-core` depends on `apollo-datasource-rest`, importing errors from core lead to circular dependency issues.

One unexpected difficulty is that `formatApolloErrors` takes a `logFunction`, and that leads to another circular dependency (between core and errors). I've commented this our for now because I'm not sure it's actually used (I think log functions should probably be deprecated or removed). But if we want a solution where this keeps working maybe we could put `formatApolloErrors` back into core.