### PR TITLE
Typescript Improvements and esModuleInterop fix

### DIFF
--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -25,10 +25,11 @@ const typeDefs = gql`
 `;
 
 //Some projects use schemas imported from external files
-const typeDefs = gql`${IMPORT_FUNCTION('./schema-file')}`;
+const fs = require('fs');
+const typeDefs = gql`${fs.readFileSync(__dirname.concat('/schema.graphql'), 'utf8')}`;
 
 //gql can also be used as regular function to convert a string to an AST
-const typeDefs = gql(IMPORT_FUNCTION('./schema-file'))
+const typeDefs = gql(fs.readFileSync(__dirname.concat('/schema.graphql'), 'utf8'))
 ```
 
 <h2 id="app-deps">Changes to app dependencies</h2>

--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -1,4 +1,4 @@
-import CachePolicy from 'http-cache-semantics';
+import CachePolicy = require('http-cache-semantics');
 
 import { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
 

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -1,4 +1,4 @@
-import LRU from 'lru-cache';
+import * as LRU from 'lru-cache';
 import { KeyValueCache } from './KeyValueCache';
 
 export class InMemoryLRUCache implements KeyValueCache {

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -32,6 +32,6 @@ export * from 'graphql-subscriptions';
 import { DocumentNode } from 'graphql';
 import gqlTag from 'graphql-tag';
 export const gql: (
-  template: TemplateStringsArray,
+  template: TemplateStringsArray | string,
   ...substitutions: any[]
 ) => DocumentNode = gqlTag;

--- a/packages/apollo-server-core/src/runHttpQuery.test.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.test.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import 'mocha';
-import MockReq from 'mock-req';
+import * as MockReq from 'mock-req';
 
 import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -1,5 +1,5 @@
 import { ExecutionResult } from 'graphql';
-import sha256 from 'hash.js/lib/hash/sha/256';
+import * as sha256 from 'hash.js/lib/hash/sha/256';
 
 import { runQuery, QueryOptions } from './runQuery';
 import {

--- a/packages/apollo-server-core/src/runQuery.test.ts
+++ b/packages/apollo-server-core/src/runQuery.test.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import MockReq from 'mock-req';
+import * as MockReq from 'mock-req';
 import 'mocha';
 
 import {

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -1,7 +1,7 @@
 import { GraphQLSchema, DocumentNode } from 'graphql';
 import { SchemaDirectiveVisitor, IResolvers, IMocks } from 'graphql-tools';
 import { ConnectionContext } from 'subscriptions-transport-ws';
-import WebSocket from 'ws';
+import * as WebSocket from 'ws';
 import { GraphQLExtension } from 'graphql-extensions';
 import { EngineReportingOptions } from 'apollo-engine-reporting';
 export { GraphQLExtension } from 'graphql-extensions';

--- a/packages/apollo-server-express/src/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/ApolloServer.test.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import 'mocha';
-import express from 'express';
+import * as express from 'express';
 
-import net from 'net';
-import http from 'http';
+import * as net from 'net';
+import * as http from 'http';
 
-import request from 'request';
-import FormData from 'form-data';
-import fs from 'fs';
+import * as request from 'request';
+import * as FormData from 'form-data';
+import * as fs from 'fs';
 import fetch from 'node-fetch';
 import { createApolloFetch } from 'apollo-fetch';
 

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -1,10 +1,10 @@
-import express from 'express';
-import corsMiddleware from 'cors';
+import * as express from 'express';
+import * as corsMiddleware from 'cors';
 import { json, OptionsJson } from 'body-parser';
 import playgroundMiddleware from 'graphql-playground-middleware-express';
 import { MiddlewareOptions as PlaygroundMiddlewareOptions } from 'graphql-playground-html';
 import { ApolloServerBase, formatApolloErrors } from 'apollo-server-core';
-import accepts from 'accepts';
+import * as accepts from 'accepts';
 import typeis from 'type-is';
 
 import { graphqlExpress } from './expressApollo';

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -5,7 +5,7 @@ import playgroundMiddleware from 'graphql-playground-middleware-express';
 import { MiddlewareOptions as PlaygroundMiddlewareOptions } from 'graphql-playground-html';
 import { ApolloServerBase, formatApolloErrors } from 'apollo-server-core';
 import * as accepts from 'accepts';
-import typeis from 'type-is';
+import * as typeis from 'type-is';
 
 import { graphqlExpress } from './expressApollo';
 

--- a/packages/apollo-server-express/src/apolloServerHttp.test.ts
+++ b/packages/apollo-server-express/src/apolloServerHttp.test.ts
@@ -22,9 +22,9 @@ import { graphqlExpress } from './expressApollo';
  */
 
 import { expect } from 'chai';
-import zlib from 'zlib';
-import multer from 'multer';
-import bodyParser from 'body-parser';
+import * as zlib from 'zlib';
+import * as multer from 'multer';
+import * as bodyParser from 'body-parser';
 const request = require('supertest');
 const express4 = require('express'); // modern
 import {

--- a/packages/apollo-server-express/src/connectApollo.test.ts
+++ b/packages/apollo-server-express/src/connectApollo.test.ts
@@ -1,5 +1,5 @@
-import connect from 'connect';
-import query from 'qs-middleware';
+import * as connect from 'connect';
+import * as query from 'qs-middleware';
 import { ApolloServer } from './ApolloServer';
 import { Config } from 'apollo-server-core';
 import 'mocha';

--- a/packages/apollo-server-express/src/datasource.test.ts
+++ b/packages/apollo-server-express/src/datasource.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import 'mocha';
-import express from 'express';
+import * as express from 'express';
 
-import http from 'http';
+import * as http from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 

--- a/packages/apollo-server-express/src/expressApollo.test.ts
+++ b/packages/apollo-server-express/src/expressApollo.test.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import * as express from 'express';
 import { ApolloServer } from './ApolloServer';
 import testSuite, {
   schema as Schema,

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import * as express from 'express';
 import {
   GraphQLOptions,
   HttpQueryError,

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import hapi from 'hapi';
+import * as hapi from 'hapi';
 import { ApolloServerBase } from 'apollo-server-core';
 import { parseAll } from 'accept';
 import {

--- a/packages/apollo-server-hapi/src/hapiApollo.test.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.test.ts
@@ -1,4 +1,4 @@
-import hapi from 'hapi';
+import * as hapi from 'hapi';
 import { ApolloServer } from './ApolloServer';
 import { Config } from 'apollo-server-core';
 import 'mocha';

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,4 +1,4 @@
-import Boom from 'boom';
+import * as Boom from 'boom';
 import { Server, Request } from 'hapi';
 import {
   GraphQLOptions,

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1,8 +1,8 @@
 /* tslint:disable:no-unused-expression */
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import http from 'http';
-import net from 'net';
+import * as http from 'http';
+import * as net from 'net';
 import 'mocha';
 import { sha256 } from 'js-sha256';
 
@@ -17,7 +17,7 @@ import {
 
 import { PubSub } from 'graphql-subscriptions';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
-import WebSocket from 'ws';
+import * as WebSocket from 'ws';
 
 import { execute } from 'apollo-link';
 import { createHttpLink } from 'apollo-link-http';

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -17,8 +17,7 @@ import {
   BREAK,
 } from 'graphql';
 
-// tslint:disable-next-line
-const request = require('supertest');
+import request = require('supertest');
 
 import { GraphQLOptions, Config } from 'apollo-server-core';
 import gql from 'graphql-tag';

--- a/packages/apollo-server-memcached/src/index.ts
+++ b/packages/apollo-server-memcached/src/index.ts
@@ -1,5 +1,5 @@
 import { KeyValueCache } from 'apollo-server-caching';
-import Memcached from 'memcached';
+import * as Memcached from 'memcached';
 import { promisify } from 'util';
 
 export class MemcachedCache implements KeyValueCache {

--- a/packages/apollo-server-redis/src/index.ts
+++ b/packages/apollo-server-redis/src/index.ts
@@ -1,5 +1,5 @@
 import { KeyValueCache } from 'apollo-server-caching';
-import Redis from 'redis';
+import * as Redis from 'redis';
 import { promisify } from 'util';
 
 export class RedisCache implements KeyValueCache {

--- a/packages/apollo-server/src/index.test.ts
+++ b/packages/apollo-server/src/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import request from 'request';
+import * as request from 'request';
 import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, ApolloServer } from './index';

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -2,9 +2,9 @@
 // an express app for you instead of registerServer (which you might not even
 // use with express). The dependency is unused otherwise, so don't worry if
 // you're not using express or your version doesn't quite match up.
-import express from 'express';
-import http from 'http';
-import net from 'net';
+import * as express from 'express';
+import * as http from 'http';
+import * as net from 'net';
 import { ApolloServer as ApolloServerBase } from 'apollo-server-express';
 
 export { GraphQLOptions, GraphQLExtension, gql } from 'apollo-server-core';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2016",
     "module": "commonjs",
     "moduleResolution": "node",
-    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
This removes exModuleInterop, which was breaking some builds with TS #1182 

Additionally adds in support for strings passed directly to gql and adds the documentation requested by #1194. For example: 

```js
const typeDefinitions = readFileSync(join(__dirname, "../../schema.graphql"), "utf8");

export default gql`
  ${typeDefinitions}
`;

//vs 

const typeDefinitions = gql(readFileSync(join(__dirname, "../../schema.graphql"), "utf8"));


// app file
const apolloServer = new ApolloServer({ typeDefs, resolvers });
```


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->