### PR TITLE
Ensures formatError gets a value that passes instanceof Error

### DIFF
--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -38,6 +38,7 @@ export class ApolloError extends Error implements GraphQLError {
 
 function enrichError(error: Partial<GraphQLError>, debug: boolean = false) {
   const expanded = {} as any;
+  Object.setPrototypeOf(expanded, Object.getPrototypeOf(error));
   // follows similar structure to https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js#L145-L193
   // with the addition of name
   Object.defineProperties(expanded, {

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -37,11 +37,9 @@ export class ApolloError extends Error implements GraphQLError {
 }
 
 function enrichError(error: Partial<GraphQLError>, debug: boolean = false) {
-  const expanded = {} as any;
-  Object.setPrototypeOf(expanded, Object.getPrototypeOf(error));
   // follows similar structure to https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js#L145-L193
   // with the addition of name
-  Object.defineProperties(expanded, {
+  const expanded = Object.create(Object.getPrototypeOf(error), {
     name: {
       value: error.name,
     },

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -133,10 +133,16 @@ export function testApolloServer<AS extends ApolloServerBase>(
             },
           });
 
+          const formatError = stub().callsFake(error => {
+            expect(error instanceof Error).true;
+            return error;
+          });
+
           const { url: uri } = await createApolloServer({
             schema,
             validationRules: [NoTestString],
             introspection: false,
+            formatError,
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -151,6 +157,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const result = await apolloFetch({ query: TEST_STRING_QUERY });
           expect(result.data, 'data should not exist').not.to.exist;
           expect(result.errors, 'errors should exist').to.exist;
+          expect(formatError.called).true;
         });
 
         it('allows introspection by default', async () => {
@@ -286,6 +293,40 @@ export function testApolloServer<AS extends ApolloServerBase>(
           expect(result.data).to.deep.equal({ hello: 'mock city' });
           expect(result.errors, 'errors should exist').not.to.exist;
         });
+      });
+    });
+
+    describe('formatError', () => {
+      it('wraps thrown error from validation rules', async () => {
+        const throwError = stub().callsFake(() => {
+          throw new Error('nope');
+        });
+
+        const formatError = stub().callsFake(error => {
+          expect(error instanceof Error).true;
+          return error;
+        });
+
+        const { url: uri } = await createApolloServer({
+          schema,
+          validationRules: [throwError],
+          introspection: true,
+          formatError,
+        });
+
+        const apolloFetch = createApolloFetch({ uri });
+
+        const introspectionResult = await apolloFetch({
+          query: INTROSPECTION_QUERY,
+        });
+        expect(introspectionResult.data, 'data should not exist').not.to.exist;
+        expect(introspectionResult.errors, 'errors should exist').to.exist;
+
+        const result = await apolloFetch({ query: TEST_STRING_QUERY });
+        expect(result.data, 'data should not exist').not.to.exist;
+        expect(result.errors, 'errors should exist').to.exist;
+        expect(formatError.called).true;
+        expect(throwError.called).true;
       });
     });
 

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -304,6 +304,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
         const formatError = stub().callsFake(error => {
           expect(error instanceof Error).true;
+          expect(error.constructor.name).to.equal('Error');
           return error;
         });
 

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -815,7 +815,33 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
         app = await createApp({
           graphqlOptions: {
             schema,
-            formatError: () => ({ message: expected }),
+            formatError: error => {
+              expect(error instanceof Error).true;
+              return { message: expected };
+            },
+          },
+        });
+        const req = request(app)
+          .post('/graphql')
+          .send({
+            query: 'query test{ testError }',
+          });
+        return req.then(res => {
+          expect(res.status).to.equal(200);
+          expect(res.body.errors[0].message).to.equal(expected);
+        });
+      });
+
+      it('formatError receives error that passes instanceof checks', async () => {
+        const expected = '--blank--';
+        app = await createApp({
+          graphqlOptions: {
+            schema,
+            formatError: error => {
+              expect(error instanceof Error).true;
+              expect(error instanceof GraphQLError).true;
+              return { message: expected };
+            },
           },
         });
         const req = request(app)


### PR DESCRIPTION
Fixes an issue brought up by @wKovacs64


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->