### PR TITLE
docs: fix typo in whats new documentation

### DIFF
--- a/docs/source/whats-new.md
+++ b/docs/source/whats-new.md
@@ -116,7 +116,7 @@ server.listen().then(({ url }) => {
 
 ## Health Checks
 
-The default Apollo server provides a health check endpoint at `/.well-known/apollo/server-health` hat returns a 200 status code by default. If `onHealthCheck` is defined, the promise returned from the callback determines the status code. A successful resolution causes a 200 and rejection causes a 503. Health checks are often used by load balancers to determine if a server is available.
+The default Apollo server provides a health check endpoint at `/.well-known/apollo/server-health` that returns a 200 status code by default. If `onHealthCheck` is defined, the promise returned from the callback determines the status code. A successful resolution causes a 200 and rejection causes a 503. Health checks are often used by load balancers to determine if a server is available.
 
 ```js
 const { ApolloServer, gql } = require('apollo-server');


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Hello! This just fixes a small typo in the whats new documentation (_hat_ => _that_).

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->