### PR TITLE
[docs] fixed datasource examples

### DIFF
--- a/docs/source/features/data-sources.md
+++ b/docs/source/features/data-sources.md
@@ -23,7 +23,7 @@ const { RESTDataSource } = require('apollo-datasource-rest');
 class MoviesAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = 'https://movies-api.example.com';
+    this.baseURL = 'https://movies-api.example.com/';
   }
 
   async getMovie(id) {
@@ -46,7 +46,7 @@ Data sources allow you to intercept fetches to set headers or make other changes
 class PersonalizationAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = 'https://personalization-api.example.com';
+    this.baseURL = 'https://personalization-api.example.com/';
   }
 
   willSendRequest(request) {
@@ -118,7 +118,7 @@ Our recommendation is to restrict batching to requests that can't be cached. In 
 class PersonalizationAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = 'https://personalization-api.example.com';
+    this.baseURL = 'https://personalization-api.example.com/';
   }
 
   willSendRequest(request) {

--- a/docs/source/features/data-sources.md
+++ b/docs/source/features/data-sources.md
@@ -21,7 +21,10 @@ To define a data source, extend the `RESTDataSource` class and implement the dat
 const { RESTDataSource } = require('apollo-datasource-rest');
 
 class MoviesAPI extends RESTDataSource {
-  baseURL = 'https://movies-api.example.com';
+  constructor() {
+    super();
+    this.baseURL = 'https://movies-api.example.com';
+  }
 
   async getMovie(id) {
     return this.get(`movies/${id}`);
@@ -41,7 +44,10 @@ Data sources allow you to intercept fetches to set headers or make other changes
 
 ```js
 class PersonalizationAPI extends RESTDataSource {
-  baseURL = 'https://personalization-api.example.com';
+  constructor() {
+    super();
+    this.baseURL = 'https://personalization-api.example.com';
+  }
 
   willSendRequest(request) {
     request.headers.set('Authorization', this.context.token);
@@ -110,7 +116,10 @@ Our recommendation is to restrict batching to requests that can't be cached. In 
 
 ```js
 class PersonalizationAPI extends RESTDataSource {
-  baseURL = 'https://personalization-api.example.com';
+  constructor() {
+    super();
+    this.baseURL = 'https://personalization-api.example.com';
+  }
 
   willSendRequest(request) {
     request.headers.set('Authorization', this.context.token);


### PR DESCRIPTION
I updated the DataSource docs to use a constructor in the class to set the `baseURL` instead of using `baseURL = '...'`, since that's a proposed syntax, and only usable in TS or with build tooling.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

