### PR TITLE
Apollo Server 2.0: AWS Lambda, graphql dependency in docs

### DIFF
--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -9,7 +9,7 @@ AWS Lambda is a service that lets you run code without provisioning or managing 
 Learn how to integrate Apollo Server 2 with AWS Lambda. First, install the `apollo-server-lambda` package:
 
 ```sh
-npm install apollo-server-lambda@rc
+npm install apollo-server-lambda@rc graphql
 ```
 
 ## Deploying with AWS Serverless Application Model (SAM)

--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -8,7 +8,7 @@ description: Setting up Apollo Server with AWS Lambda
 This is the AWS Lambda integration of GraphQL Server. Apollo Server is a community-maintained open-source GraphQL server that works with many Node.js HTTP server frameworks. [Read the docs](https://www.apollographql.com/docs/apollo-server/v2). [Read the CHANGELOG](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md).
 
 ```sh
-npm install apollo-server-lambda@rc
+npm install apollo-server-lambda@rc graphql
 ```
 
 ## Deploying with AWS Serverless Application Model (SAM)


### PR DESCRIPTION
Added `graphql` dependency in AWS Lambda docs.