### PR TITLE
Apollo Server 2.0: AWS Lambda, handle OPTIONS method and default cors options

### DIFF
--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -90,22 +90,22 @@ export class ApolloServer extends ApolloServerBase {
       context: lambda.Context,
       callback: lambda.APIGatewayProxyCallback,
     ) => {
-      if (event.httpMethod === 'OPTIONS') {
-        if (typeof cors === 'object' && cors.origin) {
-          if (typeof cors.origin === 'string') {
-            corsHeaders['Access-Control-Allow-Origin'] = cors.origin;
-          } else if (
-            typeof cors.origin === 'boolean' ||
-            (Array.isArray(cors.origin) &&
-              cors.origin.includes(
-                event.headers['Origin'] || event.headers['origin'],
-              ))
-          ) {
-            corsHeaders['Access-Control-Allow-Origin'] =
-              event.headers['Origin'] || event.headers['origin'];
-          }
+      if (typeof cors === 'object' && cors.origin) {
+        if (typeof cors.origin === 'string') {
+          corsHeaders['Access-Control-Allow-Origin'] = cors.origin;
+        } else if (
+          typeof cors.origin === 'boolean' ||
+          (Array.isArray(cors.origin) &&
+            cors.origin.includes(
+              event.headers['Origin'] || event.headers['origin'],
+            ))
+        ) {
+          corsHeaders['Access-Control-Allow-Origin'] =
+            event.headers['Origin'] || event.headers['origin'];
         }
+      }
 
+      if (event.httpMethod === 'OPTIONS') {
         return callback(null, {
           body: '',
           statusCode: 200,
@@ -132,6 +132,7 @@ export class ApolloServer extends ApolloServerBase {
             body: playgroundPageHtml,
             statusCode: 200,
             headers: {
+              ...corsHeaders,
               'Content-Type': 'text/html',
               'Content-Length': playgroundPageHtml.length,
             },
@@ -145,7 +146,10 @@ export class ApolloServer extends ApolloServerBase {
       ) => {
         callback(error, {
           ...result,
-          headers: result.headers,
+          headers: {
+            ...corsHeaders,
+            ...result.headers,
+          },
         });
       };
 

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -52,7 +52,10 @@ export function graphqlLambda(
         callback(null, {
           body: graphqlResponse,
           statusCode: 200,
-          headers: responseInit.headers,
+          headers: {
+            ...responseInit.headers,
+            'Content-Length': graphqlResponse.length,
+          },
         });
       },
       (error: HttpQueryError) => {


### PR DESCRIPTION
Reply to OPTIONS request with cors and an empty body.

Added default cors options:
```
Access-Control-Allow-Methods: GET,POST
Access-Control-Allow-Headers: *
Access-Control-Allow-Origin: *
```

To use the default cors options simply set `cors` as `true`:
```typescript
export const handler = server.createHandler({
  cors: true
})
```