### PR TITLE
Added other HTTP methods to DataSource Docs

### DIFF
--- a/docs/source/features/data-sources.md
+++ b/docs/source/features/data-sources.md
@@ -40,6 +40,8 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
+### Supported Methods
+
 The `get` method on the `RESTDataSource` makes an HTTP `GET` request. Similarly, there are methods built-in to allow for `POST`, `PUT`, `PATCH`, and `DELETE` requests.
 
 ```js
@@ -84,7 +86,9 @@ class MoviesAPI extends RESTDataSource {
 
 All of the HTTP helper functions (`get`, `put`, `post`, `patch`, and `delete`) accept a third `options` parameter, which can be used to set things like headers and referrers. For more info on the options available, see MDN's [fetch docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
 
-Data sources also allow you to intercept fetches to set headers or make other changes to the outgoing request. This is most often used for authorization. Data sources also get access to the GraphQL execution context, which is a great place to store a user token or other information you need to have available.
+### Example API
+
+Data sources allow you to intercept fetches to set headers or make other changes to the outgoing request. This is most often used for authorization. Data sources also get access to the GraphQL execution context, which is a great place to store a user token or other information you need to have available.
 
 ```js
 class PersonalizationAPI extends RESTDataSource {

--- a/docs/source/features/data-sources.md
+++ b/docs/source/features/data-sources.md
@@ -40,7 +40,51 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
-Data sources allow you to intercept fetches to set headers or make other changes to the outgoing request. This is most often used for authorization. Data sources also get access to the GraphQL execution context, which is a great place to store a user token or other information you need to have available.
+The `get` method on the `RESTDataSource` makes an HTTP `GET` request. Similarly, there are methods built-in to allow for `POST`, `PUT`, `PATCH`, and `DELETE` requests.
+
+```js
+class MoviesAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = 'https://movies-api.example.com/';
+  }
+
+  // an example making an HTTP POST request
+  async postMovie(movie) {
+    return this.post(
+      `movies`, // path
+      movie, // request body
+    );
+  }
+
+  // an example making an HTTP PUT request
+  async newMovie(movie) {
+    return this.put(
+      `movies`, // path
+      movie, // request body
+    );
+  }
+
+  // an example making an HTTP PATCH request
+  async updateMovie(movie) {
+    return this.patch(
+      `movies`, // path
+      { id: movie.id, movie }, // request body
+    );
+  }
+
+  // an example making an HTTP DELETE request
+  async deleteMovie(movie) {
+    return this.delete(
+      `movies/${movie.id}`, // path
+    );
+  }
+}
+```
+
+All of the HTTP helper functions (`get`, `put`, `post`, `patch`, and `delete`) accept a third `options` parameter, which can be used to set things like headers and referrers. For more info on the options available, see MDN's [fetch docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
+
+Data sources also allow you to intercept fetches to set headers or make other changes to the outgoing request. This is most often used for authorization. Data sources also get access to the GraphQL execution context, which is a great place to store a user token or other information you need to have available.
 
 ```js
 class PersonalizationAPI extends RESTDataSource {


### PR DESCRIPTION
Per request in #1242, I added a very simple example of all of the different methods to handle different forms of HTTP requests in the DataSource docs.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->