### PR TITLE
Improve Subscriptions Dev/Docs Experience

### DIFF
--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -18,7 +18,7 @@ const pubsub = new PubSub();
 
 To enable subscription we add them to our schema:
 
-```js lines=2-4
+```js line=2-4
 const typeDefs = gql`
 type Subscription {
   postAdded: Post
@@ -38,10 +38,10 @@ type Post {
 
 Our resolver map:
 
-```js lines=3-7
+```js line=4-8
 const POST_ADDED = 'POST_ADDED';
 
-const postResolver = {
+const resolvers = {
   Subscription: {
     postAdded: {
       subscribe: () => pubsub.asyncIterator([POST_ADDED]),
@@ -59,8 +59,6 @@ const postResolver = {
     },
   },
 };
-
-export default postResolver;
 ```
 
 ## Context with Subscriptions
@@ -87,9 +85,100 @@ const server = new ApolloServer({
 As you can see Apollo Server 2.0 allows realtime data without invasive changes to existing code.
 For a full working example please have a look to [this repo](https://github.com/daniele-zurico/apollo2-subscriptions-how-to) provided by [Daniele Zurico](https://github.com/daniele-zurico/apollo2-subscriptions-how-to)
 
+<h2 id="subscriptions-filters">Subscription Filters</h2>
+
+Sometimes a client will want filter out specific events based on context and arguments.
+
+To do so, we can use `withFilter` helper from this package, which wraps `AsyncIterator` with a filter function, and let you control each publication for each user.
+
+Let's see an example - for the `commentAdded` server-side subscription, the client want to subscribe only to comments added to a specific repo:
+
+```
+subscription($repoName: String!){
+  commentAdded(repoFullName: $repoName) {
+    id
+    content
+  }
+}
+```
+
+When using `withFilter`, provide a filter function, which executed with the payload (the published value), variables, context and operation info, and it must return boolean or Promise<boolean> indicating if the payload should pass to the subscriber.
+
+Here is the following definition of the subscription resolver, with `withFilter` that will filter out all of the `commentAdded` events that are not the requested repository:
+
+```js
+const { withFilter } = require('apollo-server');
+
+const rootResolver = {
+    Query: () => { ... },
+    Mutation: () => { ... },
+    Subscription: {
+        commentAdded: {
+          subscribe: withFilter(() => pubsub.asyncIterator('commentAdded'), (payload, variables) => {
+             return payload.commentAdded.repository_name === variables.repoFullName;
+          }),
+        }
+    },
+};
+```
+
+## Authentication Over WebSocket
+
+The subscription lifecycle hooks to create an authenticated transport by using `onConnect` to validate the connection.
+
+`SubscriptionsClient` supports `connectionParams` ([example available here](../react/advanced/subscriptions.html#authentication)) that will be sent with the first WebSocket message. All GraphQL subscriptions are delayed until the connection has been fully authenticated and your `onConnect` callback returns a truthy value.
+
+`connectionParams` in the `onConnect` callback provide the ability to validate user credentials.
+The GraphQL context can  also be extended with the authenticated user data.
+
+```js
+const { ApolloServer } = require('apollo-server');
+const { resolvers, typeDefs } = require('./schema');
+
+const validateToken = authToken => {
+  // ... validate token and return a Promise, rejects in case of an error
+};
+
+const findUser = authToken => {
+  return tokenValidationResult => {
+    // ... finds user by auth token and return a Promise, rejects in case of an error
+  };
+};
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  subscriptions: {
+    onConnect: (connectionParams, webSocket) => {
+      if (connectionParams.authToken) {
+        return validateToken(connectionParams.authToken)
+          .then(findUser(connectionParams.authToken))
+          .then(user => {
+            return {
+              currentUser: user,
+            };
+          });
+      }
+
+      throw new Error('Missing auth token!');
+    },
+  },
+});
+
+server.listen().then(({ url, subscriptionsUrl }) => {
+  console.log(`🚀 Server ready at ${url}`);
+  console.log(`🚀 Subscriptions ready at ${subscriptionsUrl}`);
+});
+```
+
+The example above validates the user's token that is sent with the first initialization message on the transport, then it looks up the user and returns the user object as a Promise. The user object found will be available as `context.currentUser` in your GraphQL resolvers.
+
+In case of an authentication error, the Promise will be rejected, and the client's connection will be rejected as well.
+
 <h2 id="middleware">Subscriptions with Additional Middleware</h2>
 
-With an existing HTTP server (created with `createServer`), we can easily add subscriptions.
+With an existing HTTP server (created with `createServer`), we can add subscriptions using the `installSubscriptionHandlers`. Additionally, the subscription-capable integrations export `PubSub` and other subscription functionality.
+
 For example: with an Express server already running on port 4000 that accepts GraphQL HTTP connections (POST) we can expose the subscriptions:
 
 ```js line=12
@@ -106,5 +195,30 @@ server.applyMiddleware({app})
 const httpServer = http.createServer(app);
 server.installSubscriptionHandlers(httpServer);
 
-httpServer.listen(PORT, () => console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`))
+httpServer.listen(PORT, () => {
+  console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`)
+  console.log(`🚀 Subscriptions ready at ws://localhost:${PORT}${server.subscriptionsPath}`)
+})
+```
+
+## Lifecycle Events
+
+`ApolloServer` exposes lifecycle hooks you can use to manage subscriptions and clients:
+
+* `onConnect` - called upon client connection, with the `connectionParams` passed to `SubscriptionsClient` - you can return a Promise and reject the connection by throwing an exception. The resolved return value will be appended to the GraphQL `context` of your subscriptions.
+* `onDisconnect` - called when the client disconnects.
+* `onOperation` - called when the client executes a GraphQL operation - use this method to create custom params that will be used when resolving the operation.
+* `onOperationComplete` - called when client's operation has been done it's execution (for subscriptions called when unsubscribe, and for query/mutation called immediately).
+
+```js
+const server = new ApolloServer(
+  subscriptions: {
+    onConnect: (connectionParams, webSocket, context) => {
+      // ...
+    },
+    onDisconnect: (webSocket, context) => {
+      // ...
+    },
+  },
+);
 ```

--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -207,8 +207,6 @@ httpServer.listen(PORT, () => {
 
 * `onConnect` - called upon client connection, with the `connectionParams` passed to `SubscriptionsClient` - you can return a Promise and reject the connection by throwing an exception. The resolved return value will be appended to the GraphQL `context` of your subscriptions.
 * `onDisconnect` - called when the client disconnects.
-* `onOperation` - called when the client executes a GraphQL operation - use this method to create custom params that will be used when resolving the operation.
-* `onOperationComplete` - called when client's operation has been done it's execution (for subscriptions called when unsubscribe, and for query/mutation called immediately).
 
 ```js
 const server = new ApolloServer(

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -84,7 +84,7 @@ export class ApolloServer extends ApolloServerBase {
             const middlewareOptions = {
               endpoint: path,
               subscriptionEndpoint: this.subscriptionsPath,
-              version: '1.4.0',
+              version: '1.7.0',
               ...(typeof gui === 'boolean' ? {} : gui),
             };
 

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -15,6 +15,7 @@ export interface ServerInfo {
   address: string;
   family: string;
   url: string;
+  subscriptionsUrl: string;
   port: number | string;
   subscriptionsPath: string;
   server: http.Server;
@@ -48,6 +49,14 @@ export class ApolloServer extends ApolloServerBase {
       hostname: hostForUrl,
       port: serverInfo.port,
       pathname: this.graphqlPath,
+    });
+
+    serverInfo.subscriptionsUrl = require('url').format({
+      protocol: 'ws',
+      hostname: hostForUrl,
+      port: serverInfo.port,
+      slashes: true,
+      pathname: subscriptionsPath,
     });
 
     return serverInfo;


### PR DESCRIPTION
Documents subscriptions, bumps hapi graphql playground version and improves subscriptions info for apollo-server.

Fixes #1248

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->