### PR TITLE
Engine Reporting API and pass Engine API key in constructor

### DIFF
--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -9,7 +9,25 @@ Understanding the behavior of GraphQL execution inside of Apollo Server is criti
 
 Apollo Engine provides an integrated hub for all GraphQL performance data that is free for one million queries per month. With an API key from the [Engine UI](https://engine.apollographql.com/), Apollo Server reports performance and error data out-of-band. Apollo Engine then aggregates and displays information for [queries](https://www.apollographql.com/docs/engine/query-tracking.html), [requests](https://www.apollographql.com/docs/engine/performance.html), the [schema](https://www.apollographql.com/docs/engine/schema-analytics.html), and [errors](https://www.apollographql.com/docs/engine/error-tracking.html). In addition to aggregating data, Apollo Server provides [proactive alerts](https://www.apollographql.com/docs/engine/alerts.html), [daily slack reports](https://www.apollographql.com/docs/engine/reports.html), and [Datadog integration](https://www.apollographql.com/docs/engine/datadog.html).
 
-To set up Apollo Server with Engine, [click here](https://engine.apollographql.com/) to get an Engine API key and provide it to the `ENGINE_API_KEY` environment variable. Setting an environment variable can be done in commandline as seen below or with the [dotenv npm package](https://www.npmjs.com/package/dotenv).
+To set up Apollo Server with Engine, [click here](https://engine.apollographql.com/) to get an Engine API key. This API key can be passed directly to the Apollo Server constructor.
+
+```js line=6-8
+const { ApolloServer } = require("apollo-server");
+
+const server = new ApolloSever({
+  typeDefs,
+  resolvers,
+  engine: {
+    apiKey: "YOUR API KEY HERE"
+  }
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀  Server ready at ${url}`);
+});
+```
+
+The API key can also be set with the `ENGINE_API_KEY` environment variable. Setting an environment variable can be done in commandline as seen below or with the [dotenv npm package](https://www.npmjs.com/package/dotenv).
 
 ```bash
 #Replace YOUR_API_KEY with the api key for you service in the Engine UI
@@ -66,5 +84,5 @@ server.listen().then(({ url }) => {
 });
 ```
 
-For example the `logFunction` from Apollo Server 1 can be implemented as an [extension](https://github.com/apollographql/apollo-server/blob/8914b135df9840051fe81cc9224b444cfc5b61ab/packages/apollo-server-core/src/logging.ts) and could be modified to add additional state or functionality. The example uses a beta of `graphql-extensions, which can be added to a project with `npm install graphql-extensions@beta`.
+For example the `logFunction` from Apollo Server 1 can be implemented as an [extension](https://github.com/apollographql/apollo-server/blob/8914b135df9840051fe81cc9224b444cfc5b61ab/packages/apollo-server-core/src/logging.ts) and could be modified to add additional state or functionality. The example uses a beta of `graphql-extensions`, which can be added to a project with `npm install graphql-extensions@beta`.
 

--- a/docs/source/whats-new.md
+++ b/docs/source/whats-new.md
@@ -149,11 +149,11 @@ To set up Apollo Server with Engine, [click here](https://engine.apollographql.c
 ```bash
 #Replace YOUR_API_KEY with the api key for you service in the Engine UI
 ENGINE_API_KEY=YOUR_API_KEY node start-server.js
-``` 
+```
 
 The simplest option is to pass the Engine API Key directly to the Apollo Server constructor.
 
-```js lines=6-8
+```js line=6-8
 const { ApolloServer } = require("apollo-server");
 
 const server = new ApolloSever({


### PR DESCRIPTION
Syncs the documentation with apollographql/engine-docs#196 and add the engine reporting api

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->