### PR TITLE
Fix dependencies and exports

### DIFF
--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -1,11 +1,14 @@
 import 'apollo-server-env';
+
 export { runQuery } from './runQuery';
 export { runHttpQuery, HttpQueryRequest, HttpQueryError } from './runHttpQuery';
+
 export {
   default as GraphQLOptions,
   resolveGraphqlOptions,
   PersistedQueryOptions,
 } from './graphqlOptions';
+
 export {
   ApolloError,
   toApolloError,

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -26,9 +26,6 @@ export { convertNodeHttpToRequest } from './nodeHttpToRequest';
 export { ApolloServerBase } from './ApolloServer';
 export * from './types';
 
-export * from 'graphql-tools';
-export * from 'graphql-subscriptions';
-
 // This currently provides the ability to have syntax highlighting as well as
 // consistency between client and server gql tags
 import { DocumentNode } from 'graphql';

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -21,13 +21,13 @@
   "engines": {
     "node": ">=6"
   },
-  "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
-  },
   "devDependencies": {
     "@types/jest": "^23.0.0",
     "jest": "^23.1.0",
     "ts-jest": "^22.4.6"
+  },
+  "peerDependencies": {
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -39,6 +39,8 @@
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "graphql-playground-middleware-express": "^1.7.1",
+    "graphql-subscriptions": "^0.5.8",
+    "graphql-tools": "^3.0.4",
     "type-is": "^1.6.16"
   },
   "devDependencies": {

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -1,4 +1,3 @@
-// Expose types which can be used by both middleware flavors.
 export { GraphQLOptions, gql } from 'apollo-server-core';
 
 export {
@@ -11,7 +10,10 @@ export {
   UserInputError,
 } from 'apollo-server-core';
 
-// ApolloServer integration
+export * from 'graphql-tools';
+export * from 'graphql-subscriptions';
+
+// ApolloServer integration.
 export {
   ApolloServer,
   registerServer,

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -32,7 +32,9 @@
     "apollo-server-core": "^2.0.0-rc.5",
     "apollo-upload-server": "^5.0.0",
     "boom": "^7.1.0",
-    "graphql-playground-html": "^1.6.0"
+    "graphql-playground-html": "^1.6.0",
+    "graphql-subscriptions": "^0.5.8",
+    "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
     "@types/hapi": "^17.0.12",

--- a/packages/apollo-server-hapi/src/index.ts
+++ b/packages/apollo-server-hapi/src/index.ts
@@ -1,5 +1,5 @@
-// Expose types which can be used by both middleware flavors.
 export { GraphQLOptions, gql } from 'apollo-server-core';
+
 export {
   ApolloError,
   toApolloError,
@@ -10,7 +10,10 @@ export {
   UserInputError,
 } from 'apollo-server-core';
 
-// ApolloServer integration
+export * from 'graphql-tools';
+export * from 'graphql-subscriptions';
+
+// ApolloServer integration.
 export {
   ApolloServer,
   registerServer,

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -25,10 +25,6 @@
   "dependencies": {
     "apollo-server-core": "^2.0.0-rc.5"
   },
-  "typings": "dist/index.d.ts",
-  "typescript": {
-    "definition": "dist/index.d.ts"
-  },
   "devDependencies": {
     "apollo-fetch": "^0.7.0",
     "apollo-link": "^1.2.2",
@@ -39,5 +35,9 @@
     "js-sha256": "^0.9.0",
     "subscriptions-transport-ws": "^0.9.11",
     "ws": "^5.2.0"
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
   }
 }

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "apollo-server-core": "^2.0.0-rc.5",
-    "graphql-playground-html": "^1.6.0"
+    "graphql-playground-html": "^1.6.0",
+    "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.6",

--- a/packages/apollo-server-lambda/src/index.ts
+++ b/packages/apollo-server-lambda/src/index.ts
@@ -1,4 +1,3 @@
-// Expose types which can be used by both middleware flavors.
 export { GraphQLOptions, gql } from 'apollo-server-core';
 
 export {
@@ -11,5 +10,7 @@ export {
   UserInputError,
 } from 'apollo-server-core';
 
-// ApolloServer integration
+export * from 'graphql-tools';
+
+// ApolloServer integration.
 export { ApolloServer, CreateHandlerOptions } from './ApolloServer';

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -28,7 +28,8 @@
     "apollo-server-core": "^2.0.0-rc.5",
     "apollo-server-express": "^2.0.0-rc.5",
     "express": "^4.0.0",
-    "graphql-subscriptions": "^0.5.8"
+    "graphql-subscriptions": "^0.5.8",
+    "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
     "@types/request": "^2.47.0",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -24,6 +24,12 @@
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
+  "dependencies": {
+    "apollo-server-core": "^2.0.0-rc.5",
+    "apollo-server-express": "^2.0.0-rc.5",
+    "express": "^4.0.0",
+    "graphql-subscriptions": "^0.5.8"
+  },
   "devDependencies": {
     "@types/request": "^2.47.0",
     "request": "^2.87.0"
@@ -31,11 +37,5 @@
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
-  "typings": "dist/index.d.ts",
-  "dependencies": {
-    "apollo-server-core": "^2.0.0-rc.5",
-    "apollo-server-express": "^2.0.0-rc.5",
-    "express": "^4.0.0",
-    "graphql-subscriptions": "^0.5.8"
-  }
+  "typings": "dist/index.d.ts"
 }


### PR DESCRIPTION
This fixes #1251 by adding the `graphql-tools` and `graphql-subscriptions` dependencies to integrations to allow `export * from 'graphql-tools'` and `export * from 'graphql-subscriptions'` from them. 

> **NOTE:** `graphql-subscriptions` was only added to and exported from those integrations that support subscriptions.

Also, we are not exporting everything from `graphql-tools` and `graphql-subscriptions` from the `apollo-server-core` package anymore (no consumer of it was using any of those exports). If there's any objection with this, I can revert that commit.