### PR TITLE
Further improves subscriptions docs

### DIFF
--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -3,12 +3,13 @@ title: Subscriptions
 subtitle: Adding subscriptions to Apollo Server
 ---
 
-The native Apollo Server 2.0 supports GraphQL subscriptions without additional configuration.
 Subscriptions are GraphQL operations that watch events emitted from Apollo Server.
-All integration that allow http servers, such as express and hapi, contain the ability support GraphQL subscriptions.
-As example we want to display a list of post that contains author and comment (Query) and we want to add a post to them (Mutation).
+The native Apollo Server supports GraphQL subscriptions without additional configuration.
+All integration that allow HTTP servers, such as express and Hapi, also provide GraphQL subscriptions.
 
-The following examples use a publish and subscribe primitive to generate the events that notify a subscription.
+## Subscriptions Example
+
+Subscriptions depend on use a publish and subscribe primitive to generate the events that notify a subscription. `PubSub` is a factory that creates event generators that is provided by all supported packages. `PubSub` is an implementation of the `PubSubEngine` interface, which has been adopted by a variety of additional [event-generating backends](#).
 
 ```js
 const { PubSub } = require('apollo-server');
@@ -16,7 +17,7 @@ const { PubSub } = require('apollo-server');
 const pubsub = new PubSub();
 ```
 
-To enable subscription we add them to our schema:
+Subscriptions are another root level type, similar to Query and Mutation. To start, we need add to add the `Subscription` type to our schema:
 
 ```js line=2-4
 const typeDefs = gql`
@@ -36,14 +37,15 @@ type Post {
 `
 ```
 
-Our resolver map:
+Inside our resolver map, we add a Subscription resolver that returns an `AsyncIterator`, which listens to the events asynchronously. To generate events in the example, we notified the `pubsub` implementation inside of our Mutation resolver with `publish`. This `publish` call can occur outside of a resolver if required.
 
-```js line=4-8
+```js line=4-9,17
 const POST_ADDED = 'POST_ADDED';
 
 const resolvers = {
   Subscription: {
     postAdded: {
+      // Additional event labels can be passed to asyncIterator creation
       subscribe: () => pubsub.asyncIterator([POST_ADDED]),
     },
   },
@@ -85,51 +87,14 @@ const server = new ApolloServer({
 As you can see Apollo Server 2.0 allows realtime data without invasive changes to existing code.
 For a full working example please have a look to [this repo](https://github.com/daniele-zurico/apollo2-subscriptions-how-to) provided by [Daniele Zurico](https://github.com/daniele-zurico/apollo2-subscriptions-how-to)
 
-<h2 id="subscriptions-filters">Subscription Filters</h2>
-
-Sometimes a client will want filter out specific events based on context and arguments.
-
-To do so, we can use `withFilter` helper from this package, which wraps `AsyncIterator` with a filter function, and let you control each publication for each user.
-
-Let's see an example - for the `commentAdded` server-side subscription, the client want to subscribe only to comments added to a specific repo:
-
-```
-subscription($repoName: String!){
-  commentAdded(repoFullName: $repoName) {
-    id
-    content
-  }
-}
-```
-
-When using `withFilter`, provide a filter function, which executed with the payload (the published value), variables, context and operation info, and it must return boolean or Promise<boolean> indicating if the payload should pass to the subscriber.
-
-Here is the following definition of the subscription resolver, with `withFilter` that will filter out all of the `commentAdded` events that are not the requested repository:
-
-```js
-const { withFilter } = require('apollo-server');
-
-const rootResolver = {
-    Query: () => { ... },
-    Mutation: () => { ... },
-    Subscription: {
-        commentAdded: {
-          subscribe: withFilter(() => pubsub.asyncIterator('commentAdded'), (payload, variables) => {
-             return payload.commentAdded.repository_name === variables.repoFullName;
-          }),
-        }
-    },
-};
-```
-
 ## Authentication Over WebSocket
 
-The subscription lifecycle hooks to create an authenticated transport by using `onConnect` to validate the connection.
+To support an authenticated transport, Apollo Server provides lifecycle hooks, including `onConnect` to validate the connection.
 
-`SubscriptionsClient` supports `connectionParams` ([example available here](../react/advanced/subscriptions.html#authentication)) that will be sent with the first WebSocket message. All GraphQL subscriptions are delayed until the connection has been fully authenticated and your `onConnect` callback returns a truthy value.
+On the client, `SubscriptionsClient` supports adding token information to `connectionParams` ([example](/docs/react/advanced/subscriptions.html#authentication)) that will be sent with the first WebSocket message. In the server, all GraphQL subscriptions are delayed until the connection has been fully authenticated and the `onConnect` callback returns a truthy value.
 
-`connectionParams` in the `onConnect` callback provide the ability to validate user credentials.
-The GraphQL context can  also be extended with the authenticated user data.
+The `connectionParams` argument in the `onConnect` callback contains the information passed by the client and can be used to validate user credentials.
+The GraphQL context can also be extended with the authenticated user data to enable fine grain authorization.
 
 ```js
 const { ApolloServer } = require('apollo-server');
@@ -173,7 +138,44 @@ server.listen().then(({ url, subscriptionsUrl }) => {
 
 The example above validates the user's token that is sent with the first initialization message on the transport, then it looks up the user and returns the user object as a Promise. The user object found will be available as `context.currentUser` in your GraphQL resolvers.
 
-In case of an authentication error, the Promise will be rejected, and the client's connection will be rejected as well.
+In case of an authentication error, the Promise will be rejected, which prevents the client's connection.
+
+<h2 id="subscription-filters">Subscription Filters</h2>
+
+Sometimes a client will want to filter out specific events based on context and arguments.
+
+To do so, we can use the `withFilter` helper from the `apollo-server` or `apollo-server-{integration} package to control each publication for each user. Inside of `withFilter`,  the `AsyncIterator` created by `PubSub` is wrapped with a filter function.
+
+Let's see an example - for the `commentAdded` server-side subscription, the client want to subscribe only to comments added to a specific repo:
+
+```
+subscription($repoName: String!){
+  commentAdded(repoFullName: $repoName) {
+    id
+    content
+  }
+}
+```
+
+When using `withFilter`, provide a filter function. The filter is executed with the payload (a published value), variables, context and operation info. This function must return a `boolean` or `Promise<boolean>` indicating if the payload should be passed to the subscriber.
+
+The following definition of the subscription resolver will filter out all of the `commentAdded` events that are not associated with the requested repository:
+
+```js
+const { withFilter } = require('apollo-server');
+
+const rootResolver = {
+    Query: () => { ... },
+    Mutation: () => { ... },
+    Subscription: {
+        commentAdded: {
+          subscribe: withFilter(() => pubsub.asyncIterator('commentAdded'), (payload, variables) => {
+             return payload.commentAdded.repository_name === variables.repoFullName;
+          }),
+        }
+    },
+};
+```
 
 <h2 id="middleware">Subscriptions with Additional Middleware</h2>
 
@@ -201,7 +203,7 @@ httpServer.listen(PORT, () => {
 })
 ```
 
-## Lifecycle Events
+## Lifecycle events
 
 `ApolloServer` exposes lifecycle hooks you can use to manage subscriptions and clients:
 


### PR DESCRIPTION
Pulls in the information from apollographql/subscriptions-transport-ws and address the feedback from #1255 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->