### PR TITLE
[2.0] Allow dynamic configuration of data sources

### DIFF
--- a/__mocks__/apollo-server-env.ts
+++ b/__mocks__/apollo-server-env.ts
@@ -3,12 +3,15 @@
 import {
   fetch,
   Request,
+  RequestInit,
   Response,
+  Body,
   BodyInit,
   Headers,
   HeadersInit,
   URL,
   URLSearchParams,
+  URLSearchParamsInit,
 } from '../packages/apollo-server-env';
 
 interface FetchMock extends jest.Mock<typeof fetch> {
@@ -43,4 +46,16 @@ mockFetch.mockJSONResponseOnce = (
   );
 };
 
-export { mockFetch as fetch, Request, Response, Headers, URL, URLSearchParams };
+export {
+  mockFetch as fetch,
+  Request,
+  RequestInit,
+  Response,
+  Body,
+  BodyInit,
+  Headers,
+  HeadersInit,
+  URL,
+  URLSearchParams,
+  URLSearchParamsInit,
+};

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -1,11 +1,12 @@
 import {
-  BodyInit,
-  Headers,
   Request,
   RequestInit,
   Response,
+  BodyInit,
+  Headers,
   URL,
   URLSearchParams,
+  URLSearchParamsInit,
 } from 'apollo-server-env';
 
 import { HTTPCache } from './HTTPCache';
@@ -17,11 +18,11 @@ import {
 
 export type RequestOptions = RequestInit & {
   path: string;
-  params?: Params;
+  params: URLSearchParams;
+  headers: Headers;
   body?: Body;
 };
 
-export type Params = { [key: string]: Object };
 export type Body = BodyInit | object;
 export { Request };
 
@@ -44,11 +45,9 @@ export abstract class RESTDataSource<TContext = any> {
   httpCache!: HTTPCache;
   context!: TContext;
 
-  defaults?: ValueOrFunction<ValueOrPromise<RequestInit | undefined>>;
   abstract baseURL: ValueOrFunction<ValueOrPromise<string>>;
-  defaultParams?: ValueOrFunction<ValueOrPromise<Params | undefined>>;
 
-  protected willSendRequest?(request: Request): ValueOrPromise<void>;
+  protected willSendRequest?(request: RequestOptions): ValueOrPromise<void>;
 
   protected async didReceiveErrorResponse<TResult = any>(
     response: Response,
@@ -68,96 +67,98 @@ export abstract class RESTDataSource<TContext = any> {
 
   protected async get<TResult = any>(
     path: string,
-    params?: Params,
-    options?: RequestOptions,
+    params?: URLSearchParamsInit,
+    init?: RequestInit,
   ): Promise<TResult> {
     return this.fetch<TResult>(
-      Object.assign({ method: 'GET', path, params }, options),
+      Object.assign({ method: 'GET', path, params }, init),
     );
   }
 
   protected async post<TResult = any>(
     path: string,
     body?: Body,
-    options?: RequestOptions,
+    init?: RequestInit,
   ): Promise<TResult> {
     return this.fetch<TResult>(
-      Object.assign({ method: 'POST', path, body }, options),
+      Object.assign({ method: 'POST', path, body }, init),
     );
   }
 
   protected async patch<TResult = any>(
     path: string,
     body?: Body,
-    options?: RequestOptions,
+    init?: RequestInit,
   ): Promise<TResult> {
     return this.fetch<TResult>(
-      Object.assign({ method: 'PATCH', path, body }, options),
+      Object.assign({ method: 'PATCH', path, body }, init),
     );
   }
 
   protected async put<TResult = any>(
     path: string,
     body?: Body,
-    options?: RequestOptions,
+    init?: RequestInit,
   ): Promise<TResult> {
     return this.fetch<TResult>(
-      Object.assign({ method: 'PUT', path, body }, options),
+      Object.assign({ method: 'PUT', path, body }, init),
     );
   }
 
   protected async delete<TResult = any>(
     path: string,
-    params?: Params,
-    options?: RequestOptions,
+    params?: URLSearchParamsInit,
+    init?: RequestInit,
   ): Promise<TResult> {
     return this.fetch<TResult>(
-      Object.assign({ method: 'DELETE', path, params }, options),
+      Object.assign({ method: 'DELETE', path, params }, init),
     );
   }
 
-  private async fetch<TResult>(options: RequestOptions): Promise<TResult> {
-    const { path, params, ...init } = Object.assign(
-      {},
-      await resolveIfNeeded(this.defaults, options),
-      options,
-    );
+  private async fetch<TResult>(
+    init: RequestInit & {
+      path: string;
+      params?: URLSearchParamsInit;
+    },
+  ): Promise<TResult> {
+    if (!(init.params instanceof URLSearchParams)) {
+      init.params = new URLSearchParams(init.params);
+    }
+
+    if (!(init.headers && init.headers instanceof Headers)) {
+      init.headers = new Headers(init.headers);
+    }
+
+    const options = init as RequestOptions;
+
+    if (this.willSendRequest) {
+      await this.willSendRequest(options);
+    }
 
     const baseURL = await resolveIfNeeded(this.baseURL, options);
     const normalizedBaseURL = baseURL.endsWith('/')
       ? baseURL
       : baseURL.concat('/');
-    const url = new URL(path, normalizedBaseURL);
-
-    const defaultParams = await resolveIfNeeded(this.defaultParams, options);
+    const url = new URL(options.path, normalizedBaseURL);
 
     // Append params to existing params in the path
-    for (const [name, value] of new URLSearchParams(
-      Object.assign({}, defaultParams, params),
-    )) {
+    for (const [name, value] of options.params) {
       url.searchParams.append(name, value);
     }
 
     // We accept arbitrary objects as body and serialize them as JSON
     if (
-      init.body !== undefined &&
-      typeof init.body !== 'string' &&
-      !(init.body instanceof ArrayBuffer)
+      options.body !== undefined &&
+      typeof options.body !== 'string' &&
+      !(options.body instanceof ArrayBuffer)
     ) {
-      init.body = JSON.stringify(init.body);
-      if (!(init.headers instanceof Headers)) {
-        init.headers = new Headers(init.headers);
-      }
-      init.headers.set('Content-Type', 'application/json');
+      options.body = JSON.stringify(options.body);
+      options.headers.set('Content-Type', 'application/json');
     }
 
-    const request = new Request(String(url), init);
+    const request = new Request(String(url), options);
 
-    if (this.willSendRequest) {
-      await this.willSendRequest(request);
-    }
-
-    return this.trace(`${init.method || 'GET'} ${url}`, async () => {
+    return this.trace(`${options.method || 'GET'} ${url}`, async () => {
       const response = await this.httpCache.fetch(request);
       if (response.ok) {
         const contentType = response.headers.get('Content-Type');

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -207,7 +207,7 @@ describe('RESTDataSource', () => {
       baseURL = 'https://api.example.com';
 
       willSendRequest(request: RequestOptions) {
-        request.params.set('api_key', 'secret');
+        request.params.set('api_key', this.context.token);
       }
 
       getFoo() {
@@ -257,7 +257,7 @@ describe('RESTDataSource', () => {
       baseURL = 'https://api.example.com';
 
       willSendRequest(request: RequestOptions) {
-        request.headers.set('Authorization', 'secret');
+        request.headers.set('Authorization', this.context.token);
       }
 
       getFoo() {
@@ -265,6 +265,7 @@ describe('RESTDataSource', () => {
       }
     }();
 
+    dataSource.context = { token: 'secret' };
     dataSource.httpCache = httpCache;
 
     fetch.mockJSONResponseOnce();


### PR DESCRIPTION
This PR adds callbacks to `RESTDataSource` that allow for asynchronous and dynamic configuration of data sources. It addresses #1181 and #1238.

It allows a data source to specify `baseURL`, `defaults` and `defaultParams` either as simple properties, properties that return a `Promise`, or as a function that takes `RequestOptions` and returns either a value or a `Promise`.

So you could implement the example from https://github.com/apollographql/apollo-server/issues/1181#issuecomment-398871456 as follows:

```typescript
class FooAPI extends RESTDataSource {
  baseURL = (options: RequestOptions) => {
    return new Promise<string>((resolve, reject) => {
      dns.resolveSrv(options.path.split("/")[1] + ".service.consul", (err, addresses) => {
        err ? reject(err) : resolve("http://" + addresses[0].name + ":" + addresses[0].port);
      });
    });
  }

  getFoo() {
    return this.get('foo');
  }
}
```

And you can specify default params as discussed in #1238:

```typescript
class FooAPI extends RESTDataSource {
  baseURL = 'https://api.example.com';

  defaultParams = () => ({
    api_key: this.context.token,
  });

  getFoo(a) {
    return this.get('foo', { a });
  }
}
```

So `getFoo(1)` would result in a request to `'https://api.example.com/foo?api_key=secret&a=1'`.

I also added a `defaults` callback, which allows you to specify default fetch options:
```typescript
class FooAPI extends RESTDataSource {
  baseURL = 'https://api.example.com';
  defaults = { credentials: 'include' };
}
```

One worry is that there is overlap between `defaults` and `willSendRequest`. You could use both to set headers for example:
```typescript
class FooAPI extends RESTDataSource {
  baseURL = 'https://api.example.com';
  defaults = () => ({
    headers: { 'Authorization': this.context.token }
  });
}
```

vs:

```typescript
class FooAPI extends RESTDataSource {
  baseURL = 'https://api.example.com';

  willSendRequest(request: Request) {
    request.headers.set('Authorization', this.context.token);
  }

  getFoo() {
    return this.get('foo');
  }
}
```

It seems this could get confusing.

Also, I think ideally we could get rid of `defaultParams` and rely on `willSendRequest` for this as well, but unfortunately `request.url` is a read-only string, not a `URL`. So you can't do:

```typescript
class FooAPI extends RESTDataSource {
  baseURL = 'https://api.example.com';

  willSendRequest(request: Request) {
    if (request.method === 'GET') {
      request.url.searchParams.set('api_key', this.context.token);
    } else {
      request.headers.set('Authorization', this.context.token);
    }
  }

  getFoo() {
    return this.get('foo');
  }
}
```

One option would be to pass in `RequestInit` and `URL` to `willSendRequest` instead of `Request`, but that also feels awkward.