### PR TITLE
[V2 Docs] Related Guides

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -38,6 +38,15 @@ sidebar_categories:
     - deployment/heroku
     - deployment/lambda
     - deployment/now
+  Related Guides:
+    - title: Monitoring
+      href: https://www.apollographql.com/docs/guides/monitoring.html
+    - title: Versioning
+      href: https://www.apollographql.com/docs/guides/versioning.html
+    - title: Access Control
+      href: https://www.apollographql.com/docs/guides/access-control.html
+    - title: Security
+      href: https://www.apollographql.com/docs/guides/security.html
   API Reference:
     - api/apollo-server
     - title: graphql-subscriptions


### PR DESCRIPTION
I Added a section on the sidebar with links to related guides.

I chose `Monitoring`, `Versioning`, `Access Control`, and `Security` as I thought those were the most relevant guides to server developers.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->