### PR TITLE
Removes flattening of Errors inside of formatApolloErrors

### DIFF
--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -222,30 +222,27 @@ export function formatApolloErrors(
   }
   const { formatter, debug } = options;
 
-  const flattenedErrors: Error[] = [];
-  errors.forEach(error => {
-    // Errors that occur in graphql-tools can contain an errors array that contains the errors thrown in a merged schema
-    // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L104-L107
-    //
-    // They are are wrapped in an extra GraphQL error
-    // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L109-L113
-    // which calls:
-    // https://github.com/graphql/graphql-js/blob/0a30b62964/src/error/locatedError.js#L18-L37
-    if (Array.isArray((error as any).errors)) {
-      (error as any).errors.forEach(e => flattenedErrors.push(e));
-    } else if (
-      (error as any).originalError &&
-      Array.isArray((error as any).originalError.errors)
-    ) {
-      (error as any).originalError.errors.forEach(e => flattenedErrors.push(e));
-    } else {
-      flattenedErrors.push(error);
-    }
-  });
+  // Errors that occur in graphql-tools can contain an errors array that contains the errors thrown in a merged schema
+  // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L104-L107
+  //
+  // They are are wrapped in an extra GraphQL error
+  // https://github.com/apollographql/graphql-tools/blob/3d53986ca/src/stitching/errors.ts#L109-L113
+  // which calls:
+  // https://github.com/graphql/graphql-js/blob/0a30b62964/src/error/locatedError.js#L18-L37
+  // Some processing for these nested errors could be done here:
+  //
+  // if (Array.isArray((error as any).errors)) {
+  //   (error as any).errors.forEach(e => flattenedErrors.push(e));
+  // } else if (
+  //   (error as any).originalError &&
+  //   Array.isArray((error as any).originalError.errors)
+  // ) {
+  //   (error as any).originalError.errors.forEach(e => flattenedErrors.push(e));
+  // } else {
+  //   flattenedErrors.push(error);
+  // }
 
-  const enrichedErrors = flattenedErrors.map(error =>
-    enrichError(error, debug),
-  );
+  const enrichedErrors = errors.map(error => enrichError(error, debug));
 
   if (!formatter) {
     return enrichedErrors;

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -39,7 +39,8 @@
     "graphql-tag": "^2.9.2",
     "js-sha256": "^0.9.0",
     "subscriptions-transport-ws": "^0.9.11",
-    "ws": "^5.2.0"
+    "ws": "^5.2.0",
+    "yup": "^0.25.1"
   },
   "typings": "dist/index.d.ts",
   "typescript": {


### PR DESCRIPTION
In order to support errors thrown during GraphQL resolution that include nested errors, we need to keep the structure of the errors, rather than flattening them. The reason why the flattening code was present for `mergeSchemas` from `graphql-tools`, which returns a combinedError when ever an error is thrown from a remoteSchema. 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->