### PR TITLE
Enable engine reporting in Lambda

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -316,7 +316,3 @@ addMockFunctionsToSchema({
    itself. Set this to false to disable. You can manually invoke 'stop()' and
    'sendReport()' on other signals if you'd like. Note that 'sendReport()'
    does not run synchronously so it cannot work usefully in an 'exit' handler.
-
-*  `disableInterval`: boolean;
-
-   Disables reporting on an interval for stateless environments

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -316,3 +316,7 @@ addMockFunctionsToSchema({
    itself. Set this to false to disable. You can manually invoke 'stop()' and
    'sendReport()' on other signals if you'd like. Note that 'sendReport()'
    does not run synchronously so it cannot work usefully in an 'exit' handler.
+
+*  `disableInterval`: boolean;
+
+   Disables reporting on an interval for stateless environments

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -120,7 +120,7 @@ export class EngineReportingAgent<TContext = any> {
     this.resetReport();
 
     this.sendReportsImmediately = options.sendReportsImmediately;
-    if (this.sendReportsImmediately) {
+    if (!this.sendReportsImmediately) {
       this.reportTimer = setInterval(
         () => this.sendReportAndReportErrors(),
         this.options.reportIntervalMs || 10 * 1000,

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -102,8 +102,8 @@ const REPORT_HEADER = new ReportHeader({
 export class EngineReportingAgent<TContext = any> {
   private options: EngineReportingOptions;
   private apiKey: string;
-  private report: FullTracesReport;
-  private reportSize: number;
+  private report!: FullTracesReport;
+  private reportSize!: number;
   private reportTimer: any; // timer typing is weird and node-specific
   private sendReportsImmediately?: boolean;
   private stopped: boolean = false;
@@ -172,7 +172,7 @@ export class EngineReportingAgent<TContext = any> {
 
     // If the buffer gets big (according to our estimate), send.
     if (
-      this.sendReportsImmediately &&
+      this.sendReportsImmediately ||
       this.reportSize >=
         (this.options.maxUncompressedReportSize || 4 * 1024 * 1024)
     ) {

--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -17,6 +17,8 @@ To deploy the AWS Lambda function we must create a Cloudformation Template and a
 
 #### 1. Write the API handlers
 
+In a file named `graphql.js`, place the following code:
+
 ```js
 const { ApolloServer, gql } = require('apollo-server-lambda');
 
@@ -136,7 +138,7 @@ exports.graphqlHandler = server.createHandler();
 
 ## Modifying the Lambda Response (Enable CORS)
 
-To enable CORS the response HTTP headers need to be modified. To accomplish this use `cors` options.
+To enable CORS the response HTTP headers need to be modified. To accomplish this use the `cors` option.
 
 ```js
 const { ApolloServer, gql } = require('apollo-server-lambda');

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@apollographql/graphql-playground-html": "^1.6.0",
     "apollo-server-core": "^2.0.0-rc.6",
+    "apollo-server-env": "^2.0.0-rc.6",
     "graphql-tools": "^3.0.4"
   },
   "devDependencies": {

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -28,8 +28,7 @@ export class ApolloServer extends ApolloServerBase {
   constructor(options: Config) {
     if (process.env.ENGINE_API_KEY || options.engine) {
       options.engine = {
-        disableInterval: true,
-        maxUncompressedReportSize: 1,
+        sendReportsImmediately: true,
         ...(typeof options.engine !== 'boolean' ? options.engine : {}),
       };
     }

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -1,7 +1,7 @@
 import * as lambda from 'aws-lambda';
 import { ApolloServerBase } from 'apollo-server-core';
 export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
-import { GraphQLOptions } from 'apollo-server-core';
+import { GraphQLOptions, Config } from 'apollo-server-core';
 import {
   renderPlaygroundPage,
   RenderPageOptions as PlaygroundRenderPageOptions,
@@ -22,6 +22,17 @@ export interface CreateHandlerOptions {
 }
 
 export class ApolloServer extends ApolloServerBase {
+  constructor(options: Config) {
+    if (process.env.ENGINE_API_KEY || options.engine) {
+      options.engine = {
+        disableInterval: true,
+        maxUncompressedReportSize: 1,
+        ...(typeof options.engine !== 'boolean' ? options.engine : {}),
+      };
+    }
+    super(options);
+  }
+
   // This translates the arguments from the middleware into graphQL options It
   // provides typings for the integration specific behavior, ideally this would
   // be propagated with a generic to the super class

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -22,6 +22,9 @@ export interface CreateHandlerOptions {
 }
 
 export class ApolloServer extends ApolloServerBase {
+  // If you feel tempted to add an option to this constructor. Please consider
+  // another place, since the documentation becomes much more complicated when
+  // the constructor is not longer shared between all integration
   constructor(options: Config) {
     if (process.env.ENGINE_API_KEY || options.engine) {
       options.engine = {

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -4,6 +4,7 @@ import {
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
+import { Headers } from 'apollo-server-env';
 
 export interface LambdaGraphQLOptionsFunction {
   (event: lambda.APIGatewayProxyEvent, context: lambda.Context):
@@ -45,7 +46,7 @@ export function graphqlLambda(
       request: {
         url: event.path,
         method: event.httpMethod,
-        headers: event.headers as any,
+        headers: new Headers(event.headers),
       },
     }).then(
       ({ graphqlResponse, responseInit }) => {


### PR DESCRIPTION
This PR adds the ability to report from a stateless environment by adding the option to disable the interval that the engine reporting agent uses.

Ideally there would be a way to determine when the lambda is spinning down and gracefully send a report, however a quick skim of the documentation does not illicit any nice hook. @adnsio if you have any advice, I'd love to hear your thoughts.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->