### PR TITLE
Exposes applyMiddleware from apollo-server

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -134,10 +134,10 @@ The `applyMiddleware` method is provided by the `apollo-server-{integration}` pa
 
 ### Usage
 
-The `applyMiddleware` method from `apollo-server-express` registration of middleware as shown in the example below:
+The `applyMiddleware` method from `apollo-server` registration of middleware as shown in the example below:
 
 ```js
-const { ApolloServer } = require('apollo-server-express');
+const { ApolloServer } = require('apollo-server');
 const { typeDefs, resolvers } = require('./schema');
 
 const server = new ApolloServer({

--- a/docs/source/essentials/server.md
+++ b/docs/source/essentials/server.md
@@ -17,10 +17,6 @@ To install, run:
 
     npm install --save apollo-server@rc graphql
 
-When adding Apollo Server to an existing application, a corresponding HTTP server support package needs to be installed as well.  For example, for Express this is:
-
-    npm install --save apollo-server-express@rc graphql
-
 > Note: During the release candidate period, it's necessary to use the `rc` npm package, as shown in the above commands.
 
 <h2 id="creating">Creating a server</h2>
@@ -117,10 +113,8 @@ Existing applications generally already have middleware in place and Apollo Serv
 
 > The existing application is frequently already named `app`, especially when using Express.  If the application is identified by a different variable, pass the existing variable in place of `app`.
 
-The following code uses the `apollo-server-express` package, which can be installed with `npm install apollo-server-express@rc`.
-
 ```js
-const { ApolloServer, gql } = require('apollo-server-express');
+const { ApolloServer, gql } = require('apollo-server');
 const { typeDefs, resolvers } = require('./schema');
 
 const server = new ApolloServer({
@@ -136,9 +130,7 @@ app.listen({ port: 4000 }, () =>
 )
 ```
 
-Hapi follows the same pattern with `apollo-server-express` replaced with `apollo-server-hapi` and `app` replaced with Hapi server. `applyMiddleware` registers plugins, so it should be called with `await`.
-
-> When transition from `apollo-server` to an integration package, running `npm uninstall apollo-server` will remove the extra dependency.
+Currently the `apollo-server` package can be used directly with Express only. Koa and Hapi follow the same pattern with `apollo-server` replaced with `apollo-server-koa` and `apollo-server-hapi` and `app` replaced with Koa and Hapi server. For Hapi, `applyMiddleware` registers plugins, so it should be called with `await`.
 
 <h3 id="serverless">Serverless</h3>
 

--- a/docs/source/features/playground.md
+++ b/docs/source/features/playground.md
@@ -11,17 +11,10 @@ description: Visually exploring a Apollo Server
 
 ## Enabling Playground in Production
 
-To enable Playground in production, an integration package must be installed to provide more control over the middlewares used. The following example uses the express integration:
-
-```bash
-npm install --save apollo-server-express@rc graphql
-```
-
-Introspection and the gui can be enabled explicitly in the following manner.
+By default, Apollo Server disables introspection and GraphQL Playground in production. For some applications, it is possible to expose them in production. In those case, introspection and the gui can be enabled explicitly in the following manner.
 
 ```js line=8,16
-const { ApolloServer, gql } = require('apollo-server-express');
-const express = require('express');
+const { ApolloServer, gql } = require('apollo-server');
 const { typeDefs, resolvers } = require('./schema');
 
 const server = new ApolloServer({
@@ -30,11 +23,8 @@ const server = new ApolloServer({
   introspection: true,
 });
 
-const app = express();
-
 // gui accepts a Playground configuration
 server.applyMiddleware({
-  app,
   gui: true,
 });
 

--- a/docs/source/features/playground.md
+++ b/docs/source/features/playground.md
@@ -32,5 +32,3 @@ app.listen({ port: 4000 }, () =>
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`),
 );
 ```
-
-> Note: when using apollo-server-express, you can remove apollo-server from your package.json

--- a/docs/source/features/subscriptions.md
+++ b/docs/source/features/subscriptions.md
@@ -188,14 +188,14 @@ For example: with an Express server already running on port 4000 that accepts Gr
 
 ```js line=12
 const http = require('http');
-const { ApolloServer } = require('apollo-server-express');
+const { ApolloServer } = require('apollo-server');
 const express = require('express');
 
 const PORT = 4000;
 const app = express();
 const server = new ApolloServer({ typeDefs, resolvers });
 
-server.applyMiddleware({app})
+server.applyMiddleware({ app })
 
 const httpServer = http.createServer(app);
 server.installSubscriptionHandlers(httpServer);

--- a/docs/source/migration-engine.md
+++ b/docs/source/migration-engine.md
@@ -28,7 +28,7 @@ Some infrastructure already contains the Engine proxy and requires it for full r
 
 ```js
 const { ApolloEngine } = require('apollo-engine');
-const { ApolloServer } = require('apollo-server-express');
+const { ApolloServer } = require('apollo-server');
 const express = require('express');
 
 const app = express();

--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -36,7 +36,7 @@ const typeDefs = gql(fs.readFileSync(__dirname.concat('/schema.graphql'), 'utf8'
 
 > Apollo Server 2.0 RC requires Node.js v6 and higher.
 
-Apollo Server 2.0 simplifies implementing a GraphQL server.  Apollo Server 1.0 revolved around providing middleware-based solutions, which had to be added to an application which already existed.  These middleware implementations were tied to the HTTP server in use (e.g. `apollo-server-express` for Express implementations, `apollo-server-hapi` for hapi, etc.).
+Apollo Server 2.0 simplifies implementing a GraphQL server.  Apollo Server 1.0 revolved around providing middleware-based solutions, which had to be added to an application which already existed.  These middleware implementations were tied to the HTTP server in use (e.g. `apollo-server-koa` for Koa implementations, `apollo-server-hapi` for hapi, etc.).
 
 There is a consideration to be made when following the rest of the guide:
 
@@ -55,9 +55,9 @@ Check out the following changes for Apollo Server 2.0 RC.
 
 <h2 id="Middleware">Middleware</h2>
 
-With the middleware option used by Apollo Server 1.0 users, it is necessary to install the release candidate version of `apollo-server-express`.  To do this, use the `rc` tag when installing:
+With the middleware option used by Apollo Server 1.0 users, it is necessary to install the release candidate version of `apollo-server`.  To do this, use the `rc` tag when installing:
 
-    npm install --save apollo-server-express@rc graphql
+    npm install --save apollo-server@rc graphql
 
 The changes are best shown by comparing the before and after of the application.
 
@@ -104,7 +104,7 @@ Now, you can just do this instead:
 
 ```js
 const express = require('express');
-const { ApolloServer, gql } = require('apollo-server-express');
+const { ApolloServer, gql } = require('apollo-server');
 
 const app = express();
 
@@ -172,7 +172,7 @@ For middleware that is collocated with the GraphQL endpoint, Apollo Server 2 all
 
 ```js
 const express = require('express');
-const { ApolloServer, gql } = require('apollo-server-express');
+const { ApolloServer, gql } = require('apollo-server');
 
 const app = express();
 const path = '/graphql';
@@ -256,7 +256,7 @@ Apollo Server 2 removes the `logFunction` in favor of using `graphql-extensions`
 Apollo Server 2 ships with GraphQL Playground instead of GraphiQL and collocates the gui with the endpoint. GraphQL playground can be customized in the following manner.
 
 ```js
-const { ApolloServer, gql } = require('apollo-server-express');
+const { ApolloServer, gql } = require('apollo-server');
 
 const server = new ApolloServer({
   // These will be defined for both new or existing servers


### PR DESCRIPTION
To make the transition from no middleware to using an express server, we're exposing `applyMiddleware` in `apollo-server`'s `ApolloServer`. This enables users to configure the gui and other options for the vanilla version of apollo-server.

The argument in the past against this was the possibility of moving to a different underlying framework. We're still able to do so, since in the cases that a user does not specify an `app` in `applyMiddleware`, so we are not locked into a framework unless the user requires it.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->