### PR TITLE
Do not serialize body values that aren't objects (like FormData)

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -144,8 +144,8 @@ export abstract class RESTDataSource<TContext = any> {
     // We accept arbitrary objects as body and serialize them as JSON
     if (
       options.body !== undefined &&
-      typeof options.body !== 'string' &&
-      !(options.body instanceof ArrayBuffer)
+      options.body !== null &&
+      options.body.constructor === Object
     ) {
       options.body = JSON.stringify(options.body);
       options.headers.set('Content-Type', 'application/json');

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -301,6 +301,33 @@ describe('RESTDataSource', () => {
     );
   });
 
+  it('does not serialize a request body that is not an object', async () => {
+    const dataSource = new class extends RESTDataSource {
+      baseURL = 'https://api.example.com';
+
+      postFoo(foo) {
+        return this.post('foo', foo);
+      }
+    }();
+
+    dataSource.httpCache = httpCache;
+
+    fetch.mockJSONResponseOnce();
+
+    // Dumb FormData constructor
+    function FormData() {}
+    const form = new FormData();
+
+    await dataSource.postFoo(form);
+
+    expect(fetch.mock.calls.length).toEqual(1);
+    expect(fetch.mock.calls[0][0].url).toEqual('https://api.example.com/foo');
+    expect(fetch.mock.calls[0][0].body).not.toEqual('{}');
+    expect(fetch.mock.calls[0][0].headers.get('Content-Type')).not.toEqual(
+      'application/json',
+    );
+  });
+
   for (const method of ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']) {
     const dataSource = new class extends RESTDataSource {
       baseURL = 'https://api.example.com';


### PR DESCRIPTION
Would love some feedback on this. Not sure if my solution is optimal as I'm not that familiar with this.

When using RESTDataSource while setting up apollo-server and learning GraphQL, I had trouble getting my POST requests to work. Looking through the sources, I saw that the fetch method in RESTDataSource was running JSON.stringify on my FormData, causing our backend server to reject them.

I don't think this should be by design? I saw that there was coded in an exception for ArrayBuffer, but to add FormData would perhaps require pulling in the `form-data` dependency, which isn't very practical. So I thought we might as well only serialize body values that are javascript objects. (`constructor === Object`) Does this make sense?