### PR TITLE
Hint about Upload scalar when setting schema manually

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -67,7 +67,7 @@ new ApolloServer({
 
 * `schema`: <`Object`>
 
-  An executable GraphQL schema that will override the `typeDefs` and `resolvers` provided
+  An executable GraphQL schema that will override the `typeDefs` and `resolvers` provided. If you are using [file uploads](https://www.apollographql.com/docs/guides/file-uploads.html), you will have to add the `Upload` scalar to the schema, as it is not automatically added in case of setting the `schema` manually.
 
 * `subscriptions`: <`Object`> | <`String`> | false
 


### PR DESCRIPTION
See https://github.com/apollographql/apollo-server/blob/version-2/packages/apollo-server-core/src/ApolloServer.ts#L177 

Upload is only added when not setting the schema manually.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->