### PR TITLE
Apollo Server 2: Remove formatParams

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -61,7 +61,7 @@ new ApolloServer({
 
   Add tracing or cacheControl meta data to the GraphQL response
 
-* `formatError`, `formatResponse`, `formatParams`: <`Function`>
+* `formatError`, `formatResponse`: <`Function`>
 
   Functions to format the errors and response returned from the server, as well as the parameters to graphql execution(`runQuery`)
 

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -40,7 +40,7 @@ Apollo Server provides two ways to log a server: per input, response, and errors
 
 ### High Level Logging
 
-To log the inputs, response, and request, Apollo Server provides three methods: `formatError` and `formatResponse`. This example uses `console.log` to record the information, servers can use other more sophisticated tools.
+To log, Apollo Server provides: `formatError` and `formatResponse`. This example uses `console.log` to record the information, servers can use other more sophisticated tools.
 
 ```js
 const server = new ApolloServer({
@@ -63,7 +63,7 @@ server.listen().then(({ url }) => {
 
 ### Granular Logs
 
-Additionally for more advanced cases, Apollo Server accepts an array of `graphql-extensions` to the `extensions` field. These extensions receive a variety of lifecycle calls for each phase of a GraphQL request and can keep state, such as the request headers.
+For more advanced cases, Apollo Server provides an experimental api that accepts an array of `graphql-extensions` to the `extensions` field. These extensions receive a variety of lifecycle calls for each phase of a GraphQL request and can keep state, such as the request headers.
 
 ```js
 const { ApolloServer }  = require('apollo-server');

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -40,16 +40,12 @@ Apollo Server provides two ways to log a server: per input, response, and errors
 
 ### High Level Logging
 
-To log the inputs, response, and request, Apollo Server provides three methods: `formatParams`, `formatError`, and `formatResponse`. This example uses `console.log` to record the information, servers can use other more sophisticated tools.
+To log the inputs, response, and request, Apollo Server provides three methods: `formatError` and `formatResponse`. This example uses `console.log` to record the information, servers can use other more sophisticated tools.
 
 ```js
 const server = new ApolloServer({
   typeDefs,
   resolvers,
-  formatParams: params => {
-    console.log(params);
-    return params;
-  },
   formatError: error => {
     console.log(error);
     return error;

--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -245,7 +245,7 @@ new ApolloServer({
 
 <h2 id="log-function">Replacing `logFunction`</h2>
 
-Apollo Server 2 removes the `logFunction` in favor of using `graphql-extensions`, which provides a more structured and flexible way of instrumenting Apollo Server. The explanation of how to do this more granular logging, can be found in the [metrics section](./features/metrics.html)
+Apollo Server 2 removes the `logFunction` to reduce the exposure of internal implementation details. The experimental, non-public `graphql-extensions` provides a more structured and flexible way of instrumenting Apollo Server. An explanation of to do more granular logging, can be found in the [metrics section](./features/metrics.html).
 
 <h2 id="graphiql">Replacing GraphiQL</h2>
 

--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -243,10 +243,6 @@ new ApolloServer({
 });
 ```
 
-For most other functions that might have required access to the middleware arguments, such as `formatParams`, `formatError`, and `formatResponse`, it is possible to create a `graphql-extension`.
-
-For more complicated use cases, the `ApolloServer` class can be extended to override the `createGraphQLServerOptions` function to create parameters based on the same argument that's passed to the context.
-
 <h2 id="log-function">Replacing `logFunction`</h2>
 
 Apollo Server 2 removes the `logFunction` in favor of using `graphql-extensions`, which provides a more structured and flexible way of instrumenting Apollo Server. The explanation of how to do this more granular logging, can be found in the [metrics section](./features/metrics.html)

--- a/docs/source/setup.md
+++ b/docs/source/setup.md
@@ -100,9 +100,6 @@ The above are the only options you need most of the time. Here are some others t
 ```js
 // options object
 const GraphQLOptions = {
-  // a function applied to the parameters of every invocation of runQuery
-  formatParams?: Function,
-
   // * - (optional) validationRules: extra validation rules applied to requests
   validationRules?: Array<ValidationRule>,
 

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -15,7 +15,6 @@ import { KeyValueCache } from 'apollo-server-caching';
  * - (optional) formatError: Formatting function applied to all errors before response is sent
  * - (optional) rootValue: rootValue passed to GraphQL execution
  * - (optional) context: the context passed to GraphQL execution
- * - (optional) formatParams: a function applied to the parameters of every invocation of runQuery
  * - (optional) validationRules: extra validation rules applied to requests
  * - (optional) formatResponse: a function applied to each graphQL execution result
  * - (optional) fieldResolver: a custom default field resolver
@@ -32,7 +31,6 @@ export interface GraphQLServerOptions<
   formatError?: Function;
   rootValue?: any;
   context?: TContext;
-  formatParams?: Function;
   validationRules?: Array<(context: ValidationContext) => any>;
   formatResponse?: Function;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -258,7 +258,6 @@ export async function runHttpQuery(
         }
       }
 
-      // We ensure that there is a queryString or parsedQuery after formatParams
       if (queryString && typeof queryString !== 'string') {
         // Check for a common error first.
         if (queryString && (queryString as any).kind === 'Document') {
@@ -405,15 +404,6 @@ export async function runHttpQuery(
         persistedQueryHit,
         persistedQueryRegister,
       };
-
-      if (optionsObject.formatParams) {
-        params = optionsObject.formatParams(params);
-      }
-
-      if (!params.queryString && !params.parsedQuery) {
-        // Note that we've already thrown a different error if it looks like APQ.
-        throw new HttpQueryError(400, 'Must provide query string.');
-      }
 
       return runQuery(params);
     } catch (e) {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -258,7 +258,11 @@ export async function runHttpQuery(
         }
       }
 
-      if (queryString && typeof queryString !== 'string') {
+      if (!queryString) {
+        throw new HttpQueryError(400, 'Must provide query string.');
+      }
+
+      if (typeof queryString !== 'string') {
         // Check for a common error first.
         if (queryString && (queryString as any).kind === 'Document') {
           throw new HttpQueryError(

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -37,7 +37,6 @@ export interface Config
       | 'formatError'
       | 'debug'
       | 'rootValue'
-      | 'formatParams'
       | 'validationRules'
       | 'formatResponse'
       | 'fieldResolver'


### PR DESCRIPTION
This removes `formatParams`, because it is an internal implementation detail of the new Apollo Server as opposed to a first class functionality as in the middleware.  It was originally used to implement a form of persisted queries, which is now unnecessary.

In the future, we are planning to move to a more extensible request pathway inside of Apollo Server that should provide the functionality that was originally provided by `formatParams`. If you are dependent on the behavior of `formatParams`, please open an issue and we can continue discussions there. In the meantime, the release candidate(rc.7) provides a stop-gap measure.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->