### PR TITLE
[apollo-server-koa] use exported bodyParser.Options type 

### DIFF
--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -33,7 +33,7 @@
     "@types/accepts": "^1.3.5",
     "@types/cors": "^2.8.4",
     "@types/koa": "^2.0.46",
-    "@types/koa-bodyparser": "^4.2.0",
+    "@types/koa-bodyparser": "^5.0.1",
     "@types/koa-compose": "^3.2.2",
     "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -17,17 +17,11 @@ import { processRequest as processFileUploads } from 'apollo-upload-server';
 export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
 import { GraphQLOptions, FileUploadOptions } from 'apollo-server-core';
 
-// koa-bodyparser does not expose an Options interface so we infer the type here.
-// we can replace this when this PR get merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27047
-export type BodyParserOptions = typeof bodyParser extends (opts: infer U) => any
-  ? U
-  : never;
-
 export interface ServerRegistration {
   app: Koa;
   path?: string;
   cors?: corsMiddleware.Options | boolean;
-  bodyParserConfig?: BodyParserOptions | boolean;
+  bodyParserConfig?: bodyParser.Options | boolean;
   onHealthCheck?: (ctx: Koa.Context) => Promise<any>;
   disableHealthCheck?: boolean;
   gui?: boolean;


### PR DESCRIPTION
Use exported `bodyParser.Options` type instead of inferred type.

close #1213