### PR TITLE
Expose Cors option from vanilla ApolloServer constructor

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -88,7 +88,7 @@ new ApolloServer({
 
 * `cors`: <`Object` | `boolean`> ([apollo-server](https://github.com/expressjs/cors#cors))
 
-  Pass the integration-specific cors options. False removes the cors middleware and true uses the defaults. This option is only available to apollo-sever. For other server integrations, place `cors` inside of `applyMiddleware`.
+  Pass the integration-specific CORS options. `false` removes the CORS middleware and `true` uses the defaults. This option is only available to `apollo-server`. For other server integrations, place `cors` inside of `applyMiddleware`.
 
 #### Returns
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -86,6 +86,10 @@ new ApolloServer({
 
   The persisted queries option can be set to an object containing a `cache` field, which will be used to store the mapping between hash and query string.
 
+* `cors`: <`Object` | `boolean`> ([apollo-server](https://github.com/expressjs/cors#cors))
+
+  Pass the integration-specific cors options. False removes the cors middleware and true uses the defaults. This option is only available to apollo-sever. For other server integrations, place `cors` inside of `applyMiddleware`.
+
 #### Returns
 
 `ApolloServer`

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -21,3 +21,6 @@ export {
   registerServer,
   ServerRegistration,
 } from './ApolloServer';
+
+export { CorsOptions } from 'cors';
+export { OptionsJson } from 'body-parser';

--- a/packages/apollo-server/src/index.test.ts
+++ b/packages/apollo-server/src/index.test.ts
@@ -102,6 +102,26 @@ describe('apollo-server', () => {
       await apolloFetch({ query: '{hello}' });
     });
 
+    it('configures cors', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+        cors: { origin: 'localhost' },
+      });
+
+      const { url: uri } = await server.listen();
+
+      const apolloFetch = createApolloFetch({ uri }).useAfter(
+        (response, next) => {
+          expect(
+            response.response.headers.get('access-control-allow-origin'),
+          ).to.equal('localhost');
+          next();
+        },
+      );
+      await apolloFetch({ query: '{hello}' });
+    });
+
     it('creates a healthcheck endpoint', async () => {
       server = new ApolloServer({
         typeDefs,

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -5,13 +5,16 @@
 import * as express from 'express';
 import * as http from 'http';
 import * as net from 'net';
+import { CorsOptions } from 'cors';
 import { ApolloServer as ApolloServerBase } from 'apollo-server-express';
+import { Config } from 'apollo-server-core';
 
 export {
   GraphQLUpload,
   GraphQLOptions,
   GraphQLExtension,
   gql,
+  Config,
 } from 'apollo-server-core';
 
 export * from './exports';
@@ -27,7 +30,13 @@ export interface ServerInfo {
 }
 
 export class ApolloServer extends ApolloServerBase {
-  private httpServer: http.Server;
+  private httpServer!: http.Server;
+  private cors?: CorsOptions | boolean;
+
+  constructor(config: Config & { cors?: CorsOptions | boolean }) {
+    super(config);
+    this.cors = config && config.cors;
+  }
 
   private createServerInfo(
     server: http.Server,
@@ -78,9 +87,12 @@ export class ApolloServer extends ApolloServerBase {
       app,
       path: '/',
       bodyParserConfig: { limit: '50mb' },
-      cors: {
-        origin: '*',
-      },
+      cors:
+        typeof this.cors !== 'undefined'
+          ? this.cors
+          : {
+              origin: '*',
+            },
     });
 
     this.httpServer = http.createServer(app);

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -5,8 +5,10 @@
 import * as express from 'express';
 import * as http from 'http';
 import * as net from 'net';
-import { CorsOptions } from 'cors';
-import { ApolloServer as ApolloServerBase } from 'apollo-server-express';
+import {
+  ApolloServer as ApolloServerBase,
+  CorsOptions,
+} from 'apollo-server-express';
 import { Config } from 'apollo-server-core';
 
 export {
@@ -16,6 +18,8 @@ export {
   gql,
   Config,
 } from 'apollo-server-core';
+
+export { CorsOptions } from 'apollo-server-express';
 
 export * from './exports';
 


### PR DESCRIPTION
 This places a cors option inside of apollo-server's constructor. In order to get to create a production server, cors must be configurable. To get to production, we should not have to use an alternative integration, so while this removes the universal constructor, it's a necessary change.

Fixes #1326 

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->