### PR TITLE
Remove calculate headers as a function from cacheControl

### DIFF
--- a/packages/apollo-server-core/src/caching.ts
+++ b/packages/apollo-server-core/src/caching.ts
@@ -1,10 +1,6 @@
 import { ExecutionResult } from 'graphql';
 import { CacheControlFormat } from 'apollo-cache-control';
 
-export type HttpHeaderCalculation = (
-  responses: Array<ExecutionResult & { extensions?: Record<string, any> }>,
-) => Record<string, string>;
-
 export function calculateCacheControlHeaders(
   responses: Array<ExecutionResult & { extensions?: Record<string, any> }>,
 ): Record<string, string> {

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -3,7 +3,6 @@ import {
   ValidationContext,
   GraphQLFieldResolver,
 } from 'graphql';
-import { HttpHeaderCalculation } from './caching';
 import { GraphQLExtension } from 'graphql-extensions';
 import { CacheControlExtensionOptions } from 'apollo-cache-control';
 import { KeyValueCache } from 'apollo-server-caching';
@@ -41,7 +40,7 @@ export interface GraphQLServerOptions<
   cacheControl?:
     | boolean
     | (CacheControlExtensionOptions & {
-        calculateHttpHeaders?: boolean | HttpHeaderCalculation;
+        calculateHttpHeaders?: boolean;
         stripFormattedExtensions?: boolean;
       });
   extensions?: Array<() => GraphQLExtension>;

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -17,7 +17,7 @@ import {
   PersistedQueryNotSupportedError,
   PersistedQueryNotFoundError,
 } from 'apollo-server-errors';
-import { calculateCacheControlHeaders, HttpHeaderCalculation } from './caching';
+import { calculateCacheControlHeaders } from './caching';
 
 export interface HttpQueryRequest {
   method: string;
@@ -104,7 +104,7 @@ export async function runHttpQuery(
     process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
   let cacheControl:
     | CacheControlExtensionOptions & {
-        calculateHttpHeaders: boolean | HttpHeaderCalculation;
+        calculateHttpHeaders: boolean;
         stripFormattedExtensions: boolean;
       }
     | undefined;
@@ -450,10 +450,7 @@ export async function runHttpQuery(
 
   if (cacheControl) {
     if (cacheControl.calculateHttpHeaders) {
-      const calculatedHeaders =
-        typeof cacheControl.calculateHttpHeaders === 'function'
-          ? cacheControl.calculateHttpHeaders(responses)
-          : calculateCacheControlHeaders(responses);
+      const calculatedHeaders = calculateCacheControlHeaders(responses);
 
       responseInit.headers = {
         ...responseInit.headers,


### PR DESCRIPTION
The calculation of the headers from cacheControl currently mirrors the Engine Proxy. There does not need to be another way to configure the headers, since all major CDN vendors support `cache-control`. If you need access to this method, please open an issue and we'll discuss a way to expose it for your use case.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->