### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -18,7 +18,7 @@ If you want to get started quickly, take a look at the [quick start code snippet
 
 <h2 id="tutorial">End-to-end GraphQL server tutorial</h2>
 
-If you're looking to learn about how to connect to different data sources, check out our recently updated tutorial which walks you through building a server from start to finish: [How To Build a GraphQL Server to talk to SQL, MongoDB, and REST](https://dev-blog.apollodata.com/tutorial-building-a-graphql-server-cddaa023c035)
+If you're looking to learn about how to connect to different data sources, check out our recently updated tutorial which walks you through building a server from start to finish: [How To Build a GraphQL Server to talk to SQL, MongoDB, and REST](https://blog.apollographql.com/tutorial-building-a-graphql-server-cddaa023c035)
 
 <h2 id="selecting-package">Selecting the right package</h2>
 

--- a/docs/source/migration-one-dot.md
+++ b/docs/source/migration-one-dot.md
@@ -3,7 +3,7 @@ title: Migrating to v1.0
 description: How to migrate to Apollo Server 1.0
 ---
 
-In July of 2017, we [announced the release of Apollo Server 1.0](https://dev-blog.apollodata.com/apollo-server-1-0-a-graphql-server-for-all-node-js-frameworks-2b37d3342f7c). This was not a major change, except for one thing: All of the packages have been renamed from `graphql-server-*` to `apollo-server-*`.
+In July of 2017, we [announced the release of Apollo Server 1.0](https://blog.apollographql.com/apollo-server-1-0-a-graphql-server-for-all-node-js-frameworks-2b37d3342f7c). This was not a major change, except for one thing: All of the packages have been renamed from `graphql-server-*` to `apollo-server-*`.
 
 All of the options, names, and API are identical to pre-1.0 versions.
 


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.