### PR TITLE
fix: add url for cached response

### DIFF
--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -37,7 +37,11 @@ export class HTTPCache {
 
     if (policy.satisfiesWithoutRevalidation(policyRequestFrom(request))) {
       const headers = policy.responseHeaders();
-      return new Response(body, { status: policy._status, headers });
+      return new Response(body, {
+        url: policy._url,
+        status: policy._status,
+        headers,
+      });
     } else {
       const revalidationHeaders = policy.revalidationHeaders(
         policyRequestFrom(request),
@@ -57,6 +61,7 @@ export class HTTPCache {
         modified
           ? revalidationResponse
           : new Response(body, {
+              url: revalidatedPolicy._url,
               status: revalidatedPolicy._status,
               headers: revalidatedPolicy.responseHeaders(),
             }),
@@ -91,6 +96,7 @@ export class HTTPCache {
     // To avoid https://github.com/bitinn/node-fetch/issues/151, we don't use
     // response.clone() but create a new response from the consumed body
     return new Response(body, {
+      url: response.url,
       status: response.status,
       statusText: response.statusText,
       headers: policy.responseHeaders(),

--- a/packages/apollo-datasource-rest/src/types/http-cache-semantics/index.d.ts
+++ b/packages/apollo-datasource-rest/src/types/http-cache-semantics/index.d.ts
@@ -31,6 +31,7 @@ declare module 'http-cache-semantics' {
     static fromObject(object: object): CachePolicy;
     toObject(): object;
 
+    _url: string;
     _status: number;
   }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -40,6 +40,7 @@ function prettyJSONStringify(value: any) {
 export interface ApolloServerHttpResponse {
   headers?: Record<string, string>;
   // ResponseInit contains the follow, which we do not use
+  // url?: string;
   // status?: number;
   // statusText?: string;
 }

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -40,7 +40,6 @@ function prettyJSONStringify(value: any) {
 export interface ApolloServerHttpResponse {
   headers?: Record<string, string>;
   // ResponseInit contains the follow, which we do not use
-  // url?: string;
   // status?: number;
   // statusText?: string;
 }

--- a/packages/apollo-server-env/src/fetch.d.ts
+++ b/packages/apollo-server-env/src/fetch.d.ts
@@ -78,7 +78,8 @@ export type ReferrerPolicy =
   | 'unsafe-url';
 
 export declare class Response extends Body {
-  constructor(body?: BodyInit, init?: ResponseInit);
+  // node-fetch accepts options as the second argument instead of a pure ResponseInit
+  constructor(body?: BodyInit, options?: ResponseOptions);
   static error(): Response;
   static redirect(url: string, status?: number): Response;
 
@@ -94,9 +95,12 @@ export declare class Response extends Body {
 
 export interface ResponseInit {
   headers?: HeadersInit;
-  url?: string;
   status?: number;
   statusText?: string;
+}
+
+export interface ResponseOptions extends ResponseInit {
+  url?: string;
 }
 
 export type BodyInit = ArrayBuffer | ArrayBufferView | string;

--- a/packages/apollo-server-env/src/fetch.d.ts
+++ b/packages/apollo-server-env/src/fetch.d.ts
@@ -94,6 +94,7 @@ export declare class Response extends Body {
 
 export interface ResponseInit {
   headers?: HeadersInit;
+  url?: string;
   status?: number;
   statusText?: string;
 }


### PR DESCRIPTION
In a response from httpCache, some props are missing (`url`, `ok` etc.)

https://github.com/apollographql/apollo-server/blob/version-2/packages/apollo-server-env/src/fetch.d.ts#L85-L90

While only `url` is cached:
https://github.com/kornelski/http-cache-semantics/blob/master/index.js#L67:14

I add it to the response.

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->