### PR TITLE
Lambda: fix cors documentation and default allowed headers

### DIFF
--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -164,7 +164,6 @@ exports.handler = server.createHandler({
   cors: {
     origin: '*',
     credentials: true,
-    allowedHeaders: ['X-Apollo-Tracing', 'Content-Type', 'Authorization'],
   },
 });
 ```
@@ -200,6 +199,17 @@ exports.handler = server.createHandler({
   },
 });
 ```
+
+### Cors Options
+
+The options correspond to the [express cors configuration](https://github.com/expressjs/cors#configuration-options) with the following fields(all are optional):
+
+* `origin`: boolean | string | string[]
+* `methods`: string | string[]
+* `allowedHeaders`: string | string[]
+* `exposedHeaders`: string | string[]
+* `credentials`: boolean
+* `maxAge`: number
 
 ## Principles
 

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -101,6 +101,11 @@ export class ApolloServer extends ApolloServerBase {
           corsHeaders['Access-Control-Allow-Origin'] =
             event.headers['Origin'] || event.headers['origin'];
         }
+
+        if (!cors.allowedHeaders) {
+          corsHeaders['Access-Control-Allow-Headers'] =
+            event.headers['Access-Control-Request-Headers'];
+        }
       }
 
       if (event.httpMethod === 'OPTIONS') {


### PR DESCRIPTION
Fixes lambda's behavior with cors allowedHeaders to reflect the default in the express configuration. Now when a request come and requests access for specific headers apollo-server-lambda will mirror them if no allowedHeaders are specified directly.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->