### PR TITLE
Fix versioning for docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,10 +2,9 @@ title: Apollo Server
 propertytitle: Using Apollo Server
 subtitle: Apollo Server
 description: A guide to using Apollo Server.
-version: 2
 versions:
-  - '1'
   - '2'
+  - '1'
 sidebar_categories:
   null:
     - index


### PR DESCRIPTION
Switch versioning to label master as v2 and default. Add 1 to the
versions list to pull from version-2

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->