### PR TITLE
[2.0] Remove Node dependencies for edge environments

### DIFF
--- a/packages/apollo-server-cloudflare/src/index.ts
+++ b/packages/apollo-server-cloudflare/src/index.ts
@@ -1,7 +1,3 @@
-export * from 'graphql-tools';
-
-export { ApolloServer } from './ApolloServer';
-
 export {
   GraphQLUpload,
   GraphQLOptions,
@@ -21,3 +17,7 @@ export {
   PlaygroundConfig,
   PlaygroundRenderPageOptions,
 } from 'apollo-server-core';
+
+export { ApolloServer } from './ApolloServer';
+
+export * from 'graphql-tools';

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -14,8 +14,6 @@ import { GraphQLExtension } from 'graphql-extensions';
 import { EngineReportingAgent } from 'apollo-engine-reporting';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 
-import { GraphQLUpload } from '@apollographql/apollo-upload-server';
-
 import {
   SubscriptionServer,
   ExecutionParams,
@@ -151,6 +149,7 @@ export class ApolloServerBase {
 
     //Add upload resolver
     if (this.uploadsConfig) {
+      const { GraphQLUpload } = require('@apollographql/apollo-upload-server');
       if (resolvers && !resolvers.Upload) {
         resolvers.Upload = GraphQLUpload;
       }

--- a/packages/apollo-server-core/src/types/apollo-upload-server.d.ts
+++ b/packages/apollo-server-core/src/types/apollo-upload-server.d.ts
@@ -2,4 +2,26 @@ declare module '@apollographql/apollo-upload-server' {
   import { GraphQLScalarType } from 'graphql';
 
   export const GraphQLUpload: GraphQLScalarType;
+
+  export interface ApolloUploadOptions {
+    /**
+     * Max allowed non-file multipart form field size in bytes; enough for your queries (default: 1 MB)
+     */
+    maxFieldSize?: number;
+    /**
+     * Max allowed file size in bytes (default: Infinity)
+     */
+    maxFileSize?: number;
+    /**
+     * Max allowed number of files (default: Infinity)
+     */
+    maxFiles?: number;
+  }
+
+  export type Request = any;
+
+  export function processRequest(
+    request: Request,
+    options?: ApolloUploadOptions,
+  ): Promise<any>;
 }

--- a/packages/apollo-server-env/package.json
+++ b/packages/apollo-server-env/package.json
@@ -17,6 +17,7 @@
     "prepare": "npm run clean && npm run compile"
   },
   "main": "dist/index.js",
+  "browser": "dist/index.browser.js",
   "types": "dist/index.d.ts",
   "engines": {
     "node": ">=6"

--- a/packages/apollo-server-env/src/index.browser.js
+++ b/packages/apollo-server-env/src/index.browser.js
@@ -1,2 +1,44 @@
-const { fetch, Request, Response, Headers, URL, URLSearchParams } = global;
+if (!global) {
+  global = self;
+}
+
+let { fetch, Request, Response, Headers, URL, URLSearchParams } = global;
+fetch = fetch.bind(global);
 export { fetch, Request, Response, Headers, URL, URLSearchParams };
+
+if (!global.process) {
+  global.process = {};
+}
+
+if (!global.process.env) {
+  global.process.env = {
+    NODE_ENV: 'production',
+  };
+}
+
+if (!global.process.version) {
+  global.process.version = '';
+}
+
+if (!global.process.hrtime) {
+  // Adapted from https://github.com/kumavis/browser-process-hrtime
+  global.process.hrtime = function hrtime(previousTimestamp) {
+    var clocktime = Date.now() * 1e-3;
+    var seconds = Math.floor(clocktime);
+    var nanoseconds = Math.floor((clocktime % 1) * 1e9);
+    if (previousTimestamp) {
+      seconds = seconds - previousTimestamp[0];
+      nanoseconds = nanoseconds - previousTimestamp[1];
+      if (nanoseconds < 0) {
+        seconds--;
+        nanoseconds += 1e9;
+      }
+    }
+    return [seconds, nanoseconds];
+  };
+}
+
+if (!global.os) {
+  // FIXME: Add some sensible values
+  global.os = {};
+}

--- a/packages/apollo-server-env/src/index.browser.js
+++ b/packages/apollo-server-env/src/index.browser.js
@@ -12,7 +12,8 @@ if (!global.process) {
 
 if (!global.process.env) {
   global.process.env = {
-    NODE_ENV: 'production',
+    // app is a global available on fly.io
+    NODE_ENV: app ? app.env : 'production',
   };
 }
 

--- a/packages/apollo-server-env/src/index.browser.js
+++ b/packages/apollo-server-env/src/index.browser.js
@@ -1,0 +1,2 @@
+const { fetch, Request, Response, Headers, URL, URLSearchParams } = global;
+export { fetch, Request, Response, Headers, URL, URLSearchParams };


### PR DESCRIPTION
This PR removes some Node dependencies to allow Apollo Server to run in edge environments like Cloudflare Workers and fly.io.

Because `apollo-upload-server` requires Node, we only import it when uploads are enabled and don't export `GraphQLUpload` from the `apollo-server-cloudflare` package. We currently configure bundling for edge to skip `apollo-upload-server`, but we should find a more principled way to avoid the dependency.