### PR TITLE
[datasource-rest] disable cache for POST, PUT, DELETE... methods

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -61,7 +61,10 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
   // Although we do validate header fields and don't serve responses from cache when they don't match,
   // new reponses overwrite old ones with different vary header fields.
   protected cacheKeyFor(request: Request): string {
-    return request.url;
+    if (request.method === 'GET') {
+      return request.url;
+    }
+    return request.url + Date.now();
   }
 
   protected willSendRequest?(request: RequestOptions): ValueOrPromise<void>;


### PR DESCRIPTION
https://github.com/apollographql/apollo-server/blob/a78f13a8e0666ccc1d79341db5ab075a78a32f24/packages/apollo-datasource-rest/src/RESTDataSource.ts#L231-L233

In my opinion, it should not default memoize or cache for non-GET methods.