### PR TITLE
Add support for inherit key on cacheControl.

### DIFF
--- a/packages/apollo-cache-control/CHANGELOG.md
+++ b/packages/apollo-cache-control/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Unreleased
+
+* Add support for `inherited` key to skip setting a `maxAge` to 0 if a
+    type has no explicit `maxAge` set.
+
 ### v0.1.1
 
 * Fix `defaultMaxAge` feature (introduced in 0.1.0) so that `maxAge: 0` overrides the default, as previously documented.


### PR DESCRIPTION
This adds support for skipping using defaultMaxAge on types if inherited is
set to true. This allows to more easily cache a whole node if you do not
want or cannot set an specific maxAge.

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->