### PR TITLE
docs: Remove `@rc` dist-tag from `apollo-server-express` README.md.

### DIFF
--- a/packages/apollo-server-express/README.md
+++ b/packages/apollo-server-express/README.md
@@ -8,7 +8,7 @@ description: Setting up Apollo Server with Express.js or Connect
 This is the Express and Connect integration of GraphQL Server. Apollo Server is a community-maintained open-source GraphQL server that works with many Node.js HTTP server frameworks. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md)
 
 ```sh
-npm install apollo-server-express@rc
+npm install apollo-server-express
 ```
 
 ## Express


### PR DESCRIPTION
It is no longer necessary to use the `rc` dist-tag when installing the `apollo-server-express` integration.