### PR TITLE
[WIP] Add support for `Server Timing` headers

### DIFF
--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -36,6 +36,7 @@ export interface GraphQLServerOptions<
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   debug?: boolean;
   tracing?: boolean;
+  serverTiming?: boolean;
   cacheControl?:
     | boolean
     | (CacheControlExtensionOptions & {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -492,7 +492,7 @@ export async function runHttpQuery(
           if (!keyToIDs.has(rootKey)) {
             keyToIDs.set(rootKey, keyToIDs.size + 1);
           }
-          const durationInMS = Math.round(value.duration / 1000000);
+          const durationInMS = (value.duration / 1000000).toFixed(2);
 
           timings.push(
             `gql-${keyToIDs.get(rootKey)};dur=${durationInMS};desc="${key}"`,


### PR DESCRIPTION
This PR is not merge ready, I'm opening it early to discuss the prospect of the feature itself and if I'm on the right track with it or not. 

The Server Timing headers enable more information in the Chrome DevTools on each individual request:

<img width="434" alt="skjermbilde 2018-08-05 kl 17 29 30" src="https://user-images.githubusercontent.com/81981/43687424-31960044-98d5-11e8-8342-58fb7bc1dc33.png">

<details>
  <summary>View larger image with more context.</summary>
  <img width="1680" alt="skjermbilde 2018-08-05 kl 17 30 45" src="https://user-images.githubusercontent.com/81981/43687431-5aa2dfa2-98d5-11e8-8b57-b817a887c8f6.png">
</details>

Server Timing information is complimentary to existing tracing information. Some of its constraints is that you can only specify a duration per field, no start or end times to create a timeline context in relation to the other fields that might happen in parallel or before/after one another.

It's very suitable to show a brief overview over where the most time were spent in a query. This PR walks through the tracing information in the response and reduces it to the longest duration per path.

Looking forward to your feedback 😄 

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

**Pull Request Labels**

- [x] feature
- [ ] blocking
- [ ] docs