### PR TITLE
Look in event.path first when selecting endpoint for GraphQL Playground on Lambda, and check for null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All of the packages in the `apollo-server` repo are released with the same versi
 - express, koa: remove next after playground [#1436](https://github.com/apollographql/apollo-server/pull/1436)
 - Hapi: Pass the response toolkit to the context function. [#1407](https://github.com/apollographql/apollo-server/pull/1407)
 - update apollo-engine-reporting-protobuf to non-beta [#1429](https://github.com/apollographql/apollo-server/pull/1429)
+- Lambda: Look in event.path first when picking endpoint for GraphQL Playground [#1527](https://github.com/apollographql/apollo-server/pull/1527)
 
 ### rc.10
 

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -119,8 +119,13 @@ export class ApolloServer extends ApolloServerBase {
       if (this.playgroundOptions && event.httpMethod === 'GET') {
         const acceptHeader = event.headers['Accept'] || event.headers['accept'];
         if (acceptHeader && acceptHeader.includes('text/html')) {
+          const path =
+            event.path ||
+            (event.requestContext && event.requestContext.path) ||
+            '/';
+
           const playgroundRenderPageOptions: PlaygroundRenderPageOptions = {
-            endpoint: event.requestContext.path,
+            endpoint: path,
             ...this.playgroundOptions,
           };
 


### PR DESCRIPTION
See here: https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->