### PR TITLE
use apollo-upload-server 6.0.0-alpha.1

### DIFF
--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -37,7 +37,7 @@
     "apollo-server-env": "file:../apollo-server-env",
     "apollo-server-errors": "file:../apollo-server-errors",
     "apollo-tracing": "file:../apollo-tracing",
-    "apollo-upload-server": "^5.0.0",
+    "apollo-upload-server": "^6.0.0-alpha.1",
     "graphql-extensions": "file:../graphql-extensions",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tag": "^2.9.2",


### PR DESCRIPTION
It's not a perfect solution but moving to the latest alpha version should fix #1542.

The originating dependency issue can be found [here](https://github.com/jaydenseric/apollo-upload-server/issues/103).

/label dependencies