### PR TITLE
Add option to mock the entire schema(i.e. set preserveResolvers)

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -57,6 +57,10 @@ new ApolloServer({
 
   A boolean enabling the default mocks or object that contains definitions
 
+* `mockEntireSchema`: <`Boolean`>
+
+  A boolean controlling whether existing resolvers are overridden by mocks. Defaults to true, meaning that all resolvers receive mocked values.
+
 * `schemaDirectives`: <`Object`>
 
   Contains definition of schema directives used in the `typeDefs`

--- a/docs/source/features/mocking.md
+++ b/docs/source/features/mocking.md
@@ -143,6 +143,44 @@ const mocks = {
 
 For some more background and flavor on this approach, read the ["Mocking your server with one line of code"](https://medium.com/apollo-stack/mocking-your-server-with-just-one-line-of-code-692feda6e9cd) article on the Apollo blog.
 
+### Using existing resolvers with mocks
+
+The default behavior for mocks is to overwrite the resolvers already present in the schema. To keep the existing resolvers, set the `mockEntireSchema` field to false.
+
+```js line=26
+const { ApolloServer } = require('apollo-server');
+
+const typeDefs = gql`
+type Query {
+  hello: String
+  resolved: String
+}
+`;
+
+const resolvers = {
+  Query: {
+    resolved: () => 'Resolved',
+  },
+};
+
+const mocks = {
+  Int: () => 6,
+  Float: () => 22.1,
+  String: () => 'Hello',
+};
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  mocks,
+  mockEntireSchema: false,
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀 Server ready at ${url}`)
+});
+```
+
 ## Mocking a schema using introspection
 
 The GraphQL specification allows clients to introspect the schema with a [special set of types and fields](https://facebook.github.io/graphql/#sec-Introspection) that every schema must include. The results of a [standard introspection query](https://github.com/graphql/graphql-js/blob/master/src/utilities/introspectionQuery.js) can be used to generate an instance of GraphQLSchema which can be mocked as explained above.

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -86,6 +86,7 @@ export class ApolloServerBase {
       typeDefs,
       introspection,
       mocks,
+      mockEntireSchema,
       extensions,
       engine,
       subscriptions,
@@ -178,11 +179,15 @@ export class ApolloServerBase {
       });
     }
 
-    if (mocks) {
+    if (mocks || typeof mockEntireSchema !== 'undefined') {
       addMockFunctionsToSchema({
         schema: this.schema,
-        preserveResolvers: true,
-        mocks: typeof mocks === 'boolean' ? {} : mocks,
+        mocks:
+          typeof mocks === 'boolean' || typeof mocks === 'undefined'
+            ? {}
+            : mocks,
+        preserveResolvers:
+          typeof mockEntireSchema === 'undefined' ? false : !mockEntireSchema,
       });
     }
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -56,6 +56,7 @@ export interface Config
   context?: Context<any> | ContextFunction<any>;
   introspection?: boolean;
   mocks?: boolean | IMocks;
+  mockEntireSchema?: boolean;
   engine?: boolean | EngineReportingOptions;
   extensions?: Array<() => GraphQLExtension>;
   persistedQueries?: PersistedQueryOptions | false;

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -442,7 +442,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
             },
           });
         return req.then(res => {
-          expect(res.status).toEqual(200);
+          expect(res.statusCode).toEqual(200);
           expect(res.body.errors).toBeDefined();
           expect(res.body.errors.length).toEqual(1);
           expect(res.body.errors[0].message).toEqual(
@@ -465,7 +465,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
             }),
           });
         return req.then(res => {
-          expect(res.status).toEqual(200);
+          expect(res.statusCode).toEqual(200);
           expect(res.body.errors).toBeDefined();
           expect(res.body.errors.length).toEqual(1);
           expect(res.body.errors[0].message).toEqual('PersistedQueryNotFound');


### PR DESCRIPTION
Adds the option to mock the entire schema or preserve the resolvers without specified mocks.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->