### PR TITLE
Fix implicit any types in apollo-server-cloud-function

### DIFF
--- a/packages/apollo-server-cloud-function/package.json
+++ b/packages/apollo-server-cloud-function/package.json
@@ -36,6 +36,7 @@
     "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
+    "@types/express": "4.16.0",
     "apollo-server-integration-testsuite": "2.0.0"
   },
   "peerDependencies": {

--- a/packages/apollo-server-cloud-function/src/ApolloServer.ts
+++ b/packages/apollo-server-cloud-function/src/ApolloServer.ts
@@ -1,9 +1,9 @@
-import { ApolloServerBase } from 'apollo-server-core';
-import { GraphQLOptions, Config } from 'apollo-server-core';
+import { ApolloServerBase, GraphQLOptions, Config } from 'apollo-server-core';
 import {
   renderPlaygroundPage,
   RenderPageOptions as PlaygroundRenderPageOptions,
 } from '@apollographql/graphql-playground-html';
+import { Request, Response } from 'express';
 
 import { graphqlCloudFunction } from './googleCloudApollo';
 
@@ -35,12 +35,15 @@ export class ApolloServer extends ApolloServerBase {
   // This translates the arguments from the middleware into graphQL options It
   // provides typings for the integration specific behavior, ideally this would
   // be propagated with a generic to the super class
-  createGraphQLServerOptions(req, res): Promise<GraphQLOptions> {
+  createGraphQLServerOptions(
+    req: Request,
+    res: Response,
+  ): Promise<GraphQLOptions> {
     return super.graphQLServerOptions({ req, res });
   }
 
   public createHandler({ cors }: CreateHandlerOptions = { cors: undefined }) {
-    const corsHeaders = {};
+    const corsHeaders = {} as Record<string, any>;
 
     if (cors) {
       if (cors.methods) {
@@ -79,14 +82,14 @@ export class ApolloServer extends ApolloServerBase {
       }
     }
 
-    return (req: any, res: any) => {
+    return (req: Request, res: Response) => {
       if (cors) {
         if (typeof cors.origin === 'string') {
           res.set('Access-Control-Allow-Origin', cors.origin);
         } else if (
           typeof cors.origin === 'boolean' ||
           (Array.isArray(cors.origin) &&
-            cors.origin.includes(req.get('origin')))
+            cors.origin.includes(req.get('origin') || ''))
         ) {
           res.set('Access-Control-Allow-Origin', req.get('origin'));
         }

--- a/packages/apollo-server-cloud-function/src/googleCloudApollo.test.ts
+++ b/packages/apollo-server-cloud-function/src/googleCloudApollo.test.ts
@@ -1,3 +1,4 @@
+import { Request, Response } from 'express';
 import { ApolloServer } from './ApolloServer';
 import testSuite, {
   schema as Schema,
@@ -5,7 +6,6 @@ import testSuite, {
 } from 'apollo-server-integration-testsuite';
 import { Config } from 'apollo-server-core';
 import 'mocha';
-import { IncomingMessage, ServerResponse } from 'http';
 
 const createCloudFunction = (options: CreateAppOptions = {}) => {
   const server = new ApolloServer(
@@ -14,7 +14,7 @@ const createCloudFunction = (options: CreateAppOptions = {}) => {
 
   const handler = server.createHandler();
 
-  return (req: IncomingMessage, res: ServerResponse) => {
+  return (req: Request, res: Response) => {
     // return 404 if path is /bogus-route to pass the test, lambda doesn't have paths
     if (req.url.includes('/bogus-route')) {
       res.statusCode = 404;

--- a/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
+++ b/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
@@ -4,6 +4,7 @@ import {
   runHttpQuery,
 } from 'apollo-server-core';
 import { Headers } from 'apollo-server-env';
+import { Request, Response } from 'express';
 
 export function graphqlCloudFunction(options: GraphQLOptions): any {
   if (!options) {
@@ -16,7 +17,7 @@ export function graphqlCloudFunction(options: GraphQLOptions): any {
     );
   }
 
-  const graphqlHandler: any = (req, res): void => {
+  const graphqlHandler: any = (req: Request, res: Response): void => {
     if (req.method === 'POST' && !req.body) {
       res.status(500).send('POST body missing.');
       return;
@@ -29,7 +30,7 @@ export function graphqlCloudFunction(options: GraphQLOptions): any {
       request: {
         url: req.url,
         method: req.method,
-        headers: new Headers(req.headers), // ? Check if this actually works
+        headers: new Headers(req.headers as any), // ? Check if this actually works
       },
     }).then(
       ({ graphqlResponse, responseInit }) => {


### PR DESCRIPTION
I was working on a separate feature and the build was failing locally with several implicit `any` type warnings from the merge of #1446, so I decided to fix them.

Google cloud functions appears to use express internally, so I used those type definitions to type the `req` / `res` params.

I didn't look to see why this would have originally passed CI without any issues.