### PR TITLE
Switch to a fork of `apollo-upload-server` to fix missing `core-js` dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1717,7 +1717,7 @@
     "apollo-server-core": {
       "version": "file:packages/apollo-server-core",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.1",
+        "@apollographql/apollo-upload-server": "^5.0.2",
         "@types/ws": "^5.1.2",
         "apollo-cache-control": "file:packages/apollo-cache-control",
         "apollo-datasource": "file:packages/apollo-datasource",
@@ -1758,7 +1758,7 @@
     "apollo-server-express": {
       "version": "file:packages/apollo-server-express",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.1",
+        "@apollographql/apollo-upload-server": "^5.0.2",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
@@ -1776,7 +1776,7 @@
     "apollo-server-hapi": {
       "version": "file:packages/apollo-server-hapi",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.1",
+        "@apollographql/apollo-upload-server": "^5.0.2",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
@@ -1794,7 +1794,7 @@
     "apollo-server-koa": {
       "version": "file:packages/apollo-server-koa",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.1",
+        "@apollographql/apollo-upload-server": "^5.0.2",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "@koa/cors": "^2.2.1",
         "@types/accepts": "^1.3.5",
@@ -1825,7 +1825,7 @@
     "apollo-server-micro": {
       "version": "file:packages/apollo-server-micro",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.1",
+        "@apollographql/apollo-upload-server": "^5.0.2",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,16 +3,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@apollographql/apollo-upload-server": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-upload-server/-/apollo-upload-server-5.0.1.tgz",
-      "integrity": "sha512-vGmQg5YcmSF+/B0dDefAPqaq758lv+2M0kol2C7DWVNyhElerqjSVwMy8dx/cDjnV2bjuf36EeiflJAIyyK7hA==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.0.0-rc.1",
-        "busboy": "^0.2.14",
-        "object-path": "^0.11.4"
-      }
-    },
     "@apollographql/graphql-playground-html": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.0.tgz",
@@ -1717,7 +1707,7 @@
     "apollo-server-core": {
       "version": "file:packages/apollo-server-core",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.2",
+        "@apollographql/apollo-upload-server": "^5.0.3",
         "@types/ws": "^5.1.2",
         "apollo-cache-control": "file:packages/apollo-cache-control",
         "apollo-datasource": "file:packages/apollo-datasource",
@@ -1736,6 +1726,15 @@
         "ws": "^5.2.0"
       },
       "dependencies": {
+        "@apollographql/apollo-upload-server": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs2": "^7.0.0-rc.1",
+            "busboy": "^0.2.14",
+            "object-path": "^0.11.4"
+          }
+        },
         "ws": {
           "version": "5.2.2",
           "bundled": true,
@@ -1758,7 +1757,7 @@
     "apollo-server-express": {
       "version": "file:packages/apollo-server-express",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.2",
+        "@apollographql/apollo-upload-server": "^5.0.3",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
@@ -1771,18 +1770,40 @@
         "graphql-subscriptions": "^0.5.8",
         "graphql-tools": "^3.0.4",
         "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "@apollographql/apollo-upload-server": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs2": "^7.0.0-rc.1",
+            "busboy": "^0.2.14",
+            "object-path": "^0.11.4"
+          }
+        }
       }
     },
     "apollo-server-hapi": {
       "version": "file:packages/apollo-server-hapi",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.2",
+        "@apollographql/apollo-upload-server": "^5.0.3",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "boom": "^7.1.0",
         "graphql-subscriptions": "^0.5.8",
         "graphql-tools": "^3.0.4"
+      },
+      "dependencies": {
+        "@apollographql/apollo-upload-server": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs2": "^7.0.0-rc.1",
+            "busboy": "^0.2.14",
+            "object-path": "^0.11.4"
+          }
+        }
       }
     },
     "apollo-server-integration-testsuite": {
@@ -1794,7 +1815,7 @@
     "apollo-server-koa": {
       "version": "file:packages/apollo-server-koa",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.2",
+        "@apollographql/apollo-upload-server": "^5.0.3",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "@koa/cors": "^2.2.1",
         "@types/accepts": "^1.3.5",
@@ -1811,6 +1832,17 @@
         "koa-bodyparser": "^3.0.0",
         "koa-router": "^7.4.0",
         "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "@apollographql/apollo-upload-server": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs2": "^7.0.0-rc.1",
+            "busboy": "^0.2.14",
+            "object-path": "^0.11.4"
+          }
+        }
       }
     },
     "apollo-server-lambda": {
@@ -1825,11 +1857,22 @@
     "apollo-server-micro": {
       "version": "file:packages/apollo-server-micro",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.2",
+        "@apollographql/apollo-upload-server": "^5.0.3",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "micro": "^9.3.2"
+      },
+      "dependencies": {
+        "@apollographql/apollo-upload-server": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs2": "^7.0.0-rc.1",
+            "busboy": "^0.2.14",
+            "object-path": "^0.11.4"
+          }
+        }
       }
     },
     "apollo-tracing": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,16 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@apollographql/apollo-upload-server": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-upload-server/-/apollo-upload-server-5.0.1.tgz",
+      "integrity": "sha512-vGmQg5YcmSF+/B0dDefAPqaq758lv+2M0kol2C7DWVNyhElerqjSVwMy8dx/cDjnV2bjuf36EeiflJAIyyK7hA==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.0.0-rc.1",
+        "busboy": "^0.2.14",
+        "object-path": "^0.11.4"
+      }
+    },
     "@apollographql/graphql-playground-html": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.0.tgz",
@@ -32,7 +42,17 @@
       "version": "7.0.0-rc.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-rc.1.tgz",
       "integrity": "sha512-Nifv2kwP/nwR39cAOasNxzjYfpeuf/ZbZNtQz5eYxWTC9yHARU9wItFnAwz1GTZ62MU+AtSjzZPMbLK5Q9hmbg==",
+      "dev": true,
       "requires": {
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0-rc.1.tgz",
+      "integrity": "sha512-2QWAvXXu7r0zmgrXExWXnXh7vuarvjgsDB9qL4hN925dSRrrFZWXjiIQ+LB14753shjZkZ+4xLEJrO9hBKGwRA==",
+      "requires": {
+        "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
       }
     },
@@ -1697,6 +1717,7 @@
     "apollo-server-core": {
       "version": "file:packages/apollo-server-core",
       "requires": {
+        "@apollographql/apollo-upload-server": "^5.0.1",
         "@types/ws": "^5.1.2",
         "apollo-cache-control": "file:packages/apollo-cache-control",
         "apollo-datasource": "file:packages/apollo-datasource",
@@ -1705,7 +1726,6 @@
         "apollo-server-env": "file:packages/apollo-server-env",
         "apollo-server-errors": "file:packages/apollo-server-errors",
         "apollo-tracing": "file:packages/apollo-tracing",
-        "apollo-upload-server": "^5.0.0",
         "graphql-extensions": "file:packages/graphql-extensions",
         "graphql-subscriptions": "^0.5.8",
         "graphql-tag": "^2.9.2",
@@ -1738,6 +1758,7 @@
     "apollo-server-express": {
       "version": "file:packages/apollo-server-express",
       "requires": {
+        "@apollographql/apollo-upload-server": "^5.0.1",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
@@ -1745,7 +1766,6 @@
         "@types/express": "4.16.0",
         "accepts": "^1.3.5",
         "apollo-server-core": "file:packages/apollo-server-core",
-        "apollo-upload-server": "^5.0.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "graphql-subscriptions": "^0.5.8",
@@ -1756,10 +1776,10 @@
     "apollo-server-hapi": {
       "version": "file:packages/apollo-server-hapi",
       "requires": {
+        "@apollographql/apollo-upload-server": "^5.0.1",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
-        "apollo-upload-server": "^5.0.0",
         "boom": "^7.1.0",
         "graphql-subscriptions": "^0.5.8",
         "graphql-tools": "^3.0.4"
@@ -1774,6 +1794,7 @@
     "apollo-server-koa": {
       "version": "file:packages/apollo-server-koa",
       "requires": {
+        "@apollographql/apollo-upload-server": "^5.0.1",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "@koa/cors": "^2.2.1",
         "@types/accepts": "^1.3.5",
@@ -1784,7 +1805,6 @@
         "@types/koa__cors": "^2.2.1",
         "accepts": "^1.3.5",
         "apollo-server-core": "file:packages/apollo-server-core",
-        "apollo-upload-server": "^5.0.0",
         "graphql-subscriptions": "^0.5.8",
         "graphql-tools": "^3.0.4",
         "koa": "2.5.2",
@@ -1805,10 +1825,10 @@
     "apollo-server-micro": {
       "version": "file:packages/apollo-server-micro",
       "requires": {
+        "@apollographql/apollo-upload-server": "^5.0.1",
         "@apollographql/graphql-playground-html": "^1.6.0",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
-        "apollo-upload-server": "^5.0.0",
         "micro": "^9.3.2"
       }
     },
@@ -1849,16 +1869,6 @@
             }
           }
         }
-      }
-    },
-    "apollo-upload-server": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/apollo-upload-server/-/apollo-upload-server-5.0.0.tgz",
-      "integrity": "sha512-CzbHvMo/6TO5XrovzmV/ojTft17s9Cd+vKLGngChpB0UW1ObxKlNLlcXRLD+yt6Nec32/Kt209HmA31hnwxB/g==",
-      "requires": {
-        "@babel/runtime": "^7.0.0-beta.40",
-        "busboy": "^0.2.14",
-        "object-path": "^0.11.4"
       }
     },
     "apollo-utilities": {
@@ -3304,8 +3314,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -37,7 +37,7 @@
     "apollo-server-env": "file:../apollo-server-env",
     "apollo-server-errors": "file:../apollo-server-errors",
     "apollo-tracing": "file:../apollo-tracing",
-    "@apollographql/apollo-upload-server": "^5.0.2",
+    "@apollographql/apollo-upload-server": "^5.0.3",
     "graphql-extensions": "file:../graphql-extensions",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tag": "^2.9.2",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -37,7 +37,7 @@
     "apollo-server-env": "file:../apollo-server-env",
     "apollo-server-errors": "file:../apollo-server-errors",
     "apollo-tracing": "file:../apollo-tracing",
-    "apollo-upload-server": "^5.0.0",
+    "@apollographql/apollo-upload-server": "^5.0.1",
     "graphql-extensions": "file:../graphql-extensions",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tag": "^2.9.2",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -37,7 +37,7 @@
     "apollo-server-env": "file:../apollo-server-env",
     "apollo-server-errors": "file:../apollo-server-errors",
     "apollo-tracing": "file:../apollo-tracing",
-    "@apollographql/apollo-upload-server": "^5.0.1",
+    "@apollographql/apollo-upload-server": "^5.0.2",
     "graphql-extensions": "file:../graphql-extensions",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tag": "^2.9.2",

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -14,7 +14,7 @@ import { GraphQLExtension } from 'graphql-extensions';
 import { EngineReportingAgent } from 'apollo-engine-reporting';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 
-import { GraphQLUpload } from 'apollo-upload-server';
+import { GraphQLUpload } from '@apollographql/apollo-upload-server';
 
 import {
   SubscriptionServer,

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -43,5 +43,5 @@ export const gql: (
 ) => DocumentNode = gqlTag;
 
 import { GraphQLScalarType } from 'graphql';
-import { GraphQLUpload as UploadScalar } from 'apollo-upload-server';
+import { GraphQLUpload as UploadScalar } from '@apollographql/apollo-upload-server';
 export const GraphQLUpload = UploadScalar as GraphQLScalarType;

--- a/packages/apollo-server-core/src/types/apollo-upload-server.d.ts
+++ b/packages/apollo-server-core/src/types/apollo-upload-server.d.ts
@@ -1,4 +1,4 @@
-declare module 'apollo-upload-server' {
+declare module '@apollographql/apollo-upload-server' {
   import { GraphQLScalarType } from 'graphql';
 
   export const GraphQLUpload: GraphQLScalarType;

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -38,7 +38,7 @@
     "@types/express": "4.16.0",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.2",
+    "@apollographql/apollo-upload-server": "^5.0.3",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "graphql-subscriptions": "^0.5.8",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -38,7 +38,7 @@
     "@types/express": "4.16.0",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.1",
+    "@apollographql/apollo-upload-server": "^5.0.2",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "graphql-subscriptions": "^0.5.8",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -38,7 +38,7 @@
     "@types/express": "4.16.0",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
-    "apollo-upload-server": "^5.0.0",
+    "@apollographql/apollo-upload-server": "^5.0.1",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "graphql-subscriptions": "^0.5.8",

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -16,7 +16,7 @@ import * as typeis from 'type-is';
 
 import { graphqlExpress } from './expressApollo';
 
-import { processRequest as processFileUploads } from 'apollo-upload-server';
+import { processRequest as processFileUploads } from '@apollographql/apollo-upload-server';
 
 export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
 

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -33,7 +33,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "apollo-upload-server": "^5.0.0",
+    "@apollographql/apollo-upload-server": "^5.0.1",
     "boom": "^7.1.0",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.4"

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -33,7 +33,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.2",
+    "@apollographql/apollo-upload-server": "^5.0.3",
     "boom": "^7.1.0",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.4"

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -33,7 +33,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.1",
+    "@apollographql/apollo-upload-server": "^5.0.2",
     "boom": "^7.1.0",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.4"

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -4,7 +4,7 @@ import {
   renderPlaygroundPage,
   RenderPageOptions as PlaygroundRenderPageOptions,
 } from '@apollographql/graphql-playground-html';
-import { processRequest as processFileUploads } from 'apollo-upload-server';
+import { processRequest as processFileUploads } from '@apollographql/apollo-upload-server';
 
 import { graphqlHapi } from './hapiApollo';
 

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -40,7 +40,7 @@
     "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.2",
+    "@apollographql/apollo-upload-server": "^5.0.3",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.4",
     "koa": "2.5.2",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -40,7 +40,7 @@
     "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
-    "apollo-upload-server": "^5.0.0",
+    "@apollographql/apollo-upload-server": "^5.0.1",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.4",
     "koa": "2.5.2",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -40,7 +40,7 @@
     "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.1",
+    "@apollographql/apollo-upload-server": "^5.0.2",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^3.0.4",
     "koa": "2.5.2",

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -12,7 +12,7 @@ import * as typeis from 'type-is';
 
 import { graphqlKoa } from './koaApollo';
 
-import { processRequest as processFileUploads } from 'apollo-upload-server';
+import { processRequest as processFileUploads } from '@apollographql/apollo-upload-server';
 
 export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
 import { GraphQLOptions, FileUploadOptions } from 'apollo-server-core';

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -31,7 +31,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.1",
+    "@apollographql/apollo-upload-server": "^5.0.2",
     "micro": "^9.3.2"
   }
 }

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -31,7 +31,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "apollo-upload-server": "^5.0.0",
+    "@apollographql/apollo-upload-server": "^5.0.1",
     "micro": "^9.3.2"
   }
 }

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -31,7 +31,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "@apollographql/apollo-upload-server": "^5.0.2",
+    "@apollographql/apollo-upload-server": "^5.0.3",
     "micro": "^9.3.2"
   }
 }

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -1,5 +1,5 @@
 import { ApolloServerBase, GraphQLOptions } from 'apollo-server-core';
-import { processRequest as processFileUploads } from 'apollo-upload-server';
+import { processRequest as processFileUploads } from '@apollographql/apollo-upload-server';
 import { ServerResponse } from 'http';
 import { send } from 'micro';
 import { renderPlaygroundPage } from '@apollographql/graphql-playground-html';


### PR DESCRIPTION
As reported in https://github.com/apollographql/apollo-server/issues/1542, the `apollo-upload-server` package (v5.0.0, which `apollo-server` relies on) is no longer able to provide a `core-js` package because of change that was outside of its control in a Babel release.

The problem is resolved in newer versions of `apollo-upload-server`, however, regrettably, the newer versions of that package (notably, v6 and v7) drop support for Node.js 6 — one of two versions of Node.js that are currently under the terms of the Node.js Foundation's Long-Term-Support (LTS) agreements.

Since Apollo Server aims to support versions of Node.js which are under LTS (and will drop support for Node.js 6 in April 2019, per Node.js' schedule) the current, immediate solution is to fork the `apollo-upload-server` package as `@apollographql/apollo-upload-server`.

With the inclusion of https://github.com/apollographql/apollo-upload-server/pull/1, we are able to keep supporting Node.js 6.  Without this change, every new installation of `apollo-server`, which doesn't have a `package-lock.json` preventing transitive dependency updates - specifically, the updates to `@babel/runtime` versions newer than `-beta.56` - is broken.