### PR TITLE
Update schema-stitching.md

### DIFF
--- a/docs/source/features/schema-stitching.md
+++ b/docs/source/features/schema-stitching.md
@@ -151,7 +151,7 @@ Combining existing root fields is a great start, but in practice we will often w
 To add this ability to navigate between types, we need to _extend_ existing types with new fields that translate between the types:
 
 ```js
-const linkTypeDefs = gql`
+const linkTypeDefs = `
   extend type User {
     chirps: [Chirp]
   }


### PR DESCRIPTION
On version 3.1.1 there is an error ( `Error: Invalid schema passed` ) when wrapping the `linkTypeDefs` in `gql`. Passing the plain string the example works.

Does that warrant a changelog update?

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->