### PR TITLE
[wip] Full Query Caching

### DIFF
--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-unused-expression */
-import MockReq = require('mock-req');
+import { Request } from 'apollo-server-env';
 
 import {
   GraphQLSchema,
@@ -85,7 +85,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: query,
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
     });
@@ -97,7 +97,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       parsedQuery: query,
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
     });
@@ -110,7 +110,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       variables: { base: 1 },
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toBeUndefined();
       expect(res.errors!.length).toEqual(1);
@@ -125,7 +125,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       debug: true,
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(() => {
       logStub.mockRestore();
       expect(logStub.mock.calls.length).toEqual(0);
@@ -139,7 +139,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       debug: false,
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(() => {
       logStub.mockRestore();
       expect(logStub.mock.calls.length).toEqual(0);
@@ -154,7 +154,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       variables: { base: 1 },
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toBeUndefined();
       expect(res.errors!.length).toEqual(1);
@@ -169,7 +169,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       rootValue: 'it also',
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
     });
@@ -182,7 +182,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       context: { s: 'it still' },
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
     });
@@ -199,7 +199,7 @@ describe('runQuery', () => {
         response['extensions'] = context.s;
         return response;
       },
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
       expect(res['extensions']).toEqual('it still');
@@ -213,7 +213,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       variables: { base: 1 },
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
     });
@@ -226,7 +226,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: query,
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.errors![0].message).toEqual(expected);
     });
@@ -236,7 +236,7 @@ describe('runQuery', () => {
     return runQuery({
       schema,
       queryString: `{ testAwaitedValue }`,
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual({
         testAwaitedValue: 'it works',
@@ -259,7 +259,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       operationName: 'Q1',
-      request: new MockReq(),
+      request: new Request('local'),
     }).then(res => {
       expect(res.data).toEqual(expected);
     });
@@ -278,7 +278,7 @@ describe('runQuery', () => {
       schema,
       queryString: query,
       operationName: 'Q1',
-      request: new MockReq(),
+      request: new Request('local'),
     });
 
     expect(result1.data).toEqual({
@@ -292,7 +292,7 @@ describe('runQuery', () => {
       queryString: query,
       operationName: 'Q1',
       fieldResolver: () => 'a very testful field resolver string',
-      request: new MockReq(),
+      request: new Request('local'),
     });
 
     expect(result2.data).toEqual({
@@ -333,7 +333,7 @@ describe('runQuery', () => {
         }),
         queryString,
         extensions,
-        request: new MockReq(),
+        request: new Request('local'),
       });
     });
 
@@ -345,7 +345,7 @@ describe('runQuery', () => {
         schema,
         queryString,
         extensions,
-        request: new MockReq(),
+        request: new Request('local'),
       }).then(res => {
         expect(res.data).toEqual(expected);
         expect(res.extensions).toEqual({
@@ -390,7 +390,7 @@ describe('runQuery', () => {
         schema,
         queryString: query,
         operationName: 'Q1',
-        request: new MockReq(),
+        request: new Request('local'),
       });
 
       // Expect there to be several async ids provided

--- a/packages/apollo-server-core/src/caching.ts
+++ b/packages/apollo-server-core/src/caching.ts
@@ -3,7 +3,11 @@ import { CacheControlFormat } from 'apollo-cache-control';
 
 export function calculateCacheControlHeaders(
   responses: Array<ExecutionResult & { extensions?: Record<string, any> }>,
-): Record<string, string> {
+): Partial<{
+  'Cache-Control': string;
+  lowestMaxAge: number;
+  publicOrPrivate: string;
+}> {
   let lowestMaxAge = Number.MAX_VALUE;
   let publicOrPrivate = 'public';
 
@@ -62,5 +66,7 @@ export function calculateCacheControlHeaders(
 
   return {
     'Cache-Control': `max-age=${lowestMaxAge}, ${publicOrPrivate}`,
+    lowestMaxAge,
+    publicOrPrivate,
   };
 }

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -41,6 +41,8 @@ export interface GraphQLServerOptions<
     | (CacheControlExtensionOptions & {
         calculateHttpHeaders?: boolean;
         stripFormattedExtensions?: boolean;
+        cache?: KeyValueCache;
+        privateCache?: KeyValueCache;
       });
   extensions?: Array<() => GraphQLExtension>;
   dataSources?: () => DataSources<TContext>;

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -370,8 +370,8 @@ export async function runHttpQuery(
           cacheControl = {
             stripFormattedExtensions: false,
             calculateHttpHeaders: false,
-            privateCache: optionsObject.cache,
-            cache: optionsObject.cache,
+            privateCache: optionsObject.cache!,
+            cache: optionsObject.cache!,
             defaultMaxAge: 0,
           };
         } else {
@@ -381,8 +381,8 @@ export async function runHttpQuery(
             stripFormattedExtensions: true,
             calculateHttpHeaders: true,
             defaultMaxAge: 0,
-            privateCache: optionsObject.cache,
-            cache: optionsObject.cache,
+            privateCache: optionsObject.cache!,
+            cache: optionsObject.cache!,
             ...optionsObject.cacheControl,
           };
         }
@@ -413,7 +413,6 @@ export async function runHttpQuery(
         persistedQueryHit,
         persistedQueryRegister,
         queryHash: calculatedSha,
-        privateCache,
       };
 
       return runQuery(params);
@@ -455,7 +454,10 @@ export async function runHttpQuery(
 
       responseInit.headers = {
         ...responseInit.headers,
-        ...calculatedHeaders,
+        ...(omit(calculatedHeaders, [
+          'lowestMaxAge',
+          'publicOrPrivate',
+        ]) as Record<string, string>),
       };
     }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -375,13 +375,16 @@ export async function runHttpQuery(
             defaultMaxAge: 0,
           };
         } else {
+          const privateCache =
+            (optionsObject.cacheControl && optionsObject.cacheControl.cache) ||
+            optionsObject.cache!;
           // Default behavior is to run default header calculation and return
           // no cacheControl extensions
           cacheControl = {
             stripFormattedExtensions: true,
             calculateHttpHeaders: true,
             defaultMaxAge: 0,
-            privateCache: optionsObject.cache!,
+            privateCache,
             cache: optionsObject.cache!,
             ...optionsObject.cacheControl,
           };

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -12,8 +12,10 @@ import {
   specifiedRules,
   ValidationContext,
 } from 'graphql';
+const sha256 = require('hash.js/lib/hash/sha/256');
 
 import { Request } from 'apollo-server-env';
+import { KeyValueCache } from 'apollo-server-caching';
 
 import {
   enableGraphQLExtensions,
@@ -62,12 +64,18 @@ export interface QueryOptions {
   formatError?: Function;
   formatResponse?: Function;
   debug?: boolean;
-  tracing?: boolean;
-  cacheControl?: boolean | CacheControlExtensionOptions;
+  tracing: boolean;
+  cacheControl:
+    | false
+    | CacheControlExtensionOptions & {
+        privateCache: KeyValueCache;
+        cache: KeyValueCache;
+      };
   request: Pick<Request, 'url' | 'method' | 'headers'>;
   extensions?: Array<() => GraphQLExtension>;
   persistedQueryHit?: boolean;
   persistedQueryRegister?: boolean;
+  queryHash: string;
 }
 
 function isQueryOperation(query: DocumentNode, operationName?: string) {
@@ -136,9 +144,49 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
     persistedQueryHit: options.persistedQueryHit,
     persistedQueryRegister: options.persistedQueryRegister,
   });
-  return Promise.resolve()
+
+  let varyString;
+  const varyHeader = options.request.headers.get('Vary');
+  if (varyHeader) {
+    const varyHeaders = varyHeader.split(',').map(header => header.trim());
+    varyString = varyHeaders
+      .map(header => options.request.headers.get(header))
+      .join('');
+  }
+
+  let cacheKey: string | undefined;
+  let cache: KeyValueCache;
+  let cacheGet: Promise<string | undefined>;
+  if (options.cacheControl) {
+    const sessionId = options.request.headers.get('Authorization');
+    const keyExtension =
+      options.operationName +
+      JSON.stringify(options.variables) +
+      varyString +
+      (sessionId || '');
+
+    cacheKey =
+      'q' +
+      options.queryHash +
+      sha256(keyExtension)
+        .update()
+        .digest('hex');
+    cache = sessionId
+      ? options.cacheControl.privateCache
+      : options.cacheControl.cache;
+    cacheGet = cache.get(cacheKey);
+  } else {
+    cacheGet = Promise.resolve(undefined);
+  }
+
+  return cacheGet
     .then(
-      (): Promise<GraphQLResponse> => {
+      (cacheResult): Promise<GraphQLResponse> | GraphQLResponse => {
+        if (cacheResult) {
+          // XXX Ideally we would return this response directly back to the user without parsing and stringifying again
+          return JSON.parse(cacheResult);
+        }
+
         // Parse the document.
         let documentAST: DocumentNode;
         if (options.parsedQuery) {
@@ -264,6 +312,15 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
 
             if (options.formatResponse) {
               response = options.formatResponse(response, options);
+            }
+
+            if (cacheKey && cache) {
+              (async () => {
+                // We do not wait on the cache storage to complete
+                return cache.set(cacheKey, JSON.stringify(response));
+              })().catch(error => {
+                console.warn(error);
+              });
             }
 
             return response;

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1224,12 +1224,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
           privateUser: PrivateUser
         }
 
-        type User @cacheControl(maxAge: 100){
-          cached
+        type User @cacheControl(maxAge: 100) {
+          cached: String
         }
 
-        type PrivateUser @cacheControl(maxAge: 100, scope: PRIVATE){
-          cached
+        type PrivateUser @cacheControl(maxAge: 100, scope: PRIVATE) {
+          cached: String
         }
       `;
 
@@ -1263,12 +1263,20 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
         const apolloFetch = createApolloFetch({ uri });
 
-        const result = await apolloFetch({ query: '{ publicUser }' });
-        expect(result.data).toEqual({ publicUser: 'public decency' });
+        const result = await apolloFetch({
+          query: '{ publicUser { cached } }',
+        });
+        expect(result.data).toEqual({
+          publicUser: { cached: 'public decency' },
+        });
         expect(setSpy.mock.calls.length === 1);
 
-        const cachedResult = await apolloFetch({ query: '{ publicUser }' });
-        expect(cachedResult.data).toEqual({ publicUser: 'public decency' });
+        const cachedResult = await apolloFetch({
+          query: '{ publicUser { cached } }',
+        });
+        expect(cachedResult.data).toEqual({
+          publicUser: { cached: 'public decency' },
+        });
         expect(getSpy.mock.calls.length === 1);
       });
 
@@ -1295,12 +1303,18 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
         const apolloFetch = createApolloFetch({ uri });
 
-        const result = await apolloFetch({ query: '{ publicUser }' });
-        expect(result.data).toEqual({ publicUser: 'public decency' });
+        const result = await apolloFetch({
+          query: '{ privateUser { cached } }',
+        });
+        expect(result.data).toEqual({ privateUser: { cached: 'censored' } });
         expect(setSpy.mock.calls.length === 1);
 
-        const cachedResult = await apolloFetch({ query: '{ publicUser }' });
-        expect(cachedResult.data).toEqual({ publicUser: 'public decency' });
+        const cachedResult = await apolloFetch({
+          query: '{ privateUser { cached } }',
+        });
+        expect(cachedResult.data).toEqual({
+          privateUser: { cached: 'censored' },
+        });
         expect(getSpy.mock.calls.length === 1);
       });
     });

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -35,6 +35,7 @@ import {
   gql,
   Config,
   ApolloServerBase,
+  KeyValueCache,
 } from 'apollo-server-core';
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
 
@@ -1213,6 +1214,94 @@ export function testApolloServer<AS extends ApolloServerBase>(
           expect(result.data).toEqual({ testString: 'test string' });
           done();
         }, done.fail);
+      });
+    });
+
+    describe('Full Response Caching', () => {
+      const typeDefs = gql`
+        type Query {
+          publicUser: User
+          privateUser: PrivateUser
+        }
+
+        type User @cacheControl(maxAge: 100){
+          cached
+        }
+
+        type PrivateUser @cacheControl(maxAge: 100, scope: PRIVATE){
+          cached
+        }
+      `;
+
+      const resolvers = {
+        Query: {
+          publicUser: () => ({ cached: 'public decency' }),
+          privateUser: () => ({ cached: 'censored' }),
+        },
+      };
+
+      it('it caches and retreives a full response in the public cache', async () => {
+        const real$ = new Map();
+        const getSpy = jest.fn(async (key: string) => {
+          return real$.get(key);
+        });
+        const setSpy = jest.fn(async (key: string, value: string) => {
+          real$.set(key, value);
+        });
+
+        const cache: KeyValueCache = {
+          get: getSpy,
+          set: setSpy,
+        };
+        const { url: uri } = await createApolloServer({
+          typeDefs,
+          resolvers,
+          cacheControl: {
+            privateCache: cache,
+          },
+        });
+
+        const apolloFetch = createApolloFetch({ uri });
+
+        const result = await apolloFetch({ query: '{ publicUser }' });
+        expect(result.data).toEqual({ publicUser: 'public decency' });
+        expect(setSpy.mock.calls.length === 1);
+
+        const cachedResult = await apolloFetch({ query: '{ publicUser }' });
+        expect(cachedResult.data).toEqual({ publicUser: 'public decency' });
+        expect(getSpy.mock.calls.length === 1);
+      });
+
+      it('it stores a full response in the private cache when scoped to private', async () => {
+        const real$ = new Map();
+        const getSpy = jest.fn(async (key: string) => {
+          return real$.get(key);
+        });
+        const setSpy = jest.fn(async (key: string, value: string) => {
+          real$.set(key, value);
+        });
+
+        const cache: KeyValueCache = {
+          get: getSpy,
+          set: setSpy,
+        };
+        const { url: uri } = await createApolloServer({
+          typeDefs,
+          resolvers,
+          cacheControl: {
+            privateCache: cache,
+          },
+        });
+
+        const apolloFetch = createApolloFetch({ uri });
+
+        const result = await apolloFetch({ query: '{ publicUser }' });
+        expect(result.data).toEqual({ publicUser: 'public decency' });
+        expect(setSpy.mock.calls.length === 1);
+
+        const cachedResult = await apolloFetch({ query: '{ publicUser }' });
+        expect(cachedResult.data).toEqual({ publicUser: 'public decency' });
+        expect(getSpy.mock.calls.length === 1);
       });
     });
   });

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -49,6 +49,7 @@ export class GraphQLExtension<TContext = any> {
 
   public willSendResponse?(o: {
     graphqlResponse: GraphQLResponse;
+    cacheHit?: boolean;
   }): void | { graphqlResponse: GraphQLResponse };
 
   public willResolveField?(


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This add full response caching. Currently there are plans for an improved request pipeline, so this is wip. Currently this full response caching only applies to http traffic. 

It offers a separate public and private cache that can be configured with the `cacheControl` object. If no cache is specified, then the responses are stored in the default cache. Since caching is opt in, we don't have an easy way to disable the functionality besides creating a cache that always returns null for a get.

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Documentation

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->