### PR TITLE
fixed: enabled not to be false

### DIFF
--- a/packages/apollo-server-core/src/playground.ts
+++ b/packages/apollo-server-core/src/playground.ts
@@ -36,7 +36,7 @@ export const defaultPlaygroundOptions = {
 };
 
 export function createPlaygroundOptions(
-  playground: PlaygroundConfig = {},
+  playground: PlaygroundConfig,
 ): PlaygroundRenderPageOptions | undefined {
   const isDev = process.env.NODE_ENV !== 'production';
   const enabled: boolean =


### PR DESCRIPTION
when playground is undefined , createPlaygroundOptions still set its default value

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->