### PR TITLE
Google Cloud Functions tests

### DIFF
--- a/packages/apollo-server-cloud-function/package.json
+++ b/packages/apollo-server-cloud-function/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@apollographql/graphql-playground-html": "^1.6.0",
-    "apollo-server-core": "2.0.0",
-    "apollo-server-env": "2.0.0",
+    "apollo-server-core": "file:../apollo-server-core",
+    "apollo-server-env": "file:../apollo-server-env",
     "graphql-tools": "^3.0.4"
   },
   "peerDependencies": {

--- a/packages/apollo-server-cloud-function/src/__tests__/googleCloudApollo.test.ts
+++ b/packages/apollo-server-cloud-function/src/__tests__/googleCloudApollo.test.ts
@@ -1,11 +1,10 @@
 import { Request, Response } from 'express';
-import { ApolloServer } from './ApolloServer';
+import { ApolloServer } from '../ApolloServer';
 import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
 import { Config } from 'apollo-server-core';
-import 'mocha';
 
 const createCloudFunction = (options: CreateAppOptions = {}) => {
   const server = new ApolloServer(

--- a/packages/apollo-server-cloud-function/tsconfig.json
+++ b/packages/apollo-server-cloud-function/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist",
-    "lib": ["es2017", "esnext.asynciterable", "dom"]
+    "outDir": "./dist"
   },
-  "exclude": ["node_modules", "dist"]
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__", "**/__mocks__"]
 }


### PR DESCRIPTION
We recently merged [a PR](https://github.com/apollographql/apollo-server/pull/1446) that adds support for Google Cloud Functions to Apollo Server.

It turns our the integration tests weren't actually being run because they weren't under a `__tests__` directory. After changing that, the tests unfortunately all fail.

From what I can see, this is caused by `apollo-server-integration-testsuite` expecting request and response types to be of the underlying Node types and not Express types, as can be seen in the Lambda integration: https://github.com/apollographql/apollo-server/blob/a7301080b7e2c5a5eec4a9a9724050c3d55d9451/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts#L17

@reaktivo: Would you be able to take another look at this? I assume things are actually working for you, but we also need the tests to pass to assure the integration behaves as expected.

@tgriesser: Since you added types in https://github.com/apollographql/apollo-server/pull/1554/files, maybe you also want to chime in?