### PR TITLE
Provide ability to specify client info in traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All of the packages in the `apollo-server` repo are released with the same versi
 ### vNEXT
 
 - Update link inside Authentication Docs [PR #1682](https://github.com/apollographql/apollo-server/pull/1682)
+- Provide ability to specify client info in traces [#1631](https://github.com/apollographql/apollo-server/pull/1631)
 
 ### v2.0.8
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -351,8 +351,12 @@ addMockFunctionsToSchema({
 
    Set to true to remove error details from the traces sent to Apollo's servers. Defaults to false.
 
-* createClientInfo?: (o: { request: Request, queryString?: string, parsedQuery?: DocumentNode, variables: Record<string, any>}) => ClientInfo;
+* generateClientInfo?: (o: { context: any, extensions?: Record<string, any>}) => ClientInfo;
 
    Creates the client information that is attached to the traces sent to the
-   Apollo backend. `ClientInfo` contains fields for `clientName` and
-   `clientVersion`, which can both be optional.
+   Apollo backend. The context field is the execution context passed to the
+   resolvers and the extensions field is the field provided in the request's
+   query, operationName, and variables. `ClientInfo` contains fields for
+   `clientName` and `clientVersion`, which can both be optional. The default
+   value copies the respective fields from the `extensions`'s `clientInfo`
+   field.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -355,8 +355,8 @@ addMockFunctionsToSchema({
 
    Creates the client information that is attached to the traces sent to the
    Apollo backend. The context field is the execution context passed to the
-   resolvers and the extensions field is the field provided in the request's
-   query, operationName, and variables. `ClientInfo` contains fields for
-   `clientName` and `clientVersion`, which can both be optional. The default
-   value copies the respective fields from the `extensions`'s `clientInfo`
-   field.
+   resolvers and the extensions field corresponds to the same value in the POST
+   body or GET parameters. `ClientInfo` contains fields for `clientName` and
+   `clientVersion`, which are both optional. The default generation copies the
+   respective fields from `extensions.clientInfo`. If `clientName` or
+   `clientVersion` is not present, the values are set to the empty string.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -354,5 +354,5 @@ addMockFunctionsToSchema({
 * createClientInfo?: (o: { request: Request, queryString?: string, parsedQuery?: DocumentNode, variables: Record<string, any>}) => ClientInfo;
 
    Creates the client information that is attached to the traces sent to the
-   Apollo backend. `ClientInfo` contains fields for `clientName`,
-   `clientVersion`, and `clientAddress`, which can all be optional.
+   Apollo backend. `ClientInfo` contains fields for `clientName` and
+   `clientVersion`, which can both be optional.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -350,3 +350,9 @@ addMockFunctionsToSchema({
 *  `maskErrorDetails`: boolean
 
    Set to true to remove error details from the traces sent to Apollo's servers. Defaults to false.
+
+* createClientInfo?: (o: { request: Request, queryString?: string, parsedQuery?: DocumentNode, variables: Record<string, any>}) => ClientInfo;
+
+   Creates the client information that is attached to the traces sent to the
+   Apollo backend. `ClientInfo` contains fields for `clientName`,
+   `clientVersion`, and `clientAddress`, which can all be optional.

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -8,7 +8,7 @@ import {
   Trace,
 } from 'apollo-engine-reporting-protobuf';
 
-import { fetch, Response } from 'apollo-server-env';
+import { fetch, Request, Response } from 'apollo-server-env';
 import * as retry from 'async-retry';
 
 import { EngineReportingExtension } from './extension';
@@ -33,6 +33,12 @@ Traces.encode = function(message, originalWriter) {
   }
   return writer;
 };
+
+export interface ClientInfo {
+  clientName?: string;
+  clientAddress?: string;
+  clientVersion?: string;
+}
 
 export interface EngineReportingOptions {
   // API key for the service. Get this from
@@ -83,6 +89,16 @@ export interface EngineReportingOptions {
   sendReportsImmediately?: boolean;
   // To remove the error message from traces, set this to true. Defaults to false
   maskErrorDetails?: boolean;
+  // Creates the client information attached to the traces sent to the Apollo
+  // backend
+  createClientInfo?: (
+    o: {
+      request: Request;
+      queryString?: string;
+      parsedQuery?: DocumentNode;
+      variables: Record<string, any>;
+    },
+  ) => ClientInfo;
 
   // XXX Provide a way to set client_name, client_version, client_address,
   // service, and service_version fields. They are currently not revealed in the

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -36,7 +36,6 @@ Traces.encode = function(message, originalWriter) {
 
 export interface ClientInfo {
   clientName?: string;
-  clientAddress?: string;
   clientVersion?: string;
 }
 

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -90,7 +90,7 @@ export interface EngineReportingOptions {
   maskErrorDetails?: boolean;
   // Creates the client information attached to the traces sent to the Apollo
   // backend
-  createClientInfo?: (
+  generateClientInfo?: (
     o: {
       context: any;
       extensions?: Record<string, any>;

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -8,7 +8,7 @@ import {
   Trace,
 } from 'apollo-engine-reporting-protobuf';
 
-import { fetch, Request, Response } from 'apollo-server-env';
+import { fetch, Response } from 'apollo-server-env';
 import * as retry from 'async-retry';
 
 import { EngineReportingExtension } from './extension';
@@ -93,10 +93,8 @@ export interface EngineReportingOptions {
   // backend
   createClientInfo?: (
     o: {
-      request: Request;
-      queryString?: string;
-      parsedQuery?: DocumentNode;
-      variables: Record<string, any>;
+      context: any;
+      extensions?: Record<string, any>;
     },
   ) => ClientInfo;
 

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -15,7 +15,7 @@ import {
 } from 'graphql-extensions';
 import { Trace, google } from 'apollo-engine-reporting-protobuf';
 
-import { EngineReportingOptions } from './agent';
+import { EngineReportingOptions, ClientInfo } from './agent';
 import { defaultSignature } from './signature';
 
 // EngineReportingExtension is the per-request GraphQLExtension which creates a
@@ -153,6 +153,19 @@ export class EngineReportingExtension<TContext = any>
         }
       });
     }
+
+    const { clientName, clientAddress, clientVersion } =
+      (this.options.createClientInfo &&
+        this.options.createClientInfo({
+          request: o.request,
+          queryString: o.queryString,
+          parsedQuery: o.parsedQuery,
+          variables: o.variables,
+        })) ||
+      ({} as ClientInfo);
+    this.trace.clientName = clientName || '';
+    this.trace.clientAddress = clientAddress || '';
+    this.trace.clientVersion = clientVersion || '';
 
     return () => {
       this.trace.durationNs = durationHrTimeToNanos(

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -156,7 +156,10 @@ export class EngineReportingExtension<TContext = any>
       });
     }
 
-    const { clientName, clientAddress, clientVersion } =
+    // While clientAddress could be a part of the protobuf, we'll ignore it for
+    // now, since the backend does not group by it and Engine frontend will not
+    // support it in the short term
+    const { clientName, clientVersion } =
       (this.options.createClientInfo &&
         this.options.createClientInfo({
           context: o.context,
@@ -164,7 +167,6 @@ export class EngineReportingExtension<TContext = any>
         })) ||
       ({} as ClientInfo);
     this.trace.clientName = clientName || '';
-    this.trace.clientAddress = clientAddress || '';
     this.trace.clientVersion = clientVersion || '';
 
     return () => {

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -60,6 +60,8 @@ export class EngineReportingExtension<TContext = any>
     variables?: Record<string, any>;
     persistedQueryHit?: boolean;
     persistedQueryRegister?: boolean;
+    context: any;
+    extensions?: Record<string, any>;
   }): EndHandler {
     this.trace.startTime = dateToTimestamp(new Date());
     this.startHrTime = process.hrtime();
@@ -157,10 +159,8 @@ export class EngineReportingExtension<TContext = any>
     const { clientName, clientAddress, clientVersion } =
       (this.options.createClientInfo &&
         this.options.createClientInfo({
-          request: o.request,
-          queryString: o.queryString,
-          parsedQuery: o.parsedQuery,
-          variables: o.variables,
+          context: o.context,
+          extensions: o.extensions,
         })) ||
       ({} as ClientInfo);
     this.trace.clientName = clientName || '';

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -59,7 +59,8 @@ export class EngineReportingExtension<TContext = any>
     this.nodes.set(responsePathAsString(undefined), root);
     this.generateClientInfo =
       options.generateClientInfo ||
-      // Default to using the clientInfo field of the request
+      // Default to using the clientInfo field of the request's extensions, when
+      // the ClientInfo fields are undefined, we send the empty string
       (({ extensions }) => (extensions && extensions.clientInfo) || {});
   }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -402,6 +402,7 @@ export async function runHttpQuery(
           : false,
         request: request.request,
         extensions: optionsObject.extensions,
+        queryExtensions: extensions,
         persistedQueryHit,
         persistedQueryRegister,
       };

--- a/packages/apollo-server-core/src/runQuery.ts
+++ b/packages/apollo-server-core/src/runQuery.ts
@@ -66,6 +66,7 @@ export interface QueryOptions {
   cacheControl?: boolean | CacheControlExtensionOptions;
   request: Pick<Request, 'url' | 'method' | 'headers'>;
   extensions?: Array<() => GraphQLExtension>;
+  queryExtensions?: Record<string, any>;
   persistedQueryHit?: boolean;
   persistedQueryRegister?: boolean;
 }
@@ -136,6 +137,7 @@ function doRunQuery(options: QueryOptions): Promise<GraphQLResponse> {
     persistedQueryHit: options.persistedQueryHit,
     persistedQueryRegister: options.persistedQueryRegister,
     context,
+    extensions: options.queryExtensions,
   });
   return Promise.resolve()
     .then(

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -81,6 +81,7 @@ export class GraphQLExtensionStack<TContext = any> {
     persistedQueryHit?: boolean;
     persistedQueryRegister?: boolean;
     context: TContext;
+    extensions?: Record<string, any>;
   }): EndHandler {
     return this.handleDidStart(
       ext => ext.requestDidStart && ext.requestDidStart(o),


### PR DESCRIPTION
Adds the createClientInfo to apollo-engine-reporting, which enables the
differentiation of clients based on the request, operation, and
variables. This could be extended to include the response. However for
the first release. It doesn't quite make sense.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->