### PR TITLE
Add option to filter errors from being reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow an optional function to resolve the `rootValue`, passing the `DocumentNode` AST to determine the value. [PR #1555](https://github.com/apollographql/apollo-server/pull/1555)
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
+- Add option to filter errors from being reported [#1639](https://github.com/apollographql/apollo-server/pull/1639)
 
 ### v2.1.0
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -365,3 +365,9 @@ addMockFunctionsToSchema({
 *  `maskErrorDetails`: boolean
 
    Set to true to remove error details from the traces sent to Apollo's servers. Defaults to false.
+
+* `errorFilter`: (err: Error) => boolean
+
+   By default, all errors get reported to Engine servers. You can specify a
+   a filter function to exclude specific errors from being reported by
+   returning false.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -362,12 +362,9 @@ addMockFunctionsToSchema({
    'sendReport()' on other signals if you'd like. Note that 'sendReport()'
    does not run synchronously so it cannot work usefully in an 'exit' handler.
 
-*  `maskErrorDetails`: boolean
-
-   Set to true to remove error details from the traces sent to Apollo's servers. Defaults to false.
-
-* `errorFilter`: (err: Error) => boolean
+* `filterErrors`: (err: Error) => Error | null
 
    By default, all errors get reported to Engine servers. You can specify a
    a filter function to exclude specific errors from being reported by
-   returning false.
+   returning null, or you can mask certain details of the error and return the
+   error to be reported.

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -88,6 +88,10 @@ export interface EngineReportingOptions {
   sendReportsImmediately?: boolean;
   // To remove the error message from traces, set this to true. Defaults to false
   maskErrorDetails?: boolean;
+  // By default, all errors get reported to Engine servers. You can specify a
+  // a filter function to exclude specific errors from being reported by
+  // returning false.
+  errorFilter?: (err: Error) => boolean;
 
   /**
    * (Experimental) Creates the client information for operation traces.

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import { gzip } from 'zlib';
-import { DocumentNode } from 'graphql';
+import { DocumentNode, GraphQLError } from 'graphql';
 import {
   FullTracesReport,
   ReportHeader,
@@ -86,12 +86,11 @@ export interface EngineReportingOptions {
   handleSignals?: boolean;
   // Sends the trace report immediately. This options is useful for stateless environments
   sendReportsImmediately?: boolean;
-  // To remove the error message from traces, set this to true. Defaults to false
-  maskErrorDetails?: boolean;
   // By default, all errors get reported to Engine servers. You can specify a
   // a filter function to exclude specific errors from being reported by
-  // returning false.
-  errorFilter?: (err: Error) => boolean;
+  // returning null, or you can mask certain details of the error and return the
+  // error to be reported.
+  filterErrors?: (err: GraphQLError) => GraphQLError | null;
 
   /**
    * (Experimental) Creates the client information for operation traces.

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -90,7 +90,8 @@ export interface EngineReportingOptions {
   // a filter function to exclude specific errors from being reported by
   // returning null, or you can mask certain details of the error and return the
   // error to be reported.
-  filterErrors?: (err: GraphQLError) => GraphQLError | null;
+  // If set to 'true' instead of a function, it will mask the error details.
+  filterErrors?: ((err: GraphQLError) => GraphQLError | null) | boolean;
 
   /**
    * (Experimental) Creates the client information for operation traces.

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -51,6 +51,7 @@ export class EngineReportingExtension<TContext = any>
   ) {
     this.options = {
       maskErrorDetails: false,
+      errorFilter: () => true,
       ...options,
     };
     this.addTrace = addTrace;
@@ -272,7 +273,9 @@ export class EngineReportingExtension<TContext = any>
               json: JSON.stringify(error),
             };
 
-        node!.error!.push(new Trace.Error(errorInfo));
+        if (!this.options.errorFilter || this.options.errorFilter(error)) {
+          node!.error!.push(new Trace.Error(errorInfo));
+        }
       });
     }
   }

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -49,8 +49,18 @@ export class EngineReportingExtension<TContext = any>
     options: EngineReportingOptions,
     addTrace: (signature: string, operationName: string, trace: Trace) => void,
   ) {
+    const filterErrors = (() => {
+      if (options.filterErrors === true) {
+        return (error: GraphQLError) => new GraphQLError('masked', error.nodes);
+      } else if (options.filterErrors) {
+        return options.filterErrors;
+      } else {
+        return (error: GraphQLError) => error;
+      }
+    })();
+
     this.options = {
-      filterErrors: error => error,
+      filterErrors,
       ...options,
     };
     this.addTrace = addTrace;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Add errorFilter option to make it possible to filter certain errors from being reported to the Engine service. (For user errors, like invalid password, etc...)

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->