### PR TITLE
Add support for json api content type

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -104,11 +104,8 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
 
   protected parseBody(response: Response): Promise<object | string> {
     const contentType = response.headers.get('Content-Type');
-    if (
-      contentType &&
-      (contentType.startsWith('application/json') ||
-        contentType.startsWith('application/hal+json'))
-    ) {
+    const applicationJsonRegEx = /^application\/(\S*\+)?json/;
+    if (contentType && applicationJsonRegEx.test(contentType)) {
       return response.json();
     } else {
       return response.text();

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -55,6 +55,9 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
 
   baseURL?: string;
 
+  // Set the default Content-Type for json responses to 'application/json'
+  jsonContentType: string = 'application/json';
+
   // By default, we use the full request URL as the cache key.
   // You can override this to remove query parameters or compute a cache key in any way that makes sense.
   // For example, you could use this to take Vary header fields into account.
@@ -104,8 +107,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
 
   protected parseBody(response: Response): Promise<object | string> {
     const contentType = response.headers.get('Content-Type');
-    const applicationJsonRegEx = /^application\/(\S*\+)?json/;
-    if (contentType && applicationJsonRegEx.test(contentType)) {
+    if (contentType && contentType.startsWith(this.jsonContentType)) {
       return response.json();
     } else {
       return response.text();

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -392,7 +392,7 @@ describe('RESTDataSource', () => {
       expect(data).toEqual({ foo: 'bar' });
     });
 
-    it('returns data as parsed JSON when Content-Type is application/hal+json', async () => {
+    it('returns data as parsed JSON when Content-Type is application/vnd.api+json', async () => {
       const dataSource = new class extends RESTDataSource {
         baseURL = 'https://api.example.com';
 
@@ -405,7 +405,7 @@ describe('RESTDataSource', () => {
 
       fetch.mockJSONResponseOnce(
         { foo: 'bar' },
-        { 'Content-Type': 'application/hal+json' },
+        { 'Content-Type': 'application/vnd.api+json' },
       );
 
       const data = await dataSource.getFoo();

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -396,6 +396,8 @@ describe('RESTDataSource', () => {
       const dataSource = new class extends RESTDataSource {
         baseURL = 'https://api.example.com';
 
+        jsonContentType = 'application/vnd.api+json';
+
         getFoo() {
           return this.get('foo');
         }


### PR DESCRIPTION


<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Many REST end-points use hypermedia or Json API protocol. The response from such end-points have contentType of the form "application/XXX+json". For example "application/vnd.api+json" or "application/hal+json".
At the moment these responses will not be parsed as json.

This PR changes parseBoby to handle these responses.

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->