### PR TITLE
Call formatError when passed in options to runQuery, fixes #1439

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All of the packages in the `apollo-server` repo are released with the same versi
 
 ### vNEXT
 
+- Fix [#1439](https://github.com/apollographql/apollo-server/issues/1439), use `formatError` if passed in options.
 - Core: Allow context to be passed to all GraphQLExtension methods. [PR #1547](https://github.com/apollographql/apollo-server/pull/1547)
 
 ### v2.0.7

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -13,6 +13,7 @@ import {
 import { runQuery } from '../runQuery';
 
 import { GraphQLExtensionStack, GraphQLExtension } from 'graphql-extensions';
+import { FormatErrorExtension } from '../formatters';
 
 const queryType = new GraphQLObjectType({
   name: 'QueryType',
@@ -417,6 +418,41 @@ describe('runQuery', () => {
 
       // Expect there to be several async ids provided
       expect(ids.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('formatError', () => {
+    it('is called with errors if passed in options', () => {
+      const formatError = jest.fn();
+      const query = `query { testError }`;
+      return runQuery({
+        schema,
+        queryString: query,
+        variables: { base: 1 },
+        request: new MockReq(),
+        formatError,
+      }).then(() => {
+        expect(formatError).toBeCalledTimes(1);
+      });
+    });
+
+    it('overrides FormatErrorExtension in extensions if passed', () => {
+      const formatError = jest.fn();
+      const extensionsFormatError = jest.fn();
+      const query = `query { testError }`;
+      return runQuery({
+        schema,
+        queryString: query,
+        variables: { base: 1 },
+        request: new MockReq(),
+        formatError,
+        extensions: [
+          () => new FormatErrorExtension(extensionsFormatError, false),
+        ],
+      }).then(() => {
+        expect(formatError).toBeCalledTimes(1);
+        expect(extensionsFormatError).toBeCalledTimes(0);
+      });
     });
   });
 });


### PR DESCRIPTION
At first I thought my code was so good that there were no errors. On closer inspection, I found the  `formatError` option was being ignored if it's added in the `options` outside of the `ApolloServer` constructor (in `runHttpQuery`), so my logging wasn't being called. I'm not specifying in the constructor because I need to access the `request` object and this isn't available in the constructor. 

This is the cleanest solution I found without changing too much about how the current extension ordering works.

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass