### PR TITLE
Allow willResolveField's handlers to modify the result

### DIFF
--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -218,10 +218,11 @@ export class EngineReportingExtension<TContext = any>
     node.parentType = info.parentType.toString();
     node.startTime = durationHrTimeToNanos(process.hrtime(this.startHrTime));
 
-    return () => {
+    return (err: Error, result: any) => {
       node.endTime = durationHrTimeToNanos(process.hrtime(this.startHrTime));
       // We could save the error into the trace here, but it won't have all
       // the information that graphql-js adds to it later, like 'locations'.
+      return result;
     };
   }
 

--- a/packages/apollo-tracing/src/index.ts
+++ b/packages/apollo-tracing/src/index.ts
@@ -76,8 +76,9 @@ export class TracingExtension<TContext = any>
 
     this.resolverCalls.push(resolverCall);
 
-    return () => {
+    return (err: Error, result: any) => {
       resolverCall.endOffset = process.hrtime(this.startHrTime);
+      return result;
     };
   }
 


### PR DESCRIPTION
👋 What's up team Apollo?! Long time no see :). I'd like to propose a change to the Extensions API. This code **IS A POC** and **HAS NOT BEEN TESTED YET** but I'll gladly help to harden and test it if you are interested in accepting the PR.

## Problem:
Currently, there the `graphql-extension` API does not provide a way to modify the response as it passes through `willResolveField`

## A specific use case:
Automate setting cacheHints in Apollo from the TTLs specific to your data sources. For example, if your model returns data in the form: `{ __isUsingModelCache__: true, result, ttl }` you could easily write an extension to read that information. Below is a simplified example of how that would look:

```javascript
const myResolver = (obj, args, context) => context.models.customer.getById(args.id);
```

```javascript
class CacheHintExtension extends GraphQLExtension {
  constructor() {
    super();
  }

  willResolveField(obj, args, context, info) {
    if (isNil(obj) || !obj.__isUsingModelCache__) {
      return obj;
    }

    // Set cache hints
    info.cacheControl.setCacheHint({ maxAge: obj.ttl });    

    // Unwrap data
    return obj.data;
  }
}
```

Note: because of how `graphql-extensions` is written, you would need to return a callback and not a value. The above is only meant to illustrate the point.