### PR TITLE
Re-enable Typescript `esModuleInterop`

### DIFF
--- a/docs/source/essentials/server.md
+++ b/docs/source/essentials/server.md
@@ -154,9 +154,9 @@ import express from 'express'
 import { ApolloServer } from 'apollo-server-express'
 import typeDefs from './graphql/schema'
 import resolvers from './graphql/resolvers'
-import * as fs from 'fs'
-import * as https from 'https'
-import * as http from 'http'
+import fs from 'fs'
+import https from 'https'
+import http from 'http'
 
 const configurations = {
   // Note: You may need sudo to run on port 443

--- a/package-lock.json
+++ b/package-lock.json
@@ -7944,6 +7944,49 @@
       "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
       "dev": true
     },
+    "koa": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.3.tgz",
+      "integrity": "sha512-U6rgy2kwlfO+3P1phAidDrRZpGfwcpHCxl33wFe+fHXalpzEshHGnMaSU7I/ZeDFpGRQkbQOYsXkXfUjn+AtdQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.7.1",
+        "debug": "~3.1.0",
+        "delegates": "^1.0.0",
+        "depd": "^1.1.2",
+        "destroy": "^1.0.4",
+        "error-inject": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^1.2.0",
+        "koa-is-json": "^1.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "koa-bodyparser": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "jest": "23.6.0",
     "jest-matcher-utils": "23.6.0",
     "js-sha256": "0.9.0",
+    "koa": "^2.5.3",
     "koa-multer": "1.0.2",
     "lerna": "3.4.0",
     "lint-staged": "7.2.2",

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -1,4 +1,4 @@
-import * as os from 'os';
+import os from 'os';
 import { gzip } from 'zlib';
 import { DocumentNode } from 'graphql';
 import {
@@ -9,7 +9,7 @@ import {
 } from 'apollo-engine-reporting-protobuf';
 
 import { fetch, Response } from 'apollo-server-env';
-import * as retry from 'async-retry';
+import retry from 'async-retry';
 
 import { EngineReportingExtension } from './extension';
 

--- a/packages/apollo-server-cache-memcached/src/index.ts
+++ b/packages/apollo-server-cache-memcached/src/index.ts
@@ -1,5 +1,5 @@
 import { KeyValueCache } from 'apollo-server-caching';
-import * as Memcached from 'memcached';
+import Memcached from 'memcached';
 import { promisify } from 'util';
 
 export class MemcachedCache implements KeyValueCache {

--- a/packages/apollo-server-cache-redis/src/index.ts
+++ b/packages/apollo-server-cache-redis/src/index.ts
@@ -1,7 +1,7 @@
 import { KeyValueCache } from 'apollo-server-caching';
-import * as Redis from 'redis';
+import Redis from 'redis';
 import { promisify } from 'util';
-import * as DataLoader from 'dataloader';
+import DataLoader from 'dataloader';
 
 export class RedisCache implements KeyValueCache {
   // FIXME: Replace any with proper promisified type

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -1,4 +1,4 @@
-import * as LRU from 'lru-cache';
+import LRU from 'lru-cache';
 import { KeyValueCache } from './KeyValueCache';
 
 export class InMemoryLRUCache implements KeyValueCache {

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -1,7 +1,7 @@
 import { GraphQLSchema, DocumentNode } from 'graphql';
 import { SchemaDirectiveVisitor, IResolvers, IMocks } from 'graphql-tools';
 import { ConnectionContext } from 'subscriptions-transport-ws';
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 import { GraphQLExtension } from 'graphql-extensions';
 export { GraphQLExtension } from 'graphql-extensions';
 

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -1,5 +1,5 @@
-import * as express from 'express';
-import * as corsMiddleware from 'cors';
+import express from 'express';
+import corsMiddleware from 'cors';
 import { json, OptionsJson } from 'body-parser';
 import {
   renderPlaygroundPage,
@@ -11,8 +11,8 @@ import {
   ApolloServerBase,
   formatApolloErrors,
 } from 'apollo-server-core';
-import * as accepts from 'accepts';
-import * as typeis from 'type-is';
+import accepts from 'accepts';
+import typeis from 'type-is';
 
 import { graphqlExpress } from './expressApollo';
 

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -1,10 +1,10 @@
-import * as express from 'express';
+import express from 'express';
 
-import * as http from 'http';
+import http from 'http';
 
-import * as request from 'request';
-import * as FormData from 'form-data';
-import * as fs from 'fs';
+import request from 'request';
+import FormData from 'form-data';
+import fs from 'fs';
 import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError, Config } from 'apollo-server-core';

--- a/packages/apollo-server-express/src/__tests__/connectApollo.test.ts
+++ b/packages/apollo-server-express/src/__tests__/connectApollo.test.ts
@@ -1,5 +1,5 @@
-import * as connect from 'connect';
-import * as query from 'qs-middleware';
+import connect from 'connect';
+import query from 'qs-middleware';
 import { ApolloServer } from '../ApolloServer';
 import { Config } from 'apollo-server-core';
 

--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -1,6 +1,6 @@
-import * as express from 'express';
+import express from 'express';
 
-import * as http from 'http';
+import http from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 

--- a/packages/apollo-server-express/src/__tests__/expressApollo.test.ts
+++ b/packages/apollo-server-express/src/__tests__/expressApollo.test.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import express from 'express';
 import { ApolloServer } from '../ApolloServer';
 import testSuite, {
   schema as Schema,

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import express from 'express';
 import {
   GraphQLOptions,
   HttpQueryError,

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import * as hapi from 'hapi';
+import hapi from 'hapi';
 import { parseAll } from 'accept';
 import {
   renderPlaygroundPage,

--- a/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
@@ -7,7 +7,7 @@ if (NODE_MAJOR_VERSION < 8) {
   return;
 }
 
-import * as hapi from 'hapi';
+import hapi from 'hapi';
 import { ApolloServer } from '../ApolloServer';
 import { Config } from 'apollo-server-core';
 

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,4 +1,4 @@
-import * as Boom from 'boom';
+import Boom from 'boom';
 import { Server, Request, RouteOptions } from 'hapi';
 import {
   GraphQLOptions,

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-unused-expression */
-import * as http from 'http';
-import * as net from 'net';
+import http from 'http';
+import net from 'net';
 import { sha256 } from 'js-sha256';
 import express = require('express');
 import bodyParser = require('body-parser');
@@ -19,7 +19,7 @@ import {
 
 import { PubSub } from 'graphql-subscriptions';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 
 import { execute } from 'apollo-link';
 import { createHttpLink } from 'apollo-link-http';

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -1,14 +1,14 @@
-import * as Koa from 'koa';
-import * as corsMiddleware from '@koa/cors';
-import * as bodyParser from 'koa-bodyparser';
-import * as compose from 'koa-compose';
+import Koa from 'koa';
+import corsMiddleware from '@koa/cors';
+import bodyParser from 'koa-bodyparser';
+import compose from 'koa-compose';
 import {
   renderPlaygroundPage,
   RenderPageOptions as PlaygroundRenderPageOptions,
 } from '@apollographql/graphql-playground-html';
 import { ApolloServerBase, formatApolloErrors } from 'apollo-server-core';
-import * as accepts from 'accepts';
-import * as typeis from 'type-is';
+import accepts from 'accepts';
+import typeis from 'type-is';
 
 import { graphqlKoa } from './koaApollo';
 

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -1,10 +1,10 @@
-import * as Koa from 'koa';
+import Koa from 'koa';
 
-import * as http from 'http';
+import http from 'http';
 
-import * as request from 'request';
-import * as FormData from 'form-data';
-import * as fs from 'fs';
+import request from 'request';
+import FormData from 'form-data';
+import fs from 'fs';
 import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError, Config } from 'apollo-server-core';

--- a/packages/apollo-server-koa/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/datasource.test.ts
@@ -1,7 +1,7 @@
-import * as Koa from 'koa';
-import * as KoaRouter from 'koa-router';
+import Koa from 'koa';
+import KoaRouter from 'koa-router';
 
-import * as http from 'http';
+import http from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 

--- a/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
@@ -1,4 +1,4 @@
-import * as Koa from 'koa';
+import Koa from 'koa';
 import { ApolloServer } from '../ApolloServer';
 import testSuite, {
   schema as Schema,

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -1,4 +1,4 @@
-import * as Koa from 'koa';
+import Koa from 'koa';
 import {
   GraphQLOptions,
   HttpQueryError,

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import * as lambda from 'aws-lambda';
+import lambda from 'aws-lambda';
 import { ApolloServerBase } from 'apollo-server-core';
 import { GraphQLOptions, Config } from 'apollo-server-core';
 import {

--- a/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts
+++ b/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts
@@ -4,7 +4,7 @@ import testSuite, {
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
 import { Config } from 'apollo-server-core';
-import * as url from 'url';
+import url from 'url';
 import { IncomingMessage, ServerResponse } from 'http';
 
 const createLambda = (options: CreateAppOptions = {}) => {

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -1,4 +1,4 @@
-import * as lambda from 'aws-lambda';
+import lambda from 'aws-lambda';
 import {
   GraphQLOptions,
   HttpQueryError,

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -1,10 +1,10 @@
 import micro from 'micro';
-import * as listen from 'test-listen';
+import listen from 'test-listen';
 import { createApolloFetch } from 'apollo-fetch';
 import { gql } from 'apollo-server-core';
-import * as FormData from 'form-data';
-import * as fs from 'fs';
-import * as rp from 'request-promise';
+import FormData from 'form-data';
+import fs from 'fs';
+import rp from 'request-promise';
 
 import { ApolloServer } from '../ApolloServer';
 

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -4,7 +4,7 @@ import {
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import { send, json, RequestHandler } from 'micro';
-import * as url from 'url';
+import url from 'url';
 import { IncomingMessage, ServerResponse } from 'http';
 
 import { MicroRequest } from './types';

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import * as request from 'request';
+import request from 'request';
 import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, ApolloServer } from '../index';

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -2,9 +2,9 @@
 // an express app for you instead of applyMiddleware (which you might not even
 // use with express). The dependency is unused otherwise, so don't worry if
 // you're not using express or your version doesn't quite match up.
-import * as express from 'express';
-import * as http from 'http';
-import * as net from 'net';
+import express from 'express';
+import http from 'http';
+import net from 'net';
 import {
   ApolloServer as ApolloServerBase,
   CorsOptions,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2016",
     "module": "commonjs",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
`esModuleInterop` was enabled in https://github.com/apollographql/apollo-server/commit/e4164c88928d9518934fd95e22ff8eb8c3eb65e1 to help with importing from packages that use default exports. Those changes were reverted in https://github.com/apollographql/apollo-server/pull/1210 to work around a few reported issues. Those issues are no longer relevant, so this PR re-enables `esModuleInterop`, and updates all default imports to use the more common (standard) import syntax.