### PR TITLE
More nuanced handling of stack traces in errors

### DIFF
--- a/docs/source/features/errors.md
+++ b/docs/source/features/errors.md
@@ -38,7 +38,7 @@ The response will return:
 
 ![Screenshot demonstrating an error stacktrace and additional](../images/features/error-stacktrace.png)
 
-> To disable stacktraces for production, pass `debug: false` to the Apollo server constructor or set the `NODE_ENV` environment variable to 'production' or 'test'
+> To disable stacktraces for production, pass `debug: false` to the Apollo server constructor or set the `NODE_ENV` environment variable to 'production' or 'test'. Note that this will make the stacktrace unavailable to your application. If you want to log the stacktrace, but not send it in the response to the client, see [Masking and logging errors](#masking-and-logging-errors) below.
 
 ## Codes
 
@@ -118,16 +118,19 @@ new ApolloError(message, code, additionalProperties);
 
 ## Masking and logging errors
 
-The Apollo server constructor accepts a `formatError` function that is run on each error passed back to the client. This can be used to mask errors as well as logging.
-This example demonstrates masking
+The Apollo server constructor accepts a `formatError` function that is run on each error passed back to the client. This can be used to mask errors as well as for logging.
+This example demonstrates masking (or suppressing the stacktrace):
 
-```js line=4-7
+```js line=4-10
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   formatError: error => {
     console.log(error);
     return new Error('Internal server error');
+    // Or, you can delete the exception information
+    // delete error.extensions.exception;
+    // return error;
   },
 });
 


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->