### PR TITLE
[DOCS] Make schema directive example clearer

### DIFF
--- a/docs/source/features/directives.md
+++ b/docs/source/features/directives.md
@@ -28,7 +28,7 @@ GraphQL provides several default directives: [`@deprecated`](http://facebook.git
 
 ## Using custom schema directives
 
-To use a custom schema directive, pass the implemented class to Apollo server via the `schemaDirectives` argument, which is an object that maps directive names to directive implementations:
+To use a custom schema directive, pass the implemented class to Apollo Server via the `schemaDirectives` argument, which is an object that maps directive names to directive implementations:
 
 ```js
 const { ApolloServer, gql, SchemaDirectiveVisitor } = require('apollo-server');

--- a/docs/source/features/directives.md
+++ b/docs/source/features/directives.md
@@ -32,7 +32,7 @@ To use a custom schema directive, pass the implemented class to Apollo server vi
 
 ```js
 const { ApolloServer, gql, SchemaDirectiveVisitor } = require('apollo-server');
-const { defaultFieldResolver } = require("graphql");
+const { defaultFieldResolver } = require('graphql');
 
 // Create (or import) a custom schema directive
 class UpperCaseDirective extends SchemaDirectiveVisitor {
@@ -40,7 +40,7 @@ class UpperCaseDirective extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field;
     field.resolve = async function (...args) {
       const result = await resolve.apply(this, args);
-      if (typeof result === "string") {
+      if (typeof result === 'string') {
         return result.toUpperCase();
       }
       return result;

--- a/docs/source/features/directives.md
+++ b/docs/source/features/directives.md
@@ -28,31 +28,61 @@ GraphQL provides several default directives: [`@deprecated`](http://facebook.git
 
 ## Using custom schema directives
 
-Import the implementation of the directive, then pass it to Apollo server via the `schemaDirectives` argument, which is an object that maps directive names to directive implementations:
+To use a custom schema directive, pass the implemented class to Apollo server via the `schemaDirectives` argument, which is an object that maps directive names to directive implementations:
 
 ```js
-const { ApolloServer, gql } = require('apollo-server');
-const { RenameDirective } = require('rename-directive-package');
+const { ApolloServer, gql, SchemaDirectiveVisitor } = require('apollo-server');
+const { defaultFieldResolver } = require("graphql");
 
+// Create (or import) a custom schema directive
+class UpperCaseDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field) {
+    const { resolve = defaultFieldResolver } = field;
+    field.resolve = async function (...args) {
+      const result = await resolve.apply(this, args);
+      if (typeof result === "string") {
+        return result.toUpperCase();
+      }
+      return result;
+    };
+  }
+}
+
+// Construct a schema, using GraphQL schema language
 const typeDefs = gql`
-type Person @rename(to: "Human") {
-  name: String!
-  currentDateMinusDateOfBirth: Int @rename(to: "age")
-}`;
+  directive @upper on FIELD_DEFINITION
 
-//Create and start your apollo server
+  type Query {
+    hello: String @upper
+  }
+`;
+
+// Provide resolver functions for your schema fields
+const resolvers = {
+  Query: {
+    hello: (root, args, context) => {
+      return 'Hello world!';
+    },
+  },
+};
+
+// Add directive to the ApolloServer constructor
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   schemaDirectives: {
-    rename: RenameDirective,
-  },
-  app,
+    upper: UpperCaseDirective,
+  }
 });
 
 server.listen().then(({ url }) => {
-  console.log(`🚀 Server ready at ${url}`);
+  console.log(`🚀 Server ready at ${url}`)
 });
+
 ```
 
-The implementation of `RenameDirective` takes care of changing the resolver and modifying the schema if necessary. To learn how to implement your own schema directives, read through [this section](./creating-directives.html).
+The implementation of `UpperCaseDirective` takes care of changing the resolver and modifying the schema if necessary.
+
+## Building your own
+
+To learn how to implement your own schema directives, read [this guide](./creating-directives.html).


### PR DESCRIPTION
The schema directive example [here](https://www.apollographql.com/docs/apollo-server/v2/features/directives.html) doesn't work. The package being imported was meant to be an _example_, unworking directive. This is confusing for people trying to run this example, so I replaced it with a real one.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->