### PR TITLE
Revert #1698 renovate/graphql tools 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2132,7 +2132,7 @@
         "apollo-server-express": "file:packages/apollo-server-express",
         "express": "^4.0.0",
         "graphql-subscriptions": "^0.5.8",
-        "graphql-tools": "^4.0.0"
+        "graphql-tools": "^3.0.4"
       }
     },
     "apollo-server-cache-memcached": {
@@ -2180,7 +2180,7 @@
         "graphql-extensions": "file:packages/graphql-extensions",
         "graphql-subscriptions": "^0.5.8",
         "graphql-tag": "^2.9.2",
-        "graphql-tools": "^4.0.0",
+        "graphql-tools": "^3.0.4",
         "hash.js": "^1.1.3",
         "lodash": "^4.17.10",
         "subscriptions-transport-ws": "^0.9.11",
@@ -2220,7 +2220,7 @@
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "graphql-subscriptions": "^0.5.8",
-        "graphql-tools": "^4.0.0",
+        "graphql-tools": "^3.0.4",
         "type-is": "^1.6.16"
       }
     },
@@ -2233,7 +2233,7 @@
         "apollo-server-core": "file:packages/apollo-server-core",
         "boom": "^7.1.0",
         "graphql-subscriptions": "^0.5.8",
-        "graphql-tools": "^4.0.0"
+        "graphql-tools": "^3.0.4"
       }
     },
     "apollo-server-integration-testsuite": {
@@ -2257,7 +2257,7 @@
         "accepts": "^1.3.5",
         "apollo-server-core": "file:packages/apollo-server-core",
         "graphql-subscriptions": "^0.5.8",
-        "graphql-tools": "^4.0.0",
+        "graphql-tools": "^3.0.4",
         "koa": "2.5.3",
         "koa-bodyparser": "^3.0.0",
         "koa-router": "^7.4.0",
@@ -2309,7 +2309,7 @@
         "@apollographql/graphql-playground-html": "^1.6.0",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
-        "graphql-tools": "^4.0.0"
+        "graphql-tools": "^3.0.4"
       }
     },
     "apollo-server-micro": {
@@ -6232,11 +6232,11 @@
       "integrity": "sha512-qnNmof9pAqj/LUzs3lStP0Gw1qhdVCUS7Ab7+SUB6KD5aX1uqxWQRwMnOGTkhKuLvLNIs1TvNz+iS9kUGl1MhA=="
     },
     "graphql-tools": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.0.tgz",
-      "integrity": "sha512-WokvjkanuZwY4BZBS3SlkDjrjCPu7WlCtLB2i9JiiXembVEkNos3Rl90zf7sJu72zSidGzTXU63iXRO2Fg3TtA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.1.1.tgz",
+      "integrity": "sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==",
       "requires": {
-        "apollo-link": "^1.2.3",
+        "apollo-link": "^1.2.2",
         "apollo-utilities": "^1.0.1",
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "graphql": "14.0.2",
     "graphql-subscriptions": "0.5.8",
     "graphql-tag": "2.9.2",
-    "graphql-tools": "4.0.0",
+    "graphql-tools": "3.1.1",
     "hapi": "17.5.5",
     "husky": "0.14.3",
     "jest": "23.6.0",

--- a/packages/apollo-server-cloud-function/package.json
+++ b/packages/apollo-server-cloud-function/package.json
@@ -33,7 +33,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
-    "graphql-tools": "^4.0.0"
+    "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -41,7 +41,7 @@
     "graphql-extensions": "file:../graphql-extensions",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tag": "^2.9.2",
-    "graphql-tools": "^4.0.0",
+    "graphql-tools": "^3.0.4",
     "hash.js": "^1.1.3",
     "lodash": "^4.17.10",
     "subscriptions-transport-ws": "^0.9.11",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -42,7 +42,7 @@
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "graphql-subscriptions": "^0.5.8",
-    "graphql-tools": "^4.0.0",
+    "graphql-tools": "^3.0.4",
     "type-is": "^1.6.16"
   },
   "devDependencies": {

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -36,7 +36,7 @@
     "apollo-server-core": "file:../apollo-server-core",
     "boom": "^7.1.0",
     "graphql-subscriptions": "^0.5.8",
-    "graphql-tools": "^4.0.0"
+    "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -42,7 +42,7 @@
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
     "graphql-subscriptions": "^0.5.8",
-    "graphql-tools": "^4.0.0",
+    "graphql-tools": "^3.0.4",
     "koa": "2.5.3",
     "koa-bodyparser": "^3.0.0",
     "koa-router": "^7.4.0",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -33,7 +33,7 @@
     "@apollographql/graphql-playground-html": "^1.6.0",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
-    "graphql-tools": "^4.0.0"
+    "graphql-tools": "^3.0.4"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -30,7 +30,7 @@
     "apollo-server-express": "file:../apollo-server-express",
     "express": "^4.0.0",
     "graphql-subscriptions": "^0.5.8",
-    "graphql-tools": "^4.0.0"
+    "graphql-tools": "^3.0.4"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"


### PR DESCRIPTION
I'm reverting apollographql/apollo-server#1698 not because it's been problematic in any way, but because I'd like to give it a bit more thought and don't want this to accidentally get cut into a release prior to that consideration.

More specifically: The `graphql-tools` update on its own shouldn't really cause any problems, but the [4.x version of `graphql-tools`](https://github.com/apollographql/graphql-tools/releases/tag/4.0.0) is intended to support and enable the latest `graphql@14` which contains [breaking changes](https://github.com/graphql/graphql-js/releases/tag/v14.0.0).

I believe most of those breaking changes would be show-stoppers and the failures would surface immediately (meaning that servers would completely fail to start, rather than being a surprise in other, more delayed scenarios), but it's still worth pausing and carefully considering versioning to avoid any surprises.

That said, the 14.x version of `graphql` has been an acceptable range in the `peerDependencies` of `apollo-server-*` since before its final release came out, and I don't believe we've caught wind of anything that a major version bump would have prevented or made more clear.  In the end, `graphql` is a peer dependency and any problems should only surface if consumers also update their `graphql` dependency — a clear major version bump, which deserves review by the upgrader — so perhaps we can avoid bumping the major version after all?

Input welcomed, but again, merging this now to give this a bit more thought first.

cc @hwillson 