### PR TITLE
Add clientId to apollo-engine-reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 - Allow an optional function to resolve the `rootValue`, passing the `DocumentNode` AST to determine the value. [PR #1555](https://github.com/apollographql/apollo-server/pull/1555)
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
-- Add clientId to apollo-engine-reporting [PR #1727](https://github.com/apollographql/apollo-server/pull/1727)
+- Add `clientId` to `apollo-engine-reporting`'s _experimental_ `generateClientInfo` API. [PR #1727](https://github.com/apollographql/apollo-server/pull/1727)
 
 ### v2.1.0
 
-- Updated the google-cloud-functions package to handle null paths [PR #1674](https://github.com/apollographql/apollo-server/pull/1674)
+- Updated the `google-cloud-functions` package to handle null paths [PR #1674](https://github.com/apollographql/apollo-server/pull/1674)
 - Update link inside Authentication Docs [PR #1682](https://github.com/apollographql/apollo-server/pull/1682)
 - Fix making sure all headers are getting reported to Engine properly when using `privateHeaders` [PR #1689](https://github.com/apollographql/apollo-server/pull/1689)
-- _(experimental, subject to change/removal)_ Provide ability to specify client info in traces [#1631](https://github.com/apollographql/apollo-server/pull/1631)
+- _(experimental, subject to change/removal)_ Provide ability to specify client info in traces. [#1631](https://github.com/apollographql/apollo-server/pull/1631)
 
 ### v2.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Allow an optional function to resolve the `rootValue`, passing the `DocumentNode` AST to determine the value. [PR #1555](https://github.com/apollographql/apollo-server/pull/1555)
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
+- Add clientId to apollo-engine-reporting [PR #1727](https://github.com/apollographql/apollo-server/pull/1727)
 
 ### v2.1.0
 

--- a/packages/apollo-engine-reporting-protobuf/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/reports.proto
@@ -152,6 +152,7 @@ message Trace {
 	string client_name = 7;
 	string client_version = 8;
 	string client_address = 9;
+	string client_id = 23;
 
 	HTTP http = 10;
 

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -37,6 +37,7 @@ Traces.encode = function(message, originalWriter) {
 export interface ClientInfo {
   clientName?: string;
   clientVersion?: string;
+  clientId?: string;
 }
 
 export interface EngineReportingOptions {

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -167,15 +167,13 @@ export class EngineReportingExtension<TContext = any>
       });
     }
 
-    // While clientAddress could be a part of the protobuf, we'll ignore it for
-    // now, since the backend does not group by it and Engine frontend will not
-    // support it in the short term
-    const { clientName, clientVersion } = this.generateClientInfo({
+    const { clientName, clientVersion, clientId } = this.generateClientInfo({
       context: o.context,
       extensions: o.extensions,
     });
     this.trace.clientName = clientName || '';
     this.trace.clientVersion = clientVersion || '';
+    this.trace.clientId = clientId || '';
 
     return () => {
       this.trace.durationNs = durationHrTimeToNanos(

--- a/packages/apollo-server-express/package-lock.json
+++ b/packages/apollo-server-express/package-lock.json
@@ -1,0 +1,373 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"express": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"requires": {
+				"accepts": "1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0",
+				"type-is": "1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"accepts": {
+					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+					"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+					"requires": {
+						"mime-types": "2.1.18",
+						"negotiator": "0.6.1"
+					}
+				},
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "1.0.4",
+						"debug": "2.6.9",
+						"depd": "1.1.2",
+						"http-errors": "1.6.3",
+						"iconv-lite": "0.4.19",
+						"on-finished": "2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "1.6.16"
+					}
+				},
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+				},
+				"content-disposition": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+				},
+				"content-type": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+					"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+				},
+				"cookie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+					"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+				},
+				"cookie-signature": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+					"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"depd": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+					"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+				},
+				"destroy": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+				},
+				"ee-first": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+				},
+				"encodeurl": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+				},
+				"escape-html": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+				},
+				"etag": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+				},
+				"finalhandler": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+					"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "1.0.2",
+						"escape-html": "1.0.3",
+						"on-finished": "2.3.0",
+						"parseurl": "1.3.2",
+						"statuses": "1.4.0",
+						"unpipe": "1.0.0"
+					}
+				},
+				"forwarded": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+					"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+				},
+				"fresh": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"requires": {
+						"depd": "1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": "1.4.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"ipaddr.js": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+					"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+				},
+				"media-typer": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+					"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+				},
+				"merge-descriptors": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+					"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+				},
+				"methods": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+					"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "1.33.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"negotiator": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+					"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+				},
+				"on-finished": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+					"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+					"requires": {
+						"ee-first": "1.1.1"
+					}
+				},
+				"parseurl": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+				},
+				"path-to-regexp": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+				},
+				"proxy-addr": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+					"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+					"requires": {
+						"forwarded": "0.1.2",
+						"ipaddr.js": "1.6.0"
+					}
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"range-parser": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+					"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": "1.4.0"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+				},
+				"send": {
+					"version": "0.16.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "1.1.2",
+						"destroy": "1.0.4",
+						"encodeurl": "1.0.2",
+						"escape-html": "1.0.3",
+						"etag": "1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "1.6.3",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "2.3.0",
+						"range-parser": "1.2.0",
+						"statuses": "1.4.0"
+					}
+				},
+				"serve-static": {
+					"version": "1.13.2",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+					"requires": {
+						"encodeurl": "1.0.2",
+						"escape-html": "1.0.3",
+						"parseurl": "1.3.2",
+						"send": "0.16.2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				},
+				"type-is": {
+					"version": "1.6.16",
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+					"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+					"requires": {
+						"media-typer": "0.3.0",
+						"mime-types": "2.1.18"
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+				},
+				"utils-merge": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+				},
+				"vary": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+					"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The Apollo cloud now accepts the a clientId in the
apollo-engine-reporting-protobuf. This commit also
adds the type to generateClientInfo.

mdg-private/monorepo/pull/1382 provides the server side of clientId

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->