### PR TITLE
Docs: fix the example for "Using an Existing Schema"

### DIFF
--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -193,12 +193,15 @@ app.listen({ port: 4000 }, () =>
 
 For many existing instances of Apollo Server, the schema is created at runtime before server startup, using `makeExecutableSchema` or `mergeSchemas`. Apollo Server 2 stays backwards compatible with these more complex schemas, accepting it as the `schema` field in the server constructor options. Additionally, Apollo Server 2 exports all of `graphql-tools`, so `makeExecutableSchema` and other functions can be imported directly from Apollo Server.
 
-> Note: the string to create these schema will not use the `gql` tag exported from apollo-server.
+> Note: The string to create these schema intentionally does not use the `gql` tagged template literal
+>       exported from `apollo-server` since `makeExecutableSchema` doesn't accept an AST.
 
 ```js
-const { ApolloServer, makeExecutableSchema } = require('apollo-server');
+const {
+  ApolloServer,
+  makeExecutableSchema
+} = require('apollo-server');
 
-//For developer tooling, such as autoformatting, use the following workaround
 const gql = String.raw;
 
 const typeDefs = gql`

--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -193,18 +193,18 @@ app.listen({ port: 4000 }, () =>
 
 For many existing instances of Apollo Server, the schema is created at runtime before server startup, using `makeExecutableSchema` or `mergeSchemas`. Apollo Server 2 stays backwards compatible with these more complex schemas, accepting it as the `schema` field in the server constructor options. Additionally, Apollo Server 2 exports all of `graphql-tools`, so `makeExecutableSchema` and other functions can be imported directly from Apollo Server.
 
-> Note: The string to create these schema intentionally does not use the `gql` tagged template literal
->       exported from `apollo-server` since `makeExecutableSchema` doesn't accept an AST.
-
 ```js
 const {
   ApolloServer,
   makeExecutableSchema
 } = require('apollo-server');
 
-const gql = String.raw;
-
-const typeDefs = gql`
+// The `typeDefs` passed into `makeExecutableSchema` are _intentionally_
+// passed in without using the `gql` tag since it requires a `String` and
+// the `gql` tag returns an AST.  When not using `makeExecutableSchema`
+// and passing `typeDefs` into the `ApolloServer` constructor, it's
+// recommended to use the `gql` tag.
+const typeDefs = `
   type Query {
     hello: String
   }

--- a/docs/source/migration-two-dot.md
+++ b/docs/source/migration-two-dot.md
@@ -196,7 +196,7 @@ For many existing instances of Apollo Server, the schema is created at runtime b
 > Note: the string to create these schema will not use the `gql` tag exported from apollo-server.
 
 ```js
-const { ApolloServer, makeExecutableSchema, gql } = require('apollo-server');
+const { ApolloServer, makeExecutableSchema } = require('apollo-server');
 
 //For developer tooling, such as autoformatting, use the following workaround
 const gql = String.raw;


### PR DESCRIPTION
The file included in the documentation caused the following error:

```js
const gql = String.raw;
      ^
SyntaxError: Identifier 'gql' has already been declared
```

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->