### PR TITLE
Use TypeScript project references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2995,6 +2995,15 @@
         "resolve": "1.1.7"
       }
     },
+    "bs-logger": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.5.tgz",
+      "integrity": "sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "^2.0.0"
+      }
+    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -3346,12 +3355,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
-    },
-    "closest-file-data": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/closest-file-data/-/closest-file-data-0.1.4.tgz",
-      "integrity": "sha1-l1+HwTLymdJKA3W59jyj+4j3Kzo=",
       "dev": true
     },
     "cmd-shim": {
@@ -5326,17 +5329,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
       }
     },
     "fs-minipass": {
@@ -8918,6 +8910,12 @@
         "pify": "^3.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
     "make-fetch-happen": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
@@ -12372,15 +12370,51 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "23.1.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.1.4.tgz",
-      "integrity": "sha512-9rCSxbWfoZxxeXnSoEIzRNr9hDIQ8iEJAWmSRsWhDHDT8OeuGfURhJQUE8jtJlkyEygs6rngH8RYtHz9cfjmEA==",
+      "version": "23.10.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.3.tgz",
+      "integrity": "sha512-Lgyfw1MYPfqAs1qrFBmqXu8LRrde8ItH70pmp1iQuRbkVXaap7QcaEpN+yiSxuppfvO8rqezVv8wOYZkKhR5wA==",
       "dev": true,
       "requires": {
-        "closest-file-data": "^0.1.4",
-        "fs-extra": "6.0.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.10"
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "make-error": "1.x",
+        "mkdirp": "0.x",
+        "semver": "^5.5",
+        "yargs-parser": "10.x"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12470,9 +12470,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "test-listen": "1.1.0",
     "ts-jest": "23.1.4",
     "tslint": "5.11.0",
-    "typescript": "3.0.3",
+    "typescript": "3.1.1",
     "ws": "6.0.0",
     "yup": "0.26.5"
   },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "subscriptions-transport-ws": "0.9.15",
     "supertest": "3.3.0",
     "test-listen": "1.1.0",
-    "ts-jest": "23.1.4",
+    "ts-jest": "23.10.3",
     "tslint": "5.11.0",
     "typescript": "3.1.1",
     "ws": "6.0.0",
@@ -122,9 +122,8 @@
     "setupFiles": [
       "<rootDir>/packages/apollo-server-env/dist/index.js"
     ],
-    "transform": {
-      "^.+\\.ts$": "ts-jest"
-    },
+    "preset": "ts-jest",
+    "testMatch": null,
     "testRegex": "/__tests__/.*\\.test\\.(js|ts)$",
     "moduleFileExtensions": [
       "ts",
@@ -134,6 +133,12 @@
       "/node_modules/",
       "/dist/"
     ],
-    "clearMocks": true
+    "clearMocks": true,
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.test.json",
+        "diagnostics": false
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "repository": "github:apollographql/apollo-server",
   "scripts": {
     "clean": "git clean -dfqX -- ./node_modules **/{dist,node_modules}/",
-    "compile": "lerna run compile",
+    "compile": "tsc --build",
     "release": "npm run clean && npm ci && lerna publish --exact",
     "precommit": "lint-staged",
-    "postinstall": "lerna run prepare",
+    "postinstall": "lerna run prepare && npm run compile",
     "lint": "prettier-check '**/*.{js,ts}'",
     "lint-fix": "prettier '**/*.{js,ts}' --write",
     "test": "jest --verbose",

--- a/packages/apollo-cache-control/package.json
+++ b/packages/apollo-cache-control/package.json
@@ -4,11 +4,6 @@
   "description": "A GraphQL extension for cache control",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "license": "MIT",
   "repository": "apollographql/apollo-cache-control-js",
   "author": "Martijn Walraven <martijn@martijnwalraven.com>",

--- a/packages/apollo-cache-control/tsconfig.json
+++ b/packages/apollo-cache-control/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-cache-control/tsconfig.json
+++ b/packages/apollo-cache-control/tsconfig.json
@@ -7,7 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
-    { "path": "../apollo-server-env" },
     { "path": "../graphql-extensions" }
   ]
 }

--- a/packages/apollo-cache-control/tsconfig.json
+++ b/packages/apollo-cache-control/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-env" },
+    { "path": "../graphql-extensions" }
+  ]
 }

--- a/packages/apollo-datasource-rest/package.json
+++ b/packages/apollo-datasource-rest/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/packages/apollo-datasource-rest/tsconfig.json
+++ b/packages/apollo-datasource-rest/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-datasource-rest/tsconfig.json
+++ b/packages/apollo-datasource-rest/tsconfig.json
@@ -9,7 +9,6 @@
   "references": [
     { "path": "../apollo-datasource" },
     { "path": "../apollo-server-caching" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-errors" }
   ]
 }

--- a/packages/apollo-datasource-rest/tsconfig.json
+++ b/packages/apollo-datasource-rest/tsconfig.json
@@ -5,5 +5,11 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-datasource" },
+    { "path": "../apollo-server-caching" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-errors" }
+  ]
 }

--- a/packages/apollo-datasource/package.json
+++ b/packages/apollo-datasource/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/packages/apollo-datasource/tsconfig.json
+++ b/packages/apollo-datasource/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-datasource/tsconfig.json
+++ b/packages/apollo-datasource/tsconfig.json
@@ -8,6 +8,5 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-caching" },
-    { "path": "../apollo-server-env" }
   ]
 }

--- a/packages/apollo-datasource/tsconfig.json
+++ b/packages/apollo-datasource/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-caching" },
+    { "path": "../apollo-server-env" }
+  ]
 }

--- a/packages/apollo-engine-reporting-protobuf/tsconfig.json
+++ b/packages/apollo-engine-reporting-protobuf/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-engine-reporting-protobuf/tsconfig.json
+++ b/packages/apollo-engine-reporting-protobuf/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.base",
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
-}

--- a/packages/apollo-engine-reporting/package.json
+++ b/packages/apollo-engine-reporting/package.json
@@ -4,13 +4,6 @@
   "description": "Send reports about your GraphQL services to Apollo Engine",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile",
-    "lint": "prettier -l 'src/**/*.{ts,js}' && tslint -p tsconfig.json 'src/**/*.ts'",
-    "lint-fix": "prettier --write 'src/**/*.{ts,js}' && tslint --fix -p tsconfig.json 'src/**/*.ts'"
-  },
   "license": "MIT",
   "repository": "https://github.com/apollographql/apollo-engine-reporting",
   "author": "Apollo <community@apollographql.com>",

--- a/packages/apollo-engine-reporting/tsconfig.json
+++ b/packages/apollo-engine-reporting/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-engine-reporting/tsconfig.json
+++ b/packages/apollo-engine-reporting/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-engine-reporting-protobuf" },
+    { "path": "../apollo-server-env" },
+    { "path": "../graphql-extensions" }
+  ]
 }

--- a/packages/apollo-engine-reporting/tsconfig.json
+++ b/packages/apollo-engine-reporting/tsconfig.json
@@ -7,8 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
-    { "path": "../apollo-engine-reporting-protobuf" },
-    { "path": "../apollo-server-env" },
     { "path": "../graphql-extensions" }
   ]
 }

--- a/packages/apollo-server-cache-memcached/package.json
+++ b/packages/apollo-server-cache-memcached/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/packages/apollo-server-cache-memcached/tsconfig.json
+++ b/packages/apollo-server-cache-memcached/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-cache-memcached/tsconfig.json
+++ b/packages/apollo-server-cache-memcached/tsconfig.json
@@ -8,6 +8,5 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-caching" },
-    { "path": "../apollo-server-env" },
   ]
 }

--- a/packages/apollo-server-cache-memcached/tsconfig.json
+++ b/packages/apollo-server-cache-memcached/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-caching" },
+    { "path": "../apollo-server-env" },
+  ]
 }

--- a/packages/apollo-server-cache-redis/package.json
+++ b/packages/apollo-server-cache-redis/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/packages/apollo-server-cache-redis/tsconfig.json
+++ b/packages/apollo-server-cache-redis/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-cache-redis/tsconfig.json
+++ b/packages/apollo-server-cache-redis/tsconfig.json
@@ -8,6 +8,5 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-caching" },
-    { "path": "../apollo-server-env" }
   ]
 }

--- a/packages/apollo-server-cache-redis/tsconfig.json
+++ b/packages/apollo-server-cache-redis/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-caching" },
+    { "path": "../apollo-server-env" }
+  ]
 }

--- a/packages/apollo-server-caching/package.json
+++ b/packages/apollo-server-caching/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/packages/apollo-server-caching/tsconfig.json
+++ b/packages/apollo-server-caching/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-cloud-function/package.json
+++ b/packages/apollo-server-cloud-function/package.json
@@ -24,11 +24,6 @@
   "engines": {
     "node": ">=6"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepublish": "npm run clean && npm run compile"
-  },
   "dependencies": {
     "@apollographql/graphql-playground-html": "^1.6.0",
     "apollo-server-core": "file:../apollo-server-core",

--- a/packages/apollo-server-cloud-function/tsconfig.json
+++ b/packages/apollo-server-cloud-function/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-cloud-function/tsconfig.json
+++ b/packages/apollo-server-cloud-function/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server-cloud-function/tsconfig.json
+++ b/packages/apollo-server-cloud-function/tsconfig.json
@@ -8,7 +8,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -4,11 +4,6 @@
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-cloudflare-workers"

--- a/packages/apollo-server-cloudflare/tsconfig.json
+++ b/packages/apollo-server-cloudflare/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-cloudflare/tsconfig.json
+++ b/packages/apollo-server-cloudflare/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server-cloudflare/tsconfig.json
+++ b/packages/apollo-server-cloudflare/tsconfig.json
@@ -8,7 +8,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -4,11 +4,6 @@
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-core"

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -313,7 +313,7 @@ export async function runHttpQuery(
         context = {} as Record<string, any>;
       } else if (typeof context === 'function') {
         try {
-          context = await context();
+          context = await (context as Function)();
         } catch (e) {
           e.message = `Context creation failed: ${e.message}`;
           // For errors that are not internal, such as authentication, we
@@ -342,11 +342,14 @@ export async function runHttpQuery(
 
         for (const dataSource of Object.values(dataSources)) {
           if (dataSource.initialize) {
-            dataSource.initialize({ context, cache: optionsObject.cache! });
+            dataSource.initialize({
+              context: context!,
+              cache: optionsObject.cache!,
+            });
           }
         }
 
-        if ('dataSources' in context) {
+        if ('dataSources' in context!) {
           throw new Error(
             'Please use the dataSources config option instead of putting dataSources on the context yourself.',
           );

--- a/packages/apollo-server-core/tsconfig.json
+++ b/packages/apollo-server-core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-core/tsconfig.json
+++ b/packages/apollo-server-core/tsconfig.json
@@ -11,7 +11,6 @@
     { "path": "../apollo-datasource" },
     { "path": "../apollo-engine-reporting" },
     { "path": "../apollo-server-caching" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-errors" },
     { "path": "../apollo-tracing" },
     { "path": "../graphql-extensions" }

--- a/packages/apollo-server-core/tsconfig.json
+++ b/packages/apollo-server-core/tsconfig.json
@@ -5,5 +5,15 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-cache-control" },
+    { "path": "../apollo-datasource" },
+    { "path": "../apollo-engine-reporting" },
+    { "path": "../apollo-server-caching" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-errors" },
+    { "path": "../apollo-tracing" },
+    { "path": "../graphql-extensions" }
+  ]
 }

--- a/packages/apollo-server-env/package.json
+++ b/packages/apollo-server-env/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc && cp src/*.d.ts dist",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-env/package.json
+++ b/packages/apollo-server-env/package.json
@@ -14,6 +14,11 @@
   "main": "dist/index.js",
   "browser": "dist/index.browser.js",
   "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "compile": "tsc && cp src/*.d.ts dist",
+    "prepare": "npm run clean && npm run compile"
+  },
   "engines": {
     "node": ">=6"
   },

--- a/packages/apollo-server-env/tsconfig.json
+++ b/packages/apollo-server-env/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "composite": false,
     "rootDir": "./src",

--- a/packages/apollo-server-env/tsconfig.json
+++ b/packages/apollo-server-env/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    "composite": false,
     "rootDir": "./src",
     "outDir": "./dist",
     "allowJs": true,

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -11,11 +11,6 @@
   "bugs": {
     "url": "https://github.com/apollographql/apollo-server/issues"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/packages/apollo-server-errors/tsconfig.json
+++ b/packages/apollo-server-errors/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -4,11 +4,6 @@
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-express"

--- a/packages/apollo-server-express/tsconfig.json
+++ b/packages/apollo-server-express/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/apollo-server-express/tsconfig.json
+++ b/packages/apollo-server-express/tsconfig.json
@@ -10,7 +10,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-express/tsconfig.json
+++ b/packages/apollo-server-express/tsconfig.json
@@ -7,5 +7,10 @@
     "strictNullChecks": false
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -4,11 +4,6 @@
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-hapi"

--- a/packages/apollo-server-hapi/tsconfig.json
+++ b/packages/apollo-server-hapi/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/apollo-server-hapi/tsconfig.json
+++ b/packages/apollo-server-hapi/tsconfig.json
@@ -8,5 +8,10 @@
     "strictNullChecks": false
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server-hapi/tsconfig.json
+++ b/packages/apollo-server-hapi/tsconfig.json
@@ -11,7 +11,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -5,11 +5,6 @@
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-integration-testsuite"

--- a/packages/apollo-server-integration-testsuite/tsconfig.json
+++ b/packages/apollo-server-integration-testsuite/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/apollo-server-integration-testsuite/tsconfig.json
+++ b/packages/apollo-server-integration-testsuite/tsconfig.json
@@ -8,5 +8,8 @@
     "lib": ["es2017", "esnext.asynciterable", "dom"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" }
+  ]
 }

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -4,11 +4,6 @@
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-koa"

--- a/packages/apollo-server-koa/tsconfig.json
+++ b/packages/apollo-server-koa/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/apollo-server-koa/tsconfig.json
+++ b/packages/apollo-server-koa/tsconfig.json
@@ -11,7 +11,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-koa/tsconfig.json
+++ b/packages/apollo-server-koa/tsconfig.json
@@ -8,5 +8,10 @@
     "noImplicitReturns": false
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -24,11 +24,6 @@
   "engines": {
     "node": ">=6"
   },
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "dependencies": {
     "@apollographql/graphql-playground-html": "^1.6.0",
     "apollo-server-core": "file:../apollo-server-core",

--- a/packages/apollo-server-lambda/tsconfig.json
+++ b/packages/apollo-server-lambda/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server-lambda/tsconfig.json
+++ b/packages/apollo-server-lambda/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server-lambda/tsconfig.json
+++ b/packages/apollo-server-lambda/tsconfig.json
@@ -8,7 +8,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -4,11 +4,6 @@
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-micro"

--- a/packages/apollo-server-micro/tsconfig.json
+++ b/packages/apollo-server-micro/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/apollo-server-micro/tsconfig.json
+++ b/packages/apollo-server-micro/tsconfig.json
@@ -10,7 +10,6 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../apollo-server-core" },
-    { "path": "../apollo-server-env" },
     { "path": "../apollo-server-integration-testsuite" }
   ]
 }

--- a/packages/apollo-server-micro/tsconfig.json
+++ b/packages/apollo-server-micro/tsconfig.json
@@ -7,5 +7,10 @@
     "strictNullChecks": false
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-env" },
+    { "path": "../apollo-server-integration-testsuite" }
+  ]
 }

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -5,11 +5,6 @@
   "author": "opensource@apollographql.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server"

--- a/packages/apollo-server/tsconfig.json
+++ b/packages/apollo-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-server/tsconfig.json
+++ b/packages/apollo-server/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-core" },
+    { "path": "../apollo-server-express" }
+  ]
 }

--- a/packages/apollo-tracing/package.json
+++ b/packages/apollo-tracing/package.json
@@ -4,11 +4,6 @@
   "description": "Collect and expose trace data for GraphQL requests",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile"
-  },
   "license": "MIT",
   "repository": "apollographql/apollo-tracing-js",
   "author": "Martijn Walraven <martijn@martijnwalraven.com>",

--- a/packages/apollo-tracing/tsconfig.json
+++ b/packages/apollo-tracing/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/apollo-tracing/tsconfig.json
+++ b/packages/apollo-tracing/tsconfig.json
@@ -7,7 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
-    { "path": "../apollo-server-env" },
     { "path": "../graphql-extensions" }
   ]
 }

--- a/packages/apollo-tracing/tsconfig.json
+++ b/packages/apollo-tracing/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-env" },
+    { "path": "../graphql-extensions" }
+  ]
 }

--- a/packages/graphql-extensions/package.json
+++ b/packages/graphql-extensions/package.json
@@ -4,13 +4,6 @@
   "description": "Add extensions to GraphQL servers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "scripts": {
-    "clean": "rm -rf dist",
-    "compile": "tsc",
-    "prepare": "npm run clean && npm run compile",
-    "lint": "prettier -l 'src/**/*.ts' && tslint -p tsconfig.json 'src/**/*.ts'",
-    "lint-fix": "prettier --write 'src/**/*.ts' && tslint --fix -p tsconfig.json 'src/**/*.ts'"
-  },
   "repository": {
     "type": "git",
     "url": "apollographql/graphql-extensions"

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -20,7 +20,7 @@ export type EndHandler = (...errors: Array<Error>) => void;
 // arguments.
 type StartHandlerInvoker<TContext = any> = (
   ext: GraphQLExtension<TContext>,
-) => void;
+) => EndHandler | void;
 
 // Copied from runQuery in apollo-server-core.
 // XXX Will this work properly if it's an identical interface of the

--- a/packages/graphql-extensions/tsconfig.json
+++ b/packages/graphql-extensions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/graphql-extensions/tsconfig.json
+++ b/packages/graphql-extensions/tsconfig.json
@@ -7,6 +7,5 @@
   "include": ["src/**/*"],
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
-    { "path": "../apollo-server-env" }
   ]
 }

--- a/packages/graphql-extensions/tsconfig.json
+++ b/packages/graphql-extensions/tsconfig.json
@@ -5,5 +5,8 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__", "**/__mocks__"]
+  "exclude": ["**/__tests__", "**/__mocks__"],
+  "references": [
+    { "path": "../apollo-server-env" }
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "es2016",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "removeComments": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "lib": ["es2017", "esnext.asynciterable"],
+    "types": ["node", "jest"]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,16 @@
 {
+  "files": [],
   "references": [
     { "path": "./packages/apollo-cache-control" },
     { "path": "./packages/apollo-datasource" },
     { "path": "./packages/apollo-datasource-rest" },
     { "path": "./packages/apollo-engine-reporting" },
-    { "path": "./packages/apollo-engine-reporting-protobuf" },
     { "path": "./packages/apollo-server" },
     { "path": "./packages/apollo-server-cache-memcached" },
     { "path": "./packages/apollo-server-cache-redis" },
     { "path": "./packages/apollo-server-caching" },
     { "path": "./packages/apollo-server-cloudflare" },
     { "path": "./packages/apollo-server-core" },
-    { "path": "./packages/apollo-server-env" },
     { "path": "./packages/apollo-server-errors" },
     { "path": "./packages/apollo-server-express" },
     { "path": "./packages/apollo-server-hapi" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "es2016",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,25 @@
 {
-  "compilerOptions": {
-    "composite": true,
-    "target": "es2016",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "removeComments": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedParameters": true,
-    "noUnusedLocals": true,
-    "lib": ["es2017", "esnext.asynciterable"],
-    "types": ["node", "jest"]
-  }
+  "references": [
+    { "path": "./packages/apollo-cache-control" },
+    { "path": "./packages/apollo-datasource" },
+    { "path": "./packages/apollo-datasource-rest" },
+    { "path": "./packages/apollo-engine-reporting" },
+    { "path": "./packages/apollo-engine-reporting-protobuf" },
+    { "path": "./packages/apollo-server" },
+    { "path": "./packages/apollo-server-cache-memcached" },
+    { "path": "./packages/apollo-server-cache-redis" },
+    { "path": "./packages/apollo-server-caching" },
+    { "path": "./packages/apollo-server-cloudflare" },
+    { "path": "./packages/apollo-server-core" },
+    { "path": "./packages/apollo-server-env" },
+    { "path": "./packages/apollo-server-errors" },
+    { "path": "./packages/apollo-server-express" },
+    { "path": "./packages/apollo-server-hapi" },
+    { "path": "./packages/apollo-server-integration-testsuite" },
+    { "path": "./packages/apollo-server-koa" },
+    { "path": "./packages/apollo-server-lambda" },
+    { "path": "./packages/apollo-server-micro" },
+    { "path": "./packages/apollo-tracing" },
+    { "path": "./packages/graphql-extensions" }
+  ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base",
+  "compilerOptions": {
+    "rootDir": "./packages",
+  },
+  "include": ["**/__tests__", "**/__mocks__"],
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,3 @@
 {
-  "extends": "./tsconfig.base",
-  "compilerOptions": {
-    "rootDir": "./packages",
-  },
-  "include": ["**/__tests__", "**/__mocks__"],
+  "extends": "./tsconfig.base"
 }


### PR DESCRIPTION
This PR updates this repo to use [TypeScript project references](https://www.typescriptlang.org/docs/handbook/project-references.html), which enable incremental compilation and repo-wide file watching.

(The only exception is `apollo-server-env`, which isn't compatible with project references because it needs `allowJs: true` and `declaration: false`. So we compile it on installation as part of `prepare`, and it can be compiled manually when needed.)

We'll have to figure out the best workflow here, but both initial compilation and watching seem to work. Tests are also passing (after an upgrade of `ts-jest` and some configuration changes). There seem to be some ordering issues however, so tests may run before compilation completes.