### PR TITLE
 Triggers and tests for `serverWillStart` lifecycle hook.

### DIFF
--- a/packages/apollo-server-cloud-function/src/ApolloServer.ts
+++ b/packages/apollo-server-cloud-function/src/ApolloServer.ts
@@ -43,6 +43,11 @@ export class ApolloServer extends ApolloServerBase {
   }
 
   public createHandler({ cors }: CreateHandlerOptions = { cors: undefined }) {
+    // We will kick off the `willStart` event once for the server, and then
+    // await it before processing any requests by incorporating its `await` into
+    // the GraphQLServerOptions function which is called before each request.
+    const promiseWillStart = this.willStart();
+
     const corsHeaders = {} as Record<string, any>;
 
     if (cors) {
@@ -132,10 +137,17 @@ export class ApolloServer extends ApolloServerBase {
 
       res.set(corsHeaders);
 
-      graphqlCloudFunction(this.createGraphQLServerOptions.bind(this))(
-        req,
-        res,
-      );
+      graphqlCloudFunction(async () => {
+        // In a world where this `createHandler` was async, we might avoid this
+        // but since we don't want to introduce a breaking change to this API
+        // (by switching it to `async`), we'll leverage the
+        // `GraphQLServerOptions`, which are dynamically built on each request,
+        // to `await` the `promiseWillStart` which we kicked off at the top of
+        // this method to ensure that it runs to completion (which is part of
+        // its contract) prior to processing the request.
+        await promiseWillStart;
+        return this.createGraphQLServerOptions(req, res);
+      })(req, res);
     };
   }
 }

--- a/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
+++ b/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
@@ -1,12 +1,19 @@
 import {
   GraphQLOptions,
+  ServerOptionsFunction,
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
 import { Headers } from 'apollo-server-env';
 import { Request, Response } from 'express';
 
-export function graphqlCloudFunction(options: GraphQLOptions): any {
+type CloudFunctionGraphQLOptionsFunction = ServerOptionsFunction<
+  [Request, Response]
+>;
+
+export function graphqlCloudFunction(
+  options: GraphQLOptions | CloudFunctionGraphQLOptionsFunction,
+): any {
   if (!options) {
     throw new Error('Apollo Server requires options.');
   }

--- a/packages/apollo-server-cloudflare/src/ApolloServer.ts
+++ b/packages/apollo-server-cloudflare/src/ApolloServer.ts
@@ -14,6 +14,7 @@ export class ApolloServer extends ApolloServerBase {
   }
 
   public async listen() {
+    await this.willStart();
     const graphql = this.createGraphQLServerOptions.bind(this);
     addEventListener('fetch', (event: FetchEvent) => {
       event.respondWith(graphqlCloudflare(graphql)(event.request));

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -115,7 +115,6 @@ export class ApolloServer extends ApolloServerBase {
     });
 
     if (!disableHealthCheck) {
-      // uses same path as engine proxy, but is generally useful.
       app.use('/.well-known/apollo/server-health', (req, res) => {
         // Response follows https://tools.ietf.org/html/draft-inadarei-api-health-check-01
         res.type('application/health+json');

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -53,6 +53,8 @@ export class ApolloServer extends ApolloServerBase {
     disableHealthCheck,
     onHealthCheck,
   }: ServerRegistration) {
+    await this.willStart();
+
     if (!path) path = '/graphql';
 
     await app.ext({

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -1072,6 +1072,80 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
       });
     });
 
+    describe('request pipeline plugins', () => {
+      describe('lifecycle hooks', () => {
+        it('calls serverWillStart before serving a request', async () => {
+          // We'll use this eventually-assigned function to programmatically
+          // resolve the `serverWillStart` event.
+          let resolveServerWillStart: Function;
+
+          // We'll use this mocked function to determine the order in which
+          // the events we're expecting to happen actually occur and validate
+          // those expectations in various stages of this test.
+          const fn = jest.fn();
+
+          // We want this to create the app as fast as `createApp` will allow.
+          // for integrations whose `applyMiddleware` currently returns a
+          // Promise we want them to resolve at whatever eventual pace they
+          // will so we can make sure that things are happening in order.
+          const unawaitedApp = createApp({
+            graphqlOptions: {
+              schema,
+              plugins: [
+                {
+                  serverWillStart() {
+                    fn('zero');
+                    return new Promise(resolve => {
+                      resolveServerWillStart = () => {
+                        fn('one');
+                        resolve();
+                      };
+                    });
+                  },
+                },
+              ],
+            },
+          });
+
+          // Make sure that things were called in the expected order.
+          expect(fn.mock.calls).toEqual([['zero']]);
+
+          resolveServerWillStart();
+
+          // Account for the fact that `createApp` might return a Promise,
+          // and might not, depending on the integration's implementation of
+          // createApp.  This is entirely to account for the fact that
+          // non-async implementations of `applyMiddleware` leverage a
+          // middleware as the technique for yielding to `startWillStart`
+          // hooks while their `async` counterparts simply `await` those same
+          // hooks.  In a future where we make the behavior of `applyMiddleware`
+          // the same across all integrations, this should be changed to simply
+          // `await unawaitedApp`.
+          app = 'then' in unawaitedApp ? await unawaitedApp : unawaitedApp;
+
+          // Intentionally fire off the request asynchronously, without await.
+          const res = request(app)
+            .get('/graphql')
+            .query({
+              query: 'query test{ testString }',
+            })
+            .then(res => {
+              fn('two');
+              return res;
+            });
+
+          // Ensure the request has not gone through.
+          expect(fn.mock.calls).toEqual([['zero'], ['one']]);
+
+          // Now, wait for the request to finish.
+          await res;
+
+          // Finally, ensure that the order we expected was achieved.
+          expect(fn.mock.calls).toEqual([['zero'], ['one'], ['two']]);
+        });
+      });
+    });
+
     describe('Persisted Queries', () => {
       const query = '{testString}';
       const query2 = '{ testString }';

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -109,7 +109,6 @@ export class ApolloServer extends ApolloServerBase {
     );
 
     if (!disableHealthCheck) {
-      // uses same path as engine proxy, but is generally useful.
       app.use(
         middlewareFromPath(
           '/.well-known/apollo/server-health',

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -30,8 +30,14 @@ export class ApolloServer extends ApolloServerBase {
     disableHealthCheck,
     onHealthCheck,
   }: ServerRegistration = {}) {
+    // We'll kick off the `willStart` right away, so hopefully it'll finish
+    // before the first request comes in.
+    const promiseWillStart = this.willStart();
+
     return async (req, res) => {
       this.graphqlPath = path || '/graphql';
+
+      await promiseWillStart;
 
       await this.handleFileUploads(req);
 


### PR DESCRIPTION
This commit follows-up on #1795, which introduced the new request pipeline, and implements the triggers for its new life-cycle hooks within the various integration packages.  Previously, the only implementation was within the `apollo-server` package and didn't get triggered for those invoking the `applyMiddleware` method on integrations (e.g. `apollo-server-express`, `...-hapi` and `...-koa`).

While in an ideal world, ALL existing `applyMiddleware` functions would be marked as `async` functions and allow us to `await ApolloServer#willStart`, in practice the only `applyMiddleware` which is currently `async` is the one within the Hapi implementation.  Therefore, we'll instead kick off the `willStart` lifecycle hook as soon as `applyMiddleware` is started, return as quickly as we have before and then (essentially) yield the completion of Apollo Server's `willStart` prior to serving the first request — thus ensuring the completion of server-startup activities.

Similarly, we'll do the same for `createHandler` methods on integrations which don't utilize Node.js server frameworks but don't have `async` handlers (e.g. AWS, Lambda, etc.).