### PR TITLE
Update to GraphQL Playground latest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+- Update `graphql-playground-html` to 1.7.8
 - Allow an optional function to resolve the `rootValue`, passing the `DocumentNode` AST to determine the value. [PR #1555](https://github.com/apollographql/apollo-server/pull/1555)
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2224,7 +2224,7 @@
       "version": "file:packages/apollo-server-express",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.0",
+        "@apollographql/graphql-playground-html": "^1.6.4",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
         "@types/cors": "^2.8.4",
@@ -2242,7 +2242,7 @@
       "version": "file:packages/apollo-server-hapi",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.0",
+        "@apollographql/graphql-playground-html": "^1.6.4",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "boom": "^7.1.0",
@@ -2260,7 +2260,7 @@
       "version": "file:packages/apollo-server-koa",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.0",
+        "@apollographql/graphql-playground-html": "^1.6.4",
         "@koa/cors": "^2.2.1",
         "@types/accepts": "^1.3.5",
         "@types/cors": "^2.8.4",
@@ -2281,7 +2281,7 @@
     "apollo-server-lambda": {
       "version": "file:packages/apollo-server-lambda",
       "requires": {
-        "@apollographql/graphql-playground-html": "^1.6.0",
+        "@apollographql/graphql-playground-html": "^1.6.4",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "graphql-tools": "^4.0.0"
@@ -2291,7 +2291,7 @@
       "version": "file:packages/apollo-server-micro",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.0",
+        "@apollographql/graphql-playground-html": "^1.6.4",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "micro": "^9.3.2"

--- a/packages/apollo-server-cloud-function/package.json
+++ b/packages/apollo-server-cloud-function/package.json
@@ -25,7 +25,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/graphql-playground-html": "^1.6.0",
+    "@apollographql/graphql-playground-html": "^1.6.4",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "graphql-tools": "^4.0.0"

--- a/packages/apollo-server-core/src/playground.ts
+++ b/packages/apollo-server-core/src/playground.ts
@@ -6,9 +6,9 @@ export {
   RenderPageOptions as PlaygroundRenderPageOptions,
 } from '@apollographql/graphql-playground-html/dist/render-playground-page';
 
-// This specifies the version of GraphQL Playground that will be served
-// from graphql-playground-html, and is passed to renderPlaygroundPage
-// by the integration subclasses
+// This specifies the version of `graphql-playground-react` that will be served
+// from `graphql-playground-html`.  It's passed to ``graphql-playground-html`'s
+// renderPlaygroundPage` via the integration packages' playground configuration.
 const playgroundVersion = '1.7.8';
 
 // https://stackoverflow.com/a/51365037

--- a/packages/apollo-server-core/src/playground.ts
+++ b/packages/apollo-server-core/src/playground.ts
@@ -9,7 +9,7 @@ export {
 // This specifies the version of GraphQL Playground that will be served
 // from graphql-playground-html, and is passed to renderPlaygroundPage
 // by the integration subclasses
-const playgroundVersion = '1.7.4';
+const playgroundVersion = '1.7.8';
 
 // https://stackoverflow.com/a/51365037
 type RecursivePartial<T> = {

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.0",
+    "@apollographql/graphql-playground-html": "^1.6.4",
     "@types/accepts": "^1.3.5",
     "@types/body-parser": "1.17.0",
     "@types/cors": "^2.8.4",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.0",
+    "@apollographql/graphql-playground-html": "^1.6.4",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
     "boom": "^7.1.0",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.0",
+    "@apollographql/graphql-playground-html": "^1.6.4",
     "@koa/cors": "^2.2.1",
     "@types/accepts": "^1.3.5",
     "@types/cors": "^2.8.4",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -25,7 +25,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/graphql-playground-html": "^1.6.0",
+    "@apollographql/graphql-playground-html": "^1.6.4",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "graphql-tools": "^4.0.0"

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.0",
+    "@apollographql/graphql-playground-html": "^1.6.4",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
     "micro": "^9.3.2"


### PR DESCRIPTION
In addition to updating the `@apollographql/graphql-playground-html` fork,
which is necessary to avoid bundling `graphql-config` which had been
problematic in serverless environments, this updates the version number
which is served from the CDN.

I've just published `@apollographql/graphql-playground-html@1.6.4`.

Closes: https://github.com/apollographql/apollo-server/issues/1746
Ref: https://github.com/apollographql/graphql-playground/pull/2
Ref: https://github.com/apollographql/graphql-playground/pull/1

Thanks for @javlund for kicking off some of this work!