### PR TITLE
feature(apollo-engine-reporting): Add custom http agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Allow an optional function to resolve the `rootValue`, passing the `DocumentNode` AST to determine the value. [PR #1555](https://github.com/apollographql/apollo-server/pull/1555)
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
 - Allow JSON parsing in `RESTDataSource` of Content Type `application/hal+json`. [PR ##185](https://github.com/apollographql/apollo-server/pull/1853)
-- Add support for custom http(s) agent on apollo-engine-reporting to be used on the network requests to apollo-engine endpoint. [PR #1879](https://github.com/apollographql/apollo-server/pull/1879)
+- Add support for a `requestAgent` configuration parameter within the `engine` configuration.  This can be utilized when a proxy is necessary to transmit tracing and metrics data to Apollo Engine.  It accepts either an [`http.Agent`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_class_http_agent) or [`https.Agent`](https://nodejs.org/docs/latest-v8.x/api/https.html#https_class_https_agent) and behaves the same as the `agent` parameter to Node.js' [`http.request`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_http_request_options_callback). [PR #1879](https://github.com/apollographql/apollo-server/pull/1879)
 
 ### v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Allow an optional function to resolve the `rootValue`, passing the `DocumentNode` AST to determine the value. [PR #1555](https://github.com/apollographql/apollo-server/pull/1555)
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
 - Allow JSON parsing in `RESTDataSource` of Content Type `application/hal+json`. [PR ##185](https://github.com/apollographql/apollo-server/pull/1853)
+- Add support for custom http(s) agent on apollo-engine-reporting to be used on the network requests to apollo-engine endpoint. [PR #1879](https://github.com/apollographql/apollo-server/pull/1879)
 
 ### v2.1.0
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -322,6 +322,10 @@ addMockFunctionsToSchema({
 
    The URL of the Engine report ingress server.
 
+*  `requestAgent`: `http.Agent | https.Agent | false`
+
+   HTTP(s) agent to be used on the metrics reporting request to apollo engine endpoint. For more details on the supported configurations, refer to [http.Agent](https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_agent) and [https.Agent](https://nodejs.org/docs/latest-v10.x/api/https.html#https_class_https_agent) docs.
+
 *  `debugPrintReports`: boolean
 
    If set, prints all reports as JSON when they are sent.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -324,7 +324,7 @@ addMockFunctionsToSchema({
 
 *  `requestAgent`: `http.Agent | https.Agent | false`
 
-   HTTP(s) agent to be used on the metrics reporting request to apollo engine endpoint. For more details on the supported configurations, refer to [http.Agent](https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_agent) and [https.Agent](https://nodejs.org/docs/latest-v10.x/api/https.html#https_class_https_agent) docs.
+   HTTP(s) agent to be used for Apollo Engine metrics reporting.  This accepts either an [`http.Agent`](https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_agent) or [`https.Agent`](https://nodejs.org/docs/latest-v10.x/api/https.html#https_class_https_agent) and behaves the same as the `agent` parameter to Node.js' [`http.request`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_http_request_options_callback).
 
 *  `debugPrintReports`: boolean
 

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -8,7 +8,7 @@ import {
   Trace,
 } from 'apollo-engine-reporting-protobuf';
 
-import { fetch, Response } from 'apollo-server-env';
+import { fetch, RequestAgent, Response } from 'apollo-server-env';
 import retry from 'async-retry';
 
 import { EngineReportingExtension } from './extension';
@@ -60,6 +60,8 @@ export interface EngineReportingOptions {
   endpointUrl?: string;
   // If set, prints all reports as JSON when they are sent.
   debugPrintReports?: boolean;
+  // HTTP(s) agent to be used on the fetch call to apollo-engine metrics endpoint
+  requestAgent?: RequestAgent | false;
   // Reporting is retried with exponential backoff up to this many times
   // (including the original request). Defaults to 5.
   maxAttempts?: number;
@@ -256,6 +258,7 @@ export class EngineReportingAgent<TContext = any> {
             'content-encoding': 'gzip',
           },
           body: compressed,
+          agent: this.options.requestAgent,
         });
 
         if (curResponse.status >= 500 && curResponse.status < 600) {

--- a/packages/apollo-server-env/src/fetch.d.ts
+++ b/packages/apollo-server-env/src/fetch.d.ts
@@ -1,9 +1,12 @@
-import { Agent } from 'http';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 
 export declare function fetch(
   input?: RequestInfo,
   init?: RequestInit,
 ): Promise<Response>;
+
+export type RequestAgent = HttpAgent | HttpsAgent;
 
 export type RequestInfo = Request | string;
 
@@ -58,7 +61,7 @@ export interface RequestInit {
   timeout?: number;
   compress?: boolean;
   size?: number;
-  agent?: Agent;
+  agent?: RequestAgent | false;
 
   // Cloudflare Workers accept a `cf` property to control Cloudflare features
   // See https://developers.cloudflare.com/workers/reference/cloudflare-features/

--- a/packages/apollo-server-env/src/global.d.ts
+++ b/packages/apollo-server-env/src/global.d.ts
@@ -12,6 +12,7 @@ type Headers = import('./fetch').Headers;
 type HeadersInit = import('./fetch').HeadersInit;
 type Body = import('./fetch').Body;
 type Request = import('./fetch').Request;
+type RequestAgent = import('./fetch').RequestAgent;
 type RequestInit = import('./fetch').RequestInit;
 type RequestMode = import('./fetch').RequestMode;
 type RequestCredentials = import('./fetch').RequestCredentials;


### PR DESCRIPTION
This PR fixes #1836.

This PR enables developers to inject the http agent to be used on the network requests to apollo engine endpoint.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->