### PR TITLE
centralized “Get Started” Image in the doc

### DIFF
--- a/docs/source/images/index-get-started.svg
+++ b/docs/source/images/index-get-started.svg
@@ -8,7 +8,7 @@
         <g id="Group">
             <rect id="Rectangle" fill="#E534AB" x="0" y="0" width="231" height="49" rx="22"></rect>
             <text id="Get-Started!" font-family="SourceSansPro-Bold, Source Sans Pro" font-size="20" font-weight="bold" line-spacing="20" letter-spacing="0.5" fill="#FFFFFF">
-                <tspan x="29.53" y="31.52">GET STARTED !</tspan>
+                <tspan x="50%" y="50%" text-anchor="middle" dominant-baseline="central" >GET STARTED!</tspan>
             </text>
         </g>
     </g>

--- a/docs/source/images/index-get-started.svg
+++ b/docs/source/images/index-get-started.svg
@@ -8,7 +8,7 @@
         <g id="Group">
             <rect id="Rectangle" fill="#E534AB" x="0" y="0" width="231" height="49" rx="22"></rect>
             <text id="Get-Started!" font-family="SourceSansPro-Bold, Source Sans Pro" font-size="20" font-weight="bold" line-spacing="20" letter-spacing="0.5" fill="#FFFFFF">
-                <tspan x="45.53" y="30.52">GET STARTED!</tspan>
+                <tspan x="29.53" y="31.52">GET STARTED !</tspan>
             </text>
         </g>
     </g>


### PR DESCRIPTION
- [x] docs

the image is used in this page
https://www.apollographql.com/docs/apollo-server/

<img width="824" alt="introduction___apollo_server" src="https://user-images.githubusercontent.com/6080698/47543445-2ef6b800-d91d-11e8-9ae2-4685357715fa.png">
