### PR TITLE
Add typescript 3 update to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Follow-up on the work in [PR #1516](https://github.com/apollographql/apollo-server/pull/1516) to also fix missing insertion cursor/caret when a custom GraphQL configuration is specified which doesn't specify its own `cursorShape` property. [PR #1607](https://github.com/apollographql/apollo-server/pull/1607)
 - Allow JSON parsing in `RESTDataSource` of Content Type `application/hal+json`. [PR ##185](https://github.com/apollographql/apollo-server/pull/1853)
 - Add support for a `requestAgent` configuration parameter within the `engine` configuration.  This can be utilized when a proxy is necessary to transmit tracing and metrics data to Apollo Engine.  It accepts either an [`http.Agent`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_class_http_agent) or [`https.Agent`](https://nodejs.org/docs/latest-v8.x/api/https.html#https_class_https_agent) and behaves the same as the `agent` parameter to Node.js' [`http.request`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_http_request_options_callback). [PR #1879](https://github.com/apollographql/apollo-server/pull/1879)
+- Update to Typescript 3 (typescript users must upgrade to 3.x) [PR #1772](https://github.com/apollographql/apollo-server/pull/1772) [PR #1806](https://github.com/apollographql/apollo-server/pull/1806)
 
 ### v2.1.0
 


### PR DESCRIPTION
Users still on typescript 2 will not be able to compile, since
https://github.com/apollographql/apollo-server/blob/5b8388323325c14970601310d7864b86010cbebe/packages/apollo-server-core/src/graphqlOptions.ts#L58
compiles to input that is not compatible.

Error using `typescript@^2.8.3`:
![image](https://user-images.githubusercontent.com/5565407/47594014-6a4db280-d92e-11e8-9e52-a4956215e9e8.png)

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->