### PR TITLE
Preserve TypeScript 2 Backwards compatibility until Semver Major

### DIFF
--- a/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
+++ b/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
@@ -1,15 +1,14 @@
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
 import { Headers } from 'apollo-server-env';
 import { Request, Response } from 'express';
 
-export type CloudFunctionGraphQLOptionsFunction = ServerOptionsFunction<
-  [Request, Response]
->;
+export interface CloudFunctionGraphQLOptionsFunction {
+  (req?: Request, res?: Response): GraphQLOptions | Promise<GraphQLOptions>;
+}
 
 export function graphqlCloudFunction(
   options: GraphQLOptions | CloudFunctionGraphQLOptionsFunction,

--- a/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
+++ b/packages/apollo-server-cloud-function/src/googleCloudApollo.ts
@@ -7,7 +7,7 @@ import {
 import { Headers } from 'apollo-server-env';
 import { Request, Response } from 'express';
 
-type CloudFunctionGraphQLOptionsFunction = ServerOptionsFunction<
+export type CloudFunctionGraphQLOptionsFunction = ServerOptionsFunction<
   [Request, Response]
 >;
 

--- a/packages/apollo-server-cloudflare/src/ApolloServer.ts
+++ b/packages/apollo-server-cloudflare/src/ApolloServer.ts
@@ -15,9 +15,12 @@ export class ApolloServer extends ApolloServerBase {
 
   public async listen() {
     await this.willStart();
-    const graphql = this.createGraphQLServerOptions.bind(this);
     addEventListener('fetch', (event: FetchEvent) => {
-      event.respondWith(graphqlCloudflare(graphql)(event.request));
+      event.respondWith(
+        graphqlCloudflare(() => {
+          return this.createGraphQLServerOptions(event.request);
+        })(event.request),
+      );
     });
     return await { url: '', port: null };
   }

--- a/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
+++ b/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
@@ -1,6 +1,5 @@
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
@@ -12,7 +11,9 @@ import { Request, Response, URL } from 'apollo-server-env';
 // - simple, fast and secure
 //
 
-export type CloudflareOptionsFunction = ServerOptionsFunction<[Request]>;
+export interface CloudflareOptionsFunction {
+  (req?: Request): GraphQLOptions | Promise<GraphQLOptions>;
+}
 
 export function graphqlCloudflare(
   options: GraphQLOptions | CloudflareOptionsFunction,

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -55,13 +55,13 @@ export interface PersistedQueryOptions {
 
 export default GraphQLServerOptions;
 
-export async function resolveGraphqlOptions<HandlerArguments extends any[]>(
+export async function resolveGraphqlOptions(
   options:
     | GraphQLServerOptions
     | ((
-        ...args: HandlerArguments
+        ...args: Array<any>
       ) => Promise<GraphQLServerOptions> | GraphQLServerOptions),
-  ...args: HandlerArguments
+  ...args: Array<any>
 ): Promise<GraphQLServerOptions> {
   if (typeof options === 'function') {
     return await options(...args);

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -18,7 +18,7 @@ import {
 import { CacheControlExtensionOptions } from 'apollo-cache-control';
 import { ApolloServerPlugin, WithRequired } from 'apollo-server-plugin-base';
 
-export interface HttpQueryRequest<HandlerArguments extends any[]> {
+export interface HttpQueryRequest {
   method: string;
   // query is either the POST body or the GET query string map.  In the GET
   // case, all values are strings and need to be parsed as JSON; in the POST
@@ -28,7 +28,7 @@ export interface HttpQueryRequest<HandlerArguments extends any[]> {
   query: Record<string, any> | Array<Record<string, any>>;
   options:
     | GraphQLOptions
-    | ((...args: HandlerArguments) => Promise<GraphQLOptions> | GraphQLOptions);
+    | ((...args: Array<any>) => Promise<GraphQLOptions> | GraphQLOptions);
   request: Pick<Request, 'url' | 'method' | 'headers'>;
 }
 
@@ -91,9 +91,9 @@ function throwHttpGraphQLError<E extends Error>(
   );
 }
 
-export async function runHttpQuery<HandlerArguments extends any[]>(
-  handlerArguments: HandlerArguments,
-  request: HttpQueryRequest<HandlerArguments>,
+export async function runHttpQuery(
+  handlerArguments: Array<any>,
+  request: HttpQueryRequest,
 ): Promise<HttpQueryResponse> {
   let options: GraphQLOptions;
   const debugDefault =
@@ -178,7 +178,7 @@ export async function processHTTPRequest<TContext>(
   options: WithRequired<GraphQLOptions<TContext>, 'cache' | 'plugins'> & {
     context: TContext;
   },
-  httpRequest: HttpQueryRequest<any>,
+  httpRequest: HttpQueryRequest,
 ): Promise<HttpQueryResponse> {
   let requestPayload;
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -24,12 +24,6 @@ export type ContextFunction<T = any> = (
   context: Context<T>,
 ) => Promise<Context<T>>;
 
-type ValueOrPromise<T> = T | Promise<T>;
-
-export type ServerOptionsFunction<HandlerArguments extends any[]> = (
-  ...args: HandlerArguments
-) => ValueOrPromise<GraphQLOptions>;
-
 export interface SubscriptionServerOptions {
   path: string;
   keepAlive?: number;

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -188,11 +188,9 @@ export class ApolloServer extends ApolloServerBase {
           return;
         }
       }
-      return graphqlExpress(this.createGraphQLServerOptions.bind(this))(
-        req,
-        res,
-        next,
-      );
+      return graphqlExpress(() => {
+        return this.createGraphQLServerOptions(req, res);
+      })(req, res, next);
     });
   }
 }

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -1,15 +1,16 @@
 import express from 'express';
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   HttpQueryError,
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
 
-export type ExpressGraphQLOptionsFunction = ServerOptionsFunction<
-  [express.Request, express.Response]
->;
+export interface ExpressGraphQLOptionsFunction {
+  (req?: express.Request, res?: express.Response):
+    | GraphQLOptions
+    | Promise<GraphQLOptions>;
+}
 
 // Design principles:
 // - there is just one way allowed: POST request with JSON body. Nothing else.

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,8 +1,7 @@
 import Boom from 'boom';
-import { Server, Request, RouteOptions, ResponseToolkit } from 'hapi';
+import { Server, Request, RouteOptions } from 'hapi';
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
@@ -17,9 +16,9 @@ export interface IPlugin {
   register: IRegister;
 }
 
-export type HapiOptionsFunction = ServerOptionsFunction<
-  [Request, ResponseToolkit]
->;
+export interface HapiOptionsFunction {
+  (request?: Request): GraphQLOptions | Promise<GraphQLOptions>;
+}
 
 export interface HapiPluginOptions {
   path: string;

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -181,10 +181,9 @@ export class ApolloServer extends ApolloServerBase {
             return;
           }
         }
-        return graphqlKoa(this.createGraphQLServerOptions.bind(this))(
-          ctx,
-          next,
-        );
+        return graphqlKoa(() => {
+          return this.createGraphQLServerOptions(ctx);
+        })(ctx, next);
       }),
     );
   }

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -1,13 +1,14 @@
 import Koa from 'koa';
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   HttpQueryError,
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
 
-export type KoaGraphQLOptionsFunction = ServerOptionsFunction<[Koa.Context]>;
+export interface KoaGraphQLOptionsFunction {
+  (ctx: Koa.Context): GraphQLOptions | Promise<GraphQLOptions>;
+}
 
 export interface KoaHandler {
   (ctx: Koa.Context, next): void;

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -1,15 +1,16 @@
 import lambda from 'aws-lambda';
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
 import { Headers } from 'apollo-server-env';
 
-export type LambdaGraphQLOptionsFunction = ServerOptionsFunction<
-  [lambda.APIGatewayProxyEvent, lambda.Context]
->;
+export interface LambdaGraphQLOptionsFunction {
+  (event: lambda.APIGatewayProxyEvent, context: lambda.Context):
+    | GraphQLOptions
+    | Promise<GraphQLOptions>;
+}
 
 export function graphqlLambda(
   options: GraphQLOptions | LambdaGraphQLOptionsFunction,

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -149,9 +149,9 @@ export class ApolloServer extends ApolloServerBase {
     let handled = false;
     const url = req.url.split('?')[0];
     if (url === this.graphqlPath) {
-      const graphqlHandler = graphqlMicro(
-        this.createGraphQLServerOptions.bind(this),
-      );
+      const graphqlHandler = graphqlMicro(() => {
+        return this.createGraphQLServerOptions(req, res);
+      });
       const responseData = await graphqlHandler(req, res);
       send(res, 200, responseData);
       handled = true;

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -1,20 +1,18 @@
 import {
   GraphQLOptions,
-  ServerOptionsFunction,
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
 import { send, json, RequestHandler } from 'micro';
 import url from 'url';
-import { ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 
 import { MicroRequest } from './types';
 
 // Allowed Micro Apollo Server options.
-
-export type MicroGraphQLOptionsFunction = ServerOptionsFunction<
-  [MicroRequest, ServerResponse]
->;
+export interface MicroGraphQLOptionsFunction {
+  (req?: IncomingMessage): GraphQLOptions | Promise<GraphQLOptions>;
+}
 
 // Utility function used to set multiple headers on a response object.
 function setHeaders(res: ServerResponse, headers: Object): void {

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -21,15 +21,14 @@ export abstract class ApolloServerPlugin {
 }
 
 export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
-export type DidEndHook<TArgs extends any[]> = (...args: TArgs) => void;
 
 export interface GraphQLRequestListener<TContext = Record<string, any>> {
   parsingDidStart?(
     requestContext: GraphQLRequestContext<TContext>,
-  ): DidEndHook<[Error?]> | void;
+  ): (err?: Error) => void | void;
   validationDidStart?(
     requestContext: WithRequired<GraphQLRequestContext<TContext>, 'document'>,
-  ): DidEndHook<[ReadonlyArray<Error>?]> | void;
+  ): (err?: ReadonlyArray<Error>) => void | void;
   didResolveOperation?(
     requestContext: WithRequired<
       GraphQLRequestContext<TContext>,
@@ -41,7 +40,7 @@ export interface GraphQLRequestListener<TContext = Record<string, any>> {
       GraphQLRequestContext<TContext>,
       'document' | 'operationName' | 'operation'
     >,
-  ): DidEndHook<[Error?]> | void;
+  ): (err?: Error) => void | void;
   willSendResponse?(
     requestContext: WithRequired<GraphQLRequestContext<TContext>, 'response'>,
   ): ValueOrPromise<void>;


### PR DESCRIPTION
This mostly reverts fd34771 along with a number of slight adjustments to avoid other typing luxuries which were introduced with TypeScript 3.x, as they resulted in test failures in our own internal smoke testing.

While the generic `ServerOptionFunction` types and `HandlerArguments` generic rest argument type were certainly welcome additions to the codebase, they present a backwards compatibility problem for consumers of Apollo Server 2.x who have not yet updated their own projects to use TypeScript 3.x since attempting to use the definition files which were generated from these types would result in typescript compilation failures from `tsc@2.x`.

Therefore, we'll roll these back, since these were _intended_ to land in a minor release of Apollo Server.  With any luck, when we eventually bump the major version of Apollo Server, in accordance with semantic versioning, we'll be in a position to simply revert e24804f00515fe5dae041472ef64cb514f093113.

It should be noted though that the two _other_ commits contained in this PR (b98191c and 64e9099) should not be reverted, and they've been carefully placed first to make sure that reversion is still simple.