### PR TITLE
Clarified wording of mocking docs

### DIFF
--- a/docs/source/features/mocking.md
+++ b/docs/source/features/mocking.md
@@ -32,7 +32,7 @@ server.listen().then(({ url }) => {
 
 > Note: If `typeDefs` has custom scalar types, `resolvers` must still contain the `serialize`, `parseValue`, and `parseLiteral` functions
 
-Mocking logic simply looks at the type definitions and returns a string where a string is expected, a number for a number, etc. This provides the right shape of result. By default, when using mocks, any existing resolvers are ignored. See the ["Using existing resolvers with mocks"](./#existing-resolvers) section below for more info on how to change this behavior. 
+Mocking logic simply looks at the type definitions and returns a string where a string is expected, a number for a number, etc. This provides the right shape of result. By default, when using mocks, any existing resolvers are ignored. See the ["Using existing resolvers with mocks"](#existing-resolvers) section below for more info on how to change this behavior. 
 
 For more sophisticated testing, mocks can be customized to a particular data model.
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This is just an update to the wording of the mocking docs with the following changes:

- Added note about using existing resolvers at the top to make it more obvious (even though it's already on the sidebar... I'm open to taking this back out)
- Added note that `mocks` can disable the `mockEntireSchema` feature if it's set to `false`
- API description clarification at the bottom. It looked like it said that `preserveResolvers` was always true, which isn't accurate

Anything else that seems confusing/wrong?