### PR TITLE
Failed the lambda on exception for API Gateway

### DIFF
--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -51,10 +51,16 @@ export function graphqlLambda(
       },
     }).then(
       ({ graphqlResponse, responseInit }) => {
+        let graphqlResponseJson = JSON.parse(graphqlResponse);
+        if(graphqlResponseJson.errors != undefined) {
+          graphqlResponseJson.code = "error";
+          graphqlResponse = JSON.stringify(graphqlResponseJson);
+          callback(graphqlResponse);
+        } else {
         callback(null, {
-          body: graphqlResponse,
-          statusCode: 200,
-          headers: responseInit.headers,
+            body: graphqlResponse,
+            statusCode: 200,
+            headers: responseInit.headers,
         });
       },
       (error: HttpQueryError) => {


### PR DESCRIPTION
- Added "code" field with value "error" to the graphql response and failed the lambda whenever there is the exception
- The exception is identified using the errors field in the response.