### PR TITLE
Add client awareness reference api and some docs

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -380,8 +380,14 @@ addMockFunctionsToSchema({
    name.  The default function will use the `clientInfo` field inside of
    GraphQL Query `extensions`.
 
-   For some advanced cases, the `clientReferenceId` can be used as a unique
-   identifier for a client name. These clientReferenceIds should have a one
-   to one relationship to a client name and are used to correlate with other
-   systems, such as client ownership or team identity.
+   For advanced use cases when you already have an opaque string to identify
+   your client (e.g. an API key, x509 certificate, or team codename), use the
+   `clientReferenceId` field to add a reference to its internal identity. This
+   client reference ID will not be displayed in the UI but will be available
+   for cross-correspondence, so names and reference ids should have a one to
+   one relationship.
+
+   > [WARNING] If you specify a `clientReferenceId`, Engine will treat the
+   > `clientName` as a secondary lookup, so changing a `clientName` may result
+   > in an unwanted experience.
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -372,14 +372,16 @@ addMockFunctionsToSchema({
 
 *  `generateClientInfo`: (GraphQLRequestContext) => ClientInfo **AS 2.2**
 
-   Creates a client context(`ClientInfo`) based on the request pipeline's
-   context, which contains values like the `request`, `response`, `cache`, and
-   `context`. This generated client information will be provided to Apollo
-   Engine and can be used to filter metrics. `ClientInfo` can contain a
-   `clientName`, `clientVersion`, and `clientReferenceId`. While all of these
-   fields are optional, `clientName` and `clientVersion` should be specified.
-   For some use cases, the `clientReferenceId` can be used as a unique
-   identifier for a client name. These `clientReferenceId`s should have a one
+   Creates a client context(ClientInfo) based on the request pipeline's
+   context, which contains values like the request, response, cache, and
+   context. This generated client information will be provided to Apollo
+   Engine and can be used to filter metrics. Set `clientName` to identify a
+   particular client. Use `clientVersion` to specify a version for a client
+   name.  The default function will use the `clientInfo` field inside of
+   GraphQL Query `extensions`.
+
+   For some advanced cases, the `clientReferenceId` can be used as a unique
+   identifier for a client name. These clientReferenceIds should have a one
    to one relationship to a client name and are used to correlate with other
    systems, such as client ownership or team identity.
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -369,3 +369,17 @@ addMockFunctionsToSchema({
 *  `maskErrorDetails`: boolean
 
    Set to true to remove error details from the traces sent to Apollo's servers. Defaults to false.
+
+*  `generateClientInfo`: (GraphQLRequestContext) => ClientInfo **AS 2.2**
+
+   Creates a client context(`ClientInfo`) based on the request pipeline's
+   context, which contains values like the `request`, `response`, `cache`, and
+   `context`. This generated client information will be provided to Apollo
+   Engine and can be used to filter metrics. `ClientInfo` can contain a
+   `clientName`, `clientVersion`, and `clientReferenceId`. While all of these
+   fields are optional, `clientName` and `clientVersion` should be specified.
+   For some use cases, the `clientReferenceId` can be used as a unique
+   identifier for a client name. These `clientReferenceId`s should have a one
+   to one relationship to a client name and are used to correlate with other
+   systems, such as client ownership or team identity.
+

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -34,6 +34,43 @@ The API key can also be set with the `ENGINE_API_KEY` environment variable. Sett
 ENGINE_API_KEY=YOUR_API_KEY node start-server.js
 ```
 
+### Client Awareness
+
+Apollo Engine accepts metrics annotated with client information. The Engine UI
+is then able to filter metrics and usage patterns by these names and versions. To provide metrics to the Engine, pass a `generateClientInfo` function into the `ApolloServer` constructor, like so:
+
+```js line=8-23
+const { ApolloServer } = require("apollo-server");
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  engine: {
+    apiKey: "YOUR API KEY HERE",
+    generateClientInfo: ({
+      request
+    }) => {
+      const extensions = request.extensions;
+      if(extensions) {
+        return {
+          clientName: extensions.clientName,
+          clientVersion: extensions.clientVersion,
+        };
+      } else {
+        return {
+          clientName: "Unknown Client",
+          clientVersion: "Unversioned",
+        };
+      }
+    },
+  }
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀  Server ready at ${url}`);
+});
+```
+
 ## Logging
 
 Apollo Server provides two ways to log a server: per input, response, and errors or periodically throughout a request's lifecycle. Treating the GraphQL execution as a black box by logging the inputs and outputs of the system allows developers to diagnose issues quickly without being mired by lower level logs. Once a problem has been found at a high level, the lower level logs enable accurate tracing of how a request was handled.

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -50,11 +50,11 @@ const server = new ApolloServer({
     generateClientInfo: ({
       request
     }) => {
-      const extensions = request.extensions;
-      if(extensions) {
+      const headers = request.http & request.http.headers;
+      if(headers) {
         return {
-          clientName: extensions.clientName,
-          clientVersion: extensions.clientVersion,
+          clientName: headers['apollo-client-name'],
+          clientVersion: headers['apollo-client-version'],
         };
       } else {
         return {
@@ -70,6 +70,9 @@ server.listen().then(({ url }) => {
   console.log(`🚀  Server ready at ${url}`);
 });
 ```
+
+> Note: the default implementation looks at `clientInfo` field in the
+> `extensions` of the GraphQL request
 
 ## Logging
 


### PR DESCRIPTION
Provides information on how to enable client awareness in Apollo Server. 

May end up having some overlap with: https://github.com/apollographql/apollo/pull/226, though I'm happy with the overlap for now, since the docs are still evolving.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->