### PR TITLE
Update Renovate Configuration: Remove ineffective limitation.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,5 @@
         "version-2"
       ]
     }
-  ],
-  "packageRules": [
-    {
-      "packageNames": ["lint-staged"],
-      "allowedVersions": "<7"
-    }
   ]
 }


### PR DESCRIPTION
This updates the `renovate.json` to remove a version pinning of `lint-staged` which clearly didn't work since the current version of `lint-staged` is newer than `v7`.