### PR TITLE
Update Renovate Configuration: Use shared base configuration.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,5 @@
 {
-  "extends": [":pinOnlyDevDependencies"],
-  "semanticCommits": true,
-  "timezone": "America/Los_Angeles",
-  "schedule": ["after 6pm and before 8am on every weekday"],
-  "rebaseStalePrs": true,
-  "prCreation": "not-pending",
-  "automerge": "minor",
-  "labels": ["tooling", "dependencies"],
+  "extends": ["apollo-open-source"],
   "pathRules": [
     {
       "paths": ["docs/package.json"],


### PR DESCRIPTION
This updates `renovate.json` to use a shared, base configuration rather than repeating the same defaults across multiple repositories.

That base configuration lives at https://github.com/apollographql/renovate-config-apollo-open-source and is published to npm as `renovate-config-apollo-open-source` (https://npm.im/renovate-config-apollo-open-source).  It is referenced here by its short name `apollo-open-source`.

For more information on sharable Renovate config presets, see https://renovatebot.com/docs/config-presets/.