### PR TITLE
Consistently use `parent`, rather than `root`, as first resolver argument.

### DIFF
--- a/docs/source/api/graphql-tools.md
+++ b/docs/source/api/graphql-tools.md
@@ -25,7 +25,7 @@ const schema = makeExecutableSchema({
   resolvers,
 });
 
-const rootResolveFunction = (root, args, context, info) => {
+const rootResolveFunction = (parent, args, context, info) => {
   //perform action before any other resolvers
 };
 

--- a/docs/source/essentials/data.md
+++ b/docs/source/essentials/data.md
@@ -32,7 +32,7 @@ type Query {
 
 const resolvers = {
   Query: {
-    author(root, args, context, info) {
+    author(parent, args, context, info) {
       return find(authors, { id: args.id });
     },
   },

--- a/docs/source/features/authentication.md
+++ b/docs/source/features/authentication.md
@@ -87,7 +87,7 @@ Luckily, GraphQL offers very granular control over data. In GraphQL servers, ind
 For our first example, let’s look at a resolver that’s only accessible with a valid user:
 
 ```js
-users: (root, args, context) => {
+users: (parent, args, context) => {
  // In this case, we'll pretend there is no data when
  // we're not logged in. Another option would be to
  // throw an error.
@@ -104,7 +104,7 @@ One choice to make when building out our resolvers is what an unauthorized field
 Now let’s expand that example a little further, and only allow users with an `admin` role to look at our user list. After all, we probably don’t want just anyone to have access to all our users.
 
 ```js
-users: (root, args, context) => {
+users: (parent, args, context) => {
  if (!context.user || !context.user.roles.includes('admin')) return null;
  return context.models.User.getAll();
 }

--- a/docs/source/features/directives.md
+++ b/docs/source/features/directives.md
@@ -60,7 +60,7 @@ const typeDefs = gql`
 // Provide resolver functions for your schema fields
 const resolvers = {
   Query: {
-    hello: (root, args, context) => {
+    hello: (parent, args, context) => {
       return 'Hello world!';
     },
   },

--- a/docs/source/features/mocking.md
+++ b/docs/source/features/mocking.md
@@ -138,7 +138,7 @@ The mock functions on fields are actually just GraphQL resolvers, which can use 
 const mocks = {
   Person: () => ({
     // the number of friends in the list now depends on numPages
-    paginatedFriends: (root, args, context, info) => new MockList(args.numPages * PAGE_SIZE),
+    paginatedFriends: (parent, args, context, info) => new MockList(args.numPages * PAGE_SIZE),
   }),
 };
 ```

--- a/docs/source/features/scalars-enums.md
+++ b/docs/source/features/scalars-enums.md
@@ -279,7 +279,7 @@ const typeDefs = gql`
 const resolvers = {
   Query: {
     favoriteColor: () => 'RED',
-    avatar: (root, args) => {
+    avatar: (parent, args) => {
       // args.borderColor is 'RED', 'GREEN', or 'BLUE'
     },
   }
@@ -317,7 +317,7 @@ const resolvers = {
   },
   Query: {
     favoriteColor: () => '#f00',
-    avatar: (root, args) => {
+    avatar: (parent, args) => {
       // args.borderColor is '#f00', '#0f0', or '#00f'
     },
   }

--- a/docs/source/why-apollo-server.md
+++ b/docs/source/why-apollo-server.md
@@ -29,7 +29,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    posts: (root, { authorId }, { Post }) => Post.findByAuthorId(authorId),
+    posts: (parent, { authorId }, { Post }) => Post.findByAuthorId(authorId),
   },
 };
 

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -99,13 +99,13 @@ const queryType = new GraphQLObjectType({
     },
     testContextValue: {
       type: GraphQLString,
-      resolve(_root, _args, context) {
+      resolve(_parent, _args, context) {
         return context.s + ' works';
       },
     },
     testArgumentValue: {
       type: GraphQLInt,
-      resolve(_root, args) {
+      resolve(_parent, args) {
         return args['base'] + 5;
       },
       args: {
@@ -388,7 +388,7 @@ describe('runQuery', () => {
             fields: {
               testString: {
                 type: GraphQLString,
-                resolve(_root, _args, context) {
+                resolve(_parent, _args, context) {
                   expect(context._extensionStack).toBeInstanceOf(
                     GraphQLExtensionStack,
                   );

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -126,7 +126,7 @@ const queryType = new GraphQLObjectType({
     },
     testContext: {
       type: GraphQLString,
-      resolve(_root, _args, context) {
+      resolve(_parent, _args, context) {
         if (context.otherField) {
           return 'unexpected';
         }

--- a/packages/apollo-server-micro/README.md
+++ b/packages/apollo-server-micro/README.md
@@ -31,7 +31,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    sayHello(root, args, context) {
+    sayHello(parent, args, context) {
       return 'Hello World!';
     },
   },
@@ -82,7 +82,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    sayHello(root, args, context) {
+    sayHello(parent, args, context) {
       return 'Hello World!';
     },
   },
@@ -132,7 +132,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    sayHello(root, args, context) {
+    sayHello(parent, args, context) {
       return 'Hello World!';
     },
   },
@@ -184,7 +184,7 @@ const typeDefs = gql`
 
 const resolvers = {
   Query: {
-    sayHello(root, args, context) {
+    sayHello(parent, args, context) {
       return 'Hello World!';
     },
   },


### PR DESCRIPTION
In an effort to maintain consistency and semantically correct meaning,
this changes (only in documentation and internal Apollo Server tests) the
name of the first argument in resolver signatures to use `parent` rather
than `root`.

While `root` certainly makes sense when the resolver is belonging to the
root `Query` or `Mutation` type, once nested field resolvers begin getting
called, the more semantically correct term would seem to be `parent`.

Since `parent` still makes sense at the root level, and since resolvers
frequently get copied and pasted into more deeply-nested positions, putting
this pattern in place for apps which are just beginning might just help
someone more clearly understand the relationship in the future — without
incorrectly thinking that a nested resolver is accessing the root of the
graph, rather than the parent.