### PR TITLE
Instantiate `lru-cache` class using `new` in `InMemoryLRUCache`.

### DIFF
--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -6,7 +6,7 @@ export class InMemoryLRUCache implements KeyValueCache {
 
   // FIXME: Define reasonable default max size of the cache
   constructor({ maxSize = Infinity }: { maxSize?: number } = {}) {
-    this.store = LRU({
+    this.store = new LRU({
       max: maxSize,
       length: item => item.length,
     });


### PR DESCRIPTION
This is mandated by [`lru-cache`](https://npm.im/lru-cache) v5 and surfaced in [the CircleCI failures](https://circleci.com/gh/apollographql/apollo-server/22537) on #2004 (which updates the `lru-cache` dependency):

```
TypeError: Class constructor LRUCache cannot be invoked without 'new'
```

Luckily, this is a private implementation detail of Apollo Server's `InMemoryLRUCache` so no additional changes should be necessary and we should be able to update to `lru-cache` 5.0.0 in a semver minor respectful way.