### PR TITLE
Add text/json to deserialize types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ client reference ID, Apollo Server will now default to the values present in the
 of the request (`apollographql-client-name`, `apollographql-client-reference-id` and
 `apollographql-client-version` respectively).  As a last resort, when those headers are not set,
 the query extensions' `clientInfo` values will be used. [PR #1960](https://github.com/apollographql/apollo-server/pull/1960)
+- Add `text/json` to the list of `Content-Type` header responses that will be deserialized to json, and allow adding types to the list in the `RESTDataSource` constructor, e.g.: `this.jsonContentTypes.push('application/custom+json');`. [PR #2013](https://github.com/apollographql/apollo-server/pull/2013)
 
 ### v2.2.2
 

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -47,6 +47,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
   httpCache!: HTTPCache;
   context!: TContext;
   memoizedResults = new Map<string, Promise<any>>();
+  jsonContentTypes = ['application/json', 'application/hal+json', 'text/json'];
 
   initialize(config: DataSourceConfig<TContext>): void {
     this.context = config.context;
@@ -106,8 +107,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     const contentType = response.headers.get('Content-Type');
     if (
       contentType &&
-      (contentType.startsWith('application/json') ||
-        contentType.startsWith('application/hal+json'))
+      this.jsonContentTypes.some(c => contentType.startsWith(c))
     ) {
       return response.json();
     } else {

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -371,47 +371,35 @@ describe('RESTDataSource', () => {
   });
 
   describe('response parsing', () => {
-    it('returns data as parsed JSON when Content-Type is application/json', async () => {
-      const dataSource = new class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+    const jsonContentTypes = [
+      'application/json',
+      'application/json; charset=utf-8',
+      'application/hal+json',
+      'text/json',
+    ];
+    it.each(jsonContentTypes)(
+      'returns data as parsed JSON when Content-Type is %s',
+      async () => {
+        const dataSource = new class extends RESTDataSource {
+          baseURL = 'https://api.example.com';
 
-        getFoo() {
-          return this.get('foo');
-        }
-      }();
+          getFoo() {
+            return this.get('foo');
+          }
+        }();
 
-      dataSource.httpCache = httpCache;
+        dataSource.httpCache = httpCache;
 
-      fetch.mockJSONResponseOnce(
-        { foo: 'bar' },
-        { 'Content-Type': 'application/json' },
-      );
+        fetch.mockJSONResponseOnce(
+          { foo: 'bar' },
+          { 'Content-Type': 'application/json' },
+        );
 
-      const data = await dataSource.getFoo();
+        const data = await dataSource.getFoo();
 
-      expect(data).toEqual({ foo: 'bar' });
-    });
-
-    it('returns data as parsed JSON when Content-Type is application/hal+json', async () => {
-      const dataSource = new class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
-
-        getFoo() {
-          return this.get('foo');
-        }
-      }();
-
-      dataSource.httpCache = httpCache;
-
-      fetch.mockJSONResponseOnce(
-        { foo: 'bar' },
-        { 'Content-Type': 'application/hal+json' },
-      );
-
-      const data = await dataSource.getFoo();
-
-      expect(data).toEqual({ foo: 'bar' });
-    });
+        expect(data).toEqual({ foo: 'bar' });
+      },
+    );
 
     it('returns data as a string when Content-Type is text/plain', async () => {
       const dataSource = new class extends RESTDataSource {


### PR DESCRIPTION
Solves https://github.com/apollographql/apollo-server/issues/1976

Since adding a test would make three texts with the exact same content, I changed it to use `it.each`. Hope that's fine. Tests are green, CHANGELOG.md is updated!