### PR TITLE
Testing: Use 0 as port in so an arbitrary unused port will be assigned by system

### DIFF
--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -32,8 +32,6 @@ const resolvers = {
   },
 };
 
-const port = 6666;
-
 describe('apollo-server-express', () => {
   let server;
   let httpServer;
@@ -43,7 +41,7 @@ describe('apollo-server-express', () => {
       const app = express();
       server.applyMiddleware({ app });
       httpServer = await new Promise<http.Server>(resolve => {
-        const s = app.listen({ port }, () => resolve(s));
+        const s = app.listen({ port: 0 }, () => resolve(s));
       });
       return createServerInfo(server, httpServer);
     },
@@ -70,7 +68,7 @@ describe('apollo-server-express', () => {
     server.applyMiddleware({ ...options, app });
 
     httpServer = await new Promise<http.Server>(resolve => {
-      const l = app.listen({ port }, () => resolve(l));
+      const l = app.listen({ port: 0 }, () => resolve(l));
     });
 
     return createServerInfo(server, httpServer);
@@ -201,7 +199,7 @@ describe('apollo-server-express', () => {
       outerApp.use(samplePath, innerApp);
 
       const httpRewiredServer = await new Promise<http.Server>(resolve => {
-        const l = outerApp.listen({ port }, () => resolve(l));
+        const l = outerApp.listen({ port: 0 }, () => resolve(l));
       });
 
       const { url } = createServerInfo(rewiredServer, httpRewiredServer);

--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -99,7 +99,7 @@ describe('apollo-server-express', () => {
 
     server.applyMiddleware({ app });
     httpServer = await new Promise<http.Server>(resolve => {
-      const s = app.listen({ port: 6667 }, () => resolve(s));
+      const s = app.listen({ port: 0 }, () => resolve(s));
     });
     const { url: uri } = createServerInfo(server, httpServer);
 
@@ -129,7 +129,7 @@ describe('apollo-server-express', () => {
 
     server.applyMiddleware({ app });
     httpServer = await new Promise<http.Server>(resolve => {
-      const s = app.listen({ port: 6668 }, () => resolve(s));
+      const s = app.listen({ port: 0 }, () => resolve(s));
     });
     const { url: uri } = createServerInfo(server, httpServer);
 

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -13,7 +13,7 @@ import { createApolloFetch } from 'apollo-fetch';
 import { gql, AuthenticationError } from 'apollo-server-core';
 import { ApolloServer } from '../ApolloServer';
 
-const port = 5555;
+const port = 0;
 
 // NODE: Intentionally skip for Node.js < 8 since Hapi 17 doesn't support those.
 (NODE_MAJOR_VERSION < 8 ? describe.skip : describe)(

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -37,7 +37,7 @@ describe('apollo-server-koa', () => {
       const app = new Koa();
       server.applyMiddleware({ app });
       httpServer = await new Promise<http.Server>(resolve => {
-        const s = app.listen({ port: 7777 }, () => resolve(s));
+        const s = app.listen({ port: 0 }, () => resolve(s));
       });
       return createServerInfo(server, httpServer);
     },
@@ -64,7 +64,7 @@ describe('apollo-server-koa', () => {
     server.applyMiddleware({ ...options, app });
 
     httpServer = await new Promise<http.Server>(resolve => {
-      const l = app.listen({ port: 4000 }, () => resolve(l));
+      const l = app.listen({ port: 0 }, () => resolve(l));
     });
 
     return createServerInfo(server, httpServer);

--- a/packages/apollo-server-koa/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/datasource.test.ts
@@ -100,7 +100,7 @@ describe('apollo-server-koa', () => {
 
     server.applyMiddleware({ app });
     httpServer = await new Promise<http.Server>(resolve => {
-      const s = app.listen({ port: 7778 }, () => resolve(s));
+      const s = app.listen({ port: 0 }, () => resolve(s));
     });
     const { url: uri } = createServerInfo(server, httpServer);
 
@@ -130,7 +130,7 @@ describe('apollo-server-koa', () => {
 
     server.applyMiddleware({ app });
     httpServer = await new Promise<http.Server>(resolve => {
-      const s = app.listen({ port: 7779 }, () => resolve(s));
+      const s = app.listen({ port: 0 }, () => resolve(s));
     });
     const { url: uri } = createServerInfo(server, httpServer);
 

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -87,7 +87,7 @@ describe('apollo-server', () => {
         resolvers,
       });
 
-      const { url: uri } = await server.listen();
+      const { url: uri } = await server.listen({ port: 0 });
       const apolloFetch = createApolloFetch({ uri });
       const result = await apolloFetch({ query: '{hello}' });
 
@@ -104,7 +104,7 @@ describe('apollo-server', () => {
         resolvers,
       });
 
-      const { url } = await server.listen();
+      const { url } = await server.listen({ port: 0 });
       return new Promise((resolve, reject) => {
         request(
           {
@@ -135,7 +135,7 @@ describe('apollo-server', () => {
         resolvers,
       });
 
-      const { url: uri } = await server.listen();
+      const { url: uri } = await server.listen({ port: 0 });
 
       const apolloFetch = createApolloFetch({ uri }).useAfter(
         (response, next) => {
@@ -155,7 +155,7 @@ describe('apollo-server', () => {
         cors: { origin: 'localhost' },
       });
 
-      const { url: uri } = await server.listen();
+      const { url: uri } = await server.listen({ port: 0 });
 
       const apolloFetch = createApolloFetch({ uri }).useAfter(
         (response, next) => {
@@ -174,7 +174,7 @@ describe('apollo-server', () => {
         resolvers,
       });
 
-      const { port } = await server.listen();
+      const { port } = await server.listen({ port: 0 });
       return new Promise((resolve, reject) => {
         request(
           {


### PR DESCRIPTION
Currently, if any of the ports used in tests are taken by some other services running locally, the tests will fail.

This PR is to use 0 as port values so that the operating system will assign an arbitrary unused port. https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

