### PR TITLE
Update `@apollographql/graphql-playground-html` to latest version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-- Fix GraphQL Playground documentation scrolling bug in Safari.
+- Fix GraphQL Playground documentation scrolling bug in Safari by updating to latest (rebased) fork of `graphql-playground-html`. [PR #2037](https://github.com/apollographql/apollo-server/pull/2037)
 
 ### v2.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Fix GraphQL Playground documentation scrolling bug in Safari.
+
 ### v2.2.3
 
 - When `generateClientInfo` is not used to define the client name, client version and

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "@apollographql/graphql-playground-html": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.4.tgz",
-      "integrity": "sha512-gwvaQO6/Hv4DEwhDLmmu2tzCU9oPjC5Xl9Kk8Yd0IxyKhYLlLalmkMMjsZLzU5H3fGaalLD96OYfxHL0ClVUDQ=="
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.6.tgz",
+      "integrity": "sha512-lqK94b+caNtmKFs5oUVXlSpN3sm5IXZ+KfhMxOtr0LR2SqErzkoJilitjDvJ1WbjHlxLI7WtCjRmOLdOGJqtMQ=="
     },
     "@babel/code-frame": {
       "version": "7.0.0",
@@ -2188,7 +2188,7 @@
     "apollo-server-azure-functions": {
       "version": "file:packages/apollo-server-azure-functions",
       "requires": {
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "graphql-tools": "^4.0.0"
@@ -2233,7 +2233,7 @@
     "apollo-server-cloud-functions": {
       "version": "file:packages/apollo-server-cloud-functions",
       "requires": {
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "graphql-tools": "^4.0.0"
@@ -2251,7 +2251,7 @@
       "requires": {
         "@apollographql/apollo-tools": "^0.2.6",
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "@types/ws": "^6.0.0",
         "apollo-cache-control": "file:packages/apollo-cache-control",
         "apollo-datasource": "file:packages/apollo-datasource",
@@ -2285,7 +2285,7 @@
       "version": "file:packages/apollo-server-express",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
         "@types/cors": "^2.8.4",
@@ -2300,7 +2300,7 @@
       },
       "dependencies": {
         "@apollographql/graphql-playground-html": {
-          "version": "1.6.4",
+          "version": "1.6.6",
           "bundled": true
         }
       }
@@ -2309,7 +2309,7 @@
       "version": "file:packages/apollo-server-hapi",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "boom": "^7.1.0",
@@ -2318,7 +2318,7 @@
       },
       "dependencies": {
         "@apollographql/graphql-playground-html": {
-          "version": "1.6.4",
+          "version": "1.6.6",
           "bundled": true
         }
       }
@@ -2333,7 +2333,7 @@
       "version": "file:packages/apollo-server-koa",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "@koa/cors": "^2.2.1",
         "@types/accepts": "^1.3.5",
         "@types/cors": "^2.8.4",
@@ -2352,7 +2352,7 @@
       },
       "dependencies": {
         "@apollographql/graphql-playground-html": {
-          "version": "1.6.4",
+          "version": "1.6.6",
           "bundled": true
         }
       }
@@ -2360,14 +2360,14 @@
     "apollo-server-lambda": {
       "version": "file:packages/apollo-server-lambda",
       "requires": {
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "graphql-tools": "^4.0.0"
       },
       "dependencies": {
         "@apollographql/graphql-playground-html": {
-          "version": "1.6.4",
+          "version": "1.6.6",
           "bundled": true
         }
       }
@@ -2376,14 +2376,14 @@
       "version": "file:packages/apollo-server-micro",
       "requires": {
         "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "accept": "^3.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "micro": "^9.3.2"
       },
       "dependencies": {
         "@apollographql/graphql-playground-html": {
-          "version": "1.6.4",
+          "version": "1.6.6",
           "bundled": true
         }
       }

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -25,7 +25,7 @@
 		"node": ">=6"
 	},
 	"dependencies": {
-		"@apollographql/graphql-playground-html": "^1.6.4",
+		"@apollographql/graphql-playground-html": "^1.6.6",
 		"apollo-server-core": "file:../apollo-server-core",
 		"apollo-server-env": "file:../apollo-server-env",
 		"graphql-tools": "^4.0.0"

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -25,7 +25,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "graphql-tools": "^4.0.0"

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@apollographql/apollo-tools": "^0.2.6",
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "@types/ws": "^6.0.0",
     "apollo-cache-control": "file:../apollo-cache-control",
     "apollo-datasource": "file:../apollo-datasource",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "@types/accepts": "^1.3.5",
     "@types/body-parser": "1.17.0",
     "@types/cors": "^2.8.4",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
     "boom": "^7.1.0",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "@koa/cors": "^2.2.1",
     "@types/accepts": "^1.3.5",
     "@types/cors": "^2.8.4",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -25,7 +25,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "graphql-tools": "^4.0.0"

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
     "@apollographql/apollo-upload-server": "^5.0.3",
-    "@apollographql/graphql-playground-html": "^1.6.4",
+    "@apollographql/graphql-playground-html": "^1.6.6",
     "accept": "^3.0.2",
     "apollo-server-core": "file:../apollo-server-core",
     "micro": "^9.3.2"


### PR DESCRIPTION
With any luck, we will no longer necessitate our fork which removed the
`graphql-config` dependency thanks to the work done in:

https://github.com/prisma/graphql-playground/pull/874

:tada:

Most notably though, this fixes a documentation scrolling problem with
Safari.