### PR TITLE
Correct `graphql-extensions` package dependencies.

### DIFF
--- a/packages/graphql-extensions/package.json
+++ b/packages/graphql-extensions/package.json
@@ -14,9 +14,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "@apollographql/apollo-tools": "^0.2.6"
-  },
-  "devDependencies": {
+    "@apollographql/apollo-tools": "^0.2.6",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env"
   },


### PR DESCRIPTION
Both the `apollo-server-core` and `apollo-server-env` packages are listed as
`devDependencies` for `graphql-extensions` even though they are both
directly depended upon at runtime.

While this frequently works out because of other peer dependencies, it
certainly should have its dependencies properly declared.

Closes: https://github.com/apollographql/apollo-server/issues/1963