### PR TITLE
Remove invalid HTTP method from apollo-server-micro example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Update docs for apollo-server-micro [PR #2045](https://github.com/apollographql/apollo-server/pull/2045)
 
 ### v2.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ### vNEXT
-- Update docs for apollo-server-micro [PR #2045](https://github.com/apollographql/apollo-server/pull/2045)
 
 ### v2.2.5
 

--- a/packages/apollo-server-micro/README.md
+++ b/packages/apollo-server-micro/README.md
@@ -195,7 +195,6 @@ const graphqlPath = '/data';
 const graphqlHandler = apolloServer.createHandler({ path: graphqlPath });
 module.exports = router(
   get('/', (req, res) => 'Welcome!'),
-  options(graphqlPath, graphqlHandler),
   post(graphqlPath, graphqlHandler),
   get(graphqlPath, graphqlHandler),
 );


### PR DESCRIPTION
[ApolloServer v2 does not support `OPTION` request](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-core/src/runHttpQuery.ts#L185-L213). Updated the micro example to reflect this.

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

