### PR TITLE
Async format error

### DIFF
--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from 'graphql';
 
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
-import {isPromise} from "apollo-server-errors";
+import { isPromise } from 'apollo-server-errors';
 
 export interface CacheControlFormat {
   version: 1;
@@ -137,8 +137,12 @@ export class CacheControlExtension<TContext = any>
     ];
   }
 
-  public willSendResponse?(o: { graphqlResponse: GraphQLResponse } | Promise<{ graphqlResponse: GraphQLResponse }>) {
-    if(!isPromise(o)) {
+  public willSendResponse?(
+    o:
+      | { graphqlResponse: GraphQLResponse }
+      | Promise<{ graphqlResponse: GraphQLResponse }>,
+  ) {
+    if (!isPromise(o)) {
       if (this.options.calculateHttpHeaders && o.graphqlResponse.http) {
         const overallCachePolicy = this.computeOverallCachePolicy();
 
@@ -147,13 +151,12 @@ export class CacheControlExtension<TContext = any>
             'Cache-Control',
             `max-age=${
               overallCachePolicy.maxAge
-              }, ${overallCachePolicy.scope.toLowerCase()}`,
+            }, ${overallCachePolicy.scope.toLowerCase()}`,
           );
         }
       }
-      return
-    }
-    else {
+      return;
+    } else {
       return o.then(p => {
         if (this.options.calculateHttpHeaders && p.graphqlResponse.http) {
           const overallCachePolicy = this.computeOverallCachePolicy();
@@ -163,12 +166,12 @@ export class CacheControlExtension<TContext = any>
               'Cache-Control',
               `max-age=${
                 overallCachePolicy.maxAge
-                }, ${overallCachePolicy.scope.toLowerCase()}`,
+              }, ${overallCachePolicy.scope.toLowerCase()}`,
             );
           }
         }
-        return
-      })
+        return;
+      });
     }
   }
 

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -9,7 +9,10 @@ import {
 } from 'graphql';
 
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
-import { isPromise } from 'apollo-server-errors';
+
+function isPromise(x: any): x is Promise<any> {
+  return x && typeof x.then === 'function';
+}
 
 export interface CacheControlFormat {
   version: 1;

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -18,7 +18,7 @@ import { Trace, google } from 'apollo-engine-reporting-protobuf';
 import { EngineReportingOptions, GenerateClientInfo } from './agent';
 import { defaultSignature } from './signature';
 import { GraphQLRequestContext } from 'apollo-server-core/dist/requestPipelineAPI';
-import {isPromise} from "apollo-server-errors";
+import { isPromise } from 'apollo-server-errors';
 
 const clientNameHeaderKey = 'apollographql-client-name';
 const clientReferenceIdHeaderKey = 'apollographql-client-reference-id';
@@ -276,9 +276,13 @@ export class EngineReportingExtension<TContext = any>
     };
   }
 
-  public willSendResponse(o: { graphqlResponse: GraphQLResponse } | Promise<{ graphqlResponse: GraphQLResponse }>) {
+  public willSendResponse(
+    o:
+      | { graphqlResponse: GraphQLResponse }
+      | Promise<{ graphqlResponse: GraphQLResponse }>,
+  ) {
     if (!isPromise(o)) {
-      const {errors} = o.graphqlResponse;
+      const { errors } = o.graphqlResponse;
       if (errors) {
         errors.forEach((error: GraphQLError) => {
           // By default, put errors on the root node.
@@ -292,23 +296,22 @@ export class EngineReportingExtension<TContext = any>
 
           // Always send the trace errors, so that the UI acknowledges that there is an error.
           const errorInfo = this.options.maskErrorDetails
-            ? {message: '<masked>'}
+            ? { message: '<masked>' }
             : {
-              message: error.message,
-              location: (error.locations || []).map(
-                ({line, column}) => new Trace.Location({line, column}),
-              ),
-              json: JSON.stringify(error),
-            };
+                message: error.message,
+                location: (error.locations || []).map(
+                  ({ line, column }) => new Trace.Location({ line, column }),
+                ),
+                json: JSON.stringify(error),
+              };
 
           node!.error!.push(new Trace.Error(errorInfo));
         });
       }
-      return
-    }
-    else {
+      return;
+    } else {
       return o.then(p => {
-        const {errors} = p.graphqlResponse;
+        const { errors } = p.graphqlResponse;
         if (errors) {
           errors.forEach((error: GraphQLError) => {
             // By default, put errors on the root node.
@@ -322,20 +325,20 @@ export class EngineReportingExtension<TContext = any>
 
             // Always send the trace errors, so that the UI acknowledges that there is an error.
             const errorInfo = this.options.maskErrorDetails
-              ? {message: '<masked>'}
+              ? { message: '<masked>' }
               : {
-                message: error.message,
-                location: (error.locations || []).map(
-                  ({line, column}) => new Trace.Location({line, column}),
-                ),
-                json: JSON.stringify(error),
-              };
+                  message: error.message,
+                  location: (error.locations || []).map(
+                    ({ line, column }) => new Trace.Location({ line, column }),
+                  ),
+                  json: JSON.stringify(error),
+                };
 
             node!.error!.push(new Trace.Error(errorInfo));
           });
         }
-        return
-      })
+        return;
+      });
     }
   }
 

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -18,7 +18,10 @@ import { Trace, google } from 'apollo-engine-reporting-protobuf';
 import { EngineReportingOptions, GenerateClientInfo } from './agent';
 import { defaultSignature } from './signature';
 import { GraphQLRequestContext } from 'apollo-server-core/dist/requestPipelineAPI';
-import { isPromise } from 'apollo-server-errors';
+
+function isPromise(x: any): x is Promise<any> {
+  return x && typeof x.then === 'function';
+}
 
 const clientNameHeaderKey = 'apollographql-client-name';
 const clientReferenceIdHeaderKey = 'apollographql-client-reference-id';

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -438,10 +438,10 @@ export class ApolloServerBase {
                 ? await this.context({ connection, payload: message.payload })
                 : context;
           } catch (e) {
-            throw formatApolloErrors([e], {
+            throw (await formatApolloErrors([e], {
               formatter: this.requestOptions.formatError,
               debug: this.requestOptions.debug,
-            })[0];
+            }))[0];
           }
 
           return { ...connection, context };

--- a/packages/apollo-server-core/src/formatters.ts
+++ b/packages/apollo-server-core/src/formatters.ts
@@ -1,6 +1,5 @@
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
-import {formatApolloErrors} from 'apollo-server-errors';
-
+import { formatApolloErrors } from 'apollo-server-errors';
 
 function isPromise(x: any): x is Promise<any> {
   return x && typeof x.then === 'function';
@@ -16,60 +15,63 @@ export class FormatErrorExtension<TContext = any> extends GraphQLExtension {
     this.debug = debug;
   }
 
-  public willSendResponse(o: Promise<{
-    graphqlResponse: GraphQLResponse;
-    context: TContext;
-  }> | {
-    graphqlResponse: GraphQLResponse;
-    context: TContext;
-  }): Promise<{ graphqlResponse: GraphQLResponse; context: TContext } | void> |
-    { graphqlResponse: GraphQLResponse; context: TContext } | void {
-
-
+  public willSendResponse(
+    o:
+      | Promise<{
+          graphqlResponse: GraphQLResponse;
+          context: TContext;
+        }>
+      | {
+          graphqlResponse: GraphQLResponse;
+          context: TContext;
+        },
+  ):
+    | Promise<{ graphqlResponse: GraphQLResponse; context: TContext } | void>
+    | { graphqlResponse: GraphQLResponse; context: TContext }
+    | void {
     if (isPromise(o)) {
-      return this.asyncWillSendResponse(o)
-    }
-    else if(o.graphqlResponse.errors){
-      let formattedErrors = formatApolloErrors(o.graphqlResponse.errors,  {
+      return this.asyncWillSendResponse(o);
+    } else if (o.graphqlResponse.errors) {
+      let formattedErrors = formatApolloErrors(o.graphqlResponse.errors, {
         formatter: this.formatError,
         debug: this.debug,
       });
-      if(isPromise(formattedErrors)){
-        return this.asyncWillSendResponse(o)
-      }
-      else if(o) {
-        return ({
+      if (isPromise(formattedErrors)) {
+        return this.asyncWillSendResponse(o);
+      } else if (o) {
+        return {
           ...o,
           graphqlResponse: {
             ...o.graphqlResponse,
-            errors: formattedErrors
+            errors: formattedErrors,
           },
-        })
+        };
       }
     }
-    return o
+    return o;
   }
 
-
-  public async asyncWillSendResponse(o: Promise<{
-    graphqlResponse: GraphQLResponse;
-    context: TContext;
-  }> | { graphqlResponse: GraphQLResponse; context: TContext }): Promise<{ graphqlResponse: GraphQLResponse; context: TContext } | void>
-  {
-    let p = await o
+  public async asyncWillSendResponse(
+    o:
+      | Promise<{
+          graphqlResponse: GraphQLResponse;
+          context: TContext;
+        }>
+      | { graphqlResponse: GraphQLResponse; context: TContext },
+  ): Promise<{ graphqlResponse: GraphQLResponse; context: TContext } | void> {
+    let p = await o;
     if (p.graphqlResponse.errors) {
       return {
-          ...p,
-          graphqlResponse: {
-            ...p.graphqlResponse,
-            errors: await formatApolloErrors(p.graphqlResponse.errors, {
+        ...p,
+        graphqlResponse: {
+          ...p.graphqlResponse,
+          errors: await formatApolloErrors(p.graphqlResponse.errors, {
             formatter: this.formatError,
             debug: this.debug,
           }),
         },
       };
     }
-  return o
+    return o;
   }
 }
-

--- a/packages/apollo-server-core/src/formatters.ts
+++ b/packages/apollo-server-core/src/formatters.ts
@@ -1,5 +1,10 @@
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
-import { formatApolloErrors } from 'apollo-server-errors';
+import {formatApolloErrors} from 'apollo-server-errors';
+
+
+function isPromise(x: any): x is Promise<any> {
+  return x && typeof x.then === 'function';
+}
 
 export class FormatErrorExtension<TContext = any> extends GraphQLExtension {
   private formatError?: Function;
@@ -11,21 +16,60 @@ export class FormatErrorExtension<TContext = any> extends GraphQLExtension {
     this.debug = debug;
   }
 
-  public willSendResponse(o: {
+  public willSendResponse(o: Promise<{
     graphqlResponse: GraphQLResponse;
     context: TContext;
-  }): void | { graphqlResponse: GraphQLResponse; context: TContext } {
-    if (o.graphqlResponse.errors) {
+  }> | {
+    graphqlResponse: GraphQLResponse;
+    context: TContext;
+  }): Promise<{ graphqlResponse: GraphQLResponse; context: TContext } | void> |
+    { graphqlResponse: GraphQLResponse; context: TContext } | void {
+
+
+    if (isPromise(o)) {
+      return this.asyncWillSendResponse(o)
+    }
+    else if(o.graphqlResponse.errors){
+      let formattedErrors = formatApolloErrors(o.graphqlResponse.errors,  {
+        formatter: this.formatError,
+        debug: this.debug,
+      });
+      if(isPromise(formattedErrors)){
+        return this.asyncWillSendResponse(o)
+      }
+      else if(o) {
+        return ({
+          ...o,
+          graphqlResponse: {
+            ...o.graphqlResponse,
+            errors: formattedErrors
+          },
+        })
+      }
+    }
+    return o
+  }
+
+
+  public async asyncWillSendResponse(o: Promise<{
+    graphqlResponse: GraphQLResponse;
+    context: TContext;
+  }> | { graphqlResponse: GraphQLResponse; context: TContext }): Promise<{ graphqlResponse: GraphQLResponse; context: TContext } | void>
+  {
+    let p = await o
+    if (p.graphqlResponse.errors) {
       return {
-        ...o,
-        graphqlResponse: {
-          ...o.graphqlResponse,
-          errors: formatApolloErrors(o.graphqlResponse.errors, {
+          ...p,
+          graphqlResponse: {
+            ...p.graphqlResponse,
+            errors: await formatApolloErrors(p.graphqlResponse.errors, {
             formatter: this.formatError,
             debug: this.debug,
           }),
         },
       };
     }
+  return o
   }
 }
+

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -330,7 +330,7 @@ export async function processGraphQLRequest<TContext>(
   ): Promise<GraphQLResponse> {
     // We override errors, data, and extensions with the passed in response,
     // but keep other properties (like http)
-    requestContext.response = extensionStack.willSendResponse({
+    requestContext.response = (await extensionStack.willSendResponse({
       graphqlResponse: {
         ...requestContext.response,
         errors: response.errors,
@@ -338,7 +338,7 @@ export async function processGraphQLRequest<TContext>(
         extensions: response.extensions,
       },
       context: requestContext.context,
-    }).graphqlResponse;
+    })).graphqlResponse;
     await dispatcher.invokeHookAsync(
       'willSendResponse',
       requestContext as WithRequired<typeof requestContext, 'response'>,

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from 'graphql';
 
-export function isPromise(x: any): x is Promise<any> {
+function isPromise(x: any): x is Promise<any> {
   return x && typeof x.then === 'function';
 }
 

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -251,24 +251,25 @@ export function formatApolloErrors(
   if (!formatter) {
     return enrichedErrors;
   }
-  if(isPromise(formatter)) {
-    return Promise.all(enrichedErrors.map(async error => {
-      try {
-        return await formatter(error);
-      } catch (err) {
-        if (debug) {
-          return enrichError(err, debug);
-        } else {
-          // obscure error
-          const newError = fromGraphQLError(
-            new GraphQLError('Internal server error'),
-          );
-          return enrichError(newError, debug);
+  if (isPromise(formatter)) {
+    return Promise.all(
+      enrichedErrors.map(async error => {
+        try {
+          return await formatter(error);
+        } catch (err) {
+          if (debug) {
+            return enrichError(err, debug);
+          } else {
+            // obscure error
+            const newError = fromGraphQLError(
+              new GraphQLError('Internal server error'),
+            );
+            return enrichError(newError, debug);
+          }
         }
-      }
-    }));
-  }
-  else {
+      }),
+    );
+  } else {
     return enrichedErrors.map(error => {
       try {
         return formatter(error);
@@ -283,6 +284,6 @@ export function formatApolloErrors(
           return enrichError(newError, debug);
         }
       }
-    })
+    });
   }
 }

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -641,7 +641,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             throw new Error('nope');
           });
 
-          const validationRule = jest.fn( () => {
+          const validationRule = jest.fn(() => {
             // formatError should be called after validation
             expect(formatError).not.toBeCalled();
             // extension should be called after validation
@@ -653,7 +653,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
           const formatError = jest.fn(async error => {
             try {
-              await new Promise(resolve => setTimeout(resolve, 500))
+              await new Promise(resolve => setTimeout(resolve, 500));
               expect(error).toBeInstanceOf(Error);
               // extension should be called before formatError
               expect(willSendResponseInExtension).toHaveBeenCalledTimes(1);
@@ -699,9 +699,9 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
           const { url: uri } = await createApolloServer({
             typeDefs: gql`
-                type Query {
-                    error: String
-                }
+              type Query {
+                error: String
+              }
             `,
             resolvers: {
               Query: {
@@ -715,7 +715,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             engine: {
               endpointUrl: `http://localhost:${
                 (engineServer.address() as net.AddressInfo).port
-                }`,
+              }`,
               apiKey: 'service:my-app:secret',
               maxUncompressedReportSize: 1,
               generateClientInfo: () => ({


### PR DESCRIPTION
Hi there,

This pull request is a first step to allow async formatError (and other extensions). It completes #1748 and closes #1747 

### Motivation
The motivation is for the lambda integration: a synchronous call to log an error is not satisfying, it needs to be awaited, otherwise the process is frozen before the resolution of the formatError promise. For exemple, if we want to send the error to an external service (sentry), it's never sent.

### Tests - problems
There are still a few issues: express, hapi and koa integration are synchronous, and hence the tests cannot pass. Is there a way to enable this feature only for the other integrations ? Given the motivation, this feature is not really useful for those integrations.

### Going further
I also saw in the code TODOs related to this synchronous -> asynchronous migration, is there a roadmap for thise ? Because of these synchronous integrations, there is a lot of code only to achieve retrocompatibility (isPromise, etc.)

### What it does
What it does:
- the extension stack is unpiled, at every step the extension is checked: is it a promise or a synchronous call ? It's then passed to the next extension
- cache-controle and engine-reporting have been modified so that they can handle the case where an extension in the extension stack is a promise (not tested yet). 
- a test has been written 

IMO, in the future: the whole extension stack should work with Promises, and the entry variables should be converted with `Promise.resolve(variables)`. The code would be more readable.

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [X] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

I do that as soon as I have guidance to fix this specific test issue :). What's the next step ?

Thank you !

Best,
