### PR TITLE
Return correct HTTP code if context creation fails

### DIFF
--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -133,7 +133,7 @@ export async function runHttpQuery(
       if (
         !e.extensions ||
         !e.extensions.code ||
-        !e.extensions.code === 'INTERNAL_SERVER_ERROR'
+        e.extensions.code === 'INTERNAL_SERVER_ERROR'
       ) {
         return throwHttpGraphQLError(500, [e], options);
       } else {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -131,13 +131,20 @@ export async function runHttpQuery(
       // For errors that are not internal, such as authentication, we
       // should provide a 400 response
       if (
-        e.extensions &&
-        e.extensions.code &&
-        e.extensions.code !== 'INTERNAL_SERVER_ERROR'
+        !e.extensions ||
+        !e.extensions.code ||
+        !e.extensions.code === 'INTERNAL_SERVER_ERROR'
       ) {
-        return throwHttpGraphQLError(400, [e], options);
-      } else {
         return throwHttpGraphQLError(500, [e], options);
+      } else {
+        switch(e.extensions.code) {
+          case 'UNAUTHENTICATED':
+            return throwHttpGraphQLError(401, [e], options);
+          case 'FORBIDDEN': 
+            return throwHttpGraphQLError(403, [e], options);
+          default:
+            return throwHttpGraphQLError(400, [e], options);
+        }
       }
     }
   }


### PR DESCRIPTION
Here's a proposal to fix #1709 in cases, where apollo already returns a 400 response, to handle the default AuthenticationError and ForbiddenError with fitting HTTP status codes. It doesn't make sense, that these errors set a status code, when thrown from a resolver, since partial data might still be returned in that case, but when the context creation fails, Apollo might as well return a more meaningful status code.

TODO:
* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass