### PR TITLE
[Docs] [apollo-server-lambda] document usage of playground and defaultPlaygroundOptions

### DIFF
--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -20,7 +20,7 @@ To deploy the AWS Lambda function we must create a Cloudformation Template and a
 In a file named `graphql.js`, place the following code:
 
 ```js
-const { ApolloServer, gql, defaultPlaygroundOptions } = require('apollo-server-lambda');
+const { ApolloServer, gql } = require('apollo-server-lambda');
 
 // Construct a schema, using GraphQL schema language
 const typeDefs = gql`

--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -20,7 +20,7 @@ To deploy the AWS Lambda function we must create a Cloudformation Template and a
 In a file named `graphql.js`, place the following code:
 
 ```js
-const { ApolloServer, gql } = require('apollo-server-lambda');
+const { ApolloServer, gql, defaultPlaygroundOptions } = require('apollo-server-lambda');
 
 // Construct a schema, using GraphQL schema language
 const typeDefs = gql`
@@ -39,6 +39,7 @@ const resolvers = {
 const server = new ApolloServer({
   typeDefs,
   resolvers,
+  playground: defaultPlaygroundOptions // optional, if you want the graphql playground
 });
 
 exports.handler = server.createHandler();

--- a/packages/apollo-server-lambda/README.md
+++ b/packages/apollo-server-lambda/README.md
@@ -39,7 +39,14 @@ const resolvers = {
 const server = new ApolloServer({
   typeDefs,
   resolvers,
-  playground: defaultPlaygroundOptions // optional, if you want the graphql playground
+  
+  // By default, the GraphQL Playground interface and GraphQL introspection
+  // is disabled in "production" (i.e. when `process.env.NODE_ENV` is `production`).
+  //
+  // If you'd like to have GraphQL Playground and introspection enabled in production,
+  // the `playground` and `introspection` options must be set explicitly to `true`.
+  playground: true,
+  introspection: true,
 });
 
 exports.handler = server.createHandler();


### PR DESCRIPTION
i was trying out @stubailo's tutorial here https://blog.apollographql.com/deploy-a-fullstack-apollo-app-with-netlify-45a7dfd51b0b and noticed that the playground no longer shows up when hitting the raw endpoint. this must have been a breaking change made somewhere, I can't track it down. it took a while to figure out what the right config was, which seems to be passing `defaultPlaygroundOptions`. I'm hoping to update the docs so future me's wont wonder about this.
