### PR TITLE
chore: DRY-up `runQuery` test interface via Pick'd `GraphQLOptions`.

### DIFF
--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -9,8 +9,6 @@ import {
   GraphQLNonNull,
   parse,
   DocumentNode,
-  ValidationContext,
-  GraphQLFieldResolver,
 } from 'graphql';
 
 import {
@@ -19,10 +17,9 @@ import {
   GraphQLResponse,
 } from 'graphql-extensions';
 
-import { CacheControlExtensionOptions } from 'apollo-cache-control';
-
 import { processGraphQLRequest, GraphQLRequest } from '../requestPipeline';
 import { Request } from 'apollo-server-env';
+import { GraphQLOptions, Context as GraphQLContext } from 'apollo-server-core';
 
 // This is a temporary kludge to ensure we preserve runQuery behavior with the
 // GraphQLRequestProcessor refactoring.
@@ -46,25 +43,26 @@ function runQuery(options: QueryOptions): Promise<GraphQLResponse> {
   });
 }
 
-interface QueryOptions {
-  schema: GraphQLSchema;
-
+interface QueryOptions
+  extends Pick<
+    GraphQLOptions<GraphQLContext<any>>,
+    | 'cacheControl'
+    | 'context'
+    | 'debug'
+    | 'extensions'
+    | 'fieldResolver'
+    | 'formatError'
+    | 'formatResponse'
+    | 'rootValue'
+    | 'schema'
+    | 'tracing'
+    | 'validationRules'
+  > {
   queryString?: string;
   parsedQuery?: DocumentNode;
-
-  rootValue?: any;
-  context?: any;
   variables?: { [key: string]: any };
   operationName?: string;
-  validationRules?: Array<(context: ValidationContext) => any>;
-  fieldResolver?: GraphQLFieldResolver<any, any>;
-  formatError?: Function;
-  formatResponse?: Function;
-  debug?: boolean;
-  tracing?: boolean;
-  cacheControl?: CacheControlExtensionOptions;
   request: Pick<Request, 'url' | 'method' | 'headers'>;
-  extensions?: Array<() => GraphQLExtension>;
 }
 
 const queryType = new GraphQLObjectType({


### PR DESCRIPTION
This test harness is intended to be relatively temporary, but it seems
fruitful to start picking from where these types are already defined rather
than re-implementing them in multiple places.

This change came up in a larger feature implementation and should otherwise be
a no-op but was worth surfacing as its own commit in case that feature never
lands.