### PR TITLE
chores: Request pipeline readability/DRYing.

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -135,15 +135,9 @@ export async function processGraphQLRequest<TContext>(
 
       persistedQueryRegister = true;
 
-      // Store the query asynchronously so we don't block.
-      (async () => {
-        return (
-          config.persistedQueries &&
-          config.persistedQueries.cache.set(`apq:${queryHash}`, query)
-        );
-      })().catch(error => {
-        console.warn(error);
-      });
+      Promise.resolve(
+        config.persistedQueries.cache.set(`apq:${queryHash}`, query),
+      ).catch(console.warn);
     }
   } else if (query) {
     // FIXME: We'll compute the APQ query hash to use as our cache key for

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -191,7 +191,9 @@ export async function processGraphQLRequest<TContext>(
 
     const validationErrors = validate(document);
 
-    if (validationErrors.length > 0) {
+    if (validationErrors.length === 0) {
+      validationDidEnd();
+    } else {
       validationDidEnd(validationErrors);
       return sendResponse({
         errors: validationErrors.map(validationError =>
@@ -201,8 +203,6 @@ export async function processGraphQLRequest<TContext>(
         ),
       });
     }
-
-    validationDidEnd();
 
     // FIXME: If we want to guarantee an operation has been set when invoking
     // `willExecuteOperation` and executionDidStart`, we need to throw an


### PR DESCRIPTION
These are a few low-hanging fruit commits in a never-ending pursuit to streamline the request pipeline.

These should be effective no-ops, but are more relevant given another PR which I'm in the process of staging.  Whether or not that PR lands, I think these should still be drops in the _improvements_ bucket. 🥝📈 