### PR TITLE
Improve InMemoryLRUCache implementation.

### DIFF
--- a/packages/apollo-server-cache-memcached/src/__tests__/Memcached.test.ts
+++ b/packages/apollo-server-cache-memcached/src/__tests__/Memcached.test.ts
@@ -2,6 +2,13 @@
 jest.mock('memcached', () => require('memcached-mock'));
 
 import { MemcachedCache } from '../index';
-import { testKeyValueCache } from '../../../apollo-server-caching/src/__tests__/testsuite';
+import {
+  testKeyValueCache_Basics,
+  testKeyValueCache_Expiration,
+} from '../../../apollo-server-caching/src/__tests__/testsuite';
 
-testKeyValueCache(new MemcachedCache('localhost'));
+describe('Memcached', () => {
+  const cache = new MemcachedCache('localhost');
+  testKeyValueCache_Basics(cache);
+  testKeyValueCache_Expiration(cache);
+});

--- a/packages/apollo-server-cache-memcached/src/index.ts
+++ b/packages/apollo-server-cache-memcached/src/index.ts
@@ -22,11 +22,11 @@ export class MemcachedCache implements KeyValueCache {
 
   async set(
     key: string,
-    data: string,
+    value: string,
     options?: { ttl?: number },
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
-    await this.client.set(key, data, ttl);
+    await this.client.set(key, value, ttl);
   }
 
   async get(key: string): Promise<string | undefined> {

--- a/packages/apollo-server-cache-redis/src/__tests__/Redis.test.ts
+++ b/packages/apollo-server-cache-redis/src/__tests__/Redis.test.ts
@@ -3,6 +3,13 @@ jest.mock('redis', () => require('redis-mock'));
 jest.useFakeTimers(); // mocks out setTimeout that is used in redis-mock
 
 import { RedisCache } from '../index';
-import { testKeyValueCache } from '../../../apollo-server-caching/src/__tests__/testsuite';
+import {
+  testKeyValueCache_Basics,
+  testKeyValueCache_Expiration,
+} from '../../../apollo-server-caching/src/__tests__/testsuite';
 
-testKeyValueCache(new RedisCache({ host: 'localhost' }));
+describe('Redis', () => {
+  const cache = new RedisCache({ host: 'localhost' });
+  testKeyValueCache_Basics(cache);
+  testKeyValueCache_Expiration(cache);
+});

--- a/packages/apollo-server-cache-redis/src/index.ts
+++ b/packages/apollo-server-cache-redis/src/index.ts
@@ -3,7 +3,7 @@ import Redis from 'redis';
 import { promisify } from 'util';
 import DataLoader from 'dataloader';
 
-export class RedisCache implements KeyValueCache {
+export class RedisCache implements KeyValueCache<string> {
   // FIXME: Replace any with proper promisified type
   readonly client: any;
   readonly defaultSetOptions = {

--- a/packages/apollo-server-cache-redis/src/index.ts
+++ b/packages/apollo-server-cache-redis/src/index.ts
@@ -31,11 +31,11 @@ export class RedisCache implements KeyValueCache<string> {
 
   async set(
     key: string,
-    data: string,
+    value: string,
     options?: { ttl?: number },
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
-    await this.client.set(key, data, 'EX', ttl);
+    await this.client.set(key, value, 'EX', ttl);
   }
 
   async get(key: string): Promise<string | undefined> {

--- a/packages/apollo-server-caching/README.md
+++ b/packages/apollo-server-caching/README.md
@@ -16,7 +16,9 @@ export interface KeyValueCache {
 }
 ```
 
-## Running test suite
+## Testing cache implementations
+
+### Test helpers
 
 You can export and run a jest test suite from `apollo-server-caching` to test your implementation:
 
@@ -27,5 +29,16 @@ import YourKeyValueCache from '../src/YourKeyValueCache';
 import { testKeyValueCache } from 'apollo-server-caching';
 testKeyValueCache(new MemcachedCache('localhost'));
 ```
+
+The default `testKeyValueCache` helper will run all key-value store tests on the specified store, including basic `get` and `set` functionality, along with time-based expunging rules.
+
+Some key-value cache implementations may not be able to support the full suite of tests (for example, some tests might not be able to expire based on time).  For those cases, there are more granular implementations which can be used:
+
+* `testKeyValueCache_Basic`
+* `testKeyValueCache_Expiration`
+
+For more details, consult the [source for `apollo-server-caching`](./src/__tests__/testsuite.ts).
+
+### Running tests
 
 Run tests with `jest --verbose`

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -1,21 +1,39 @@
 import LRU from 'lru-cache';
 import { KeyValueCache } from './KeyValueCache';
 
-export class InMemoryLRUCache implements KeyValueCache {
-  private store: LRU.Cache<string, string>;
+export class InMemoryLRUCache<V = string> implements KeyValueCache<V> {
+  private store: LRU.Cache<string, V>;
 
   // FIXME: Define reasonable default max size of the cache
   constructor({ maxSize = Infinity }: { maxSize?: number } = {}) {
     this.store = new LRU({
       max: maxSize,
-      length: item => item.length,
+      length(item) {
+        if (Array.isArray(item) || typeof item === 'string') {
+          return item.length;
+        }
+
+        // If it's an object, we'll use the length to get an approximate,
+        // relative size of what it would take to store it.  It's certainly not
+        // 100% accurate, but it's a very, very fast implementation and it
+        // doesn't require bringing in other dependencies or logic which we need
+        // to maintain.  In the future, we might consider something like:
+        // npm.im/object-sizeof, but this should be sufficient for now.
+        if (typeof item === 'object') {
+          return JSON.stringify(item).length;
+        }
+
+        // Go with the lru-cache default "naive" size, in lieu anything better:
+        //   https://github.com/isaacs/node-lru-cache/blob/a71be6cd/index.js#L17
+        return 1;
+      },
     });
   }
 
   async get(key: string) {
     return this.store.get(key);
   }
-  async set(key: string, value: string) {
+  async set(key: string, value: V) {
     this.store.set(key, value);
   }
   async delete(key: string) {

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -39,4 +39,7 @@ export class InMemoryLRUCache<V = string> implements KeyValueCache<V> {
   async delete(key: string) {
     this.store.del(key);
   }
+  async flush(): Promise<void> {
+    this.store.reset();
+  }
 }

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -33,8 +33,9 @@ export class InMemoryLRUCache<V = string> implements KeyValueCache<V> {
   async get(key: string) {
     return this.store.get(key);
   }
-  async set(key: string, value: V) {
-    this.store.set(key, value);
+  async set(key: string, value: V, options?: { ttl?: number }) {
+    const maxAge = options && options.ttl && options.ttl * 1000;
+    this.store.set(key, value, maxAge);
   }
   async delete(key: string) {
     this.store.del(key);

--- a/packages/apollo-server-caching/src/KeyValueCache.ts
+++ b/packages/apollo-server-caching/src/KeyValueCache.ts
@@ -1,5 +1,5 @@
-export interface KeyValueCache {
-  get(key: string): Promise<string | undefined>;
-  set(key: string, value: string, options?: { ttl?: number }): Promise<void>;
+export interface KeyValueCache<V = string> {
+  get(key: string): Promise<V | undefined>;
+  set(key: string, value: V, options?: { ttl?: number }): Promise<void>;
   delete(key: string): Promise<boolean | void>;
 }

--- a/packages/apollo-server-caching/src/__tests__/InMemoryLRUCache.test.ts
+++ b/packages/apollo-server-caching/src/__tests__/InMemoryLRUCache.test.ts
@@ -1,0 +1,7 @@
+import { testKeyValueCache_Basics } from '../../../apollo-server-caching/src/__tests__/testsuite';
+import { InMemoryLRUCache } from '../InMemoryLRUCache';
+
+describe('InMemoryLRUCache', () => {
+  const cache = new InMemoryLRUCache();
+  testKeyValueCache_Basics(cache);
+});

--- a/packages/apollo-server-caching/src/__tests__/InMemoryLRUCache.test.ts
+++ b/packages/apollo-server-caching/src/__tests__/InMemoryLRUCache.test.ts
@@ -1,7 +1,11 @@
-import { testKeyValueCache_Basics } from '../../../apollo-server-caching/src/__tests__/testsuite';
+import {
+  testKeyValueCache_Basics,
+  testKeyValueCache_Expiration,
+} from '../../../apollo-server-caching/src/__tests__/testsuite';
 import { InMemoryLRUCache } from '../InMemoryLRUCache';
 
 describe('InMemoryLRUCache', () => {
   const cache = new InMemoryLRUCache();
   testKeyValueCache_Basics(cache);
+  testKeyValueCache_Expiration(cache);
 });

--- a/packages/apollo-server-caching/src/__tests__/testsuite.ts
+++ b/packages/apollo-server-caching/src/__tests__/testsuite.ts
@@ -1,19 +1,9 @@
 import { advanceTimeBy, mockDate, unmockDate } from '__mocks__/date';
 
-export function testKeyValueCache(keyValueCache: any) {
-  describe('KeyValueCache Test Suite', () => {
-    beforeAll(() => {
-      mockDate();
-      jest.useFakeTimers();
-    });
-
+export function testKeyValueCache_Basics(keyValueCache: any) {
+  describe('basic cache functionality', () => {
     beforeEach(() => {
       keyValueCache.flush();
-    });
-
-    afterAll(() => {
-      unmockDate();
-      keyValueCache.close();
     });
 
     it('can do a basic get and set', async () => {
@@ -27,6 +17,24 @@ export function testKeyValueCache(keyValueCache: any) {
       expect(await keyValueCache.get('hello')).toBe('world');
       await keyValueCache.delete('hello');
       expect(await keyValueCache.get('hello')).toBeUndefined();
+    });
+  });
+}
+
+export function testKeyValueCache_Expiration(keyValueCache: any) {
+  describe('time-based cache expunging', () => {
+    beforeAll(() => {
+      mockDate();
+      jest.useFakeTimers();
+    });
+
+    beforeEach(() => {
+      keyValueCache.flush();
+    });
+
+    afterAll(() => {
+      unmockDate();
+      keyValueCache.close();
     });
 
     it('is able to expire keys based on ttl', async () => {
@@ -43,5 +51,12 @@ export function testKeyValueCache(keyValueCache: any) {
       expect(await keyValueCache.get('short')).toBeUndefined();
       expect(await keyValueCache.get('long')).toBeUndefined();
     });
+  });
+}
+
+export function testKeyValueCache(keyValueCache: any) {
+  describe('KeyValueCache Test Suite', () => {
+    testKeyValueCache_Basics(keyValueCache);
+    testKeyValueCache_Expiration(keyValueCache);
   });
 }


### PR DESCRIPTION
This PR contains a number of commits which make the existing `InMemoryLRUCache` more whole.  The `InMemoryLRUCache` — which crutches almost entirely on the excellent [`lru-cache`](https://npm.im/lru-cache) library — is the currently the default cache store which is used for [REST Data Sources](https://www.apollographql.com/docs/apollo-server/features/data-sources.html) (i.e. `RESTDataSource`) and persisted queries — though both of those can be provided more complex cache stores (e.g. distributed cache stores such as Redis/Memcached).

In many cases though, the `InMemoryLRUCache` is an arguably less complex, yet still powerful, piece of machinery which can still be used to increase the performance of Apollo Server and seems deserving of a more consistent interface with the distributed stores.  In that spirit, this PR brings:

* Support for `flush`, via `lru-cache`'s `reset` method.
* Tests, which were previously missing.
* Support for `ttl` expirations (defined during `set`) via `lru-cache`'s [`maxAge` parameter](https://github.com/isaacs/node-lru-cache#api).