### PR TITLE
Expose 'trace' in RESTDataSource as a protected method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Switch from `json-stable-stringify` to `fast-json-stable-stringify`. [PR #2065](https://github.com/apollographql/apollo-server/pull/2065)
 
-- Make `trace` in RESTDataSource protected so it can be overrriden.
+- Expose `trace` in RESTDataSource as protected method so it can be overrriden. [PR #2182](https://github.com/apollographql/apollo-server/pull/2182)
 
 ### v2.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Switch from `json-stable-stringify` to `fast-json-stable-stringify`. [PR #2065](https://github.com/apollographql/apollo-server/pull/2065)
 
+- Make `trace` in RESTDataSource protected so it can be overrriden.
+
 ### v2.3.1
 
 - Provide types for `graphql-upload` in a location where they can be accessed by TypeScript consumers of `apollo-server` packages. [ccf935f9](https://github.com/apollographql/apollo-server/commit/ccf935f9) [Issue #2092](https://github.com/apollographql/apollo-server/issues/2092)

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -268,7 +268,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     request: Request,
     fn: () => Promise<TResult>,
   ): Promise<TResult> {
-    const label = `${request.method || 'GET'} ${request.url}`
+    const label = `${request.method || 'GET'} ${request.url}`;
 
     if (process && process.env && process.env.NODE_ENV === 'development') {
       // We're not using console.time because that isn't supported on Cloudflare

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -235,7 +235,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     const cacheKey = this.cacheKeyFor(request);
 
     const performRequest = async () => {
-      return this.trace(`${options.method || 'GET'} ${url}`, async () => {
+      return this.trace(request, async () => {
         const cacheOptions = options.cacheOptions
           ? options.cacheOptions
           : this.cacheOptionsFor && this.cacheOptionsFor.bind(this);
@@ -264,10 +264,12 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     }
   }
 
-  private async trace<TResult>(
-    label: string,
+  protected async trace<TResult>(
+    request: Request,
     fn: () => Promise<TResult>,
   ): Promise<TResult> {
+    const label = `${request.method || 'GET'} ${request.url}`
+
     if (process && process.env && process.env.NODE_ENV === 'development') {
       // We're not using console.time because that isn't supported on Cloudflare
       const startTime = Date.now();


### PR DESCRIPTION
Expose `RESTDataSource.trace` as a protected method so implementers can override the default behavior. This is useful for instrumenting a data-source with tracing logic.

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass
