### PR TITLE
Fix Docs for applyMiddleware

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -171,7 +171,7 @@ The `applyMiddleware` method is provided by the `apollo-server-{integration}` pa
 
     Pass the integration-specific cors options. False removes the cors middleware and true uses the defaults.
 
-  * `bodyParser`: <`Object` | `boolean`> ([express](https://github.com/expressjs/body-parser#body-parser))
+  * `bodyParserConfig`: <`Object` | `boolean`> ([express](https://github.com/expressjs/body-parser#body-parser))
 
     Pass the body-parser options. False removes the body parser middleware and true uses the defaults.
 


### PR DESCRIPTION
I had trouble changing the bodyParser configuration because the param name was incorrect in the docs. Here's [the param name](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-express/src/ApolloServer.ts#L96) in the implementation.