### PR TITLE
chore(deps): update dependency @types/koa-bodyparser to a valid 4.2.1…

### DIFF
--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -30,7 +30,7 @@
     "@types/accepts": "^1.3.5",
     "@types/cors": "^2.8.4",
     "@types/koa": "^2.0.46",
-    "@types/koa-bodyparser": "^5.0.1",
+    "@types/koa-bodyparser": "^4.2.1",
     "@types/koa-compose": "^3.2.2",
     "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",


### PR DESCRIPTION
… version

This PR should hopefully correct some typing issues we are currently facing.

The problem:
- this package references v5.0.1 for @types/koa-bodyparser
- when we start our server that also uses koa-bodyparser for non-graphql routes, the type for koa.Request sets the "body" field to:

```
declare module "koa" {
    interface Request {
        body: {} | null | undefined;
        rawBody: {} | null | undefined;
    }
}
```

Which breaks our type defs for koa-bodyparser as we actually want "body" to be set to "any."

The v5.0.1 that was originally placed here is no longer "latest" and they have published a new v4 version that has the correct typing for koa-bodyparser (setting body to any). - https://www.npmjs.com/package/@types/koa-bodyparser

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

