### PR TITLE
Re-add dynamic validation by request

### DIFF
--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server-core`: Added a function wrapper to `validationRules` for dynamic validation [PR#2232](https://github.com/apollographql/apollo-server/pull/2232)
 * `apollo-server-core`: Add persisted queries [PR#1149](https://github.com/apollographql/apollo-server/pull/1149)
 * `apollo-server-core`: added `BadUserInputError`
 * `apollo-server-core`: **breaking** gql is exported from gql-tag and ApolloServer requires a DocumentNode [PR#1146](https://github.com/apollographql/apollo-server/pull/1146)

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -1,14 +1,10 @@
-import {
-  GraphQLSchema,
-  ValidationContext,
-  GraphQLFieldResolver,
-  DocumentNode,
-} from 'graphql';
+import { GraphQLSchema, GraphQLFieldResolver, DocumentNode } from 'graphql';
 import { GraphQLExtension } from 'graphql-extensions';
 import { CacheControlExtensionOptions } from 'apollo-cache-control';
 import { KeyValueCache } from 'apollo-server-caching';
 import { DataSource } from 'apollo-datasource';
-import { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import { ApolloServerPlugin, GraphQLRequest } from 'apollo-server-plugin-base';
+import { ValidationRule } from 'graphql/validation/ValidationContext';
 
 /*
  * GraphQLServerOptions
@@ -24,6 +20,10 @@ import { ApolloServerPlugin } from 'apollo-server-plugin-base';
  * - (optional) extensions: an array of functions which create GraphQLExtensions (each GraphQLExtension object is used for one request)
  *
  */
+export type ValidationRulesFunction = (
+  request: GraphQLRequest,
+) => ValidationRule[];
+
 export interface GraphQLServerOptions<
   TContext = Record<string, any>,
   TRootValue = any
@@ -32,7 +32,7 @@ export interface GraphQLServerOptions<
   formatError?: Function;
   rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
   context?: TContext | (() => never);
-  validationRules?: Array<(context: ValidationContext) => any>;
+  validationRules?: ValidationRule[] | ValidationRulesFunction;
   formatResponse?: Function;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   debug?: boolean;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This patch re-mimic the behavior of the same functionality in [graphql-yoga](https://github.com/prisma/graphql-yoga/blob/33987a018e575095bebd33e65b4853d0f0ea413c/src/index.ts#L280-L283), so that validation rules that relies on query context (e.g. variables for [slicknode/graphql-query-complexity](https://github.com/slicknode/graphql-query-complexity) & [pa-bru/graphql-cost-analysis](https://github.com/pa-bru/graphql-cost-analysis)) can work again without ugly workarounds.

Related: https://github.com/slicknode/graphql-query-complexity/issues/7, https://github.com/pa-bru/graphql-cost-analysis/issues/12, https://github.com/apollographql/apollo-server/issues/1777

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

