### PR TITLE
More strict check for node version for `graphql-upload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Avoid traversing `graphql-uploads` module tree in run-time environments which aren't Node.js. [PR #2235](https://github.com/apollographql/apollo-server/pull/2235)
+
 ### v2.3.2
 
 - Switch from `json-stable-stringify` to `fast-json-stable-stringify`. [PR #2065](https://github.com/apollographql/apollo-server/pull/2065)

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -14,7 +14,7 @@ import { GraphQLExtension } from 'graphql-extensions';
 import { EngineReportingAgent } from 'apollo-engine-reporting';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
-import supportsUploadsInNode from './utils/supportsUploadsInNode';
+import runtimeSupportsUploads from './utils/runtimeSupportsUploads';
 
 import {
   SubscriptionServer,
@@ -90,7 +90,7 @@ function getEngineServiceId(engine: Config['engine']): string | undefined {
 }
 
 const forbidUploadsForTesting =
-  process && process.env.NODE_ENV === 'test' && !supportsUploadsInNode;
+  process && process.env.NODE_ENV === 'test' && !runtimeSupportsUploads;
 
 export class ApolloServerBase {
   public subscriptionsPath?: string;
@@ -205,7 +205,7 @@ export class ApolloServerBase {
 
     if (uploads !== false && !forbidUploadsForTesting) {
       if (this.supportsUploads()) {
-        if (!supportsUploadsInNode) {
+        if (!runtimeSupportsUploads) {
           printNodeFileUploadsMessage();
           throw new Error(
             '`graphql-upload` is no longer supported on Node.js < v8.5.0.  ' +

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -41,7 +41,7 @@ export const gql: (
   ...substitutions: any[]
 ) => DocumentNode = gqlTag;
 
-import supportsUploadsInNode from './utils/supportsUploadsInNode';
+import runtimeSupportsUploads from './utils/runtimeSupportsUploads';
 import { GraphQLScalarType } from 'graphql';
 export { default as processFileUploads } from './processFileUploads';
 
@@ -53,6 +53,6 @@ export { default as processFileUploads } from './processFileUploads';
 // experimental ECMAScript modules), this conditional export is necessary
 // to avoid modern ECMAScript from failing to parse by versions of Node.js
 // which don't support it (yet — eg. Node.js 6 and async/await).
-export const GraphQLUpload = supportsUploadsInNode
+export const GraphQLUpload = runtimeSupportsUploads
   ? (require('graphql-upload').GraphQLUpload as GraphQLScalarType)
   : undefined;

--- a/packages/apollo-server-core/src/processFileUploads.ts
+++ b/packages/apollo-server-core/src/processFileUploads.ts
@@ -1,6 +1,6 @@
 /// <reference path="./types/graphql-upload.d.ts" />
 
-import supportsUploadsInNode from './utils/supportsUploadsInNode';
+import runtimeSupportsUploads from './utils/runtimeSupportsUploads';
 
 // We'll memoize this function once at module load time since it should never
 // change during runtime.  In the event that we're using a version of Node.js
@@ -8,7 +8,7 @@ import supportsUploadsInNode from './utils/supportsUploadsInNode';
 const processFileUploads:
   | typeof import('graphql-upload').processRequest
   | undefined = (() => {
-  if (supportsUploadsInNode) {
+  if (runtimeSupportsUploads) {
     return require('graphql-upload')
       .processRequest as typeof import('graphql-upload').processRequest;
   }

--- a/packages/apollo-server-core/src/utils/runtimeSupportsUploads.ts
+++ b/packages/apollo-server-core/src/utils/runtimeSupportsUploads.ts
@@ -1,4 +1,4 @@
-const supportsUploadsInNode = (() => {
+const runtimeSupportsUploads = (() => {
   if (
     process &&
     process.release &&
@@ -20,4 +20,4 @@ const supportsUploadsInNode = (() => {
   return false;
 })();
 
-export default supportsUploadsInNode;
+export default runtimeSupportsUploads;

--- a/packages/apollo-server-core/src/utils/runtimeSupportsUploads.ts
+++ b/packages/apollo-server-core/src/utils/runtimeSupportsUploads.ts
@@ -16,7 +16,8 @@ const runtimeSupportsUploads = (() => {
     return true;
   }
 
-  // not node
+  // If we haven't matched any of the above criteria, we'll remain unsupported
+  // for this mysterious environment until a pull-request proves us otherwise.
   return false;
 })();
 

--- a/packages/apollo-server-core/src/utils/supportsUploadsInNode.ts
+++ b/packages/apollo-server-core/src/utils/supportsUploadsInNode.ts
@@ -13,9 +13,11 @@ const supportsUploadsInNode = (() => {
     if (nodeMajor < 8 || (nodeMajor === 8 && nodeMinor < 5)) {
       return false;
     }
+    return true;
   }
 
-  return true;
+  // not node
+  return false;
 })();
 
 export default supportsUploadsInNode;


### PR DESCRIPTION
I'm working on a `apollo-server-flyio` package to use in fly.io apps. The fly app environment is not node, it's much closer to the browser, which means no access to `fs`, which means `graphql-upload` blows up on require. 

This PR makes the Node version check more strict — if there are no node process details it avoids requiring the `graphql-upload` package for non-node runtimes. This is useful for me, obviously, but should also improve the Cloud Flare worker build experience and help with any future Deno efforts.

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

