### PR TITLE
Remove `willStart` from `apollo-server`, already called via `…-express`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- `apollo-server` (only): Stop double-invocation of `serverWillStart` life-cycle event.  (More specific integrations - e.g. Express, Koa, Hapi, etc. - were unaffected.) [PR #2239](https://github.com/apollographql/apollo-server/pull/2239)
+
 ### v2.3.2
 
 - Switch from `json-stable-stringify` to `fast-json-stable-stringify`. [PR #2065](https://github.com/apollographql/apollo-server/pull/2065)

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -78,8 +78,6 @@ export class ApolloServer extends ApolloServerBase {
 
   // Listen takes the same arguments as http.Server.listen.
   public async listen(...opts: Array<any>): Promise<ServerInfo> {
-    await this.willStart();
-
     // This class is the easy mode for people who don't create their own express
     // object, so we have to create it.
     const app = express();


### PR DESCRIPTION
When the request pipeline was initially introduced, the integrations had yet to be updated to call the new life-cycle events.  Now, the integrations have all caught up, but `apollo-server` is still calling `willStart`, despite the fact that its dependency which provides the actual server implementation — `apollo-server-express` – is _also_ calling it, resulting in double invocation of this event.

I suspect some follow-up work should guard against this possibility, but for
now this should remove the duplication.