### PR TITLE
Export graphqlKoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Export `graphqlKoa` again in `apollo-server-koa`. [PR #2244](https://github.com/apollographql/apollo-server/pull/2244)
 
 ### v2.3.3
 
@@ -27,9 +28,9 @@
   While Node.js 6.x is covered by a [Long Term Support agreement by the Node.js Foundation](https://github.com/nodejs/Release#release-schedule) until April 2019, there are substantial performance (e.g. [V8](https://v8.dev/) improvements) and language changes (e.g. "modern" ECMAScript support) offered by newer Node.js engines (e.g. 8.x, 10.x).  We encourage _all users_ of Apollo Server to update to newer LTS versions of Node.js prior to the "end-of-life" dates for their current server version.
 
   **We intend to drop support for Node.js 6.x in the next major version of Apollo Server.**
-  
+
   For more information, see [PR #2054](https://github.com/apollographql/apollo-server/pull/2054) and [our documentation](https://www.apollographql.com/docs/apollo-server/v2/migration-file-uploads.html).
-  
+
 ### v2.2.7
 
 - `apollo-engine-reporting`: When multiple instances of `apollo-engine-reporting` are loaded (an uncommon edge case), ensure that `encodedTraces` are handled only once rather than once per loaded instance. [PR #2040](https://github.com/apollographql/apollo-server/pull/2040)

--- a/packages/apollo-server-koa/src/index.ts
+++ b/packages/apollo-server-koa/src/index.ts
@@ -27,3 +27,5 @@ export {
   registerServer,
   ServerRegistration,
 } from './ApolloServer';
+
+export { graphqlKoa } from './koaApollo';


### PR DESCRIPTION
Being able to access graphqlKoa is useful for koa-based frameworks that don't expose the app object. This was previously exported in an earlier version of apollo-server and would be useful to export in the 2.x release as well.

Here's an example of how we're currently consuming this: https://github.com/fusionjs/fusion-plugin-apollo-server/blob/90e95ef1480659073c7e4e042b75ea6205cc068f/src/server.js#L37

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

