### PR TITLE
Fix a typo in the "Custom `GraphQLScalarType` instance" example

### DIFF
--- a/docs/source/features/scalars-enums.md
+++ b/docs/source/features/scalars-enums.md
@@ -105,7 +105,7 @@ const resolverFunctions = {
   MyCustomScalar: myCustomScalarType
 };
 
-const server = new ApolloServer({ typeDefs: schemaString, resolvers: resolveFunctions });
+const server = new ApolloServer({ typeDefs: schemaString, resolvers: resolverFunctions });
 
 server.listen().then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`)


### PR DESCRIPTION
This is just a quick fix for a typo that threw me for a loop when testing out this example.
