### PR TITLE
Revert "chore(deps): update dependency @types/aws-lambda to v8.10.19"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,9 +1253,9 @@
       "dev": true
     },
     "@types/aws-lambda": {
-      "version": "8.10.19",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.19.tgz",
-      "integrity": "sha512-dEhQow/1awGGIf/unEpb97vsTtnQ3qRPAhSmZZcXKzs4nOVbIuWo5LCCzOYdSIkGkkoFXVvc8pBaSVKRYIFUBA==",
+      "version": "8.10.18",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.18.tgz",
+      "integrity": "sha512-ePcNYGsgBJaF00+fG92e8zDcre7K6/X7wJeEyn7ICAwez9+NS47XEYlGrA0+udxo0jSuZVC8xg//PUiGNk43pA==",
       "dev": true
     },
     "@types/bluebird": {
@@ -1464,6 +1464,14 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
           "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg=="
         }
+      }
+    },
+    "@types/koa-bodyparser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-5.0.1.tgz",
+      "integrity": "sha512-nL9JGPAHTnFb7zDm9u0bdXEMsbTgCJWcyHJRRPTSCkErzDSyeuSum7IemS697NTpWDwQw+Y9d/CYzvWKlAsMRQ==",
+      "requires": {
+        "@types/koa": "*"
       }
     },
     "@types/koa-compose": {
@@ -2383,15 +2391,6 @@
         "koa-bodyparser": "^3.0.0",
         "koa-router": "^7.4.0",
         "type-is": "^1.6.16"
-      },
-      "dependencies": {
-        "@types/koa-bodyparser": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "@types/koa": "*"
-          }
-        }
       }
     },
     "apollo-server-lambda": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "devDependencies": {
     "@types/async-retry": "1.2.1",
-    "@types/aws-lambda": "8.10.19",
+    "@types/aws-lambda": "8.10.18",
     "@types/body-parser": "1.17.0",
     "@types/connect": "3.4.32",
     "@types/fast-json-stable-stringify": "2.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "apollo-open-source"
   ],
+  "automerge": false,
   "packageRules": [
     {
       "paths": [


### PR DESCRIPTION
Reverts apollographql/apollo-server#2283

This was causing the following error on the `master` branch after #2283 was merged — even though the original PR passed.  It seems to repeatedly bisect back to this commit but I haven't looked into it further.  Leaving `master` in an unusable state for the weekend didn't seem ideal.

This also disables Renovate `automerge` which, while nice in theory, would probably just put this back in place.