### PR TITLE
Await on graphql.execute() before calling executionDidEnd handler (AS-59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Fix inaccurate total duration in apollo-tracing [PR #2298](https://github.com/apollographql/apollo-server/pull/2298)
 
 ### v2.4.0
 

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -356,7 +356,7 @@ export async function processGraphQLRequest<TContext>(
     });
 
     try {
-      return graphql.execute(executionArgs);
+      return await graphql.execute(executionArgs);
     } finally {
       executionDidEnd();
     }


### PR DESCRIPTION
`extensionStack`'s executionDidEnd handler (the callback function returned from `executionDidStart`) was being called before `graphql.execute` finishes running

This PR adds an `await` before the return so code in `finally` runs after `graphql.execute` finishes 

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

