### PR TITLE
Remove unused lodash dependency from apollo-server-core.

### DIFF
--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -41,7 +41,6 @@
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^4.0.0",
     "graphql-upload": "^8.0.2",
-    "lodash": "^4.17.10",
     "subscriptions-transport-ws": "^0.9.11",
     "ws": "^6.0.0"
   },


### PR DESCRIPTION
The only usage of lodash was removed by @martijnwalraven in commit a09d514e596b297f6a62acbbff653bd33fb1028c.