### PR TITLE
Add test to ensure "total duration" > "duration of resolvers" - AS-59

### DIFF
--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1269,21 +1269,30 @@ export function testApolloServer<AS extends ApolloServerBase>(
           author: String
         }
 
+        type Movie {
+          title: String
+        }
+
         type Query {
           books: [Book]
+          movies: [Movie]
         }
       `;
 
-      const books = [{ title: 'H', author: 'J' }];
+      const resolvers = {
+        Query: {
+          books: () =>
+            new Promise(resolve =>
+              setTimeout(() => resolve([{ title: 'H', author: 'J' }]), 10),
+            ),
+          movies: () =>
+            new Promise(resolve =>
+              setTimeout(() => resolve([{ title: 'H' }]), 12),
+            ),
+        },
+      };
 
       it('reports a total duration that is longer than the duration of its resolvers', async () => {
-        const resolvers = {
-          Query: {
-            books: () =>
-              new Promise(resolve => setTimeout(() => resolve(books), 10)),
-          },
-        };
-
         const { url: uri } = await createApolloServer({
           typeDefs,
           resolvers,

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1306,19 +1306,19 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
         const tracing: TracingFormat = result.extensions.tracing;
 
-        let earliestStartOffset = tracing.execution.resolvers
+        const earliestStartOffset = tracing.execution.resolvers
           .map(resolver => resolver.startOffset)
           .reduce((currentEarliestOffset, nextOffset) =>
             Math.min(currentEarliestOffset, nextOffset),
           );
 
-        let latestEndOffset = tracing.execution.resolvers
+        const latestEndOffset = tracing.execution.resolvers
           .map(resolver => resolver.startOffset + resolver.duration)
           .reduce((currentLatestEndOffset, nextEndOffset) =>
             Math.min(currentLatestEndOffset, nextEndOffset),
           );
 
-        let resolverDuration = latestEndOffset - earliestStartOffset;
+        const resolverDuration = latestEndOffset - earliestStartOffset;
 
         expect(resolverDuration).not.toBeGreaterThan(tracing.duration);
       });


### PR DESCRIPTION
Follow up to https://github.com/apollographql/apollo-server/pull/2298

This compares a trace's top-level duration (total duration) to ensure that it's longer than the duration from when its resolver first started to when when its resolvers last ends