### PR TITLE
azure-functions: Add missing test configuration files.

### DIFF
--- a/packages/apollo-server-azure-functions/jest.config.js
+++ b/packages/apollo-server-azure-functions/jest.config.js
@@ -1,0 +1,3 @@
+const config = require('../../jest.config.base');
+
+module.exports = Object.assign(Object.create(null), config);

--- a/packages/apollo-server-azure-functions/src/__tests__/tsconfig.json
+++ b/packages/apollo-server-azure-functions/src/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.test.base",
+  "include": ["**/*"],
+  "references": [
+    { "path": "../../" },
+    { "path": "../../../apollo-server-integration-testsuite" },
+  ]
+}


### PR DESCRIPTION
These missing configurations, which weren't identified in the original implementation of `apollo-server-azure-functions` in #1926, are responsible for the failures which have surfaced in the #2228, which updates Jest to v24.x.

Un-blocks #2228.