### PR TITLE
fix(installSubscriptionHandlers): don't stomp on context returned by onConnect

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -477,7 +477,7 @@ export class ApolloServerBase {
             })[0];
           }
 
-          return { ...connection, context };
+          return { ...connection, context: { ...connection.context, ...context } };
         },
         keepAlive,
       },

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -477,7 +477,10 @@ export class ApolloServerBase {
             })[0];
           }
 
-          return { ...connection, context: { ...connection.context, ...context } };
+          return {
+            ...connection,
+            context: { ...connection.context, ...context },
+          };
         },
         keepAlive,
       },


### PR DESCRIPTION
I finally found documentation of how `context` is expected to be used when called by the subscriptions connection: https://www.apollographql.com/docs/apollo-server/features/subscriptions.html#Context-with-Subscriptions

It was kind of hard, because example code in other parts of the docs always assumes that `req` is defined.  I question whether queries and subscriptions should both be calling this context function with such different parameters.