### PR TITLE
Fix the ws import error for typescript

### DIFF
--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* `apollo-server-core`: Fix ws type import error [PR#2323](https://github.com/apollographql/apollo-server/pull/2323)
 * `apollo-server-core`: Add persisted queries [PR#1149](https://github.com/apollographql/apollo-server/pull/1149)
 * `apollo-server-core`: added `BadUserInputError`
 * `apollo-server-core`: **breaking** gql is exported from gql-tag and ApolloServer requires a DocumentNode [PR#1146](https://github.com/apollographql/apollo-server/pull/1146)

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -6,7 +6,7 @@ import {
   GraphQLParseOptions,
 } from 'graphql-tools';
 import { ConnectionContext } from 'subscriptions-transport-ws';
-import WebSocket from 'ws';
+import * as WebSocket from 'ws';
 import { GraphQLExtension } from 'graphql-extensions';
 export { GraphQLExtension } from 'graphql-extensions';
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Simple fix an error encountered when using apollo-server-core directly

<img width="1436" alt="screen shot 2019-02-14 at 10 42 35 pm" src="https://user-images.githubusercontent.com/6628202/52793950-d99c0d80-30a9-11e9-9459-504d8c49c8e5.png">

Related issues:

https://github.com/apollographql/apollo-server/issues/2110

TODO:

Problem could be solved with specific typescript compile configuration, and this is why no error occurs in project, but could not be used in other personal project.

```
"esModuleInterop": true
```

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

