### PR TITLE
Provide more accurate types for apollo-server-expresse's ContextFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Add `req` and `res` typings to the `ContextFunction` argument for apollo-server and apollo-server-express. Update `ContextFunction` return type to allow returning a value syncronously. [PR #2330](https://github.com/apollographql/apollo-server/pull/2330)
+
 ### v2.4.2
 
 - `apollo-server-fastify` is now on Apollo Server and lives within the `apollo-server` repository.  This is being introduced in a _patch_ version, however it's a _major_ version bump from the last time `apollo-server-fastify` was published under `1.0.2`.  [PR #1971](https://github.com/apollostack/apollo-server/pull/1971)

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -30,7 +30,7 @@ export { KeyValueCache } from 'apollo-server-caching';
 export type Context<T = any> = T;
 export type ContextFunction<T = any> = (
   context: Context<T>,
-) => Promise<Context<T>>;
+) => Context<T> | Promise<Context<T>>;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -81,6 +81,10 @@ export interface ApolloServerExpressConfig extends Config {
 }
 
 export class ApolloServer extends ApolloServerBase {
+  constructor(config: ApolloServerExpressConfig) {
+    super(config);
+  }
+
   // This translates the arguments from the middleware into graphQL options It
   // provides typings for the integration specific behavior, ideally this would
   // be propagated with a generic to the super class

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import corsMiddleware from 'cors';
+import corsMiddleware, { CorsOptions } from 'cors';
 import { json, OptionsJson } from 'body-parser';
 import {
   renderPlaygroundPage,
@@ -11,6 +11,9 @@ import {
   ApolloServerBase,
   formatApolloErrors,
   processFileUploads,
+  ContextFunction,
+  Context,
+  Config,
 } from 'apollo-server-core';
 import accepts from 'accepts';
 import typeis from 'type-is';
@@ -66,6 +69,16 @@ const fileUploadMiddleware = (
     next();
   }
 };
+
+interface ExpressContext {
+  req: express.Request;
+  res: express.Response;
+}
+
+export interface ApolloServerExpressConfig extends Config {
+  cors?: CorsOptions | boolean;
+  context?: ContextFunction<ExpressContext> | Context<ExpressContext>;
+}
 
 export class ApolloServer extends ApolloServerBase {
   // This translates the arguments from the middleware into graphQL options It

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -26,6 +26,7 @@ export {
   ApolloServer,
   registerServer,
   ServerRegistration,
+  ApolloServerExpressConfig,
 } from './ApolloServer';
 
 export { CorsOptions } from 'cors';

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -8,8 +8,8 @@ import net from 'net';
 import {
   ApolloServer as ApolloServerBase,
   CorsOptions,
+  ApolloServerExpressConfig,
 } from 'apollo-server-express';
-import { Config } from 'apollo-server-core';
 
 export * from './exports';
 
@@ -27,7 +27,7 @@ export class ApolloServer extends ApolloServerBase {
   private httpServer?: http.Server;
   private cors?: CorsOptions | boolean;
 
-  constructor(config: Config & { cors?: CorsOptions | boolean }) {
+  constructor(config: ApolloServerExpressConfig) {
     super(config);
     this.cors = config && config.cors;
   }


### PR DESCRIPTION
This was an issue brought up in https://github.com/apollographql/apollo-server/issues/1593

This PR should provide more accurate typing information for apollo-server and apollo-server-express
- `ContextFunction` can return a new context object synchronously
- `context` for apollo-server and apollo-server-express will contain `req` and `res` 

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

