### PR TITLE
Feature: Add HTTP2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Add support for http2. [PR #2333](https://github.com/apollographql/apollo-server/pull/2333)
+
 ### v2.4.2
 
 - `apollo-server-fastify` is now on Apollo Server and lives within the `apollo-server` repository.  This is being introduced in a _patch_ version, however it's a _major_ version bump from the last time `apollo-server-fastify` was published under `1.0.2`.  [PR #1971](https://github.com/apollostack/apollo-server/pull/1971)

--- a/packages/apollo-server-core/src/nodeHttpToRequest.ts
+++ b/packages/apollo-server-core/src/nodeHttpToRequest.ts
@@ -3,7 +3,9 @@ import { Request, Headers } from 'apollo-server-env';
 
 export function convertNodeHttpToRequest(req: IncomingMessage): Request {
   const headers = new Headers();
-  Object.keys(req.headers).forEach(key => {
+  const headerKeys = Object.keys(req.headers);
+  const validHeaderKeys = headerKeys.filter(key => !key.startsWith(':'));
+  validHeaderKeys.forEach(key => {
     const values = req.headers[key]!;
     if (Array.isArray(values)) {
       values.forEach(value => headers.append(key, value));


### PR DESCRIPTION
**TODO:**
* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

**Description:**
This PR makes sure the server starts accepting HTTP2 request by filtering unsupported headers out. I'm very aware that this solution is probably not the correct one but I'm not sure what else there is to do here. The idea to do this comes from https://github.com/apollographql/apollo-server/issues/1533 and I have found myself that this works when used in combination with `apollo-server-fastify`. If there are better ways of getting HTTP2 support into the project, please let me know.

About tests, I can't find any for the method I'm changing here. So I didn't add any. Please correct me if this is wrong.

**Use case:** 
This is very useful when using a server framework that support HTTP2, which is a growing set.

**Could this be a plugin?**
I don't see any way to make this into a plugin. But perhaps it can be. I'm not very familiar with the architecture here. Could this method perhaps be overwritten via a plugin?

**Is there a workaround?**
As far as I know, there is non at this point in time.
