### PR TITLE
Add more accurate typings to formatError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `apollo-server-lambda`: Fix typings which triggered "Module has no default export" errors. [PR #2230](https://github.com/apollographql/apollo-server/pull/2230)
 - `apollo-server-koa`: Support OPTIONS requests [PR #2288](https://github.com/apollographql/apollo-server/pull/2288)
 - Add `req` and `res` typings to the `ContextFunction` argument for apollo-server and apollo-server-express. Update `ContextFunction` return type to allow returning a value syncronously. [PR #2330](https://github.com/apollographql/apollo-server/pull/2330)
-- Type the `formatError` function to accept an ApolloError as an argument and return an ApolloError [PR #2343](https://github.com/apollographql/apollo-server/pull/2343)
+- Type the `formatError` function to accept an GraphQLError as an argument and return a GraphQLFormattedError [PR #2343](https://github.com/apollographql/apollo-server/pull/2343)
 
 ### v2.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `apollo-server-lambda`: Fix typings which triggered "Module has no default export" errors. [PR #2230](https://github.com/apollographql/apollo-server/pull/2230)
 - `apollo-server-koa`: Support OPTIONS requests [PR #2288](https://github.com/apollographql/apollo-server/pull/2288)
 - Add `req` and `res` typings to the `ContextFunction` argument for apollo-server and apollo-server-express. Update `ContextFunction` return type to allow returning a value syncronously. [PR #2330](https://github.com/apollographql/apollo-server/pull/2330)
+- Type the `formatError` function to accept an ApolloError as an argument and return an ApolloError [PR #2343](https://github.com/apollographql/apollo-server/pull/2343)
 
 ### v2.4.2
 

--- a/packages/apollo-server-core/src/formatters.ts
+++ b/packages/apollo-server-core/src/formatters.ts
@@ -1,11 +1,14 @@
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
-import { formatApolloErrors } from 'apollo-server-errors';
+import { formatApolloErrors, ApolloError } from 'apollo-server-errors';
 
 export class FormatErrorExtension<TContext = any> extends GraphQLExtension {
-  private formatError?: Function;
+  private formatError?: (error: ApolloError) => ApolloError;
   private debug: boolean;
 
-  public constructor(formatError?: Function, debug: boolean = false) {
+  public constructor(
+    formatError?: (error: ApolloError) => ApolloError,
+    debug: boolean = false,
+  ) {
     super();
     this.formatError = formatError;
     this.debug = debug;

--- a/packages/apollo-server-core/src/formatters.ts
+++ b/packages/apollo-server-core/src/formatters.ts
@@ -1,12 +1,13 @@
 import { GraphQLExtension, GraphQLResponse } from 'graphql-extensions';
-import { formatApolloErrors, ApolloError } from 'apollo-server-errors';
+import { formatApolloErrors } from 'apollo-server-errors';
+import { GraphQLError, GraphQLFormattedError } from 'graphql';
 
 export class FormatErrorExtension<TContext = any> extends GraphQLExtension {
-  private formatError?: (error: ApolloError) => ApolloError;
+  private formatError?: (error: GraphQLError) => GraphQLFormattedError;
   private debug: boolean;
 
   public constructor(
-    formatError?: (error: ApolloError) => ApolloError,
+    formatError?: (error: GraphQLError) => GraphQLFormattedError,
     debug: boolean = false,
   ) {
     super();

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -10,6 +10,7 @@ import { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
 import { DataSource } from 'apollo-datasource';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import { GraphQLParseOptions } from 'graphql-tools';
+import { ApolloError } from 'apollo-server-errors';
 
 /*
  * GraphQLServerOptions
@@ -31,7 +32,7 @@ export interface GraphQLServerOptions<
   TRootValue = any
 > {
   schema: GraphQLSchema;
-  formatError?: Function;
+  formatError?: (error: ApolloError) => ApolloError;
   rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -3,6 +3,8 @@ import {
   ValidationContext,
   GraphQLFieldResolver,
   DocumentNode,
+  GraphQLError,
+  GraphQLFormattedError,
 } from 'graphql';
 import { GraphQLExtension } from 'graphql-extensions';
 import { CacheControlExtensionOptions } from 'apollo-cache-control';
@@ -10,7 +12,6 @@ import { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
 import { DataSource } from 'apollo-datasource';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import { GraphQLParseOptions } from 'graphql-tools';
-import { ApolloError } from 'apollo-server-errors';
 
 /*
  * GraphQLServerOptions
@@ -32,7 +33,7 @@ export interface GraphQLServerOptions<
   TRootValue = any
 > {
   schema: GraphQLSchema;
-  formatError?: (error: ApolloError) => ApolloError;
+  formatError?: (error: GraphQLError) => GraphQLFormattedError;
   rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -75,7 +75,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   persistedQueries?: PersistedQueryOptions;
   cacheControl?: CacheControlExtensionOptions;
 
-  formatError?: Function;
+  formatError?: (error: ApolloError) => ApolloError;
   formatResponse?: Function;
 
   plugins?: ApolloServerPlugin[];

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -7,6 +7,7 @@ import {
   ExecutionArgs,
   ExecutionResult,
   GraphQLError,
+  GraphQLFormattedError,
 } from 'graphql';
 import * as graphql from 'graphql';
 import {
@@ -75,7 +76,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   persistedQueries?: PersistedQueryOptions;
   cacheControl?: CacheControlExtensionOptions;
 
-  formatError?: (error: ApolloError) => ApolloError;
+  formatError?: (error: GraphQLError) => GraphQLFormattedError;
   formatResponse?: Function;
 
   plugins?: ApolloServerPlugin[];

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -213,7 +213,7 @@ export class UserInputError extends ApolloError {
 export function formatApolloErrors(
   errors: Array<Error>,
   options?: {
-    formatter?: Function;
+    formatter?: (error: ApolloError) => ApolloError;
     debug?: boolean;
   },
 ): Array<ApolloError> {

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError, GraphQLFormattedError } from 'graphql';
 
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
@@ -213,7 +213,7 @@ export class UserInputError extends ApolloError {
 export function formatApolloErrors(
   errors: Array<Error>,
   options?: {
-    formatter?: (error: ApolloError) => ApolloError;
+    formatter?: (error: GraphQLError) => GraphQLFormattedError;
     debug?: boolean;
   },
 ): Array<ApolloError> {


### PR DESCRIPTION
Related to https://github.com/apollographql/apollo-server/issues/2294

This updates the typings for formatError to specify that it accepts an GraphQLError as an argument, and expects a GraphQLFormattedError to be returned

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests (NA?)
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass