### PR TITLE
Keep `@types/node` types at v8.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   "automerge": false,
   "packageRules": [
     {
+      "packageNames": ["@types/node"],
+      "allowedVersions": "8.x"
+    },
+    {
       "paths": [
         "docs/package.json"
       ],


### PR DESCRIPTION
While there are newer types available for newer Node.js APIs, the `8.x` range still gets most of the important updates via back-ports on the `DefinitelyTyped` repository.  I believe it'll be safer to limit the types to the version which we intend on developing for most directly, which is Node.js 8.  Node.js 10 has newer APIs but until we can drop Node.js 8 support (which is not at all anytime soon), we should try to stick to the `8.x` API types.

We will drop Node.js 6 support in the next major version of Apollo Server since it will end it's "Long-Term Support" coverage [in April 2019](https://github.com/nodejs/LTS/).

Hopefully this will auto-close #2302. 😉 