### PR TITLE
fix: separate type parameters for input and output in ContextFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Separate type parameters for input and output in ContextFunction. [PR #2346](https://github.com/apollographql/apollo-server/pull/2346) [Issue #1593](https://github.com/apollographql/apollo-server/issues/1593)
+
 ### v2.4.3
 
 - `apollo-server-lambda`: Fix typings which triggered "Module has no default export" errors. [PR #2230](https://github.com/apollographql/apollo-server/pull/2230)

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -30,9 +30,9 @@ export { GraphQLSchemaModule };
 export { KeyValueCache } from 'apollo-server-caching';
 
 export type Context<T = any> = T;
-export type ContextFunction<T = any> = (
-  context: Context<T>,
-) => Context<T> | Promise<Context<T>>;
+export type ContextFunction<In = any, Out = any> = (
+  context: In,
+) => Context<Out> | Promise<Context<Out>>;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -75,13 +75,13 @@ interface ExpressContext {
   res: express.Response;
 }
 
-export interface ApolloServerExpressConfig extends Config {
+export interface ApolloServerExpressConfig<C> extends Config {
   cors?: CorsOptions | boolean;
-  context?: ContextFunction<ExpressContext> | Context<ExpressContext>;
+  context?: ContextFunction<ExpressContext, C> | Context<C>;
 }
 
-export class ApolloServer extends ApolloServerBase {
-  constructor(config: ApolloServerExpressConfig) {
+export class ApolloServer<Ctx = any> extends ApolloServerBase {
+  constructor(config: ApolloServerExpressConfig<Ctx>) {
     super(config);
   }
 

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -22,11 +22,11 @@ export interface ServerInfo {
   server: http.Server;
 }
 
-export class ApolloServer extends ApolloServerBase {
+export class ApolloServer<Ctx = any> extends ApolloServerBase {
   private httpServer?: http.Server;
   private cors?: CorsOptions | boolean;
 
-  constructor(config: ApolloServerExpressConfig) {
+  constructor(config: ApolloServerExpressConfig<Ctx>) {
     super(config);
     this.cors = config && config.cors;
   }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

The type of context when using a `ContextFunction` is incorrect as of `apollo-server-express@2.4.3`. Both the input context AND output context had to be `ExpressContext`. This PR redefines `ContextFunction` to have two type parameters: an input context type (in this case it's `ExpressContext`) and output context type to be supplied by consumer.

Fixes #1593

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

