### PR TITLE
Fix apollo-server-express `context` TypeScript definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### vNEXT
 
 - `apollo-server-express`: Export `ExpressContext`
+- `apollo-server-express`: Fix so you can return anything in `context`
+- `apollo-server-express`: Ability to specify a context interface to `ApolloServerExpressConfig`
+- `apollo-server-core`: Update `ContextFunction` to allow both an incoming and outcoming context
 
 ### v2.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- `apollo-server-express`: Export `ExpressContext`
+
 ### v2.4.3
 
 - `apollo-server-lambda`: Fix typings which triggered "Module has no default export" errors. [PR #2230](https://github.com/apollographql/apollo-server/pull/2230)

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -30,9 +30,12 @@ export { GraphQLSchemaModule };
 export { KeyValueCache } from 'apollo-server-caching';
 
 export type Context<T = any> = T;
-export type ContextFunction<T = any> = (
-  context: Context<T>,
-) => Context<T> | Promise<Context<T>>;
+export type ContextFunction<
+  T_IncomingContext = any,
+  T_OutgoingContext = any
+> = (
+  context: Context<T_IncomingContext>,
+) => Context<T_OutgoingContext> | Promise<Context<T_OutgoingContext>>;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.
@@ -71,7 +74,7 @@ export interface Config extends BaseConfig {
   resolvers?: IResolvers;
   schema?: GraphQLSchema;
   schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>;
-  context?: Context<any> | ContextFunction<any>;
+  context?: Context<any> | ContextFunction<any, any>;
   introspection?: boolean;
   mocks?: boolean | IMocks;
   mockEntireSchema?: boolean;

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -70,7 +70,7 @@ const fileUploadMiddleware = (
   }
 };
 
-interface ExpressContext {
+export interface ExpressContext {
   req: express.Request;
   res: express.Response;
 }

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -75,9 +75,12 @@ export interface ExpressContext {
   res: express.Response;
 }
 
-export interface ApolloServerExpressConfig extends Config {
+export interface ApolloServerExpressConfig<T_OutgoingContext = any>
+  extends Config {
   cors?: CorsOptions | boolean;
-  context?: ContextFunction<ExpressContext> | Context<ExpressContext>;
+  context?:
+    | ContextFunction<ExpressContext, T_OutgoingContext>
+    | Context<T_OutgoingContext>;
 }
 
 export class ApolloServer extends ApolloServerBase {

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -7,8 +7,12 @@ import FormData from 'form-data';
 import fs from 'fs';
 import { createApolloFetch } from 'apollo-fetch';
 
-import { gql, AuthenticationError, Config } from 'apollo-server-core';
-import { ApolloServer, ServerRegistration } from '../ApolloServer';
+import { gql, AuthenticationError } from 'apollo-server-core';
+import {
+  ApolloServer,
+  ApolloServerExpressConfig,
+  ServerRegistration,
+} from '../ApolloServer';
 
 import {
   NODE_MAJOR_VERSION,
@@ -57,7 +61,7 @@ describe('apollo-server-express', () => {
   let httpServer: http.Server;
 
   async function createServer(
-    serverOptions: Config,
+    serverOptions: ApolloServerExpressConfig,
     options: Partial<ServerRegistration> = {},
   ) {
     server = new ApolloServer(serverOptions);

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -60,8 +60,8 @@ describe('apollo-server-express', () => {
   let app: express.Application;
   let httpServer: http.Server;
 
-  async function createServer(
-    serverOptions: ApolloServerExpressConfig,
+  async function createServer<T_OutgoingContext = any>(
+    serverOptions: ApolloServerExpressConfig<T_OutgoingContext>,
     options: Partial<ServerRegistration> = {},
   ) {
     server = new ApolloServer(serverOptions);
@@ -84,6 +84,34 @@ describe('apollo-server-express', () => {
   describe('constructor', () => {
     it('accepts typeDefs and resolvers', () => {
       return createServer({ typeDefs, resolvers });
+    });
+    describe('context', () => {
+      it('can be any value', () => {
+        return createServer({
+          typeDefs,
+          resolvers,
+          context: { userId: '1123' },
+        });
+      });
+      it('can be inferred by interface', () => {
+        interface MyContext {
+          token: string | null;
+        }
+
+        return createServer<MyContext>({
+          typeDefs,
+          resolvers,
+          context: ({ req }) => {
+            const token =
+              req.headers.authorization &&
+              req.headers.authorization.split(' ')[1];
+
+            return {
+              token: token || null,
+            };
+          },
+        });
+      });
     });
   });
 

--- a/packages/apollo-server-express/src/__tests__/connectApollo.test.ts
+++ b/packages/apollo-server-express/src/__tests__/connectApollo.test.ts
@@ -1,7 +1,6 @@
 import connect from 'connect';
 import query from 'qs-middleware';
-import { ApolloServer } from '../ApolloServer';
-import { Config } from 'apollo-server-core';
+import { ApolloServer, ApolloServerExpressConfig } from '../ApolloServer';
 
 import testSuite, {
   schema as Schema,
@@ -17,7 +16,7 @@ function createConnectApp(options: CreateAppOptions = {}) {
   // connect is probably already using connect-query or qs-middleware.
   app.use(query());
   const server = new ApolloServer(
-    (options.graphqlOptions as Config) || { schema: Schema },
+    (options.graphqlOptions as ApolloServerExpressConfig) || { schema: Schema },
   );
   // See comment on ServerRegistration.app for its typing.
   server.applyMiddleware({ app: app as any });

--- a/packages/apollo-server-express/src/__tests__/expressApollo.test.ts
+++ b/packages/apollo-server-express/src/__tests__/expressApollo.test.ts
@@ -1,16 +1,16 @@
 import express from 'express';
-import { ApolloServer } from '../ApolloServer';
+import { ApolloServer, ApolloServerExpressConfig } from '../ApolloServer';
 import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { GraphQLOptions, Config } from 'apollo-server-core';
+import { GraphQLOptions } from 'apollo-server-core';
 
 function createApp(options: CreateAppOptions = {}) {
   const app = express();
 
   const server = new ApolloServer(
-    (options.graphqlOptions as Config) || { schema: Schema },
+    (options.graphqlOptions as ApolloServerExpressConfig) || { schema: Schema },
   );
   server.applyMiddleware({ app });
   return app;


### PR DESCRIPTION
Noticed an issue when updating `apollo-server-express` today - my context function started breaking.

It looked something like this

```typescript
interface MyContext {
  token?: string;
}
new ApolloServer({
  typeDefs,
  resolvers,
  context: (): MyContext => {
    return {
      // ...
    };
  },
});
```

It seem to come from #2330 which enforces the output of the ContextFunction to be the same as the first arg to the function, which I think is wrong.

This PR allows you the `ContextFunction` to have an incoming and an outgoing context and let's you return whatever value you want in your `apollo-server-express` context.


---
TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

