### PR TITLE
Type parameters for context function separately from the context it produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- Fix typing for ContextFunction incorrectly requiring the context object the function produces to match the parameters of the function [PR #2350](https://github.com/apollographql/apollo-server/pull/2350)
 
 ### v2.4.3
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -29,10 +29,10 @@ export { GraphQLSchemaModule };
 
 export { KeyValueCache } from 'apollo-server-caching';
 
-export type Context<T = any> = T;
 export type ContextFunction<T = any> = (
   context: Context<T>,
 ) => Context<T> | Promise<Context<T>>;
+export type Context<T = object> = T;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.
@@ -50,7 +50,7 @@ export interface SubscriptionServerOptions {
 }
 
 type BaseConfig = Pick<
-  GraphQLOptions<Context<any>>,
+  GraphQLOptions<Context>,
   | 'formatError'
   | 'debug'
   | 'rootValue'
@@ -71,11 +71,11 @@ export interface Config extends BaseConfig {
   resolvers?: IResolvers;
   schema?: GraphQLSchema;
   schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>;
-  context?: Context<any> | ContextFunction<any>;
+  context?: Context | ContextFunction;
   introspection?: boolean;
   mocks?: boolean | IMocks;
   mockEntireSchema?: boolean;
-  engine?: boolean | EngineReportingOptions<Context<any>>;
+  engine?: boolean | EngineReportingOptions<Context>;
   extensions?: Array<() => GraphQLExtension>;
   cacheControl?: CacheControlExtensionOptions | boolean;
   plugins?: PluginDefinition[];

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -30,9 +30,9 @@ export { GraphQLSchemaModule };
 export { KeyValueCache } from 'apollo-server-caching';
 
 export type Context<T = object> = T;
-export type ContextFunction<FunctionParams = any, ContextContent = object> = (
+export type ContextFunction<FunctionParams = any, ProducedContext = object> = (
   context: FunctionParams,
-) => Context<ContextContent> | Promise<Context<ContextContent>>;
+) => Context<ProducedContext> | Promise<Context<ProducedContext>>;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -29,10 +29,10 @@ export { GraphQLSchemaModule };
 
 export { KeyValueCache } from 'apollo-server-caching';
 
-export type ContextFunction<T = any> = (
-  context: Context<T>,
-) => Context<T> | Promise<Context<T>>;
 export type Context<T = object> = T;
+export type ContextFunction<FunctionParams = any, ContextContent = object> = (
+  context: FunctionParams,
+) => Context<ContextContent> | Promise<Context<ContextContent>>;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -77,7 +77,7 @@ interface ExpressContext {
 
 export interface ApolloServerExpressConfig extends Config {
   cors?: CorsOptions | boolean;
-  context?: ContextFunction<ExpressContext> | Context<ExpressContext>;
+  context?: ContextFunction<ExpressContext, Context> | Context;
 }
 
 export class ApolloServer extends ApolloServerBase {

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -24,6 +24,51 @@ describe('apollo-server', () => {
     it('accepts typeDefs and mocks', () => {
       expect(() => new ApolloServer({ typeDefs, mocks: true })).not.toThrow;
     });
+
+    describe('context field', () => {
+      describe('as a function', () => {
+        it('can accept and return `req`', () => {
+          expect(
+            new ApolloServer({
+              typeDefs,
+              resolvers,
+              context: ({ req }) => ({ req }),
+            }),
+          ).not.toThrow;
+        });
+
+        it('can accept nothing and return an empty object', () => {
+          expect(
+            new ApolloServer({
+              typeDefs,
+              resolvers,
+              context: () => ({}),
+            }),
+          ).not.toThrow;
+        });
+      });
+    });
+    describe('as an object', () => {
+      it('can be an empty object', () => {
+        expect(
+          new ApolloServer({
+            typeDefs,
+            resolvers,
+            context: {},
+          }),
+        ).not.toThrow;
+      });
+
+      it('can contain arbitrary values', () => {
+        expect(
+          new ApolloServer({
+            typeDefs,
+            resolvers,
+            context: { value: 'arbitrary' },
+          }),
+        ).not.toThrow;
+      });
+    });
   });
 
   describe('without registerServer', () => {


### PR DESCRIPTION
Inspired by https://github.com/apollographql/apollo-server/pull/2346 , this PR fixes the problem introduced by https://github.com/apollographql/apollo-server/pull/2330 and should be solve the problem brought up in https://github.com/apollographql/apollo-server/issues/1593

The two significant changes are

- Type parameters for context function are now separate from the context it produces https://github.com/apollographql/apollo-server/blob/d08569ef9aaeb8a05aa15fe8438253fde182959d/packages/apollo-server-core/src/types.ts#L33-L35 (so apollo-server-express can say the context function will receive `req` and, but the resulting context doesn't need to contain (or only contain) `req`)
- The type parameter for the Context object is updated from `any` to `object` https://github.com/apollographql/apollo-server/blob/d08569ef9aaeb8a05aa15fe8438253fde182959d/packages/apollo-server-core/src/types.ts#L32 , which I believe is what we really meant

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

