### PR TITLE
Allow Node.js-like runtimes to identify as Node.js as well.

### DIFF
--- a/packages/apollo-server-core/src/utils/createSHA.ts
+++ b/packages/apollo-server-core/src/utils/createSHA.ts
@@ -1,7 +1,7 @@
-import isNode from './isNode';
+import isNodeLike from './isNodeLike';
 
 export default function(kind: string): import('crypto').Hash {
-  if (isNode) {
+  if (isNodeLike) {
     // Use module.require instead of just require to avoid bundling whatever
     // crypto polyfills a non-Node bundler might fall back to.
     return module.require('crypto').createHash(kind);

--- a/packages/apollo-server-core/src/utils/isNode.ts
+++ b/packages/apollo-server-core/src/utils/isNode.ts
@@ -1,6 +1,0 @@
-export default typeof process === 'object' &&
-  process &&
-  process.release &&
-  process.release.name === 'node' &&
-  process.versions &&
-  typeof process.versions.node === 'string';

--- a/packages/apollo-server-core/src/utils/isNodeLike.ts
+++ b/packages/apollo-server-core/src/utils/isNodeLike.ts
@@ -1,0 +1,11 @@
+export default typeof process === 'object' &&
+  process &&
+  // We used to check `process.release.name === "node"`, however that doesn't
+  // account for certain forks of Node.js which are otherwise identical to
+  // Node.js.  For example, NodeSource's N|Solid reports itself as "nsolid",
+  // though it's mostly the same build of Node.js with an extra addon.
+  process.release &&
+  process.versions &&
+  // The one thing which is present on both Node.js and N|Solid (a fork of
+  // Node.js), is `process.versions.node` being defined.
+  typeof process.versions.node === 'string';

--- a/packages/apollo-server-core/src/utils/runtimeSupportsUploads.ts
+++ b/packages/apollo-server-core/src/utils/runtimeSupportsUploads.ts
@@ -1,7 +1,7 @@
-import isNode from './isNode';
+import isNodeLike from './isNodeLike';
 
 const runtimeSupportsUploads = (() => {
-  if (isNode) {
+  if (isNodeLike) {
     const [nodeMajor, nodeMinor] = process.versions.node
       .split('.', 2)
       .map(segment => parseInt(segment, 10));


### PR DESCRIPTION
Previously, in order to only load dependencies which only work on Node.js and fail in non-Node.js environments, we introduced a check which did a string-comparison of `process.release.name` to see if it is was `node`.

This was first introduced in 9c563fae5048f5e77ca2716e3aa3d47044861abf as part of #2054, but has gone on to be useful for other purposes as well.

Some Node.js forks such as NodeSource's N|Solid, which is a fork of Node.js which follows-up each Node.js release with a custom build that includes additional native addons but is otherwise the same, override this value with their own name.  This means that N|Source returns `nsolid`, despite the fact
that it is almost entirely the same as Node.js.

Luckily, N|Solid leaves the base version of its Node.js in `process.versions.node` (and additionally adds its own `process.versions.nsolid`).  By relaxing the string comparison on `process.release.name`, we should still be able to accurately detect the environment we want - which is "Close enough to Node.js!".

Fixes https://github.com/apollographql/apollo-server/issues/2356