### PR TITLE
Move tests for context types from apollo-server into integration testsuite

### DIFF
--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -690,138 +690,6 @@ export function testApolloServer<AS extends ApolloServerBase>(
         expect(formatError).toHaveBeenCalledTimes(1);
       });
 
-      it('defers context eval with thunk until after options creation', async () => {
-        const uniqueContext = { key: 'major' };
-        const typeDefs = gql`
-          type Query {
-            hello: String
-          }
-        `;
-        const resolvers = {
-          Query: {
-            hello: (_parent, _args, context) => {
-              expect(context).toEqual(Promise.resolve(uniqueContext));
-              return 'hi';
-            },
-          },
-        };
-        const spy = jest.fn(() => ({}));
-        const { url: uri } = await createApolloServer({
-          typeDefs,
-          resolvers,
-          context: spy,
-        });
-
-        const apolloFetch = createApolloFetch({ uri });
-
-        expect(spy).not.toBeCalled();
-
-        await apolloFetch({ query: '{hello}' });
-        expect(spy).toHaveBeenCalledTimes(1);
-        await apolloFetch({ query: '{hello}' });
-        expect(spy).toHaveBeenCalledTimes(2);
-      });
-
-      it('allows context to be async function', async () => {
-        const uniqueContext = { key: 'major' };
-        const spy = jest.fn(() => 'hi');
-        const typeDefs = gql`
-          type Query {
-            hello: String
-          }
-        `;
-        const resolvers = {
-          Query: {
-            hello: (_parent, _args, context) => {
-              expect(context.key).toEqual('major');
-              return spy();
-            },
-          },
-        };
-        const { url: uri } = await createApolloServer({
-          typeDefs,
-          resolvers,
-          context: async () => uniqueContext,
-        });
-
-        const apolloFetch = createApolloFetch({ uri });
-
-        expect(spy).not.toBeCalled();
-        await apolloFetch({ query: '{hello}' });
-        expect(spy).toHaveBeenCalledTimes(1);
-      });
-
-      it('clones the context for every request', async () => {
-        const uniqueContext = { key: 'major' };
-        const spy = jest.fn(() => 'hi');
-        const typeDefs = gql`
-          type Query {
-            hello: String
-          }
-        `;
-        const resolvers = {
-          Query: {
-            hello: (_parent, _args, context) => {
-              expect(context.key).toEqual('major');
-              context.key = 'minor';
-              return spy();
-            },
-          },
-        };
-        const { url: uri } = await createApolloServer({
-          typeDefs,
-          resolvers,
-          context: uniqueContext,
-        });
-
-        const apolloFetch = createApolloFetch({ uri });
-
-        expect(spy).not.toBeCalled();
-
-        await apolloFetch({ query: '{hello}' });
-        expect(spy).toHaveBeenCalledTimes(1);
-        await apolloFetch({ query: '{hello}' });
-        expect(spy).toHaveBeenCalledTimes(2);
-      });
-
-      it('returns thrown context error as a valid graphql result', async () => {
-        const nodeEnv = process.env.NODE_ENV;
-        delete process.env.NODE_ENV;
-        const typeDefs = gql`
-          type Query {
-            hello: String
-          }
-        `;
-        const resolvers = {
-          Query: {
-            hello: () => {
-              throw Error('never get here');
-            },
-          },
-        };
-        const { url: uri } = await createApolloServer({
-          typeDefs,
-          resolvers,
-          context: () => {
-            throw new AuthenticationError('valid result');
-          },
-        });
-
-        const apolloFetch = createApolloFetch({ uri });
-
-        const result = await apolloFetch({ query: '{hello}' });
-        expect(result.errors.length).toEqual(1);
-        expect(result.data).toBeUndefined();
-
-        const e = result.errors[0];
-        expect(e.message).toMatch('valid result');
-        expect(e.extensions).toBeDefined();
-        expect(e.extensions.code).toEqual('UNAUTHENTICATED');
-        expect(e.extensions.exception.stacktrace).toBeDefined();
-
-        process.env.NODE_ENV = nodeEnv;
-      });
-
       describe('context field', () => {
         const typeDefs = gql`
           type Query {
@@ -834,6 +702,71 @@ export function testApolloServer<AS extends ApolloServerBase>(
             hello: () => 'hi',
           },
         };
+
+        it('defers context eval with thunk until after options creation', async () => {
+          const uniqueContext = { key: 'major' };
+          const typeDefs = gql`
+            type Query {
+              hello: String
+            }
+          `;
+          const resolvers = {
+            Query: {
+              hello: (_parent, _args, context) => {
+                expect(context).toEqual(Promise.resolve(uniqueContext));
+                return 'hi';
+              },
+            },
+          };
+          const spy = jest.fn(() => ({}));
+          const { url: uri } = await createApolloServer({
+            typeDefs,
+            resolvers,
+            context: spy,
+          });
+
+          const apolloFetch = createApolloFetch({ uri });
+
+          expect(spy).not.toBeCalled();
+
+          await apolloFetch({ query: '{hello}' });
+          expect(spy).toHaveBeenCalledTimes(1);
+          await apolloFetch({ query: '{hello}' });
+          expect(spy).toHaveBeenCalledTimes(2);
+        });
+
+        it('clones the context for every request', async () => {
+          const uniqueContext = { key: 'major' };
+          const spy = jest.fn(() => 'hi');
+          const typeDefs = gql`
+            type Query {
+              hello: String
+            }
+          `;
+          const resolvers = {
+            Query: {
+              hello: (_parent, _args, context) => {
+                expect(context.key).toEqual('major');
+                context.key = 'minor';
+                return spy();
+              },
+            },
+          };
+          const { url: uri } = await createApolloServer({
+            typeDefs,
+            resolvers,
+            context: uniqueContext,
+          });
+
+          const apolloFetch = createApolloFetch({ uri });
+
+          expect(spy).not.toBeCalled();
+
+          await apolloFetch({ query: '{hello}' });
+          expect(spy).toHaveBeenCalledTimes(1);
+          await apolloFetch({ query: '{hello}' });
+          expect(spy).toHaveBeenCalledTimes(2);
+        });
 
         describe('as a function', () => {
           it('can accept and return `req`', async () => {
@@ -855,7 +788,75 @@ export function testApolloServer<AS extends ApolloServerBase>(
               }),
             ).not.toThrow;
           });
+
+          it('can be an async function', async () => {
+            const uniqueContext = { key: 'major' };
+            const spy = jest.fn(() => 'hi');
+            const typeDefs = gql`
+              type Query {
+                hello: String
+              }
+            `;
+            const resolvers = {
+              Query: {
+                hello: (_parent, _args, context) => {
+                  expect(context.key).toEqual('major');
+                  return spy();
+                },
+              },
+            };
+            const { url: uri } = await createApolloServer({
+              typeDefs,
+              resolvers,
+              context: async () => uniqueContext,
+            });
+
+            const apolloFetch = createApolloFetch({ uri });
+
+            expect(spy).not.toBeCalled();
+            await apolloFetch({ query: '{hello}' });
+            expect(spy).toHaveBeenCalledTimes(1);
+          });
+
+          it('returns thrown context error as a valid graphql result', async () => {
+            const nodeEnv = process.env.NODE_ENV;
+            delete process.env.NODE_ENV;
+            const typeDefs = gql`
+              type Query {
+                hello: String
+              }
+            `;
+            const resolvers = {
+              Query: {
+                hello: () => {
+                  throw Error('never get here');
+                },
+              },
+            };
+            const { url: uri } = await createApolloServer({
+              typeDefs,
+              resolvers,
+              context: () => {
+                throw new AuthenticationError('valid result');
+              },
+            });
+
+            const apolloFetch = createApolloFetch({ uri });
+
+            const result = await apolloFetch({ query: '{hello}' });
+            expect(result.errors.length).toEqual(1);
+            expect(result.data).toBeUndefined();
+
+            const e = result.errors[0];
+            expect(e.message).toMatch('valid result');
+            expect(e.extensions).toBeDefined();
+            expect(e.extensions.code).toEqual('UNAUTHENTICATED');
+            expect(e.extensions.exception.stacktrace).toBeDefined();
+
+            process.env.NODE_ENV = nodeEnv;
+          });
         });
+
         describe('as an object', () => {
           it('can be an empty object', async () => {
             expect(

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -822,6 +822,63 @@ export function testApolloServer<AS extends ApolloServerBase>(
         process.env.NODE_ENV = nodeEnv;
       });
 
+      describe('context field', () => {
+        const typeDefs = gql`
+          type Query {
+            hello: String
+          }
+        `;
+
+        const resolvers = {
+          Query: {
+            hello: () => 'hi',
+          },
+        };
+
+        describe('as a function', () => {
+          it('can accept and return `req`', async () => {
+            expect(
+              await createApolloServer({
+                typeDefs,
+                resolvers,
+                context: ({ req }) => ({ req }),
+              }),
+            ).not.toThrow;
+          });
+
+          it('can accept nothing and return an empty object', async () => {
+            expect(
+              await createApolloServer({
+                typeDefs,
+                resolvers,
+                context: () => ({}),
+              }),
+            ).not.toThrow;
+          });
+        });
+        describe('as an object', () => {
+          it('can be an empty object', async () => {
+            expect(
+              await createApolloServer({
+                typeDefs,
+                resolvers,
+                context: {},
+              }),
+            ).not.toThrow;
+          });
+
+          it('can contain arbitrary values', async () => {
+            expect(
+              await createApolloServer({
+                typeDefs,
+                resolvers,
+                context: { value: 'arbitrary' },
+              }),
+            ).not.toThrow;
+          });
+        });
+      });
+
       it('propogates error codes in production', async () => {
         const nodeEnv = process.env.NODE_ENV;
         process.env.NODE_ENV = 'production';

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -24,6 +24,55 @@ describe('apollo-server', () => {
     it('accepts typeDefs and mocks', () => {
       expect(() => new ApolloServer({ typeDefs, mocks: true })).not.toThrow;
     });
+
+    // These tests are duplicates of ones in apollo-server-integration-testsuite
+    // We don't actually expect Jest to do much here, the purpose of these
+    // tests is to make sure our typings are correct, and to trigger a
+    // compile error if they aren't
+    describe('context field', () => {
+      describe('as a function', () => {
+        it('can accept and return `req`', () => {
+          expect(
+            new ApolloServer({
+              typeDefs,
+              resolvers,
+              context: ({ req }) => ({ req }),
+            }),
+          ).not.toThrow;
+        });
+
+        it('can accept nothing and return an empty object', () => {
+          expect(
+            new ApolloServer({
+              typeDefs,
+              resolvers,
+              context: () => ({}),
+            }),
+          ).not.toThrow;
+        });
+      });
+    });
+    describe('as an object', () => {
+      it('can be an empty object', () => {
+        expect(
+          new ApolloServer({
+            typeDefs,
+            resolvers,
+            context: {},
+          }),
+        ).not.toThrow;
+      });
+
+      it('can contain arbitrary values', () => {
+        expect(
+          new ApolloServer({
+            typeDefs,
+            resolvers,
+            context: { value: 'arbitrary' },
+          }),
+        ).not.toThrow;
+      });
+    });
   });
 
   describe('without registerServer', () => {

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -24,51 +24,6 @@ describe('apollo-server', () => {
     it('accepts typeDefs and mocks', () => {
       expect(() => new ApolloServer({ typeDefs, mocks: true })).not.toThrow;
     });
-
-    describe('context field', () => {
-      describe('as a function', () => {
-        it('can accept and return `req`', () => {
-          expect(
-            new ApolloServer({
-              typeDefs,
-              resolvers,
-              context: ({ req }) => ({ req }),
-            }),
-          ).not.toThrow;
-        });
-
-        it('can accept nothing and return an empty object', () => {
-          expect(
-            new ApolloServer({
-              typeDefs,
-              resolvers,
-              context: () => ({}),
-            }),
-          ).not.toThrow;
-        });
-      });
-    });
-    describe('as an object', () => {
-      it('can be an empty object', () => {
-        expect(
-          new ApolloServer({
-            typeDefs,
-            resolvers,
-            context: {},
-          }),
-        ).not.toThrow;
-      });
-
-      it('can contain arbitrary values', () => {
-        expect(
-          new ApolloServer({
-            typeDefs,
-            resolvers,
-            context: { value: 'arbitrary' },
-          }),
-        ).not.toThrow;
-      });
-    });
   });
 
   describe('without registerServer', () => {


### PR DESCRIPTION
Follow up to https://github.com/apollographql/apollo-server/pull/2350/files

This PR only affects tests, and only with organization of tests. No logic inside tests have been changed

- Tests added in https://github.com/apollographql/apollo-server/pull/2350/files have been copied to integration testsuite
- Tests relating to context that are already in the testsuite have been moved inside `describe('context field')`

The reason that the old tests weren't removed is that their main function is to trigger type errors if our provided typing doesn't match what is expected. The integration test suite's `createApolloServer` function uses the `ApolloServerBase` typing, which is still useful to test, but we do still want to test the typing from the `ApolloServer` constructor as well