### PR TITLE
Fix: Remove incorrect cors option type from apollo-server-express's constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- Fix ApolloServerExpressConfig typing incorrectly including cors as part of constructor options [PR #2373](https://github.com/apollographql/apollo-server/pull/2373)
+
 ### v2.4.6
 
 - Allow Node.js-like runtimes to identify as Node.js as well. [PR #2357](https://github.com/apollographql/apollo-server/pull/2357) [Issue #2356](https://github.com/apollographql/apollo-server/issue/2356)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-- Fix ApolloServerExpressConfig typing incorrectly including cors as part of constructor options [PR #2373](https://github.com/apollographql/apollo-server/pull/2373)
+- Fix `ApolloServerExpressConfig` typing incorrectly including `cors` as part of its constructor options. [PR #2373](https://github.com/apollographql/apollo-server/pull/2373)
 
 ### v2.4.6
 

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import corsMiddleware, { CorsOptions } from 'cors';
+import corsMiddleware from 'cors';
 import { json, OptionsJson } from 'body-parser';
 import {
   renderPlaygroundPage,
@@ -76,7 +76,6 @@ export interface ExpressContext {
 }
 
 export interface ApolloServerExpressConfig extends Config {
-  cors?: CorsOptions | boolean;
   context?: ContextFunction<ExpressContext, Context> | Context;
 }
 

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -26,7 +26,11 @@ export class ApolloServer extends ApolloServerBase {
   private httpServer?: http.Server;
   private cors?: CorsOptions | boolean;
 
-  constructor(config: ApolloServerExpressConfig) {
+  constructor(
+    config: ApolloServerExpressConfig & {
+      cors?: CorsOptions | boolean;
+    },
+  ) {
     super(config);
     this.cors = config && config.cors;
   }


### PR DESCRIPTION
Fixes problem brought up in https://github.com/apollographql/apollo-server/pull/2330#discussion_r259773834 - cors options can only be applied to the standalone apollo-server's constructor, for apollo-server-express, their constructor can't contain cors settings, the option is only read from `applyMiddleware`

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests (NA)
* [x] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

