### PR TITLE
Send the original field name instead of its alias - BE-158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### vNEXT
+- `apollo-engine-reporting`, `apollo-engine-reporting-protobuf`: Send the original field name instead of its alias. Update protobuf. [PR #2401](https://github.com/apollographql/apollo-server/pull/2401)
 
 ### v2.4.8
 

--- a/packages/apollo-engine-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/src/reports.proto
@@ -88,10 +88,17 @@ message Trace {
 		// a list).  Note that nodes representing indexes (and the root node)
 		// don't contain all Node fields (eg types and times).
 		oneof id {
-			string field_name = 1;
+			// Older versions of Apollo Engine Reporting (AS <= 2.4.8) would set this
+			// key to be the alias if there was an alias and the field name otherwise.
+			// New agents all use the `original_field_name` key, but we support this
+			// id as well if the newer one is empty for legacy reasons. To specify an
+			// alias, use the alias key.
+			string legacy_field_name_could_be_alias = 1;
+			string original_field_name = 24;
 			uint32 index = 2;
 		}
 
+		string alias = 25;
 		// The field's return type; e.g. "String!" for User.email:String!
 		string type = 3;
 

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -266,7 +266,7 @@ export class EngineReportingExtension<TContext = any>
     }
 
     const path = info.path;
-    const node = this.newNode(path);
+    const node = this.newNode(path, info);
     node.type = info.returnType.toString();
     node.parentType = info.parentType.toString();
     node.startTime = durationHrTimeToNanos(process.hrtime(this.startHrTime));
@@ -307,13 +307,16 @@ export class EngineReportingExtension<TContext = any>
     }
   }
 
-  private newNode(path: ResponsePath): Trace.Node {
+  private newNode(path: ResponsePath, info?: GraphQLResolveInfo): Trace.Node {
     const node = new Trace.Node();
     const id = path.key;
     if (typeof id === 'number') {
       node.index = id;
+    } else if (!info || id === info.fieldName) {
+      node.originalFieldName = id;
     } else {
-      node.fieldName = id;
+      node.originalFieldName = info.fieldName;
+      node.alias = id;
     }
     this.nodes.set(responsePathAsString(path), node);
     const parentNode = this.ensureParentNode(path);


### PR DESCRIPTION
There was a bug where the aliased fieldName would be sent as part of reporting instead of the original fieldName (e.g. via `aliasOfSomeField: originalFieldName`)

The original `fieldName` is now deprecated, and we will instead report the `originalFieldName`, and also `alias` where applicable. 

Note - the `willResolveField` function receives `info`, which contains `info.fieldName` (the value for `originalFieldName`), so we can call `newNode` with the additional argument of the originalFieldName

However, the `newNode` function recursively calls itself via `ensureParentNode`, and at this point does not have the info for the parent node's original field name.

This PR is making an assumption here that (pasting Glasser's comment) "the tree always has to resolve a field before resolving its children, ensureParentNode should never actually need to make a new field (named) node. It might have to make indexed nodes, because array indexes don’t correspond to willResolveField calls. But I _think_ in practice, if parentNode isn’t found in this.nodes, then we **must** be adding an indexed node. Is that wrong?". 

We don't know for sure yet if this is wrong, but at least it will be "less wrong" than the currently reported values

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

