### PR TITLE
Extract TypeScript utility types to `apollo-server-env`

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -7,6 +7,7 @@ import {
   URL,
   URLSearchParams,
   URLSearchParamsInit,
+  ValueOrPromise,
 } from 'apollo-server-env';
 
 import { DataSource, DataSourceConfig } from 'apollo-datasource';
@@ -40,8 +41,6 @@ export interface CacheOptions {
 
 export type Body = BodyInit | object;
 export { Request };
-
-type ValueOrPromise<T> = T | Promise<T>;
 
 export abstract class RESTDataSource<TContext = any> extends DataSource {
   httpCache!: HTTPCache;

--- a/packages/apollo-server-env/src/index.d.ts
+++ b/packages/apollo-server-env/src/index.d.ts
@@ -1,2 +1,3 @@
 export * from './fetch';
 export * from './url';
+export * from './typescript-utility-types';

--- a/packages/apollo-server-env/src/typescript-utility-types.d.ts
+++ b/packages/apollo-server-env/src/typescript-utility-types.d.ts
@@ -1,0 +1,2 @@
+export type ValueOrPromise<T> = T | Promise<T>;
+export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -1,3 +1,5 @@
+import { ValueOrPromise, WithRequired } from 'apollo-server-env';
+export { WithRequired };
 import {
   GraphQLServiceContext,
   GraphQLRequestContext,
@@ -11,16 +13,12 @@ export {
   GraphQLResponse,
 };
 
-type ValueOrPromise<T> = T | Promise<T>;
-
 export interface ApolloServerPlugin {
   serverWillStart?(service: GraphQLServiceContext): ValueOrPromise<void>;
   requestDidStart?<TContext>(
     requestContext: GraphQLRequestContext<TContext>,
   ): GraphQLRequestListener<TContext> | void;
 }
-
-export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
 
 export interface GraphQLRequestListener<TContext = Record<string, any>> {
   parsingDidStart?(


### PR DESCRIPTION
We do the same in `apollo-env`, which this package will likely be merged with when we drop Node 6 support.