### PR TITLE
Propagate new `ValueOrPromise`/`WithRequired` types from `apollo-server-env`.

### DIFF
--- a/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
@@ -8,12 +8,11 @@ import {
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
-import { Headers } from 'apollo-server-env';
+import { Headers, ValueOrPromise } from 'apollo-server-env';
 
 export interface AzureFunctionGraphQLOptionsFunction {
   (request: FunctionRequest, context: HttpContext):
-    | GraphQLOptions
-    | Promise<GraphQLOptions>;
+    ValueOrPromise<GraphQLOptions>;
 }
 
 export interface AzureFunctionHandler {

--- a/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
@@ -11,8 +11,9 @@ import {
 import { Headers, ValueOrPromise } from 'apollo-server-env';
 
 export interface AzureFunctionGraphQLOptionsFunction {
-  (request: FunctionRequest, context: HttpContext):
-    ValueOrPromise<GraphQLOptions>;
+  (request: FunctionRequest, context: HttpContext): ValueOrPromise<
+    GraphQLOptions
+  >;
 }
 
 export interface AzureFunctionHandler {

--- a/packages/apollo-server-azure-functions/src/azureFunctions.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctions.ts
@@ -1,3 +1,5 @@
+import { ValueOrPromise } from 'apollo-server-env';
+
 export type Context = {
   invocationId: string;
   bindingData: any;
@@ -147,5 +149,5 @@ export type HttpContext = Context & {
 };
 
 export interface FunctionHandler {
-  (context: HttpContext, request: FunctionRequest): void | Promise<void>;
+  (context: HttpContext, request: FunctionRequest): ValueOrPromise<void>;
 }

--- a/packages/apollo-server-cloud-functions/src/googleCloudApollo.ts
+++ b/packages/apollo-server-cloud-functions/src/googleCloudApollo.ts
@@ -3,11 +3,11 @@ import {
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
-import { Headers } from 'apollo-server-env';
+import { Headers, ValueOrPromise } from 'apollo-server-env';
 import { Request, Response } from 'express';
 
 export interface CloudFunctionGraphQLOptionsFunction {
-  (req?: Request, res?: Response): GraphQLOptions | Promise<GraphQLOptions>;
+  (req?: Request, res?: Response): ValueOrPromise<GraphQLOptions>;
 }
 
 export function graphqlCloudFunction(

--- a/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
+++ b/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
@@ -4,7 +4,7 @@ import {
   runHttpQuery,
 } from 'apollo-server-core';
 
-import { Request, Response, URL } from 'apollo-server-env';
+import { Request, Response, URL, ValueOrPromise } from 'apollo-server-env';
 
 // Design principles:
 // - You can issue a GET or POST with your query.
@@ -12,7 +12,7 @@ import { Request, Response, URL } from 'apollo-server-env';
 //
 
 export interface CloudflareOptionsFunction {
-  (req?: Request): GraphQLOptions | Promise<GraphQLOptions>;
+  (req?: Request): ValueOrPromise<GraphQLOptions>;
 }
 
 export function graphqlCloudflare(

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -65,9 +65,7 @@ export default GraphQLServerOptions;
 export async function resolveGraphqlOptions(
   options:
     | GraphQLServerOptions
-    | ((
-        ...args: Array<any>
-      ) => ValueOrPromise<GraphQLServerOptions>),
+    | ((...args: Array<any>) => ValueOrPromise<GraphQLServerOptions>),
   ...args: Array<any>
 ): Promise<GraphQLServerOptions> {
   if (typeof options === 'function') {

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -12,6 +12,7 @@ import { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
 import { DataSource } from 'apollo-datasource';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import { GraphQLParseOptions } from 'graphql-tools';
+import { ValueOrPromise } from 'apollo-server-env';
 
 /*
  * GraphQLServerOptions
@@ -66,7 +67,7 @@ export async function resolveGraphqlOptions(
     | GraphQLServerOptions
     | ((
         ...args: Array<any>
-      ) => Promise<GraphQLServerOptions> | GraphQLServerOptions),
+      ) => ValueOrPromise<GraphQLServerOptions>),
   ...args: Array<any>
 ): Promise<GraphQLServerOptions> {
   if (typeof options === 'function') {

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -40,8 +40,8 @@ import {
 import {
   ApolloServerPlugin,
   GraphQLRequestListener,
-  WithRequired,
 } from 'apollo-server-plugin-base';
+import { WithRequired } from 'apollo-server-env';
 
 import { Dispatcher } from './utils/dispatcher';
 import { InMemoryLRUCache, KeyValueCache } from 'apollo-server-caching';

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -1,4 +1,4 @@
-import { Request, Headers } from 'apollo-server-env';
+import { Request, Headers, ValueOrPromise } from 'apollo-server-env';
 import {
   default as GraphQLOptions,
   resolveGraphqlOptions,
@@ -16,7 +16,8 @@ import {
   GraphQLResponse,
 } from './requestPipeline';
 import { CacheControlExtensionOptions } from 'apollo-cache-control';
-import { ApolloServerPlugin, WithRequired } from 'apollo-server-plugin-base';
+import { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import { WithRequired } from 'apollo-server-env';
 
 export interface HttpQueryRequest {
   method: string;
@@ -28,7 +29,7 @@ export interface HttpQueryRequest {
   query: Record<string, any> | Array<Record<string, any>>;
   options:
     | GraphQLOptions
-    | ((...args: Array<any>) => Promise<GraphQLOptions> | GraphQLOptions);
+    | ((...args: Array<any>) => ValueOrPromise<GraphQLOptions>);
   request: Pick<Request, 'url' | 'method' | 'headers'>;
 }
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -5,6 +5,7 @@ import {
   IMocks,
   GraphQLParseOptions,
 } from 'graphql-tools';
+import { ValueOrPromise } from 'apollo-server-env';
 import { ConnectionContext } from 'subscriptions-transport-ws';
 // The types for `ws` use `export = WebSocket`, so we'll use the
 // matching `import =` to bring in its sole export.
@@ -32,7 +33,7 @@ export { KeyValueCache } from 'apollo-server-caching';
 export type Context<T = object> = T;
 export type ContextFunction<FunctionParams = any, ProducedContext = object> = (
   context: FunctionParams,
-) => Context<ProducedContext> | Promise<Context<ProducedContext>>;
+) => ValueOrPromise<Context<ProducedContext>>;
 
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -5,11 +5,11 @@ import {
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
+import { ValueOrPromise } from 'apollo-server-env';
 
 export interface ExpressGraphQLOptionsFunction {
   (req?: express.Request, res?: express.Response):
-    | GraphQLOptions
-    | Promise<GraphQLOptions>;
+    | ValueOrPromise<GraphQLOptions>;
 }
 
 // Design principles:

--- a/packages/apollo-server-express/src/expressApollo.ts
+++ b/packages/apollo-server-express/src/expressApollo.ts
@@ -8,8 +8,9 @@ import {
 import { ValueOrPromise } from 'apollo-server-env';
 
 export interface ExpressGraphQLOptionsFunction {
-  (req?: express.Request, res?: express.Response):
-    | ValueOrPromise<GraphQLOptions>;
+  (req?: express.Request, res?: express.Response): ValueOrPromise<
+    GraphQLOptions
+  >;
 }
 
 // Design principles:

--- a/packages/apollo-server-fastify/src/fastifyApollo.ts
+++ b/packages/apollo-server-fastify/src/fastifyApollo.ts
@@ -5,12 +5,13 @@ import {
 } from 'apollo-server-core';
 import { FastifyReply, FastifyRequest, RequestHandler } from 'fastify';
 import { IncomingMessage, OutgoingMessage } from 'http';
+import { ValueOrPromise } from 'apollo-server-env';
 
 export async function graphqlFastify(
   options: (
     req?: FastifyRequest<IncomingMessage>,
     res?: FastifyReply<OutgoingMessage>,
-  ) => GraphQLOptions | Promise<GraphQLOptions>,
+  ) => ValueOrPromise<GraphQLOptions>,
 ): Promise<RequestHandler<IncomingMessage, OutgoingMessage>> {
   if (!options) {
     throw new Error('Apollo Server requires options.');

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -5,6 +5,7 @@ import {
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
+import { ValueOrPromise } from 'apollo-server-env';
 
 export interface IRegister {
   (server: Server, options: any, next?: Function): void;
@@ -17,7 +18,7 @@ export interface IPlugin {
 }
 
 export interface HapiOptionsFunction {
-  (request?: Request): GraphQLOptions | Promise<GraphQLOptions>;
+  (request?: Request): ValueOrPromise<GraphQLOptions>;
 }
 
 export interface HapiPluginOptions {

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -20,6 +20,7 @@ import request = require('supertest');
 
 import { GraphQLOptions, Config } from 'apollo-server-core';
 import gql from 'graphql-tag';
+import { ValueOrPromise } from 'apollo-server-env';
 
 export * from './ApolloServer';
 
@@ -189,16 +190,16 @@ export interface CreateAppOptions {
   excludeParser?: boolean;
   graphqlOptions?:
     | GraphQLOptions
-    | { (): GraphQLOptions | Promise<GraphQLOptions> }
+    | { (): ValueOrPromise<GraphQLOptions> }
     | Config;
 }
 
 export interface CreateAppFunc {
-  (options?: CreateAppOptions): any | Promise<any>;
+  (options?: CreateAppOptions): ValueOrPromise<any>;
 }
 
 export interface DestroyAppFunc {
-  (app: any): void | Promise<void>;
+  (app: any): ValueOrPromise<void>;
 }
 
 export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {

--- a/packages/apollo-server-koa/src/koaApollo.ts
+++ b/packages/apollo-server-koa/src/koaApollo.ts
@@ -5,9 +5,10 @@ import {
   runHttpQuery,
   convertNodeHttpToRequest,
 } from 'apollo-server-core';
+import { ValueOrPromise } from 'apollo-server-env';
 
 export interface KoaGraphQLOptionsFunction {
-  (ctx: Koa.Context): GraphQLOptions | Promise<GraphQLOptions>;
+  (ctx: Koa.Context): ValueOrPromise<GraphQLOptions>;
 }
 
 export interface KoaHandler {

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -7,8 +7,9 @@ import {
 import { Headers, ValueOrPromise } from 'apollo-server-env';
 
 export interface LambdaGraphQLOptionsFunction {
-  (event: lambda.APIGatewayProxyEvent, context: lambda.Context):
-    | ValueOrPromise<GraphQLOptions>;
+  (event: lambda.APIGatewayProxyEvent, context: lambda.Context): ValueOrPromise<
+    GraphQLOptions
+  >;
 }
 
 export function graphqlLambda(

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -4,12 +4,11 @@ import {
   HttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
-import { Headers } from 'apollo-server-env';
+import { Headers, ValueOrPromise } from 'apollo-server-env';
 
 export interface LambdaGraphQLOptionsFunction {
   (event: lambda.APIGatewayProxyEvent, context: lambda.Context):
-    | GraphQLOptions
-    | Promise<GraphQLOptions>;
+    | ValueOrPromise<GraphQLOptions>;
 }
 
 export function graphqlLambda(

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -8,10 +8,11 @@ import url from 'url';
 import { IncomingMessage, ServerResponse } from 'http';
 
 import { MicroRequest } from './types';
+import { ValueOrPromise } from 'apollo-server-env';
 
 // Allowed Micro Apollo Server options.
 export interface MicroGraphQLOptionsFunction {
-  (req?: IncomingMessage): GraphQLOptions | Promise<GraphQLOptions>;
+  (req?: IncomingMessage): ValueOrPromise<GraphQLOptions>;
 }
 
 // Utility function used to set multiple headers on a response object.

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -1,5 +1,4 @@
 import { ValueOrPromise, WithRequired } from 'apollo-server-env';
-export { WithRequired };
 import {
   GraphQLServiceContext,
   GraphQLRequestContext,


### PR DESCRIPTION
Now that the `ValueOrPromise` and `WithRequired` types are more ubiquitously available after @martijnwalraven's #2415 which brought them to `apollo-server-env`, we can change the existing cases where we've used these patterns or depended on them from less-than-ideal modules (like `apollo-server-plugin-base`).