### PR TITLE
Avoid duplicate `cacheControl` directives via `isDirectiveDefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - `apollo-datasource-rest`: Correctly allow a TTL value of `0` to represent "not-cacheable". [PR #2588](https://github.com/apollographql/apollo-server/pull/2588)
 - `apollo-datasource-rest`: Fix `Invalid argument` in IE11, when `this.headers` is `undefined`. [PR #2607](https://github.com/apollographql/apollo-server/pull/2607)
 
+- Don't add `cacheControl` directive if one has already been defined. [PR #2428](https://github.com/apollographql/apollo-server/pull/2428)
+
 ### v2.4.8
 
 - No functional changes in this version.  The patch version has been bumped to fix the `README.md` displayed on the [npm package for `apollo-server`](https://npm.im/apollo-server) as a result of a broken publish.  Apologies for the additional noise!

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -51,6 +51,7 @@ import {
 } from './playground';
 
 import { generateSchemaHash } from './utils/schemaHash';
+import { isDirectiveDefined } from './utils/isDirectiveDefined';
 import {
   processGraphQLRequest,
   GraphQLRequestContext,
@@ -270,19 +271,22 @@ export class ApolloServerBase {
 
       // We augment the typeDefs with the @cacheControl directive and associated
       // scope enum, so makeExecutableSchema won't fail SDL validation
-      augmentedTypeDefs.push(
-        gql`
-          enum CacheControlScope {
-            PUBLIC
-            PRIVATE
-          }
 
-          directive @cacheControl(
-            maxAge: Int
-            scope: CacheControlScope
-          ) on FIELD_DEFINITION | OBJECT | INTERFACE
-        `,
-      );
+      if (!isDirectiveDefined(augmentedTypeDefs, 'cacheControl')) {
+        augmentedTypeDefs.push(
+          gql`
+            enum CacheControlScope {
+              PUBLIC
+              PRIVATE
+            }
+
+            directive @cacheControl(
+              maxAge: Int
+              scope: CacheControlScope
+            ) on FIELD_DEFINITION | OBJECT | INTERFACE
+          `,
+        );
+      }
 
       if (this.uploadsConfig) {
         const { GraphQLUpload } = require('graphql-upload');

--- a/packages/apollo-server-core/src/__tests__/isDirectiveDefined.ts
+++ b/packages/apollo-server-core/src/__tests__/isDirectiveDefined.ts
@@ -1,0 +1,44 @@
+import { gql } from '../';
+import { isDirectiveDefined } from '../utils/isDirectiveDefined';
+
+describe('isDirectiveDefined', () => {
+  it('returns false when a directive is not defined', () => {
+    expect(
+      isDirectiveDefined(
+        [
+          gql`
+            type Query {
+              hello: String
+            }
+          `,
+        ],
+        'cacheControl',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when a directive is defined', () => {
+    expect(
+      isDirectiveDefined(
+        [
+          gql`
+            type Query {
+              hello: String
+            }
+
+            enum CacheControlScope {
+              PUBLIC
+              PRIVATE
+            }
+
+            directive @cacheControl(
+              maxAge: Int
+              scope: CacheControlScope
+            ) on FIELD_DEFINITION | OBJECT | INTERFACE
+          `,
+        ],
+        'cacheControl',
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/apollo-server-core/src/utils/isDirectiveDefined.ts
+++ b/packages/apollo-server-core/src/utils/isDirectiveDefined.ts
@@ -1,0 +1,16 @@
+import { DocumentNode, DefinitionNode, DirectiveDefinitionNode } from 'graphql';
+
+const isDirectiveNode = (
+  node: DefinitionNode,
+): node is DirectiveDefinitionNode => node.kind === 'DirectiveDefinition';
+
+export const isDirectiveDefined = (
+  typeDefs: DocumentNode[],
+  directiveName: string,
+) =>
+  typeDefs.some(typeDef =>
+    typeDef.definitions.some(
+      definition =>
+        isDirectiveNode(definition) && definition.name.value === directiveName,
+    ),
+  );

--- a/packages/apollo-server-core/src/utils/isDirectiveDefined.ts
+++ b/packages/apollo-server-core/src/utils/isDirectiveDefined.ts
@@ -1,12 +1,4 @@
-import {
-  DocumentNode,
-  DefinitionNode,
-  DirectiveDefinitionNode,
-} from 'graphql/language';
-
-const isDirectiveNode = (
-  node: DefinitionNode,
-): node is DirectiveDefinitionNode => node.kind === 'DirectiveDefinition';
+import { DocumentNode, Kind } from 'graphql/language';
 
 export const isDirectiveDefined = (
   typeDefs: DocumentNode[],
@@ -15,6 +7,7 @@ export const isDirectiveDefined = (
   typeDefs.some(typeDef =>
     typeDef.definitions.some(
       definition =>
-        isDirectiveNode(definition) && definition.name.value === directiveName,
+        definition.kind === Kind.DIRECTIVE_DEFINITION &&
+        definition.name.value === directiveName,
     ),
   );

--- a/packages/apollo-server-core/src/utils/isDirectiveDefined.ts
+++ b/packages/apollo-server-core/src/utils/isDirectiveDefined.ts
@@ -1,4 +1,8 @@
-import { DocumentNode, DefinitionNode, DirectiveDefinitionNode } from 'graphql';
+import {
+  DocumentNode,
+  DefinitionNode,
+  DirectiveDefinitionNode,
+} from 'graphql/language';
 
 const isDirectiveNode = (
   node: DefinitionNode,


### PR DESCRIPTION
This PR adds a utility function `isDirectiveDefined` and uses it to guard against duplicate directives when the user's schema already contains a directive (in this case, cacheControl)

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

