### PR TITLE
Make some tests run properly

### DIFF
--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -76,13 +76,13 @@ describe('apollo-server-fastify', () => {
     if (httpServer) await httpServer.close();
   });
 
-  describe('constructor', async () => {
+  describe('constructor', () => {
     it('accepts typeDefs and resolvers', () => {
       return createServer({ typeDefs, resolvers });
     });
   });
 
-  describe('applyMiddleware', async () => {
+  describe('applyMiddleware', () => {
     it('can be queried', async () => {
       const { url: uri } = await createServer({
         typeDefs,


### PR DESCRIPTION
- apollo-server-azure-functions: a test was failing (expectedResult needed to
  have {data:} and be converted to string) but it was happening in an unhandled
  promise. Restructure test to fail, then fix the test.

- apollo-server-fastify: after the upgrade in #2418, Jest started warning that
  async describe blocks were bad. Fix that.
