### PR TITLE
apollo-server-core: pass req obj to context when invoking executeOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 - Allow `GraphQLRequestListener` callbacks in plugins to depend on `this`. [PR #2470](https://github.com/apollographql/apollo-server/pull/2470)
+- `apollo-server-core`: Pass request object to `context` callback function when invoking the `executeOperation` method. [PR #2478](https://github.com/apollographql/apollo-server/pull/2478)
 
 ### v2.4.8
 

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -572,7 +572,7 @@ export class ApolloServerBase {
     let options;
 
     try {
-      options = await this.graphQLServerOptions();
+      options = await this.graphQLServerOptions({ req: request });
     } catch (e) {
       e.message = `Invalid options provided to ApolloServer: ${e.message}`;
       throw new Error(e);

--- a/packages/apollo-server-core/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/__tests__/ApolloServer.test.ts
@@ -1,0 +1,40 @@
+import MockReq = require('mock-req');
+
+import { ApolloServerBase } from '../ApolloServer';
+import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
+
+const queryType = new GraphQLObjectType({
+  name: 'QueryType',
+  fields: {
+    testString: {
+      type: GraphQLString,
+      resolve() {
+        return 'it works';
+      },
+    },
+  },
+});
+
+describe('ApolloServer', () => {
+  describe('executeOperation', () => {
+    it('Passes the request object to the context callback', () => {
+      const schema = new GraphQLSchema({
+        query: queryType,
+      });
+      const contextMock = jest.fn();
+      const apolloServer = new ApolloServerBase({
+        schema,
+        context: contextMock,
+      });
+      const mockRequest = new MockReq();
+      const operation = {
+        query: '{ }',
+        http: mockRequest,
+      };
+
+      apolloServer.executeOperation(operation);
+
+      expect(contextMock).toHaveBeenCalledWith({ req: operation });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2277.

`apollo-server-testing` relies on `apollo-server-core` to execute queries for integration tests, via the `executeOperation` method.

However, when executing a query via `executeOperation`, `apollo-server-core` was not passing the `req` object to the `context` callback function used to create the server.

This is fine if you're using a mock `context` object directly in your tests, but for tests that want to run a `context` callback that contains logic that depends on that `req` object, it would fail.

Note that long-term the best fix for this is probably that `apollo-server-testing` should use the `ApolloServer` class from `apollo-server-express` internally, instead of `ApolloServerBase` from `apollo-server-core`, since it seems like that is the class that is used by default in `apollo-server`.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

