### PR TITLE
Upgrade docs theme

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6642,9 +6642,9 @@
       }
     },
     "gatsby-theme-apollo": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo/-/gatsby-theme-apollo-0.1.9.tgz",
-      "integrity": "sha512-7/InzbHXAUYysYDFs+6+a354bCsjJqqmGbtPo8cooRV+OBAt04zxfRLtDMPRInb3hh01HqykJFLLGaWV6WGV5A==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo/-/gatsby-theme-apollo-0.1.10.tgz",
+      "integrity": "sha512-fMPPa+2HEh2ADEpbnMozNZbWSZEVppFTIXpG20pTHzUMPmgMyOeZjQ1jeVSfLozIYg+L+iKbskg3RBbBUVgIlQ==",
       "requires": {
         "@emotion/core": "^10.0.7",
         "@emotion/styled": "^10.0.7",
@@ -6666,15 +6666,15 @@
       }
     },
     "gatsby-theme-apollo-docs": {
-      "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-0.2.38.tgz",
-      "integrity": "sha512-XJ2VDqbUbP1uYfFdfamA466ydeAXP/BI0CWUmHQE5DNDj6AQ3ydjejQmaE/NAFb9HJPjOkmNkSYt/6h07KX+dg==",
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-0.2.39.tgz",
+      "integrity": "sha512-AKmWScjcxWklp6bVmYAjZSCSm6jt1mxpZ24OzUqNdpeBv7Wu6Co0PE3LBpO/z6a+MUjNogubqwqkqtOgwlLPhg==",
       "requires": {
         "detab": "^2.0.1",
         "gatsby": "^2.2.6",
         "gatsby-plugin-google-analytics": "^2.0.17",
         "gatsby-plugin-less": "^2.0.12",
-        "gatsby-theme-apollo": "^0.1.9",
+        "gatsby-theme-apollo": "^0.1.10",
         "gray-matter": "^4.0.1",
         "handlebars": "^4.1.0",
         "hast-util-is-element": "^1.0.2",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6666,9 +6666,9 @@
       }
     },
     "gatsby-theme-apollo-docs": {
-      "version": "0.2.39",
-      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-0.2.39.tgz",
-      "integrity": "sha512-AKmWScjcxWklp6bVmYAjZSCSm6jt1mxpZ24OzUqNdpeBv7Wu6Co0PE3LBpO/z6a+MUjNogubqwqkqtOgwlLPhg==",
+      "version": "0.2.40",
+      "resolved": "https://registry.npmjs.org/gatsby-theme-apollo-docs/-/gatsby-theme-apollo-docs-0.2.40.tgz",
+      "integrity": "sha512-mjwxveRCrMsVhmmpZd2YZW89CVAWnWgqwfcQp7LOYDybDV/BcmFG3U8FxtzC/heaGVQZ68u/JtmY5h26DxLwsQ==",
       "requires": {
         "detab": "^2.0.1",
         "gatsby": "^2.2.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "gatsby": "2.3.2",
-    "gatsby-theme-apollo-docs": "^0.2.39"
+    "gatsby-theme-apollo-docs": "^0.2.40"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,6 @@
   },
   "dependencies": {
     "gatsby": "2.3.2",
-    "gatsby-theme-apollo-docs": "0.2.38"
+    "gatsby-theme-apollo-docs": "^0.2.39"
   }
 }


### PR DESCRIPTION
This branch upgrades the docs theme with the following changes:

- Fix Algolia indexing
- Give the top category in the sidebar a top border
- Allow the main content to scroll with arrows/space
- Limit right nav headings to h2s