### PR TITLE
Fix playground image

### DIFF
--- a/docs/source/features/graphql-playground.md
+++ b/docs/source/features/graphql-playground.md
@@ -8,7 +8,7 @@ description: Visually exploring an Apollo Server
 In development, Apollo Server enables GraphQL Playground on the same URL as the GraphQL server itself (e.g. `http://localhost:4000/graphql`) and automatically serves the GUI to web browsers.  When `NODE_ENV` is set to `production`, GraphQL Playground (as well as introspection) is disabled as a production best-practice.
 
 <div align="center">
-![GraphQL Playground](../images/graphql-playground.png)
+  <img src="../images/graphql-playground.png" alt="GraphQL Playground">
 </div>
 
 ## Configuring Playground

--- a/docs/source/features/graphql-playground.md
+++ b/docs/source/features/graphql-playground.md
@@ -7,9 +7,7 @@ description: Visually exploring an Apollo Server
 
 In development, Apollo Server enables GraphQL Playground on the same URL as the GraphQL server itself (e.g. `http://localhost:4000/graphql`) and automatically serves the GUI to web browsers.  When `NODE_ENV` is set to `production`, GraphQL Playground (as well as introspection) is disabled as a production best-practice.
 
-<div align="center">
-  <img src="../images/graphql-playground.png" alt="GraphQL Playground">
-</div>
+![GraphQL Playground](../images/graphql-playground.png)
 
 ## Configuring Playground
 


### PR DESCRIPTION
This branch fixes a broken image in the GraphQL Playground page. Here's what it looks like:

![Screen Shot 2019-03-27 at 1 58 18 PM](https://user-images.githubusercontent.com/1216917/55111804-70d88580-5098-11e9-8fb4-98cc3902ca82.png)

Due to the way that our multi-version docs theme works, this change will be made live in prod when a new version of `apollo-server` is made and the tag is pushed to master.
