### PR TITLE
Align peer dependency range in apollo-tracing with other packages

### DIFF
--- a/packages/apollo-tracing/package.json
+++ b/packages/apollo-tracing/package.json
@@ -15,6 +15,6 @@
     "graphql-extensions": "file:../graphql-extensions"
   },
   "peerDependencies": {
-    "graphql": "0.10.x - 14.2.x"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   }
 }


### PR DESCRIPTION
All other packages in this repository specify `graphql@^14.0.0` which
allows minor and patch releases of `graphql`. But the `apollo-tracing`
package only allows `graphql@14.2.x` which covers only patch releases.
This commit changes the peer dependency range of `graphql` in the
`apollo-tracing` package to contain the same ranges as all other
packages in this repository (`^0.12.0 || ^0.13.0 || ^14.0.0`).

Technically this would be a breaking change, because before it allowed `0.10.x - 14.2.x`,
so if that is a concern we could also change the range to include `0.10.x` and `0.11.x` (`^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0`) but I figured being consistent with the other packages is more important and since none of the other packages allow `0.10.x - 0.11.x` this packages shouldn't too.

Or is there a reason why `apollo-tracing` is more strict than the other packages?

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

