### PR TITLE
tests: Expand helper for trace tests.

### DIFF
--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -452,12 +452,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
         const { url: uri } = await createApolloServer({
           typeDefs: gql`
             type Query {
-              error: String
+              fieldWhichWillError: String
             }
           `,
           resolvers: {
             Query: {
-              error: () => {
+              fieldWhichWillError: () => {
                 return throwError();
               },
             },
@@ -470,9 +470,9 @@ export function testApolloServer<AS extends ApolloServerBase>(
         const apolloFetch = createApolloFetch({ uri });
 
         const result = await apolloFetch({
-          query: '{error}',
+          query: '{fieldWhichWillError}',
         });
-        expect(result.data).toEqual({ error: null });
+        expect(result.data).toEqual({ fieldWhichWillError: null });
         expect(result.errors).toBeDefined();
         expect(result.errors[0].extensions.code).toEqual('BAD_USER_INPUT');
         expect(result.errors[0].message).toEqual('User Input Error');
@@ -626,12 +626,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const { url: uri } = await createApolloServer({
             typeDefs: gql`
               type Query {
-                error: String
+                fieldWhichWillError: String
               }
             `,
             resolvers: {
               Query: {
-                error: () => {
+                fieldWhichWillError: () => {
                   throwError();
                 },
               },
@@ -655,10 +655,10 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const apolloFetch = createApolloFetch({ uri });
 
           const result = await apolloFetch({
-            query: `{error}`,
+            query: `{fieldWhichWillError}`,
           });
           expect(result.data).toEqual({
-            error: null,
+            fieldWhichWillError: null,
           });
           expect(result.errors).toBeDefined();
           expect(result.errors[0].message).toEqual('masked');
@@ -711,12 +711,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
         const { url: uri } = await createApolloServer({
           typeDefs: gql`
             type Query {
-              error: String
+              fieldWhichWillError: String
             }
           `,
           resolvers: {
             Query: {
-              error: () => {},
+              fieldWhichWillError: () => {},
             },
           },
           extensions: [() => new Extension()],
@@ -727,7 +727,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
         const apolloFetch = createApolloFetch({ uri });
 
         const result = await apolloFetch({
-          query: `{error}`,
+          query: `{fieldWhichWillError}`,
         });
         expect(result.data).toBeUndefined();
         expect(result.errors).toBeDefined();
@@ -932,12 +932,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
         const { url: uri } = await createApolloServer({
           typeDefs: gql`
             type Query {
-              error: String
+              fieldWhichWillError: String
             }
           `,
           resolvers: {
             Query: {
-              error: () => {
+              fieldWhichWillError: () => {
                 throw new AuthenticationError('we the best music');
               },
             },
@@ -946,9 +946,9 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
         const apolloFetch = createApolloFetch({ uri });
 
-        const result = await apolloFetch({ query: `{error}` });
+        const result = await apolloFetch({ query: `{fieldWhichWillError}` });
         expect(result.data).toBeDefined();
-        expect(result.data).toEqual({ error: null });
+        expect(result.data).toEqual({ fieldWhichWillError: null });
 
         expect(result.errors).toBeDefined();
         expect(result.errors.length).toEqual(1);
@@ -965,12 +965,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
         const { url: uri } = await createApolloServer({
           typeDefs: gql`
             type Query {
-              error: String!
+              fieldWhichWillError: String!
             }
           `,
           resolvers: {
             Query: {
-              error: () => {
+              fieldWhichWillError: () => {
                 throw new AuthenticationError('we the best music');
               },
             },
@@ -979,7 +979,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
         const apolloFetch = createApolloFetch({ uri });
 
-        const result = await apolloFetch({ query: `{error}` });
+        const result = await apolloFetch({ query: `{fieldWhichWillError}` });
         expect(result.data).toBeNull();
 
         expect(result.errors).toBeDefined();


### PR DESCRIPTION
This one very important 115-line test:

https://github.com/apollographql/apollo-server/blob/c85c6d286df2e918225681ae42020ea0eb08215c/packages/apollo-server-integration-testsuite/src/ApolloServer.ts#L528-L643

...has grown to a point where it's a bit conflated.  Rather than becoming a new test with a separate concern, it's been added to as we've continued to expand observability features.

When looking at #1639, I was tempted to do the same thing, but felt it was worth breaking out the test into various helpers for reusability in new (upcoming!) tests.

There are two main changes here:

* Rename the `error` field which is used amongst many of the tests to something more recognizable, particularly since `error` itself is a protobuf property which these tests exercise:

  https://github.com/apollographql/apollo-server/blob/a849cf9ba2bf4621746803e7cbfbe594f38575cd/packages/apollo-engine-reporting-protobuf/src/reports.proto#L108

  My poor brain was confused on more than one occasion by the presence of a `error` field within an `error` object, so I hope to spare those brain palpitations in the future.

* Turn the mock engine reporting server (meant to represent a server on the receiving side of `apollo-engine-reporting`) into a reusable, strongly-typed class: `EngineMockServer`.

As I noted in the commit message for https://github.com/apollographql/apollo-server/commit/6e218ea968a37858843fa5321a3a3a929dce6a4e, another take on this might have implemented [`nock`](npm.im/nock), but that was a more substantial re-factor.