### PR TITLE
Fix createTestClient types

### DIFF
--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-testing"
   },
+  "scripts": {
+    "test": "../../node_modules/.bin/jest"
+  },
   "keywords": [
     "GraphQL",
     "Apollo",

--- a/packages/apollo-server-testing/src/__tests__/createTestClient.test.ts
+++ b/packages/apollo-server-testing/src/__tests__/createTestClient.test.ts
@@ -16,8 +16,8 @@ describe('createTestClient', () => {
 
   const resolvers = {
     Query: {
-      test: (_, { echo }) => echo,
-      hello: (_, __, { person }) => {
+      test: (_: any, { echo }: any) => echo,
+      hello: (_: any, __: any, { person }: any) => {
         return `hello ${person}`;
       },
     },


### PR DESCRIPTION
## The problem

I was following [this documentation](https://github.com/apollographql/apollo-server/blob/046327068b5cbb2d80c3865cdb2566654ea988c9/docs/source/features/testing.md) which shows code like this:

```ts
const { createTestClient } = require('apollo-server-testing');
const { query, mutate } = createTestClient(server);

query({
  query: GET_USER,
  variables: { id: 1 }
});
```

When I tried that, TypeScript complained about the `variables` object. This can be also replicated by opening the [`createTestClient.test.ts`](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-testing/src/__tests__/createTestClient.test.ts#L52) file:

<img width="635" alt="Screenshot 2019-04-12 at 18 47 00" src="https://user-images.githubusercontent.com/101152/56053098-7221d780-5d53-11e9-86ca-08ea4985ee8c.png">

## The fix

To fix this, I've updated the typing of the `test` function in 62bea35. With this and another fix in 4ccc129, the `createTestClient.test.ts` file is clear of any errors.

## VSCode experience

The experience when typing a call site code seems to be good. Initially, it offer all three properties:

<img width="600" alt="Screenshot 2019-04-12 at 18 54 37" src="https://user-images.githubusercontent.com/101152/56053477-77cbed00-5d54-11e9-9d5a-ca850b4b9881.png">

Once a query or a mutation is chosen, it narrows down suggestions to only `variables`:

<img width="528" alt="Screenshot 2019-04-12 at 18 55 54" src="https://user-images.githubusercontent.com/101152/56053523-9e8a2380-5d54-11e9-94ab-72e1c7c19b08.png">

Providing both is an error:

<img width="347" alt="Screenshot 2019-04-12 at 18 56 38" src="https://user-images.githubusercontent.com/101152/56053558-bb265b80-5d54-11e9-84cf-e11c3e672ae6.png">

Adding `variables` is valid:

<img width="459" alt="Screenshot 2019-04-12 at 18 57 43" src="https://user-images.githubusercontent.com/101152/56053614-e315bf00-5d54-11e9-8978-8e9b15bb718c.png">

It is done using function overloads which I generally don't like very much but maybe here, it's a good use case for them.

## Is the change from `...rest` to `variables` OK?

The code now only allows (strongly-typed) `variables` while previously, it worked with `...rest`. Is this change OK? I think it should be as the tests don't show any other use case but it's a change in functionality so I thought I'd rather ask.

## TODO

* [ ] _(probably not necessary?)_ Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass. _(I'm not quite sure how to do that only for the `apollo-server-testing` but I've ran all tests in this package and they are green.)_

