### PR TITLE
Update VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
   "editor.tabSize": 2,
   "editor.rulers": [80],
   "editor.wordWrapColumn": 80,
-  "editor.formatOnSave": true,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   "files.exclude": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
   "editor.wordWrapColumn": 80,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
-  "files.exclude": {
-    "**/.git": true,
-    "**/.DS_Store": true,
+  "search.exclude": {
     "**/node_modules/": true,
     "**/dist/": true,
     "coverage": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,5 @@
   "editor.wordWrapColumn": 80,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
-  "search.exclude": {
-    "**/node_modules/": true,
-    "**/dist/": true,
-    "coverage": true,
-    "coverage.lcov": true
-  },
   "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
I was thinking that something was wrong with my local clone because I could not see the `dist` folder after I ran `npm run compile`:

<img width="259" alt="Screenshot 2019-04-13 at 09 33 21" src="https://user-images.githubusercontent.com/101152/56076254-32003a80-5dcf-11e9-8f97-780d8372d876.png">

The `tsconfig.tsbuildinfo` file was there (gray because gitignored) while the `dist` folder wasn't. I thought the TypeScript setup is not correct or something only to realize that VSCode workspace settings hide this folder.

I think it's better when only "system" files like `.git` and `.DS_Store` are hidden entirely while `node_modules` and `dist` are still browsable in VSCode _but_ excluded from search (that is very important). It's occasionally useful to browse `node_modules` or to peek into `dist`...

Initially, I replaced `files.exclude` with `search.exclude` but it's not even necessary to have `search.exclude` at all – VSCode will apply `.gitignore` rules automatically.

---

The other change in this PR is removing `editor.formatOnSave` option which I believe is a user preference. For example, after I edited the `files.exclude` section and pressed Save, the whole `.vscode/settings.json` was re-formatted which produced more diffs than I intended.

---

Overall, the workspace settings now only contain simple, unopinionated values.

---

TODO:

* [ ] _(Is it necessary?)_ Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] _N/A_ Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

