### PR TITLE
apollo-server-lambda/src/lambdaApollo no longer errors when event.isBase64Encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 - Allow `GraphQLRequestListener` callbacks in plugins to depend on `this`. [PR #2470](https://github.com/apollographql/apollo-server/pull/2470)
+- `apollo-server-lambda` no longer throws SyntaxError when lambda event.isBase64Encoded === true [PR #2600](https://github.com/apollographql/apollo-server/pull/2600)
 
 ### v2.4.8
 

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -43,7 +43,11 @@ export function graphqlLambda(
       options: options,
       query:
         event.httpMethod === 'POST' && event.body
-          ? JSON.parse(event.body)
+          ? JSON.parse(
+              event.isBase64Encoded
+                ? Buffer.from(event.body, 'base64').toString()
+                : event.body,
+            )
           : event.queryStringParameters,
       request: {
         url: event.path,


### PR DESCRIPTION
Resolves https://github.com/apollographql/apollo-server/issues/2599

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

