### PR TITLE
Make ApolloServerBase#{context,subscriptionServer} protected, not pri…

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -109,7 +109,7 @@ export class ApolloServerBase {
   public graphqlPath: string = '/graphql';
   public requestOptions: Partial<GraphQLOptions<any>> = Object.create(null);
 
-  private context?: Context | ContextFunction;
+  protected context?: Context | ContextFunction;
   private engineReportingAgent?: import('apollo-engine-reporting').EngineReportingAgent;
   private engineServiceId?: string;
   private extensions: Array<() => GraphQLExtension>;
@@ -121,7 +121,7 @@ export class ApolloServerBase {
   protected uploadsConfig?: FileUploadOptions;
 
   // set by installSubscriptionHandlers.
-  private subscriptionServer?: SubscriptionServer;
+  protected subscriptionServer?: SubscriptionServer;
 
   // the default version is specified in playground.ts
   protected playgroundOptions?: PlaygroundRenderPageOptions;


### PR DESCRIPTION
…vate

This will allow extensions of `ApolloServerBase` to make alternative implementations of `#installSubscriptionHandlers` and thus use a `SubscriptionServer` implementation other than that from `subscriptions-transport-ws`.

Here is an example of an `ApolloServerBase` [mixin](https://mariusschulz.com/blog/typescript-2-2-mixin-classes) that would compile iff this PR is merged (but cannot without this PR). It looks long, but it's basically exactly what the current method does, but not hard-coded to only use `subscription-transport-ws`

```typescript
import { ApolloServerBase, Context, formatApolloErrors } from "apollo-server-core";
import {
  execute,
  ExecutionResult,
  subscribe,
} from 'graphql';
import { Server as HttpServer } from 'http';
import {
  ExecutionParams,
  SubscriptionServer,
} from 'subscriptions-transport-ws';

type Constructor<T = {}> = new (...args: any[]) => T;

/**
 * Mixin to ApolloServerBase to override the `installSubscriptionHandlers` method to use a custom implementation of SubscriptionServer.
 * Without this, it is hardcoded to use the one from subscription-transport-ws.
 */
const WithCustomSubscriptions = <ApolloServerConstructor extends Constructor<ApolloServerBase>>(
  ApolloServer: ApolloServerConstructor,
  createSubscriptionServer: typeof SubscriptionServer.create,
): Constructor<ApolloServerBase> => {
  return class ApolloServerWithCustomSubscriptions extends ApolloServer {
    /**
     * Modify an HttpServer so that it serves graphql-ws requests.
     * This also creates a SubscriptionServer and assigns it to this.subscriptionServer.
     * https://www.apollographql.com/docs/apollo-server/features/subscriptions#middleware
     */
    public installSubscriptionHandlers(server: HttpServer) {
      if (!this.subscriptionServerOptions) {
        if (this.supportsSubscriptions()) {
          throw Error(
            'Subscriptions are disabled, due to subscriptions set to false in the ApolloServer constructor',
          );
        } else {
          throw Error(
            'Subscriptions are not supported, choose an integration, such as apollo-server-express that allows persistent connections',
          );
        }
      }

      const {
        onDisconnect,
        onConnect,
        keepAlive,
        path,
      } = this.subscriptionServerOptions;

      this.subscriptionServer = createSubscriptionServer(
        {
          execute,
          keepAlive,
          onConnect: onConnect
            ? onConnect
            : (connectionParams: object) => ({ ...connectionParams }),
          onDisconnect,
          onOperation: async (
            message: {
              /** message payload for this operation */
              payload: any
            },
            connection: ExecutionParams,
          ) => {
            connection.formatResponse = (value: ExecutionResult) => ({
              ...value,
              errors:
                value.errors &&
                formatApolloErrors([...value.errors], {
                  debug: this.requestOptions.debug,
                  formatter: this.requestOptions.formatError,
                }),
            });
            let context: Context = this.context ? this.context : { connection };

            try {
              context =
                typeof this.context === 'function'
                  ? await this.context({ connection, payload: message.payload })
                  : context;
            } catch (e) {
              throw formatApolloErrors([e], {
                debug: this.requestOptions.debug,
                formatter: this.requestOptions.formatError,
              })[0];
            }

            return { ...connection, context };
          },
          schema: this.schema,
          subscribe,
        },
        {
          path,
          server,
        },
      );
    }
  };
}
```

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

