### PR TITLE
Fix Headers bug in IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 - Allow `GraphQLRequestListener` callbacks in plugins to depend on `this`. [PR #2470](https://github.com/apollographql/apollo-server/pull/2470)
+- Fix `Invalid argument` in IE11, when using `apollo-datasource-rest` when `this.headers` is `undefined`. [PR #2607](https://github.com/apollographql/apollo-server/pull/2607)
 
 ### v2.4.8
 

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -201,7 +201,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     }
 
     if (!(init.headers && init.headers instanceof Headers)) {
-      init.headers = new Headers(init.headers);
+      init.headers = new Headers(init.headers || {});
     }
 
     const options = init as RequestOptions;

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -201,7 +201,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     }
 
     if (!(init.headers && init.headers instanceof Headers)) {
-      init.headers = new Headers(init.headers || {});
+      init.headers = new Headers(init.headers || Object.create(null));
     }
 
     const options = init as RequestOptions;


### PR DESCRIPTION
When calling `new Headers(undefined)` in IE11 an `Invalid argument` exception is thrown.
With this in place, we'll call it with an empty object, resulting in an empty Headers object.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [x] Make sure all of the significant new logic is covered by tests
* [x] Rebase your changes on master so that they can be merged easily
* [x] Make sure all tests and linter rules pass

Edit:

I mistakenly wrote `null`, where I meant to write `undefined`.