### PR TITLE
disable callbackWaitsForEmptyEventLoop

### DIFF
--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -119,7 +119,7 @@ export class ApolloServer extends ApolloServerBase {
       }
 
       if (event.httpMethod === 'OPTIONS') {
-        context.callbackWaitsForEmptyEventLoop = false
+        context.callbackWaitsForEmptyEventLoop = false;
         return callback(null, {
           body: '',
           statusCode: 204,

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -119,6 +119,7 @@ export class ApolloServer extends ApolloServerBase {
       }
 
       if (event.httpMethod === 'OPTIONS') {
+        context.callbackWaitsForEmptyEventLoop = false
         return callback(null, {
           body: '',
           statusCode: 204,


### PR DESCRIPTION
Disable callbackWaitsForEmptyEventLoop for HTTP OPTIONS request since ApolloServer already disable callbackWaitsForEmptyEventLoop for POST request. (https://github.com/apollographql/apollo-server/blob/1ec2890397ca306350b0e1f33eec7b5f3f951d8d/packages/apollo-server-lambda/src/lambdaApollo.ts#L33)

Otherwise is lambda event loop is not empty, subsequence HTTP OPTIONS request will be hang and even timeout without throwing proper error.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

