### PR TITLE
Transition Apollo Tooling deps to latest from alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,23 +4,11 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@apollographql/apollo-tools": {
-      "version": "0.3.6-alpha.1",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.6-alpha.1.tgz",
-      "integrity": "sha512-fq74In3Vw9OmtKHze0L5/Ns/pdTZOqUeFVC6Um9NRgziVehXz/qswsh2r3+dsn82uqoa/AlvckHtd6aPPPYj9g==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.3.6.tgz",
+      "integrity": "sha512-j59jXpFACU1WY5+O2T7qg5OgIPIiOoynO+UlOsDWiazmqc1dOe597VlIraj1w+XClYrerx6NhhLY2yHXECYFVA==",
       "requires": {
-        "apollo-env": "0.4.1-alpha.1"
-      },
-      "dependencies": {
-        "apollo-env": {
-          "version": "0.4.1-alpha.1",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.4.1-alpha.1.tgz",
-          "integrity": "sha512-4qWiaUKWh92jvKxxRsiZSjmW9YH9GWSG1W6X+S1BcC1uqtPiHsem7ExG9MMTt+UrzHsbpQLctj12xk8lI4lgCg==",
-          "requires": {
-            "core-js": "3.0.0-beta.13",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        }
+        "apollo-env": "0.5.0"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -3103,38 +3091,27 @@
       "version": "file:packages/apollo-engine-reporting",
       "requires": {
         "apollo-engine-reporting-protobuf": "file:packages/apollo-engine-reporting-protobuf",
-        "apollo-graphql": "^0.2.1-alpha.1",
+        "apollo-graphql": "^0.3.0",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "async-retry": "^1.2.1",
         "graphql-extensions": "file:packages/graphql-extensions"
-      },
-      "dependencies": {
-        "apollo-env": {
-          "version": "0.4.1-alpha.1",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.4.1-alpha.1.tgz",
-          "integrity": "sha512-4qWiaUKWh92jvKxxRsiZSjmW9YH9GWSG1W6X+S1BcC1uqtPiHsem7ExG9MMTt+UrzHsbpQLctj12xk8lI4lgCg==",
-          "requires": {
-            "core-js": "3.0.0-beta.13",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "apollo-graphql": {
-          "version": "0.2.1-alpha.1",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.2.1-alpha.1.tgz",
-          "integrity": "sha512-kObCSpYRHEf4IozJV+TZAXEL2Yni2DpzQckohJNYXg5/KRAF20jJ7lHxuJz+kMQrc7QO4wYGSa29HuFZH2AtQA==",
-          "requires": {
-            "apollo-env": "0.4.1-alpha.1",
-            "lodash.sortby": "^4.7.0"
-          }
-        }
       }
     },
     "apollo-engine-reporting-protobuf": {
       "version": "file:packages/apollo-engine-reporting-protobuf",
       "requires": {
         "protobufjs": "^6.8.6"
+      }
+    },
+    "apollo-env": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.0.tgz",
+      "integrity": "sha512-yzajZupxouVtSUJiqkjhiQZKnagfwZeHjqRHkgV+rTCNuJkfdcoskSQm7zk5hhcS1JMunuD6INC1l4PHq+o+wQ==",
+      "requires": {
+        "core-js": "3.0.0-beta.13",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
       }
     },
     "apollo-fetch": {
@@ -3144,6 +3121,15 @@
       "dev": true,
       "requires": {
         "cross-fetch": "^1.0.0"
+      }
+    },
+    "apollo-graphql": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.0.tgz",
+      "integrity": "sha512-YDQV3Bnzmhk3e+shmqUongZ0g3ZLluya7uHoFkENWclZ8JEAsVv+75bYk2YDTJvAp85p3jvwPsbJo3fW06Orsw==",
+      "requires": {
+        "apollo-env": "0.5.0",
+        "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-link": {
@@ -3250,7 +3236,7 @@
     "apollo-server-core": {
       "version": "file:packages/apollo-server-core",
       "requires": {
-        "@apollographql/apollo-tools": "^0.3.6-alpha.1",
+        "@apollographql/apollo-tools": "^0.3.6",
         "@apollographql/graphql-playground-html": "^1.6.6",
         "@types/ws": "^6.0.0",
         "apollo-cache-control": "file:packages/apollo-cache-control",
@@ -7328,7 +7314,7 @@
     "graphql-extensions": {
       "version": "file:packages/graphql-extensions",
       "requires": {
-        "@apollographql/apollo-tools": "^0.3.6-alpha.1"
+        "@apollographql/apollo-tools": "^0.3.6"
       }
     },
     "graphql-subscriptions": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/apollo-tools": "^0.3.6-alpha.1",
+    "@apollographql/apollo-tools": "^0.3.6",
     "apollo-cache-control": "file:packages/apollo-cache-control",
     "apollo-datasource": "file:packages/apollo-datasource",
     "apollo-datasource-rest": "file:packages/apollo-datasource-rest",

--- a/packages/apollo-engine-reporting/package.json
+++ b/packages/apollo-engine-reporting/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "apollo-engine-reporting-protobuf": "file:../apollo-engine-reporting-protobuf",
-    "apollo-graphql": "^0.2.1-alpha.1",
+    "apollo-graphql": "^0.3.0",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "async-retry": "^1.2.1",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -24,7 +24,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@apollographql/apollo-tools": "^0.3.6-alpha.1",
+    "@apollographql/apollo-tools": "^0.3.6",
     "@apollographql/graphql-playground-html": "^1.6.6",
     "@types/ws": "^6.0.0",
     "apollo-cache-control": "file:../apollo-cache-control",

--- a/packages/graphql-extensions/package.json
+++ b/packages/graphql-extensions/package.json
@@ -14,7 +14,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "@apollographql/apollo-tools": "^0.3.6-alpha.1"
+    "@apollographql/apollo-tools": "^0.3.6"
   },
   "devDependencies": {
     "apollo-server-core": "file:../apollo-server-core",


### PR DESCRIPTION
With the release of federation features within the Apollo Tooling repo, we can now update `apollo-server` and friends over to use the `latest` packages from that repo, rather than the `alpha`s.

<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Make sure all of the significant new logic is covered by tests
* [ ] Rebase your changes on master so that they can be merged easily
* [ ] Make sure all tests and linter rules pass

