### PR TITLE
extensions: add setParsed and capture error in extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- extensions: add setParsed to ensure we get an operation signature and capture errors in extensions when they occur in unexpected locations [PR#2659](https://github.com/apollographql/apollo-server/pull/2659)
+
 ### v2.5.0
 
 #### New

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -95,6 +95,10 @@ export class EngineReportingExtension<TContext = any>
       });
   }
 
+  public setParsedDocument(parsedDocument: DocumentNode) {
+    this.documentAST = parsedDocument;
+  }
+
   public requestDidStart(o: {
     request: Request;
     queryString?: string;

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -95,8 +95,14 @@ export class EngineReportingExtension<TContext = any>
       });
   }
 
-  public setParsedDocument(parsedDocument: DocumentNode) {
+  public setParsedDocumentAndOperationName(
+    parsedDocument: DocumentNode,
+    operationName: string | undefined,
+  ) {
     this.documentAST = parsedDocument;
+    if (operationName) {
+      this.operationName = operationName;
+    }
   }
 
   public requestDidStart(o: {

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -217,7 +217,10 @@ export async function processGraphQLRequest<TContext>(
     }
 
     if (requestContext.document) {
-      extensionStack.setParsedDocument(requestContext.document);
+      extensionStack.setParsedDocumentAndOperationName(
+        requestContext.document,
+        request.operationName,
+      );
     } else {
       // If we still don't have a document, we'll need to parse and validate it.
       // With success, we'll attempt to save it into the store for future use.
@@ -231,7 +234,10 @@ export async function processGraphQLRequest<TContext>(
 
       try {
         requestContext.document = parse(query, config.parseOptions);
-        extensionStack.setParsedDocument(requestContext.document);
+        extensionStack.setParsedDocumentAndOperationName(
+          requestContext.document,
+          request.operationName,
+        );
         parsingDidEnd();
       } catch (syntaxError) {
         parsingDidEnd(syntaxError);

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -43,6 +43,7 @@ export class GraphQLExtension<TContext = any> {
     context: TContext;
     requestContext: GraphQLRequestContext<TContext>;
   }): EndHandler | void;
+  public setParsedDocument?(parsedDocument: DocumentNode): void;
   public parsingDidStart?(o: { queryString: string }): EndHandler | void;
   public validationDidStart?(): EndHandler | void;
   public executionDidStart?(o: {
@@ -99,6 +100,12 @@ export class GraphQLExtensionStack<TContext = any> {
       ext => ext.parsingDidStart && ext.parsingDidStart(o),
     );
   }
+  public setParsedDocument(parsedDocument: DocumentNode): void {
+    this.handleDidStart(
+      ext => ext.setParsedDocument && ext.setParsedDocument(parsedDocument),
+    );
+  }
+
   public validationDidStart(): EndHandler {
     return this.handleDidStart(
       ext => ext.validationDidStart && ext.validationDidStart(),

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -43,7 +43,10 @@ export class GraphQLExtension<TContext = any> {
     context: TContext;
     requestContext: GraphQLRequestContext<TContext>;
   }): EndHandler | void;
-  public setParsedDocument?(parsedDocument: DocumentNode): void;
+  public setParsedDocumentAndOperationName?(
+    parsedDocument: DocumentNode,
+    operationName: string | undefined,
+  ): void;
   public parsingDidStart?(o: { queryString: string }): EndHandler | void;
   public validationDidStart?(): EndHandler | void;
   public executionDidStart?(o: {
@@ -100,9 +103,14 @@ export class GraphQLExtensionStack<TContext = any> {
       ext => ext.parsingDidStart && ext.parsingDidStart(o),
     );
   }
-  public setParsedDocument(parsedDocument: DocumentNode): void {
+  public setParsedDocumentAndOperationName(
+    parsedDocument: DocumentNode,
+    operationName: string | undefined,
+  ): void {
     this.handleDidStart(
-      ext => ext.setParsedDocument && ext.setParsedDocument(parsedDocument),
+      ext =>
+        ext.setParsedDocumentAndOperationName &&
+        ext.setParsedDocumentAndOperationName(parsedDocument, operationName),
     );
   }
 


### PR DESCRIPTION
Currently we don't set the parsed document in extensions immediately,
which means that apollo-engine-reporting is forced to return a full signature
instead of the normalized signature. This leads to cardinality
explosion. This ensures that we report with a normalized signature and
report errors that occur in the requestPipeline.


<!--
  Thanks for filing a pull request on GraphQL Server!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

* [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
* [ ] Rebase your changes on master so that they can be merged easily