### PR TITLE
chore: Switch Apollo Engine Reporting comments to `tsdoc`.

### DIFF
--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -28,65 +28,103 @@ export type GenerateClientInfo<TContext> = (
 ) => ClientInfo;
 
 export interface EngineReportingOptions<TContext> {
-  // API key for the service. Get this from
-  // [Engine](https://engine.apollographql.com) by logging in and creating
-  // a service. You may also specify this with the `ENGINE_API_KEY`
-  // environment variable; the option takes precedence. __Required__.
+  /**
+   * API key for the service. Get this from
+   * [Engine](https://engine.apollographql.com) by logging in and creating
+   * a service. You may also specify this with the `ENGINE_API_KEY`
+   * environment variable; the option takes precedence. __Required__.
+   */
   apiKey?: string;
-  // Specify the function for creating a signature for a query. See signature.ts
-  // for details.
+  /**
+   * Specify the function for creating a signature for a query. See signature.ts
+   * for details.
+   */
   calculateSignature?: (ast: DocumentNode, operationName: string) => string;
-  // How often to send reports to the Engine server. We'll also send reports
-  // when the report gets big; see maxUncompressedReportSize.
+  /**
+   * How often to send reports to the Engine server. We'll also send reports
+   * when the report gets big; see maxUncompressedReportSize.
+   */
   reportIntervalMs?: number;
-  // We send a report when the report size will become bigger than this size in
-  // bytes (default: 4MB).  (This is a rough limit --- we ignore the size of the
-  // report header and some other top level bytes. We just add up the lengths of
-  // the serialized traces and signatures.)
+  /**
+   * We send a report when the report size will become bigger than this size in
+   * bytes (default: 4MB).  (This is a rough limit --- we ignore the size of the
+   * report header and some other top level bytes. We just add up the lengths of
+   * the serialized traces and signatures.)
+   */
   maxUncompressedReportSize?: number;
-  // The URL of the Engine report ingress server.
+  /**
+   * The URL of the Engine report ingress server.
+   */
   endpointUrl?: string;
-  // If set, prints all reports as JSON when they are sent.
+  /**
+   * If set, prints all reports as JSON when they are sent.
+   */
   debugPrintReports?: boolean;
-  // HTTP(s) agent to be used on the fetch call to apollo-engine metrics endpoint
+  /**
+   * HTTP(s) agent to be used on the fetch call to apollo-engine metrics endpoint
+   */
   requestAgent?: RequestAgent | false;
-  // Reporting is retried with exponential backoff up to this many times
-  // (including the original request). Defaults to 5.
+  /**
+   * Reporting is retried with exponential backoff up to this many times
+   * (including the original request). Defaults to 5.
+   */
   maxAttempts?: number;
-  // Minimum backoff for retries. Defaults to 100ms.
+  /**
+   * Minimum back-off for retries. Defaults to 100ms.
+   */
   minimumRetryDelayMs?: number;
-  // By default, errors that occur when sending trace reports to Engine servers
-  // will be logged to standard error. Specify this function to process errors
-  // in a different way.
+  /**
+   * By default, errors that occur when sending trace reports to Engine servers
+   * will be logged to standard error. Specify this function to process errors
+   * in a different way.
+   */
   reportErrorFunction?: (err: Error) => void;
-  // A case-sensitive list of names of variables whose values should not be sent
-  // to Apollo servers, or 'true' to leave out all variables. In the former
-  // case, the report will indicate that each private variable was redacted; in
-  // the latter case, no variables are sent at all.
+  /**
+   * A case-sensitive list of names of variables whose values should not be sent
+   * to Apollo servers, or 'true' to leave out all variables. In the former
+   * case, the report will indicate that each private variable was redacted; in
+   * the latter case, no variables are sent at all.
+   */
   privateVariables?: Array<String> | boolean;
-  // A case-insensitive list of names of HTTP headers whose values should not be
-  // sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike
-  // with privateVariables, names of dropped headers are not reported.
+  /**
+   * A case-insensitive list of names of HTTP headers whose values should not be
+   * sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike
+   * with privateVariables, names of dropped headers are not reported.
+   */
   privateHeaders?: Array<String> | boolean;
-  // By default, EngineReportingAgent listens for the 'SIGINT' and 'SIGTERM'
-  // signals, stops, sends a final report, and re-sends the signal to
-  // itself. Set this to false to disable. You can manually invoke 'stop()' and
-  // 'sendReport()' on other signals if you'd like. Note that 'sendReport()'
-  // does not run synchronously so it cannot work usefully in an 'exit' handler.
+  /**
+   * By default, EngineReportingAgent listens for the 'SIGINT' and 'SIGTERM'
+   * signals, stops, sends a final report, and re-sends the signal to
+   * itself. Set this to false to disable. You can manually invoke 'stop()' and
+   * 'sendReport()' on other signals if you'd like. Note that 'sendReport()'
+   * does not run synchronously so it cannot work usefully in an 'exit' handler.
+   */
   handleSignals?: boolean;
-  // Sends the trace report immediately. This options is useful for stateless environments
+  /**
+   * Sends the trace report immediately. This options is useful for stateless environments
+   */
   sendReportsImmediately?: boolean;
-  // (DEPRECATED; Use `rewriteError` instead) To remove the error message
-  // from traces, set this to true. Defaults to false.
+  /**
+   * @deprecated Use `rewriteError` instead.
+   * @default false
+   *
+   * To remove the error message from traces, set this to true.
+   */
   maskErrorDetails?: boolean;
-  // By default, all errors get reported to Engine servers. You can specify a
-  // a filter function to exclude specific errors from being reported by
-  // returning an explicit `null`, or you can mask certain details of the error
-  // by modifying it and returning the modified error.
+  /**
+   * By default, all errors get reported to Engine servers. You can specify a
+   * a filter function to exclude specific errors from being reported by
+   * returning an explicit `null`, or you can mask certain details of the error
+   * by modifying it and returning the modified error.
+   */
   rewriteError?: (err: GraphQLError) => GraphQLError | null;
-  // A human readable name to tag this variant of a schema (i.e. staging, EU)
+  /**
+   * A human readable name to tag this variant of a schema (i.e. staging, EU)
+   */
   schemaTag?: string;
-  //Creates the client information for operation traces.
+  /**
+   * Creates the client information for operation traces.
+   */
   generateClientInfo?: GenerateClientInfo<TContext>;
 }
 


### PR DESCRIPTION
Ran a quick transformation on these comments in the
`apollo-engine-reporting` package to change them to `tsdoc` format.

By using the C-style `tsdoc` comments, these descriptions will actually be
displayed within editors that support JSDoc (i.e. most).
