### PR TITLE
Defer and cache calculation of Engine reporting signature.

### DIFF
--- a/packages/apollo-cache-control/package.json
+++ b/packages/apollo-cache-control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-control",
-  "version": "0.6.0",
+  "version": "0.7.0-alpha.0",
   "description": "A GraphQL extension for cache control",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/apollo-engine-reporting/package.json
+++ b/packages/apollo-engine-reporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-engine-reporting",
-  "version": "1.1.0",
+  "version": "1.2.0-alpha.0",
   "description": "Send reports about your GraphQL services to Apollo Engine",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
@@ -1,0 +1,13 @@
+import { signatureCacheKey } from '../agent';
+
+describe('signature cache key', () => {
+  it('generates without the operationName', () => {
+    expect(signatureCacheKey('abc123', '')).toEqual('abc123');
+  });
+
+  it('generates without the operationName', () => {
+    expect(signatureCacheKey('abc123', 'myOperation')).toEqual(
+      'abc123:myOperation',
+    );
+  });
+});

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -50,7 +50,11 @@ test('trace construction', async () => {
   enableGraphQLExtensions(schema);
 
   const traces: Array<any> = [];
-  function addTrace(signature: string, operationName: string, trace: Trace) {
+  function addTrace(
+    signature: Promise<string | null>,
+    operationName: string,
+    trace: Trace,
+  ) {
     traces.push({ signature, operationName, trace });
   }
 

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -16,6 +16,8 @@ import {
   GraphQLRequestContext,
   GraphQLServiceContext,
 } from 'apollo-server-core/dist/requestPipelineAPI';
+import { InMemoryLRUCache } from 'apollo-server-caching';
+import { defaultEngineReportingSignature } from 'apollo-graphql';
 
 export interface ClientInfo {
   clientName?: string;
@@ -128,6 +130,14 @@ export interface EngineReportingOptions<TContext> {
   generateClientInfo?: GenerateClientInfo<TContext>;
 }
 
+export interface AddTraceArgs {
+  trace: Trace;
+  operationName: string;
+  queryHash: string;
+  queryString?: string;
+  documentAST?: DocumentNode;
+}
+
 const serviceHeaderDefaults = {
   hostname: os.hostname(),
   // tslint:disable-next-line no-var-requires
@@ -149,6 +159,7 @@ export class EngineReportingAgent<TContext = any> {
   private sendReportsImmediately?: boolean;
   private stopped: boolean = false;
   private reportHeader: ReportHeader;
+  private signatureCache: InMemoryLRUCache<string>;
 
   public constructor(
     options: EngineReportingOptions<TContext> = {},
@@ -161,6 +172,11 @@ export class EngineReportingAgent<TContext = any> {
         'To use EngineReportingAgent, you must specify an API key via the apiKey option or the ENGINE_API_KEY environment variable.',
       );
     }
+
+    // Since calculating the signature for Engine reporting is potentially an
+    // expensive operation, we'll cache the signatures we generate and re-use
+    // them based on repeated traces for the same `queryHash`.
+    this.signatureCache = createSignatureCache();
 
     this.reportHeader = new ReportHeader({
       ...serviceHeaderDefaults,
@@ -196,7 +212,59 @@ export class EngineReportingAgent<TContext = any> {
     );
   }
 
-  public addTrace(signature: string, operationName: string, trace: Trace) {
+  private async getTraceSignature({
+    queryHash,
+    operationName,
+    documentAST,
+    queryString,
+  }: {
+    queryHash: string;
+    operationName: string;
+    documentAST?: DocumentNode;
+    queryString?: string;
+  }): Promise<string> {
+    if (!documentAST && !queryString) {
+      // This shouldn't happen: one of those options must be passed to runQuery.
+      throw new Error('No queryString or parsedQuery?');
+    }
+
+    // If we didn't have the signature in the cache, we'll resort to
+    // calculating it asynchronously.  The `addTrace` method will
+    // `await` the `signature` if it's a Promise, prior to putting it
+    // on the stack of traces to deliver to the cloud.
+    const cachedSignature = await this.signatureCache.get(queryHash);
+
+    if (cachedSignature) {
+      return cachedSignature;
+    }
+
+    if (!documentAST) {
+      // We didn't get an AST, possibly because of a parse failure. Let's just
+      // use the full query string.
+      //
+      // XXX This does mean that even if you use a calculateSignature which
+      //     hides literals, you might end up sending literals for queries
+      //     that fail parsing or validation. Provide some way to mask them
+      //     anyway?
+      return queryString as string;
+    }
+
+    const generatedSignature = (this.options.calculateSignature ||
+      defaultEngineReportingSignature)(documentAST, operationName);
+
+    // Intentionally not awaited so the cache can be written to at leisure.
+    this.signatureCache.set(queryHash, generatedSignature);
+
+    return generatedSignature;
+  }
+
+  public async addTrace({
+    trace,
+    queryHash,
+    documentAST,
+    operationName,
+    queryString,
+  }: AddTraceArgs): Promise<void> {
     // Ignore traces that come in after stop().
     if (this.stopped) {
       return;
@@ -207,6 +275,13 @@ export class EngineReportingAgent<TContext = any> {
       throw new Error(`Error encoding trace: ${protobufError}`);
     }
     const encodedTrace = Trace.encode(trace).finish();
+
+    const signature = await this.getTraceSignature({
+      queryHash,
+      documentAST,
+      queryString,
+      operationName,
+    });
 
     const statsReportKey = `# ${operationName || '-'}\n${signature}`;
     if (!this.report.tracesPerQuery.hasOwnProperty(statsReportKey)) {
@@ -226,7 +301,7 @@ export class EngineReportingAgent<TContext = any> {
       this.reportSize >=
         (this.options.maxUncompressedReportSize || 4 * 1024 * 1024)
     ) {
-      this.sendReportAndReportErrors();
+      await this.sendReportAndReportErrors();
     }
   }
 
@@ -350,4 +425,50 @@ export class EngineReportingAgent<TContext = any> {
     this.report = new FullTracesReport({ header: this.reportHeader });
     this.reportSize = 0;
   }
+}
+
+function createSignatureCache(): InMemoryLRUCache<string> {
+  let lastSignatureCacheWarn: Date;
+  let lastSignatureCacheDisposals: number = 0;
+  return new InMemoryLRUCache<string>({
+    // Calculate the length of cache objects by the JSON.stringify byteLength.
+    sizeCalculator(obj) {
+      return Buffer.byteLength(JSON.stringify(obj), 'utf8');
+    },
+    // 3MiB limit, very much approximately since we can't be sure how V8 might
+    // be storing these strings internally. Though this should be enough to
+    // store a fair amount of operation signatures (~10000?), depending on their
+    // overall complexity. A future version of this might expose some
+    // configuration option to grow the cache, but ideally, we could do that
+    // dynamically based on the resources available to the server, and not add
+    // more configuration surface area. Hopefully the warning message will allow
+    // us to evaluate the need with more validated input from those that receive
+    // it.
+    maxSize: Math.pow(2, 20) * 3,
+    onDispose() {
+      // Count the number of disposals between warning messages.
+      lastSignatureCacheDisposals++;
+
+      // Only show a message warning about the high turnover every 60 seconds.
+      if (
+        !lastSignatureCacheWarn ||
+        new Date().getTime() - lastSignatureCacheWarn.getTime() > 60000
+      ) {
+        // Log the time that we last displayed the message.
+        lastSignatureCacheWarn = new Date();
+        console.warn(
+          [
+            'This server is processing a high number of unique operations.  ',
+            `A total of ${lastSignatureCacheDisposals} records have been `,
+            'ejected from the Engine Reporting signature cache in the past ',
+            'interval.  If you see this warning frequently, please open an ',
+            'issue on the Apollo Server repository.',
+          ].join(''),
+        );
+
+        // Reset the disposal counter for the next message interval.
+        lastSignatureCacheDisposals = 0;
+      }
+    },
+  });
 }

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -11,8 +11,11 @@ import {
 import { GraphQLExtension, EndHandler } from 'graphql-extensions';
 import { Trace, google } from 'apollo-engine-reporting-protobuf';
 
-import { EngineReportingOptions, GenerateClientInfo } from './agent';
-import { defaultEngineReportingSignature } from 'apollo-graphql';
+import {
+  EngineReportingOptions,
+  GenerateClientInfo,
+  AddTraceArgs,
+} from './agent';
 import { GraphQLRequestContext } from 'apollo-server-core/dist/requestPipelineAPI';
 
 const clientNameHeaderKey = 'apollographql-client-name';
@@ -47,16 +50,12 @@ export class EngineReportingExtension<TContext = any>
   private queryString?: string;
   private documentAST?: DocumentNode;
   private options: EngineReportingOptions<TContext>;
-  private addTrace: (
-    signature: string,
-    operationName: string,
-    trace: Trace,
-  ) => void;
+  private addTrace: (args: AddTraceArgs) => Promise<void>;
   private generateClientInfo: GenerateClientInfo<TContext>;
 
   public constructor(
     options: EngineReportingOptions<TContext>,
-    addTrace: (signature: string, operationName: string, trace: Trace) => void,
+    addTrace: (args: AddTraceArgs) => Promise<void>,
   ) {
     this.options = {
       ...options,
@@ -102,7 +101,10 @@ export class EngineReportingExtension<TContext = any>
     variables?: Record<string, any>;
     context: TContext;
     extensions?: Record<string, any>;
-    requestContext: WithRequired<GraphQLRequestContext<TContext>, 'metrics'>;
+    requestContext: WithRequired<
+      GraphQLRequestContext<TContext>,
+      'metrics' | 'queryHash'
+    >;
   }): EndHandler {
     this.trace.startTime = dateToTimestamp(new Date());
     this.startHrTime = process.hrtime();
@@ -110,6 +112,7 @@ export class EngineReportingExtension<TContext = any>
     // Generally, we'll get queryString here and not parsedQuery; we only get
     // parsedQuery if you're using an OperationStore. In normal cases we'll get
     // our documentAST in the execution callback after it is parsed.
+    const queryHash = o.requestContext.queryHash;
     this.queryString = o.queryString;
     this.documentAST = o.parsedQuery;
 
@@ -223,26 +226,14 @@ export class EngineReportingExtension<TContext = any>
         .responseCacheHit;
 
       const operationName = this.operationName || '';
-      let signature;
-      if (this.documentAST) {
-        const calculateSignature =
-          this.options.calculateSignature || defaultEngineReportingSignature;
-        signature = calculateSignature(this.documentAST, operationName);
-      } else if (this.queryString) {
-        // We didn't get an AST, possibly because of a parse failure. Let's just
-        // use the full query string.
-        //
-        // XXX This does mean that even if you use a calculateSignature which
-        //     hides literals, you might end up sending literals for queries
-        //     that fail parsing or validation. Provide some way to mask them
-        //     anyway?
-        signature = this.queryString;
-      } else {
-        // This shouldn't happen: one of those options must be passed to runQuery.
-        throw new Error('No queryString or parsedQuery?');
-      }
 
-      this.addTrace(signature, operationName, this.trace);
+      this.addTrace({
+        operationName,
+        queryHash,
+        documentAST: this.documentAST,
+        queryString: this.queryString || '',
+        trace: this.trace,
+      });
     };
   }
 

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "2.5.0",
+	"version": "2.6.0-alpha.0",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -197,7 +197,10 @@ export async function processGraphQLRequest<TContext>(
     context: requestContext.context,
     persistedQueryHit: metrics.persistedQueryHit,
     persistedQueryRegister: metrics.persistedQueryRegister,
-    requestContext,
+    requestContext: requestContext as WithRequired<
+      typeof requestContext,
+      'metrics' | 'queryHash'
+    >,
   });
 
   try {

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-base",
-  "version": "0.4.0",
+  "version": "0.5.0-alpha.0",
   "description": "Apollo Server plugin base classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-response-cache",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.0",
   "description": "Apollo Server full query response cache",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-testing",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Test utils for apollo-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.5.0",
+  "version": "2.6.0-alpha.0",
   "description": "Production ready GraphQL Server",
   "author": "opensource@apollographql.com",
   "main": "dist/index.js",

--- a/packages/apollo-tracing/package.json
+++ b/packages/apollo-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-tracing",
-  "version": "0.6.0",
+  "version": "0.7.0-alpha.0",
   "description": "Collect and expose trace data for GraphQL requests",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/graphql-extensions/package.json
+++ b/packages/graphql-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-extensions",
-  "version": "0.6.0",
+  "version": "0.7.0-alpha.0",
   "description": "Add extensions to GraphQL servers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This moves the Apollo Engine Reporting signature calculation (which the
Apollo Cloud uses to aggregate similar operations) to perform
asynchronously, after the response has been returned to the client, and also
caches the signature for use by additional operations which match the same
`queryHash` (which is an exact SHA-256 hex digest of the operation body
received from the client).

While the signature calculation is relatively quick on small operations, with
sustained load and more complex operations, this recurring calculation can
be more costly.

As a bit of validation to the success of this change, on a very basic
performance benchmark, using a schema with 1000 `String` fields (i.e.  a
`type Query` with `Field_1: String` through `Field_1000: String`) and an
incoming operation which selects from all 1000 of those fields (i.e
`Field_1`), this showed quite an improvement:

```
┌───────────────┬───────────────┬───────────────┐
│               │ Before        │ After         │
├───────────────┼───────────────┼───────────────┤
│ Percentile, % │ Resp. Time, s │ Resp. Time, s │
├───────────────┼───────────────┼───────────────┤
│           0.0 │         0.076 │         0.024 │
│          50.0 │         0.342 │          0.14 │
│          90.0 │         0.388 │         0.161 │
│          95.0 │          0.41 │         0.164 │
│          99.0 │         0.444 │          0.17 │
│          99.9 │         0.486 │         0.177 │
│         100.0 │         0.487 │         0.196 │
└───────────────┴───────────────┴───────────────┘
```

Of course, this is a relatively simple example and still includes actual
GraphQL execution, but the win factor is certainly there.  Other tests with
more dynamic fields and a higher cardinality of unique operations also
showed improvement, though extremely high cardinality of complex operations
(which have more expensive execution characteristics) certainly made the
_win_ factor less pronounced.

It's not surprising that this calculation is a bit expensive since it
requires a number of normalization steps.  Luckily, we can let this all
happen after the request is sent to the client and it's highly cacheable.

By default, we'll use a relatively small cache which should store a large
number of operations, and to avoid introducing configuration surface area
right now without much evidence as to the need, we'll simply log a message
periodically if we're ejecting operations.