### PR TITLE
Extend the typing contracts for  the request pipeline hooks.

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -246,7 +246,10 @@ export async function processGraphQLRequest<TContext>(
 
       const validationDidEnd = await dispatcher.invokeDidStartHook(
         'validationDidStart',
-        requestContext as WithRequired<typeof requestContext, 'document'>,
+        requestContext as WithRequired<
+          typeof requestContext,
+          'document' | 'source' | 'metrics'
+        >,
       );
 
       const validationErrors = validate(requestContext.document);
@@ -297,7 +300,7 @@ export async function processGraphQLRequest<TContext>(
       'didResolveOperation',
       requestContext as WithRequired<
         typeof requestContext,
-        'document' | 'operation' | 'operationName'
+        'document' | 'source' | 'operation' | 'operationName' | 'metrics'
       >,
     );
 
@@ -315,7 +318,7 @@ export async function processGraphQLRequest<TContext>(
       'responseForOperation',
       requestContext as WithRequired<
         typeof requestContext,
-        'document' | 'operation' | 'operationName'
+        'document' | 'source' | 'operation' | 'operationName' | 'metrics'
       >,
     );
     if (response == null) {
@@ -323,7 +326,7 @@ export async function processGraphQLRequest<TContext>(
         'executionDidStart',
         requestContext as WithRequired<
           typeof requestContext,
-          'document' | 'operation' | 'operationName' | 'metrics'
+          'document' | 'source' | 'operation' | 'operationName' | 'metrics'
         >,
       );
 
@@ -472,7 +475,10 @@ export async function processGraphQLRequest<TContext>(
     }).graphqlResponse;
     await dispatcher.invokeHookAsync(
       'willSendResponse',
-      requestContext as WithRequired<typeof requestContext, 'response'>,
+      requestContext as WithRequired<
+        typeof requestContext,
+        'metrics' | 'response'
+      >,
     );
     return requestContext.response!;
   }


### PR DESCRIPTION
The `WithRequired` typing declarations throughout the request pipeline API
are meant to provide integrations with type safety for their hook
implementations: a contract between plugins and Apollo Server itself.

We've added some additional properties to the `requestContext` that the
request pipeline API (already) receives but, up until this commit, those
properties haven't been explicitly marked as `WithRequired` by the request
pipeline.

I'd love to say this was my own observation but, full disclosure, while
these are not TypeScript compilation errors (in the eyes of `tsc`) this was
prompted by some new red-squiggles in my editor which hadn't been present
before.  Upon investigation, it appears that it's right!

This updates the internal request pipeline types to match that of the
`apollo-server-plugin-base` package, which is meant to be used by plugin
implementers and can be seen here:

https://github.com/apollographql/apollo-server/blob/b3cbb42d/packages/apollo-server-plugin-base/src/index.ts

As some point, I think we'll probably want to consider re-using those from
within the request pipeline, if possible.