### PR TITLE
stringify instances of classes

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -224,7 +224,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     if (
       options.body !== undefined &&
       options.body !== null &&
-      (options.body.constructor === Object ||
+      (options.body instanceof Object ||
         Array.isArray(options.body) ||
         ((options.body as any).toJSON &&
           typeof (options.body as any).toJSON === 'function'))


### PR DESCRIPTION
In my app, I use TypeScript & instances of classes.

```
class Test { }
const lol = new Test()
lol instanceof Object
=> true
lol.constructor.name === "Object"
=> false
const toast = {}
toast.constructor
toast.constructor === Object
=> false
``` 