### PR TITLE
engine-reporting: Handle errors within `didResolveOperation` life-cycle hook.

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -481,6 +481,8 @@ export async function processGraphQLRequest<TContext>(
       ? errorOrErrors
       : [errorOrErrors];
 
+    extensionStack.didEncounterErrors(errors);
+
     return sendResponse({
       errors: formatErrors(
         errors.map(err =>


### PR DESCRIPTION
This re-implements the triggering of `didEncounterErrors` during `willResolveOperation` errors which occur in the request pipeline, but in a more common code-path where it probably should have been getting called already anyway.

This re-implements part of the #2659 functionality (which is currently not included on the 2.6.0 branch) in a different manner, with the additional piece — still not included in this PR — to be included in a follow-up commit.