### PR TITLE
engine-reporting: Capture `operationName` and `document` within errors.

### DIFF
--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -199,12 +199,18 @@ export class EngineReportingExtension<TContext = any>
       this.trace.fullQueryCacheHit = !!o.requestContext.metrics
         .responseCacheHit;
 
-      const operationName = this.operationName || '';
+      // If the `operationName` was not already set elsewhere, for example,
+      // through the `executionDidStart` or the `willResolveField` hooks, then
+      // we'll resort to using the `operationName` which was requested to be
+      // executed by the client.
+      const operationName =
+        this.operationName || o.requestContext.operationName || '';
+      const documentAST = this.documentAST || o.requestContext.document;
 
       this.addTrace({
         operationName,
         queryHash,
-        documentAST: this.documentAST,
+        documentAST,
         queryString: this.queryString || '',
         trace: this.trace,
       });


### PR DESCRIPTION
This is another take on #2659 which has been otherwise excluded from the
2.6.0 release.

The work in #2659 was meant to ensure that the `document` and
`operationName` were set at the appropriate locations within the lifecycle
events for the `graphql-extensions` module, specifically when an error had
been thrown within `didResolveOperation` of the new request pipeline.

While the solution in #2659 certainly works, it introduced a new life-cycle
method for details which we could also calculate without adding to the
API surface area by using information which was already exposed.

Even though `graphql-extensions` is no longer really being supported,
avoiding growth on the API surface area of `graphql-extensions` is still
important for any API!

Ref: https://github.com/apollographql/apollo-server/pull/2659
