### PR TITLE
Prevent Cache-Control header from being set if response has errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `apollo-server`: Support `onHealthCheck` in the `ApolloServer` constructor in the same way as `cors` is supported.  This contrasts with the `-express`, `-hapi`, etc. variations which accept this parameter via their `applyMiddleware` methods and will remain as-is.  [PR #2672](https://github.com/apollographql/apollo-server/pull/2672)
 - core: Expose SHA-256 hex hash digest of the Engine API key to plugins, when available, as `engine.apiKeyHash`. [PR# 2685](https://github.com/apollographql/apollo-server/pull/2685)
 - `apollo-datasource-rest`: If another `Content-type` is already set on the response, don't overwrite it with `application/json`, allowing the user's initial `Content-type` to prevail. [PR #2520](https://github.com/apollographql/apollo-server/issues/2035)
+- `apollo-cache-control`: Do not respond with `Cache-control` headers if the HTTP response contains `errors`. [PR #2715](https://github.com/apollographql/apollo-server/pull/2715)
 
 ### v2.5.0
 

--- a/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
@@ -25,34 +25,35 @@ describe('CacheControlExtension', () => {
         },
         data: { test: 'test' },
       };
-      jest.spyOn(graphqlResponse.http!.headers, 'set');
     });
 
     it('sets cache-control header', () => {
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.set).toHaveBeenCalled();
+      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBe(
+        'max-age=300, public',
+      );
     });
 
     it('does not set cache-control header if graphqlResponse has errors', () => {
       graphqlResponse.errors = [new GraphQLError('Test Error')];
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.set).not.toHaveBeenCalled();
+      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
     });
 
     it('does not set cache-control header if there is no data', () => {
       graphqlResponse.data = undefined;
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.set).not.toHaveBeenCalled();
+      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
     });
 
     it('does not set cache-control header if there is no overall cache policy', () => {
       cacheControlExtension.computeOverallCachePolicy = () => undefined;
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.set).not.toHaveBeenCalled();
+      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
     });
 
     it('does not set cache-control header if the overall cache policy has max-age set to 0', () => {
@@ -62,7 +63,7 @@ describe('CacheControlExtension', () => {
       });
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.set).not.toHaveBeenCalled();
+      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
     });
   });
 

--- a/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
@@ -35,25 +35,25 @@ describe('CacheControlExtension', () => {
       );
     });
 
-    it('does not set cache-control header if graphqlResponse has errors', () => {
-      graphqlResponse.errors = [new GraphQLError('Test Error')];
+    const shouldNotSetCacheControlHeaders = () => {
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
       expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
+    };
+
+    it('does not set cache-control header if graphqlResponse has errors', () => {
+      graphqlResponse.errors = [new GraphQLError('Test Error')];
+      shouldNotSetCacheControlHeaders();
     });
 
     it('does not set cache-control header if there is no data', () => {
       graphqlResponse.data = undefined;
-      cacheControlExtension.willSendResponse &&
-        cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
+      shouldNotSetCacheControlHeaders();
     });
 
     it('does not set cache-control header if there is no overall cache policy', () => {
       cacheControlExtension.computeOverallCachePolicy = () => undefined;
-      cacheControlExtension.willSendResponse &&
-        cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
+      shouldNotSetCacheControlHeaders();
     });
 
     it('does not set cache-control header if the overall cache policy has max-age set to 0', () => {
@@ -61,9 +61,7 @@ describe('CacheControlExtension', () => {
         maxAge: 0,
         scope: CacheScope.Public,
       });
-      cacheControlExtension.willSendResponse &&
-        cacheControlExtension.willSendResponse({ graphqlResponse });
-      expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
+      shouldNotSetCacheControlHeaders();
     });
   });
 

--- a/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
@@ -35,33 +35,25 @@ describe('CacheControlExtension', () => {
       );
     });
 
-    const shouldNotSetCacheControlHeaders = () => {
+    const shouldNotSetCacheControlHeader = () => {
       cacheControlExtension.willSendResponse &&
         cacheControlExtension.willSendResponse({ graphqlResponse });
       expect(graphqlResponse.http!.headers.get('Cache-Control')).toBeNull();
     };
 
-    it('does not set cache-control header if graphqlResponse has errors', () => {
-      graphqlResponse.errors = [new GraphQLError('Test Error')];
-      shouldNotSetCacheControlHeaders();
+    it('does not set cache-control header if calculateHttpHeaders is set to false', () => {
+      cacheControlExtension.options.calculateHttpHeaders = false;
+      shouldNotSetCacheControlHeader();
     });
 
-    it('does not set cache-control header if there is no data', () => {
-      graphqlResponse.data = undefined;
-      shouldNotSetCacheControlHeaders();
+    it('does not set cache-control header if graphqlResponse has errors', () => {
+      graphqlResponse.errors = [new GraphQLError('Test Error')];
+      shouldNotSetCacheControlHeader();
     });
 
     it('does not set cache-control header if there is no overall cache policy', () => {
       cacheControlExtension.computeOverallCachePolicy = () => undefined;
-      shouldNotSetCacheControlHeaders();
-    });
-
-    it('does not set cache-control header if the overall cache policy has max-age set to 0', () => {
-      cacheControlExtension.computeOverallCachePolicy = () => ({
-        maxAge: 0,
-        scope: CacheScope.Public,
-      });
-      shouldNotSetCacheControlHeaders();
+      shouldNotSetCacheControlHeader();
     });
   });
 

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -156,14 +156,21 @@ export class CacheControlExtension<TContext = any>
     if (this.options.calculateHttpHeaders && o.graphqlResponse.http) {
       const overallCachePolicy = this.computeOverallCachePolicy();
 
-      if (overallCachePolicy) {
-        o.graphqlResponse.http.headers.set(
-          'Cache-Control',
-          `max-age=${
-            overallCachePolicy.maxAge
-          }, ${overallCachePolicy.scope.toLowerCase()}`,
-        );
+      if (
+        o.graphqlResponse.errors ||
+        !o.graphqlResponse.data ||
+        !overallCachePolicy ||
+        overallCachePolicy.maxAge <= 0
+      ) {
+        return;
       }
+
+      o.graphqlResponse.http.headers.set(
+        'Cache-Control',
+        `max-age=${
+          overallCachePolicy.maxAge
+        }, ${overallCachePolicy.scope.toLowerCase()}`,
+      );
     }
   }
 

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -153,18 +153,17 @@ export class CacheControlExtension<TContext = any>
   }
 
   public willSendResponse?(o: { graphqlResponse: GraphQLResponse }) {
-    if (this.options.calculateHttpHeaders && o.graphqlResponse.http) {
-      const overallCachePolicy = this.computeOverallCachePolicy();
+    if (
+      !this.options.calculateHttpHeaders ||
+      !o.graphqlResponse.http ||
+      o.graphqlResponse.errors
+    ) {
+      return;
+    }
 
-      if (
-        o.graphqlResponse.errors ||
-        !o.graphqlResponse.data ||
-        !overallCachePolicy ||
-        overallCachePolicy.maxAge <= 0
-      ) {
-        return;
-      }
+    const overallCachePolicy = this.computeOverallCachePolicy();
 
+    if (overallCachePolicy) {
       o.graphqlResponse.http.headers.set(
         'Cache-Control',
         `max-age=${


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-cache-control/issues/12

Adds a check for `errors` and for `data` before setting the `Cache-Control` header. This change is aligned with the logic in the `apollo-server-plugin-response-cache` package:

https://github.com/apollographql/apollo-server/blob/7db109efed2a193e0b459030ccd748d1f329fc82/packages/apollo-server-plugin-response-cache/src/ApolloServerPluginResponseCache.ts#L243-L261