### PR TITLE
docs: fix typo in authentication.md

### DIFF
--- a/docs/source/features/authentication.md
+++ b/docs/source/features/authentication.md
@@ -91,7 +91,7 @@ users: (parent, args, context) => {
  // In this case, we'll pretend there is no data when
  // we're not logged in. Another option would be to
  // throw an error.
- if (!context.user) return [];
+ if (!context.user) return null;
 
  return ['bob', 'jake'];
 }
@@ -99,7 +99,7 @@ users: (parent, args, context) => {
 
 This example is a field in our schema named `users` that returns a list of users’ names. The `if` check on the first line of the function looks at the `context` generated from our request, checks for a `user` object, and if one doesn’t exist, returns `null` for the whole field.
 
-One choice to make when building out our resolvers is what an unauthorized field should return. In some use cases, returning `null` here is perfectly valid. Alternatives to this would be to return an empty array, `[]` or to throw an error, telling the client that they’re not allowed to access that field. For the sake of simplicity, we just returned `[]` in this example.
+One choice to make when building out our resolvers is what an unauthorized field should return. In some use cases, returning `null` here is perfectly valid. Alternatives to this would be to return an empty array, `[]` or to throw an error, telling the client that they’re not allowed to access that field. For the sake of simplicity, we just returned `null` in this example.
 
 Now let’s expand that example a little further, and only allow users with an `admin` role to look at our user list. After all, we probably don’t want just anyone to have access to all our users.
 


### PR DESCRIPTION
This PR fixes a typo in authentication.md. It's the same as PR #2717 but with the changes requested by @abernix. I closed PR #2717 because I prematurely deleted my fork and couldn't edit the PR anymore.

@abernix Would it be better to also edit this comment that's above the code snippet where I changed `[]` to `null`?

> In this case, we'll pretend there is no data when we're not logged in.

I think saying "no data" here specifically refers to an empty array, which we just replaced `null`. I'm not sure how to improve this comment though, or if it even needs to be improved. What do you suggest?