### PR TITLE
Remove old docs

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = {
         githubRepo: 'apollographql/apollo-server',
         defaultVersion: 2,
         versions: {
-          1: 'version-1-mdx',
+          1: 'version-1',
         },
         sidebarCategories: {
           null: ['index', 'getting-started', 'whats-new'],

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -8,10 +8,10 @@ module.exports = {
         subtitle: 'Apollo Server',
         description: 'A guide to using Apollo Server',
         githubRepo: 'apollographql/apollo-server',
-        // defaultVersion: 2,
-        // versions: {
-        //   1: 'version-1-mdx',
-        // },
+        defaultVersion: 2,
+        versions: {
+          1: 'version-1-mdx',
+        },
         sidebarCategories: {
           null: ['index', 'getting-started', 'whats-new'],
           Essentials: [

--- a/docs/source/servers/adonis.md
+++ b/docs/source/servers/adonis.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-adonis/README.md

--- a/docs/source/servers/azure-functions.md
+++ b/docs/source/servers/azure-functions.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-azure-functions/README.md

--- a/docs/source/servers/express.md
+++ b/docs/source/servers/express.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-express/README.md

--- a/docs/source/servers/hapi.md
+++ b/docs/source/servers/hapi.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-hapi/README.md

--- a/docs/source/servers/koa.md
+++ b/docs/source/servers/koa.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-koa/README.md

--- a/docs/source/servers/lambda.md
+++ b/docs/source/servers/lambda.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-lambda/README.md

--- a/docs/source/servers/micro.md
+++ b/docs/source/servers/micro.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-micro/README.md

--- a/docs/source/servers/restify.md
+++ b/docs/source/servers/restify.md
@@ -1,1 +1,0 @@
-../../../packages/apollo-server-restify/README.md


### PR DESCRIPTION
This branch removes unused pages from the docs that were causing the build to hang on Netlify due to the way they handle (or don't handle) symlinks. Issue here: https://github.com/netlify/netlifyctl/issues/49

All of the deleted files still exist in the apollo-server version 1 docs, where they are still linked to and used.

This branch also re-enables versioning so that version 1 docs are visible again.