### PR TITLE
fix error handling typo

### DIFF
--- a/docs/source/features/authentication.md
+++ b/docs/source/features/authentication.md
@@ -69,7 +69,7 @@ context: ({ req }) => {
 
  // optionally block the user
  // we could also check user roles/permissions here
- if (!user) throw new AuthorizationError('you must be logged in'); 
+ if (!user) throw new AuthenticationError('you must be logged in'); 
 
  // add the user to the context
  return { user };


### PR DESCRIPTION
`AuthorizationError` -> `AuthenticationError`

I couldn't find an instance of `AuthorizationError` but elsewhere in the documentation (for similar reasons) it instructed the use of `AuthorizationError`.