### PR TITLE
Add forbidden and registered operations to requestContext.metrics - AP-478

### DIFF
--- a/packages/apollo-engine-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/src/reports.proto
@@ -86,17 +86,10 @@ message Trace {
 		// a list).  Note that nodes representing indexes (and the root node)
 		// don't contain all Node fields (eg types and times).
 		oneof id {
-			// Older versions of Apollo Engine Reporting (AS <= 2.4.8) would set this
-			// key to be the alias if there was an alias and the field name otherwise.
-			// New agents all use the `original_field_name` key, but we support this
-			// id as well for legacy reasons. To specify an
-			// alias, use the alias key.
-			string legacy_field_name_could_be_alias = 1;
-			string original_field_name = 24;
+			string field_name = 1;
 			uint32 index = 2;
 		}
 
-		string alias = 25;
 		// The field's return type; e.g. "String!" for User.email:String!
 		string type = 3;
 

--- a/packages/apollo-engine-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/src/reports.proto
@@ -4,8 +4,6 @@ package mdg.engine.proto;
 
 import "google/protobuf/timestamp.proto";
 
-option optimize_for = SPEED;
-
 message Trace {
 	message CachePolicy {
 		enum Scope {
@@ -88,10 +86,17 @@ message Trace {
 		// a list).  Note that nodes representing indexes (and the root node)
 		// don't contain all Node fields (eg types and times).
 		oneof id {
-			string field_name = 1;
+			// Older versions of Apollo Engine Reporting (AS <= 2.4.8) would set this
+			// key to be the alias if there was an alias and the field name otherwise.
+			// New agents all use the `original_field_name` key, but we support this
+			// id as well for legacy reasons. To specify an
+			// alias, use the alias key.
+			string legacy_field_name_could_be_alias = 1;
+			string original_field_name = 24;
 			uint32 index = 2;
 		}
 
+		string alias = 25;
 		// The field's return type; e.g. "String!" for User.email:String!
 		string type = 3;
 
@@ -138,11 +143,10 @@ message Trace {
 
 	// Older agents (eg the Go engineproxy) relied to some degree on the Engine
 	// backend to run their own semi-compatible implementation of a specific
-	// variant of query signatures. The backend won't do that for new agents, but
-	// we keep this old field around to ensure that queries only get new IDs when
-	// you upgrade to the new agent, not just when we make backend changes
-	// to minimize backend-side signature calculation. Deprecated and ignored
-	// in FullTracesReports.
+	// variant of query signatures. The backend does not do this for new agents (which
+	// set the above 'signature' field). It used to still "re-sign" signatures
+	// from engineproxy, but we've now simplified the backend to no longer do this.
+	// Deprecated and ignored in FullTracesReports.
 	string legacy_signature_needs_resigning = 5;
 
 	Details details = 6;
@@ -170,6 +174,12 @@ message Trace {
 	// (This typically means that a previous request was rejected as an unknown
 	// persisted query.)
 	bool persisted_query_register = 22;
+
+	// Was this operation registered and a part of the safelist?
+	bool registered_operation = 24;
+
+	// Was this operation forbidden due to lack of safelisting?
+	bool forbidden_operation = 25;
 
 	// removed: Node parse = 12; Node validate = 13;
 	//          Id128 server_id = 1; Id128 client_id = 2;
@@ -224,6 +234,8 @@ message ClientNameStats {
 	map<string, uint64> cache_hits_per_version = 4;
 	map<string, uint64> persisted_query_hits_per_version = 10;
 	map<string, uint64> persisted_query_misses_per_version = 11;
+	map<string, uint64> registered_operation_count_per_version = 12;
+	map<string, uint64> forbidden_operation_count_per_version = 13;
 	repeated int64 cache_latency_count = 5; // Duration histogram; see docs/histograms.md
 	PathErrorStats root_error_stats = 6;
 	uint64 requests_with_errors_count = 7;
@@ -244,6 +256,8 @@ message QueryLatencyStats {
 	uint64 requests_with_errors_count = 8;
 	repeated int64 public_cache_ttl_count = 9;
 	repeated int64 private_cache_ttl_count = 10;
+	uint64 registered_operation_count = 11;
+	uint64 forbidden_operation_count = 12;
 }
 
 message StatsContext {
@@ -273,7 +287,7 @@ message FieldStat {
 
 message TypeStat {
 	string name = 1; // deprecated; only set when stored in QueryStats.per_type
-	repeated FieldStat field = 2;  // deprecated; use per_field_stat instead
+	repeated FieldStat field = 2; // deprecated; use per_field_stat instead
 	// Key is (eg) "email" for User.email:String!
 	map<string, FieldStat> per_field_stat = 3;
 }
@@ -351,7 +365,6 @@ message StatsReport {
 	// FullTracesReports.
 	uint64 realtime_duration = 10;
 
-
 	// Maps from query descriptor to QueryStats. Required unless
 	// legacy_per_query_missing_operation_name is set. The keys are strings of the
 	// form `# operationName\nsignature` (literal hash and space), with
@@ -360,7 +373,7 @@ message StatsReport {
 
 	// Older agents (Go engineproxy) didn't explicitly include the operation name
 	// in the key of this map, and the server had to parse it out (after a
-	// re-signing operation). The key here is just the query
+	// re-signing operation which is no longer performed). The key here is just the query
 	// signature. Deprecated.
 	map<string, QueryStats> legacy_per_query_implicit_operation_name = 12;
 
@@ -394,4 +407,9 @@ message FullTracesReport {
 // Just a sequence of traces with the same statsReportKey.
 message Traces {
 	repeated Trace trace = 1;
+}
+
+message TraceV1 {
+	ReportHeader header = 1;
+	Trace trace = 2;
 }

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -138,6 +138,12 @@ export class EngineReportingExtension<TContext = any>
       if (o.requestContext.metrics.persistedQueryRegister) {
         this.trace.persistedQueryRegister = true;
       }
+      if (o.requestContext.metrics.forbiddenOperation) {
+        this.trace.forbiddenOperation = true;
+      }
+      if (o.requestContext.metrics.registeredOperation) {
+        this.trace.registeredOperation = true;
+      }
     }
 
     if (this.options.privateVariables !== true && o.variables) {

--- a/packages/apollo-server-core/src/requestPipelineAPI.ts
+++ b/packages/apollo-server-core/src/requestPipelineAPI.ts
@@ -54,6 +54,8 @@ export interface GraphQLRequestMetrics {
   persistedQueryHit?: boolean;
   persistedQueryRegister?: boolean;
   responseCacheHit?: boolean;
+  forbiddenOperation?: boolean;
+  registeredOperation?: boolean;
 }
 
 export interface GraphQLRequestContext<TContext = Record<string, any>> {


### PR DESCRIPTION
This PR updates `reports.proto`, adds `forbiddenOperation` and `registeredOperation` boolean fields to `GraphQLRequestMetrics`, and sets those fields on the outgoing trace

The intention is for the operation registry plugin to set these values on requestContext.metrics