### PR TITLE
docs: more federation docs tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,20 +79,10 @@ jobs:
       # (speed) --ignore-scripts to skip unnecessary Lerna build during linting.
       - run: npm install --ignore-scripts
       - run: npm run lint
-  Docs:
-    docker: [{ image: 'circleci/node:8' }]
-    steps:
-      # (speed) Intentionally omitted, unnecessary, run_install_desired_npm.
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "./docs/package.json" }}
-      # (speed) Ignore scripts to skip the Lerna build stuff for linting.
-      - run: npm install-test --prefix ./docs
-      - save_cache:
-          key: dependency-cache-{{ checksum "./docs/package.json" }}
-          paths:
-            - ./docs/node_modules
 
+# XXX We used to use this filter to only run a "Docs" job on docs branches.
+#     Now we use it to disable all jobs. It's unclear if there's a simpler way
+#     to do this!
 ignore_doc_branches: &ignore_doc_branches
   filters:
     branches:
@@ -111,4 +101,3 @@ workflows:
           <<: *ignore_doc_branches
       - Linting:
           <<: *ignore_doc_branches
-      - Docs

--- a/docs/source/api/apollo-federation.mdx
+++ b/docs/source/api/apollo-federation.mdx
@@ -11,7 +11,7 @@ The `@apollo/federation` has one export for intended public use, the `buildFeder
 
 * `modules`: `GraphQLSchemaModule[]` _(required)_
 
-    An array of schema modules made up of typeDefs and resolvers
+    An array of schema modules made up of typeDefs and resolvers.
 
 #### Usage
 
@@ -47,7 +47,7 @@ const server = new ApolloServer({
 
 ## `__resolveReference`
 
-Though not an export from `@apollo/federation`, using the `buildFederatedSchema` function allows a resovler map to define a new special field called `__resolveReference` for each type that is an entity. This function is called whenever an entity is requested as part of the fufilling a query plan. `__resolveReference` is called with the following parameters:
+Though not an export from `@apollo/federation`, using the `buildFederatedSchema` function allows a resolver map to define a new special field called `__resolveReference` for each type that is an entity. This function is called whenever an entity is requested as part of the fufilling a query plan. `__resolveReference` is called with the following parameters:
 
 #### Parameters
 

--- a/docs/source/api/apollo-gateway.mdx
+++ b/docs/source/api/apollo-gateway.mdx
@@ -18,7 +18,7 @@ The core of the federated gateway implementation. For an example, see the ["impl
 
   * `serviceList`: `ServiceDefinition[]` _(required)_
 
-    An array of service definitions. A service definition contains the `name` and `url` for a federated service.
+    An array of service definitions. A service definition contains the `name` and `url` for a federated service. The name is an arbitrary unique string and is primarily used for query planner output, error messages, logging, and the like.
 
     ```js{3-6}
     const gateway = new ApolloGateway({
@@ -52,7 +52,7 @@ The core of the federated gateway implementation. For an example, see the ["impl
 
   * `debug`: `Boolean`
 
-    With debug enabled, the server will log startup errors as well as query plans during incoming requests.
+    With debug enabled, the server will log startup messages as well as query plans during incoming requests.
 
 ### `ApolloGateway.load()`: `Promise<{ schema: GraphQLSchema, exector: GraphQLExecutor }>`
 

--- a/docs/source/federation/federation-spec.md
+++ b/docs/source/federation/federation-spec.md
@@ -8,9 +8,9 @@ description: For implementing federation in other languages
 To make a GraphQL service federation capable, it needs the following:
 
 * Implementation of the federation schema specification
+* Support for fetching service capabilities
 * Implementation of stub type generation for references
 * Implementation of request resolving for entities.
-* Support for fetching service capabilities
 
 ## Federation schema specification
 
@@ -41,7 +41,7 @@ directive @key(fields: _FieldSet!) on OBJECT
 directive @extends on OBJECT
 ```
 
-For more information on these additions, see the [glossary](#schema-modifications-glossary)
+For more information on these additions, see the [glossary](#schema-modifications-glossary).
 
 ## Fetch service capabilities
 
@@ -85,7 +85,7 @@ Execution of a federated graph requires being able to "enter" into a service at 
 * Make each entity in the schema part of the `_Entity` union
 * Implement the `_entities` field on the query root
 
-To implement the `_Entity` union, each type annotated with `@key` should be added to the `_Entity` union. If no types are annotated with the key directive, then the `_Entity` union should be removed from the schema. For example, given the following partial schema:
+To implement the `_Entity` union, each type annotated with `@key` should be added to the `_Entity` union. If no types are annotated with the key directive, then the `_Entity` union and `Query._entities` field should be removed from the schema. For example, given the following partial schema:
 
 ```graphql
 type Review @key(fields: "id") {

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -46,7 +46,7 @@ const server = new ApolloServer({
 });
 ```
 
-If you're already familiar with [setting up an Apollo Server](https://www.apollographql.com/docs/apollo-server/essentials/server#creating), this should look pretty familiar. If not, we recommend you first take a moment to get comfortable with this topic before jumping in to federation.
+If you're already familiar with [setting up an Apollo Server](/essentials/server/#creating-a-server), this should look pretty familiar. If not, we recommend you first take a moment to get comfortable with this topic before jumping in to federation.
 
 Now, let's see what this looks like as a federated service:
 
@@ -125,7 +125,7 @@ const gateway = new ApolloGateway({
 })();
 ```
 
-In this example, we provide the `serviceList` option to the `ApolloGateway` constructor, which provides a name and endpoint for each of the federated services.
+In this example, we provide the `serviceList` option to the `ApolloGateway` constructor, which provides a name and endpoint for each of the federated services. The name (an arbitrary string) is primarily used for query planner output, error messages, and logging.
 
 On startup, the gateway will fetch the service capabilities from the running servers and form an overall composed graph. It will accept incoming requests and create query plans which query the underlying services in the service list.
 
@@ -138,7 +138,7 @@ The call to `gateway.load()` returns a `Promise` which resolves to a `schema` an
 
 ## Inspecting query plans
 
-When the gateway receives a new query, it generates a query plan that defines the sequence of requests the gateway will send to the necessary downstream services. Inspecting a query plan can be a helpful tool in understanding the gateway and exploring how directives like `@requires` and `@provides` can help optimize query plans. To make it easy to access query plans, the `@apollo/gateway` package includes a build of GraphQL Playground that adds a query plan inspector.
+When the gateway receives a new query, it generates a query plan that defines the sequence of requests the gateway will send to the necessary downstream services. Inspecting a query plan can be a helpful tool in understanding the gateway and exploring how directives like [`@requires`](/federation/advanced-features/#computed-fields) and [`@provides`](/federation/advanced-features/#using-denormalized-data) can help optimize query plans. To make it easy to access query plans, the `@apollo/gateway` package includes a build of GraphQL Playground that adds a query plan inspector.
 
 
 ![playground](../images/playground.png)

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -242,7 +242,7 @@ function approximateObjectSize<T>(obj: T): number {
 
 // We can't use transformSchema here because the extension data for query
 // planning would be lost. Instead we set a resolver for each field
-// in order to counteract GraphQLExtensions preventing a defaultFieldResovler
+// in order to counteract GraphQLExtensions preventing a defaultFieldResolver
 // from doing the same job
 function wrapSchemaWithAliasResolver(schema: GraphQLSchema): GraphQLSchema {
   const typeMap = schema.getTypeMap();


### PR DESCRIPTION
- grammar, punctuation, typos (including a random typo in code)
- document the `name` field on `serviceList`, twice
- clarify that `debug` controls startup messages, not errors
- reorder list at top of federation-spec to match page order
- `Query._entities` is removed if `_Entity` is
- fix a link that would have been caught by the link checker if it was
  appropriately internal
- add links to forward references to `@requires` and `@provides`
- stop running a no-op Docs CircleCI task; the test script was removed
  in #2394