### PR TITLE
fix: use interface over class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3444,8 +3444,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -3468,16 +3467,14 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "bundled": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ioredis": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.2.0.tgz",
-          "integrity": "sha512-PdxZGNJBfPiR2RI6DkqmiacL1+ML3gaqEiaC5QXWQt9eSTlGj+BwDCct0s8irn1ed8GyzAHTzcjvU9fmnl6D7A==",
+          "bundled": true,
           "requires": {
             "cluster-key-slot": "^1.0.6",
             "debug": "^3.1.0",
@@ -3493,8 +3490,7 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "bundled": true
         }
       }
     },
@@ -3515,8 +3511,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -3554,13 +3549,11 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         },
         "subscriptions-transport-ws": {
           "version": "0.9.16",
-          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-          "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+          "bundled": true,
           "requires": {
             "backo2": "^1.0.2",
             "eventemitter3": "^3.1.0",
@@ -3610,13 +3603,11 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         },
         "@types/express": {
           "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
-          "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+          "bundled": true,
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "*",
@@ -3638,8 +3629,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -3656,8 +3646,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -3690,8 +3679,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -3706,8 +3694,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -3722,8 +3709,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.20",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.20.tgz",
-          "integrity": "sha512-3LWZa80HcP70Pl+H4KhLDJ7S0px+9/c8GTXdl6SpunRecUaB27g/oOQnAjNHLHdbWuGE0uyqcuGiTfbKB3ilaQ=="
+          "bundled": true
         }
       }
     },
@@ -6701,8 +6687,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6723,14 +6708,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6745,20 +6728,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6875,8 +6855,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6888,7 +6867,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6903,7 +6881,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6911,14 +6888,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6937,7 +6912,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7018,8 +6992,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7031,7 +7004,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7117,8 +7089,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7154,7 +7125,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7174,7 +7144,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7218,14 +7187,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -101,7 +101,17 @@ function approximateObjectSize<T>(obj: T): number {
   return Buffer.byteLength(JSON.stringify(obj), 'utf8');
 }
 
-export class ApolloServerBase {
+export interface ApolloServerBaseInt {
+  subscriptionsPath?: string;
+  graphqlPath: string;
+  requestOptions: Partial<GraphQLOptions<any>>;
+  setGraphQLPath(path: string): void;
+  stop(): Promise<void>;
+  installSubscriptionHandlers(server: HttpServer): void;
+  executeOperation(request: GraphQLRequest): Promise<import("graphql-extensions").GraphQLResponse>;
+}
+
+export class ApolloServerBase implements ApolloServerBaseInt{
   public subscriptionsPath?: string;
   public graphqlPath: string = '/graphql';
   public requestOptions: Partial<GraphQLOptions<any>> = Object.create(null);

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -108,10 +108,12 @@ export interface ApolloServerBaseInt {
   setGraphQLPath(path: string): void;
   stop(): Promise<void>;
   installSubscriptionHandlers(server: HttpServer): void;
-  executeOperation(request: GraphQLRequest): Promise<import("graphql-extensions").GraphQLResponse>;
+  executeOperation(
+    request: GraphQLRequest,
+  ): Promise<import('graphql-extensions').GraphQLResponse>;
 }
 
-export class ApolloServerBase implements ApolloServerBaseInt{
+export class ApolloServerBase implements ApolloServerBaseInt {
   public subscriptionsPath?: string;
   public graphqlPath: string = '/graphql';
   public requestOptions: Partial<GraphQLOptions<any>> = Object.create(null);

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -29,7 +29,7 @@ export {
 } from './playground';
 
 // ApolloServer Base class
-export { ApolloServerBase } from './ApolloServer';
+export { ApolloServerBase, ApolloServerBaseInt } from './ApolloServer';
 export * from './types';
 export * from './requestPipelineAPI';
 

--- a/packages/apollo-server-testing/src/createTestClient.ts
+++ b/packages/apollo-server-testing/src/createTestClient.ts
@@ -1,4 +1,4 @@
-import { ApolloServerBase } from 'apollo-server-core';
+import { ApolloServerBaseInt } from 'apollo-server-core';
 import { print, DocumentNode } from 'graphql';
 
 type StringOrAst = string | DocumentNode;
@@ -21,7 +21,7 @@ type Mutation = {
   operationName?: string;
 };
 
-export default (server: ApolloServerBase) => {
+export default (server: ApolloServerBaseInt) => {
   const executeOperation = server.executeOperation.bind(server);
   const test = ({ query, mutation, ...args }: Query | Mutation) => {
     const operation = query || mutation;


### PR DESCRIPTION
I trying upgrade `apollo-server-testing` from `2.5.0` to `2.6.2`

And after that, i got an typescript error which shown  `Types have separate declarations of a private property ‘context’.`

And after ask to M.R. Google, i find that
`https://www.stevefenton.co.uk/2017/11/typescript-using-classes-interfaces/`

So seem the error is since it used `class as interface` and class contain private member.


Code ref:
1. How i create Apollo server
https://github.com/davidNHK/service-rating-api/blob/development/app/routes/graphql.ts
2. How i construct Test Client
https://github.com/davidNHK/service-rating-api/blob/development/__tests__/graphql/serviceProvider/getOne.test.ts#L8