### PR TITLE
pass context to localGraphQLDatasource for testing purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- `apollo-gateway`: Pass `context` through to the `graphql` command in `LocalGraphQLDatasource` `process` method [PR #2821](https://github.com/apollographql/apollo-server/pull/2821)
+
 ### v2.6.2
 
 - `apollo-engine-reporting-protobuf`: Update protobuff to include `forbiddenOperations` and `registeredOperations` [PR #2768](https://github.com/apollographql/apollo-server/pull/2768)

--- a/packages/apollo-gateway/src/datasources/LocalGraphQLDatasource.ts
+++ b/packages/apollo-gateway/src/datasources/LocalGraphQLDatasource.ts
@@ -17,7 +17,8 @@ export class LocalGraphQLDataSource implements GraphQLDataSource {
   }
 
   async process<TContext>({
-    request, context
+    request,
+    context,
   }: Pick<GraphQLRequestContext<TContext>, 'request' | 'context'>): Promise<
     GraphQLResponse
   > {
@@ -26,7 +27,7 @@ export class LocalGraphQLDataSource implements GraphQLDataSource {
       source: request.query!,
       variableValues: request.variables,
       operationName: request.operationName,
-      contextValue: context
+      contextValue: context,
     });
   }
 

--- a/packages/apollo-gateway/src/datasources/LocalGraphQLDatasource.ts
+++ b/packages/apollo-gateway/src/datasources/LocalGraphQLDatasource.ts
@@ -17,7 +17,7 @@ export class LocalGraphQLDataSource implements GraphQLDataSource {
   }
 
   async process<TContext>({
-    request,
+    request, context
   }: Pick<GraphQLRequestContext<TContext>, 'request' | 'context'>): Promise<
     GraphQLResponse
   > {
@@ -26,6 +26,7 @@ export class LocalGraphQLDataSource implements GraphQLDataSource {
       source: request.query!,
       variableValues: request.variables,
       operationName: request.operationName,
+      contextValue: context
     });
   }
 

--- a/packages/apollo-gateway/src/datasources/__tests__/LocalGraphQLDatasource.test.ts
+++ b/packages/apollo-gateway/src/datasources/__tests__/LocalGraphQLDatasource.test.ts
@@ -39,6 +39,6 @@ describe('constructing requests', () => {
       context: { userId: 2 },
     });
 
-    expect(data).toEqual({ me: {name: 'james' }});
+    expect(data).toEqual({ me: { name: 'james' } });
   });
 });

--- a/packages/apollo-gateway/src/datasources/__tests__/LocalGraphQLDatasource.test.ts
+++ b/packages/apollo-gateway/src/datasources/__tests__/LocalGraphQLDatasource.test.ts
@@ -1,0 +1,44 @@
+import { LocalGraphQLDataSource } from '../LocalGraphQLDatasource';
+import { buildFederatedSchema } from '@apollo/federation';
+import gql from 'graphql-tag';
+
+describe('constructing requests', () => {
+  it('accepts context', async () => {
+    const typeDefs = gql`
+      type Query {
+        me: User
+      }
+      type User {
+        id: ID
+        name: String!
+      }
+    `;
+    const resolvers = {
+      Query: {
+        me(_, __, { userId }) {
+          const users = [
+            { id: 1, name: 'otherGuy' },
+            { id: 2, name: 'james' },
+            {
+              id: 3,
+              name: 'someoneElse',
+            },
+          ];
+          return users.find(user => user.id === userId);
+        },
+      },
+    };
+    const schema = buildFederatedSchema([{ typeDefs, resolvers }]);
+
+    const DataSource = new LocalGraphQLDataSource(schema);
+
+    const { data } = await DataSource.process({
+      request: {
+        query: '{ me { name } }',
+      },
+      context: { userId: 2 },
+    });
+
+    expect(data).toEqual({ me: {name: 'james' }});
+  });
+});


### PR DESCRIPTION
Great work with the federation/gateway!

I would like the context to be passed to the graphql execution function in the localGraphQLDataSource, the same way it is handled in the remoteGraphQLDataSource, this way I can build integration tests that do keep the required context during execution. Currently it is ignored, even though the process method receives it.

Since the change is so tiny I hope it won't be a difficult decision - is there any reason NOT to pass the context in this particular case?

Thanks!

