### PR TITLE
[Federation] Allow specified directives during validation

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+* Allow specified directives during validation (@deprecated) [#2823](https://github.com/apollographql/apollo-server/pull/2823)
+
 # v0.6.1
 
 * Normalize SDL in a normalization step before validation [#2771](https://github.com/apollographql/apollo-server/pull/2771)

--- a/packages/apollo-federation/src/composition/validate/preComposition/__tests__/keyFieldsMissingExternal.test.ts
+++ b/packages/apollo-federation/src/composition/validate/preComposition/__tests__/keyFieldsMissingExternal.test.ts
@@ -51,6 +51,37 @@ describe('keyFieldsMissingExternal', () => {
     expect(warnings).toHaveLength(0);
   });
 
+  it('has no warnings with @deprecated directive usage', () => {
+    const serviceA = {
+      typeDefs: gql`
+        extend type Car @key(fields: "model { name kit { upc } } year") {
+          model: Model! @external
+          year: String! @external
+          color: String! @deprecated(reason: "Use colors instead")
+          colors: Color!
+        }
+
+        extend type Model {
+          name: String! @external
+          kit: Kit @external
+        }
+
+        extend type Kit {
+          upc: String! @external
+        }
+
+        enum Color {
+          Red
+          Blude
+        }
+      `,
+      name: 'serviceA',
+    };
+
+    const warnings = validateKeyFieldsMissingExternal(serviceA);
+    expect(warnings).toHaveLength(0);
+  });
+
   it("warns when a @key argument doesn't reference an @external field", () => {
     const serviceA = {
       typeDefs: gql`

--- a/packages/apollo-federation/src/composition/validate/preComposition/__tests__/keyFieldsMissingExternal.test.ts
+++ b/packages/apollo-federation/src/composition/validate/preComposition/__tests__/keyFieldsMissingExternal.test.ts
@@ -72,7 +72,7 @@ describe('keyFieldsMissingExternal', () => {
 
         enum Color {
           Red
-          Blude
+          Blue
         }
       `,
       name: 'serviceA',

--- a/packages/apollo-federation/src/composition/validate/preComposition/keyFieldsMissingExternal.ts
+++ b/packages/apollo-federation/src/composition/validate/preComposition/keyFieldsMissingExternal.ts
@@ -5,6 +5,7 @@ import {
   parse,
   GraphQLSchema,
   GraphQLError,
+  specifiedDirectives,
 } from 'graphql';
 import { buildSchemaFromSDL } from 'apollo-graphql';
 import { isNotNullOrUndefined } from 'apollo-env';
@@ -58,7 +59,7 @@ export const keyFieldsMissingExternal = ({
   // this allows us to build a partial schema
   let schema = new GraphQLSchema({
     query: undefined,
-    directives: federationDirectives,
+    directives: [...specifiedDirectives, ...federationDirectives],
   });
   try {
     schema = buildSchemaFromSDL(typeDefs, schema);


### PR DESCRIPTION
The keyFieldsMissingExternal validator should permit standard
directives just like we do in composition everywhere else. Otherwise,
we'll throw validation errors for using `@deprecated`.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
