### PR TITLE
Deduplicate variable definitions for subqueries

### DIFF
--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -339,14 +339,27 @@ function mapFetchNodeToVariableDefinitions(
   node: FetchNode,
 ): VariableDefinitionNode[] {
   const variableUsage = node.variableUsages;
-  return variableUsage
-    ? variableUsage.map(({ node, type }) => ({
+  if (!variableUsage) {
+    return [];
+  }
+
+  const variableMap = variableUsage.reduce((map, { node, type }) => {
+    const key = `${node.name.value}_${type.toString()}`;
+
+    if (!map.has(key)) {
+      map.set(key, {
         kind: Kind.VARIABLE_DEFINITION,
         variable: node,
         type: astFromType(type),
-      }))
-    : [];
+      });
+    }
+
+    return map;
+  }, new Map<string, VariableDefinitionNode>());
+
+  return Array.from(variableMap.values());
 }
+
 function operationForRootFetch(
   fetch: FetchNode,
   operation: OperationTypeNode = 'query',


### PR DESCRIPTION
Fixes #2839. This is done by grouping the definitions by name and type, and only printing these once.

