### PR TITLE
fix: restore allow setting `engine: false` to ignore env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `apollo-federation`: Preserve docstrings in SDL of federated services. [PR #2830](https://github.com/apollographql/apollo-server/pull/2830)
 - `apollo-engine-reporting`: Set `forbiddenOperation` and `registeredOperation` later in the request lifecycle [PR #2828](https://github.com/apollographql/apollo-server/pull/2828)
 - `apollo-server-core`: Add queryHash to GraphQLExecutor for federation [PR #2822](https://github.com/apollographql/apollo-server/pull/2822)
+- `apollo-server-core`: fix setting `engine: false` should ignore `ENGINE_API_KEY` in environment variable [PR #2850](https://github.com/apollographql/apollo-server/pull/2850)
 
 ### v2.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `apollo-federation`: Preserve docstrings in SDL of federated services. [PR #2830](https://github.com/apollographql/apollo-server/pull/2830)
 - `apollo-engine-reporting`: Set `forbiddenOperation` and `registeredOperation` later in the request lifecycle [PR #2828](https://github.com/apollographql/apollo-server/pull/2828)
 - `apollo-server-core`: Add queryHash to GraphQLExecutor for federation [PR #2822](https://github.com/apollographql/apollo-server/pull/2822)
-- `apollo-server-core`: fix setting `engine: false` should ignore `ENGINE_API_KEY` in environment variable [PR #2850](https://github.com/apollographql/apollo-server/pull/2850)
+- `apollo-server-core`: fix setting `engine: false` should ignore `ENGINE_API_KEY` in environment variable [PR #2850](https://github.com/apollographql/apollo-server/pull/2850) (a regression introduced in 2.6.0)
 
 ### v2.6.2
 

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -77,7 +77,9 @@ const NoIntrospection = (context: ValidationContext) => ({
 
 function getEngineApiKey(engine: Config['engine']): string | undefined {
   const keyFromEnv = process.env.ENGINE_API_KEY || '';
-  if (typeof engine === 'object' && engine.apiKey) {
+  if (engine === false) {
+    return;
+  } else if (typeof engine === 'object' && engine.apiKey) {
     return engine.apiKey;
   } else if (keyFromEnv) {
     return keyFromEnv;


### PR DESCRIPTION
Followup to fix unintended side effect of https://github.com/apollographql/apollo-server/pull/2685 that David discovered where setting `engine: false` would no longer ignore the `ENGINE_API_KEY` environment variable