### PR TITLE
Update error masking example in the docs

### DIFF
--- a/docs/source/features/errors.md
+++ b/docs/source/features/errors.md
@@ -136,7 +136,7 @@ const server = new ApolloServer({
   formatError: (err) => {
     // Don't give the specific errors to the client.
     if (err.message.startsWith("Database Error: ")) {
-      return new Error('Internal server error');
+      err.message = 'Internal server error';
     }
     
     // Otherwise return the original error.  The error can also


### PR DESCRIPTION
[`formatError` expects the returned error to be of type `GraphQLFormattedError`](https://github.com/apollographql/apollo-server/blob/6ffec8e4535946289f724451aed8b2ade966cac5/packages/apollo-server-core/src/graphqlOptions.ts#L38) and the example was using `return new Error(...)` which caused TypeScript error.

The updated code just rewrites the `message` without changing the rest of the object.