### PR TITLE
apollo-cache-control does not set HTTP headers

### DIFF
--- a/docs/source/features/caching.md
+++ b/docs/source/features/caching.md
@@ -104,6 +104,8 @@ As many CDNs and caching proxies only cache GET requests (not POST requests) and
 
 If you don't want to set HTTP cache headers, pass `cacheControl: {calculateHttpHeaders: false}` to `new ApolloServer()`.
 
+> **Important note:** If you enable the `cacheControl` [extension](https://github.com/apollographql/apollo-cache-control) enabled, HTTP headers will not be set.
+
 ## Saving full responses to a cache
 
 Apollo Server lets you save cacheable responses to a Redis, Memcached, or in-process cache. Cached responses respect the `maxAge` cache hint.


### PR DESCRIPTION
I lost quite a bit of time to this and the tests finally showed me that enabling apollo-cache-control stops HTTP headers from being set.

https://github.com/apollographql/apollo-server/blob/b712eeff84221f1a9b011a8ac07272659bc2ee63/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts#L761-L773

This warning might help future folks.

Is this the expected behavior in all integrations? Or is this an oddity with apollo-server-express?