### PR TITLE
fix: Allow parseOptions.allowLegacySDLEmptyFields option

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -323,7 +323,7 @@ export class ApolloServerBase {
 
     // The schema hash is a string representation of the shape of the schema
     // it is used for reporting and can be used for a cache key if needed
-    this.schemaHash = generateSchemaHash(this.schema);
+    this.schemaHash = generateSchemaHash(this.schema, parseOptions);
 
     // Note: doRunQuery will add its own extensions if you set tracing,
     // or cacheControl.

--- a/packages/apollo-server-core/src/__tests__/configuration.test.ts
+++ b/packages/apollo-server-core/src/__tests__/configuration.test.ts
@@ -1,0 +1,27 @@
+/* tslint:disable:no-unused-expression */
+
+import { ApolloServerBase } from '../ApolloServer';
+
+describe('Configuration', () => {
+  it('should recognise parseOptions.allowLegacySDLEmptyFields as an option', () => {
+    const typeDefs = `
+        type Query { }
+        extend type Query { _: Boolean }
+        schema { query: Query }`;
+
+    let message: string;
+    try {
+      new ApolloServerBase({ typeDefs });
+    } catch (e) {
+      message = e.message;
+    }
+    expect(message).toContain('Syntax Error: Expected Name, found }');
+
+    new ApolloServerBase({
+      typeDefs,
+      parseOptions: {
+        allowLegacySDLEmptyFields: true,
+      },
+    });
+  });
+});

--- a/packages/apollo-server-core/src/utils/schemaHash.ts
+++ b/packages/apollo-server-core/src/utils/schemaHash.ts
@@ -1,3 +1,4 @@
+import { GraphQLParseOptions } from 'graphql-tools';
 import { parse } from 'graphql/language';
 import { execute, ExecutionResult } from 'graphql/execution';
 import { getIntrospectionQuery, IntrospectionSchema } from 'graphql/utilities';
@@ -5,9 +6,12 @@ import stableStringify from 'fast-json-stable-stringify';
 import { GraphQLSchema } from 'graphql/type';
 import createSHA from './createSHA';
 
-export function generateSchemaHash(schema: GraphQLSchema): string {
+export function generateSchemaHash(
+  schema: GraphQLSchema,
+  parseOptions: GraphQLParseOptions,
+): string {
   const introspectionQuery = getIntrospectionQuery();
-  const documentAST = parse(introspectionQuery);
+  const documentAST = parse(introspectionQuery, parseOptions);
   const result = execute(schema, documentAST) as ExecutionResult;
 
   // If the execution of an introspection query results in a then-able, it


### PR DESCRIPTION
fixes #2799 

The cause for the bug comes from the second `parse()` which lacks `parseOptions`. (I didn't dig in to understand why `ApolloServerBase` parses GraphQL twice)