### PR TITLE
Fix Fastify deprecation beforeHandler -> preHandler

### DIFF
--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -117,7 +117,7 @@ export class ApolloServer extends ApolloServerBase {
             reply.send();
           });
 
-          const beforeHandlers = [
+          const preHandlers = [
             (
               req: FastifyRequest<IncomingMessage>,
               reply: FastifyReply<OutgoingMessage>,
@@ -166,13 +166,14 @@ export class ApolloServer extends ApolloServerBase {
                 done(null);
               },
             );
-            beforeHandlers.push(fileUploadMiddleware(this.uploadsConfig, this));
+            preHandlers.push(fileUploadMiddleware(this.uploadsConfig, this));
           }
 
           instance.route({
             method: ['GET', 'POST'],
             url: '/',
-            beforeHandler: beforeHandlers,
+            preHandler: preHandlers,
+            beforeHandler: preHandlers,
             handler: await graphqlFastify(this.graphQLServerOptions.bind(this)),
           });
         },


### PR DESCRIPTION
Quite self-explanatory. I left the old hook to avoid unnecessary breakage for people on older Fastify versions.