### PR TITLE
[Federation] Disallow extensions without base definitions

### DIFF
--- a/packages/apollo-federation/src/composition/__tests__/compose.test.ts
+++ b/packages/apollo-federation/src/composition/__tests__/compose.test.ts
@@ -39,18 +39,18 @@ describe('composeServices', () => {
     expect(schema).toBeDefined();
 
     expect(schema.getType('User')).toMatchInlineSnapshot(`
-                  type User {
-                    name: String
-                    email: String!
-                  }
-            `);
+      type User {
+        name: String
+        email: String!
+      }
+    `);
 
     expect(schema.getType('Product')).toMatchInlineSnapshot(`
-                  type Product {
-                    sku: String!
-                    name: String!
-                  }
-            `);
+      type Product {
+        sku: String!
+        name: String!
+      }
+    `);
 
     const product = schema.getType('Product') as GraphQLObjectType;
     const user = schema.getType('User') as GraphQLObjectType;
@@ -85,12 +85,12 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-                        type Product {
-                          sku: String!
-                          name: String!
-                          price: Int!
-                        }
-                  `);
+        type Product {
+          sku: String!
+          name: String!
+          price: Int!
+        }
+      `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -124,12 +124,12 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-                        type Product {
-                          sku: String!
-                          name: String!
-                          price: Int!
-                        }
-                  `);
+        type Product {
+          sku: String!
+          name: String!
+          price: Int!
+        }
+      `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -177,13 +177,13 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-                        type Product {
-                          sku: String!
-                          name: String!
-                          price: Int!
-                          color: String!
-                        }
-                  `);
+        type Product {
+          sku: String!
+          name: String!
+          price: Int!
+          color: String!
+        }
+      `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -232,21 +232,21 @@ describe('composeServices', () => {
         serviceC,
       ]);
       expect(errors).toMatchInlineSnapshot(`
-                                Array [
-                                  [GraphQLError: Field "Product.price" can only be defined once.],
-                                ]
-                        `);
+        Array [
+          [GraphQLError: Field "Product.price" can only be defined once.],
+        ]
+      `);
       expect(schema).toBeDefined();
 
       const product = schema.getType('Product') as GraphQLObjectType;
       expect(product).toMatchInlineSnapshot(`
-                        type Product {
-                          sku: String!
-                          name: String!
-                          price: Float!
-                          color: String!
-                        }
-                  `);
+        type Product {
+          sku: String!
+          name: String!
+          price: Float!
+          color: String!
+        }
+      `);
 
       expect(product.federation.serviceName).toEqual('serviceB');
       expect(product.getFields()['price'].federation.serviceName).toEqual(
@@ -283,12 +283,12 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-                        type Product {
-                          sku: String!
-                          name(type: String): String!
-                          price(currency: Curr!): Int!
-                        }
-                  `);
+        type Product {
+          sku: String!
+          name(type: String): String!
+          price(currency: Curr!): Int!
+        }
+      `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
       expect(product.getFields()['price'].args[0].name).toEqual('currency');
@@ -318,20 +318,20 @@ describe('composeServices', () => {
       const { schema, errors } = composeServices([serviceA, serviceB]);
       expect(schema).toBeDefined();
       expect(errors).toMatchInlineSnapshot(`
-                        Array [
-                          [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
-                          [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
-                        ]
-                  `);
+        Array [
+          [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
+          [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
+        ]
+      `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
       expect(product).toMatchInlineSnapshot(`
-                        type Product {
-                          sku: String!
-                          name: String!
-                        }
-                  `);
+        type Product {
+          sku: String!
+          name: String!
+        }
+      `);
       expect(product.getFields()['sku'].federation.serviceName).toEqual(
         'serviceB',
       );
@@ -364,19 +364,19 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-                              Array [
-                                [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
-                              ]
-                        `);
+          Array [
+            [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
+          ]
+        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-                              type Product {
-                                sku: String!
-                                name: String!
-                              }
-                        `);
+          type Product {
+            sku: String!
+            name: String!
+          }
+        `);
         expect(product.getFields()['name'].federation.serviceName).toEqual(
           'serviceB',
         );
@@ -410,20 +410,20 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-                              Array [
-                                [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
-                                [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
-                              ]
-                        `);
+          Array [
+            [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
+            [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
+          ]
+        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-                              type Product {
-                                sku: String!
-                                name: String!
-                              }
-                        `);
+          type Product {
+            sku: String!
+            name: String!
+          }
+        `);
         expect(product.getFields()['name'].federation.serviceName).toEqual(
           'serviceB',
         );
@@ -454,21 +454,21 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-                              Array [
-                                [GraphQLError: Field "Product.name" can only be defined once.],
-                                [GraphQLError: There can be only one type named "Product".],
-                              ]
-                        `);
+          Array [
+            [GraphQLError: Field "Product.name" can only be defined once.],
+            [GraphQLError: There can be only one type named "Product".],
+          ]
+        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-                              type Product {
-                                id: ID!
-                                name: String!
-                                price: Int!
-                              }
-                        `);
+          type Product {
+            id: ID!
+            name: String!
+            price: Int!
+          }
+        `);
       });
     });
   });
@@ -501,12 +501,6 @@ describe('composeServices', () => {
       const { schema, errors } = composeServices([serviceA, serviceB]);
       expect(schema).toBeDefined();
       expect(errors).toMatchInlineSnapshot(`Array []`);
-
-      // const colorField = (schema.getType(
-      //   "ProductInput"
-      // ) as GraphQLInputObjectType).getFields()["color"];
-
-      // expect(colorField.serviceName).toEqual("serviceB");
     });
 
     it('extends enum types', () => {
@@ -532,10 +526,6 @@ describe('composeServices', () => {
       const { schema, errors } = composeServices([serviceA, serviceB]);
       expect(schema).toBeDefined();
       expect(errors).toMatchInlineSnapshot(`Array []`);
-
-      // const category = schema.getType("ProductCategory") as GraphQLEnumType;
-      // expect(category.serviceName).toEqual("serviceA");
-      // expect(category.getValue("BEYOND").serviceName).toEqual("serviceB");
     });
   });
 
@@ -568,19 +558,19 @@ describe('composeServices', () => {
 
       const { schema, errors } = composeServices([serviceA, serviceB]);
       expect(errors).toMatchInlineSnapshot(`
-                        Array [
-                          [GraphQLError: Field "Product.id" already exists in the schema. It cannot also be defined in this type extension.],
-                        ]
-                  `);
+        Array [
+          [GraphQLError: Field "Product.id" already exists in the schema. It cannot also be defined in this type extension.],
+        ]
+      `);
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-                        type Product implements Item {
-                          id: String!
-                          sku: String!
-                          name: String!
-                        }
-                  `);
+        type Product implements Item {
+          id: String!
+          sku: String!
+          name: String!
+        }
+      `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -616,11 +606,11 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getQueryType()).toMatchInlineSnapshot(`
-                        type Query {
-                          products: [ID!]
-                          people: [ID!]
-                        }
-                  `);
+        type Query {
+          products: [ID!]
+          people: [ID!]
+        }
+      `);
 
       const query = schema.getQueryType();
 
@@ -657,11 +647,11 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Query')).toMatchInlineSnapshot(`
-                        type Query {
-                          products: [ID!]
-                          people: [ID!]
-                        }
-                  `);
+        type Query {
+          products: [ID!]
+          people: [ID!]
+        }
+      `);
 
       const query = schema.getType('Query') as GraphQLObjectType;
 
@@ -697,11 +687,11 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Mutation')).toMatchInlineSnapshot(`
-                        type Mutation {
-                          login(credentials: Credentials!): String
-                          logout(username: String!): Boolean
-                        }
-                  `);
+        type Mutation {
+          login(credentials: Credentials!): String
+          logout(username: String!): Boolean
+        }
+      `);
     });
 
     it('treats root Mutations type definition as an extension, not base definitions', () => {
@@ -796,28 +786,28 @@ describe('composeServices', () => {
         const product = schema.getType('Product');
 
         expect(product.federation.externals).toMatchInlineSnapshot(`
-                              Object {
-                                "serviceB--MISSING": Array [
-                                  Object {
-                                    "field": sku: String! @external,
-                                    "parentTypeName": "Product",
-                                    "serviceName": "serviceB--MISSING",
-                                  },
-                                ],
-                                "serviceC--found": Array [
-                                  Object {
-                                    "field": sku: String! @external,
-                                    "parentTypeName": "Product",
-                                    "serviceName": "serviceC--found",
-                                  },
-                                  Object {
-                                    "field": upc: String! @external,
-                                    "parentTypeName": "Product",
-                                    "serviceName": "serviceC--found",
-                                  },
-                                ],
-                              }
-                        `);
+          Object {
+            "serviceB--MISSING": Array [
+              Object {
+                "field": sku: String! @external,
+                "parentTypeName": "Product",
+                "serviceName": "serviceB--MISSING",
+              },
+            ],
+            "serviceC--found": Array [
+              Object {
+                "field": sku: String! @external,
+                "parentTypeName": "Product",
+                "serviceName": "serviceC--found",
+              },
+              Object {
+                "field": upc: String! @external,
+                "parentTypeName": "Product",
+                "serviceName": "serviceC--found",
+              },
+            ],
+          }
+        `);
       });
       it('does not redefine fields with @external when composing', () => {
         const serviceA = {
@@ -847,12 +837,12 @@ describe('composeServices', () => {
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-                              type Product {
-                                sku: String!
-                                name: String!
-                                price: Int!
-                              }
-                        `);
+          type Product {
+            sku: String!
+            name: String!
+            price: Int!
+          }
+        `);
         expect(product.getFields()['price'].federation.serviceName).toEqual(
           'serviceB',
         );
@@ -921,10 +911,10 @@ describe('composeServices', () => {
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.getFields()['price'].federation.requires)
           .toMatchInlineSnapshot(`
-                                sku {
-                                  id
-                                }
-                          `);
+            sku {
+              id
+            }
+          `);
       });
     });
 
@@ -1000,10 +990,10 @@ describe('composeServices', () => {
         const review = schema.getType('Review') as GraphQLObjectType;
         expect(review.getFields()['product'].federation.provides)
           .toMatchInlineSnapshot(`
-                                sku {
-                                  id
-                                }
-                          `);
+            sku {
+              id
+            }
+          `);
       });
     });
 
@@ -1034,13 +1024,13 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.federation.keys).toMatchInlineSnapshot(`
-                              Object {
-                                "serviceA": Array [
-                                  sku,
-                                  upc,
-                                ],
-                              }
-                        `);
+          Object {
+            "serviceA": Array [
+              sku,
+              upc,
+            ],
+          }
+        `);
       });
 
       it('adds @key information to types using selection set notation', () => {
@@ -1075,15 +1065,15 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.federation.keys).toMatchInlineSnapshot(`
-                              Object {
-                                "serviceA": Array [
-                                  color {
-                                id
-                                value
-                              },
-                                ],
-                              }
-                        `);
+          Object {
+            "serviceA": Array [
+              color {
+            id
+            value
+          },
+            ],
+          }
+        `);
       });
 
       it('preserves @key information with respect to types across different services', () => {
@@ -1118,18 +1108,18 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.federation.keys).toMatchInlineSnapshot(`
-                              Object {
-                                "serviceA": Array [
-                                  color {
-                                id
-                                value
-                              },
-                                ],
-                                "serviceB": Array [
-                                  sku,
-                                ],
-                              }
-                        `);
+          Object {
+            "serviceA": Array [
+              color {
+            id
+            value
+          },
+            ],
+            "serviceB": Array [
+              sku,
+            ],
+          }
+        `);
       });
     });
 
@@ -1167,12 +1157,12 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product).toMatchInlineSnapshot(`
-                              type Product {
-                                sku: String!
-                                upc: String!
-                                price: Int!
-                              }
-                        `);
+          type Product {
+            sku: String!
+            upc: String!
+            price: Int!
+          }
+        `);
       });
     });
   });

--- a/packages/apollo-federation/src/composition/__tests__/compose.test.ts
+++ b/packages/apollo-federation/src/composition/__tests__/compose.test.ts
@@ -39,18 +39,18 @@ describe('composeServices', () => {
     expect(schema).toBeDefined();
 
     expect(schema.getType('User')).toMatchInlineSnapshot(`
-      type User {
-        name: String
-        email: String!
-      }
-    `);
+                  type User {
+                    name: String
+                    email: String!
+                  }
+            `);
 
     expect(schema.getType('Product')).toMatchInlineSnapshot(`
-      type Product {
-        sku: String!
-        name: String!
-      }
-    `);
+                  type Product {
+                    sku: String!
+                    name: String!
+                  }
+            `);
 
     const product = schema.getType('Product') as GraphQLObjectType;
     const user = schema.getType('User') as GraphQLObjectType;
@@ -85,12 +85,12 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-        type Product {
-          sku: String!
-          name: String!
-          price: Int!
-        }
-      `);
+                        type Product {
+                          sku: String!
+                          name: String!
+                          price: Int!
+                        }
+                  `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -124,12 +124,12 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-        type Product {
-          sku: String!
-          name: String!
-          price: Int!
-        }
-      `);
+                        type Product {
+                          sku: String!
+                          name: String!
+                          price: Int!
+                        }
+                  `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -177,13 +177,13 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-        type Product {
-          sku: String!
-          name: String!
-          price: Int!
-          color: String!
-        }
-      `);
+                        type Product {
+                          sku: String!
+                          name: String!
+                          price: Int!
+                          color: String!
+                        }
+                  `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -232,21 +232,21 @@ describe('composeServices', () => {
         serviceC,
       ]);
       expect(errors).toMatchInlineSnapshot(`
-                Array [
-                  [GraphQLError: Field "Product.price" can only be defined once.],
-                ]
-            `);
+                                Array [
+                                  [GraphQLError: Field "Product.price" can only be defined once.],
+                                ]
+                        `);
       expect(schema).toBeDefined();
 
       const product = schema.getType('Product') as GraphQLObjectType;
       expect(product).toMatchInlineSnapshot(`
-        type Product {
-          sku: String!
-          name: String!
-          price: Float!
-          color: String!
-        }
-      `);
+                        type Product {
+                          sku: String!
+                          name: String!
+                          price: Float!
+                          color: String!
+                        }
+                  `);
 
       expect(product.federation.serviceName).toEqual('serviceB');
       expect(product.getFields()['price'].federation.serviceName).toEqual(
@@ -283,50 +283,15 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-        type Product {
-          sku: String!
-          name(type: String): String!
-          price(currency: Curr!): Int!
-        }
-      `);
+                        type Product {
+                          sku: String!
+                          name(type: String): String!
+                          price(currency: Curr!): Int!
+                        }
+                  `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
       expect(product.getFields()['price'].args[0].name).toEqual('currency');
-    });
-
-    it('treats type extensions as a base type definition when none is available', () => {
-      const serviceA = {
-        typeDefs: gql`
-          extend type Product {
-            price: Float!
-          }
-        `,
-        name: 'serviceA',
-      };
-
-      const serviceB = {
-        typeDefs: gql`
-          extend type Product {
-            color: String!
-          }
-        `,
-        name: 'serviceB',
-      };
-
-      const { schema, errors } = composeServices([serviceA, serviceB]);
-      expect(errors).toHaveLength(0);
-      expect(schema).toBeDefined();
-
-      expect(schema.getType('Product')).toMatchInlineSnapshot(`
-        type Product {
-          price: Float!
-          color: String!
-        }
-      `);
-
-      const product = schema.getType('Product') as GraphQLObjectType;
-
-      expect(product.federation.serviceName).toEqual(null);
     });
 
     // This is a limitation of extendSchema currently (this is currently a broken test to demonstrate)
@@ -353,20 +318,20 @@ describe('composeServices', () => {
       const { schema, errors } = composeServices([serviceA, serviceB]);
       expect(schema).toBeDefined();
       expect(errors).toMatchInlineSnapshot(`
-        Array [
-          [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
-          [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
-        ]
-      `);
+                        Array [
+                          [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
+                          [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
+                        ]
+                  `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
       expect(product).toMatchInlineSnapshot(`
-        type Product {
-          sku: String!
-          name: String!
-        }
-      `);
+                        type Product {
+                          sku: String!
+                          name: String!
+                        }
+                  `);
       expect(product.getFields()['sku'].federation.serviceName).toEqual(
         'serviceB',
       );
@@ -399,19 +364,19 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-          Array [
-            [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
-          ]
-        `);
+                              Array [
+                                [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
+                              ]
+                        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-          type Product {
-            sku: String!
-            name: String!
-          }
-        `);
+                              type Product {
+                                sku: String!
+                                name: String!
+                              }
+                        `);
         expect(product.getFields()['name'].federation.serviceName).toEqual(
           'serviceB',
         );
@@ -445,20 +410,20 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-          Array [
-            [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
-            [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
-          ]
-        `);
+                              Array [
+                                [GraphQLError: Field "Product.sku" already exists in the schema. It cannot also be defined in this type extension.],
+                                [GraphQLError: Field "Product.name" already exists in the schema. It cannot also be defined in this type extension.],
+                              ]
+                        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-          type Product {
-            sku: String!
-            name: String!
-          }
-        `);
+                              type Product {
+                                sku: String!
+                                name: String!
+                              }
+                        `);
         expect(product.getFields()['name'].federation.serviceName).toEqual(
           'serviceB',
         );
@@ -489,21 +454,21 @@ describe('composeServices', () => {
         const { schema, errors } = composeServices([serviceA, serviceB]);
         expect(schema).toBeDefined();
         expect(errors).toMatchInlineSnapshot(`
-          Array [
-            [GraphQLError: Field "Product.name" can only be defined once.],
-            [GraphQLError: There can be only one type named "Product".],
-          ]
-        `);
+                              Array [
+                                [GraphQLError: Field "Product.name" can only be defined once.],
+                                [GraphQLError: There can be only one type named "Product".],
+                              ]
+                        `);
 
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-          type Product {
-            id: ID!
-            name: String!
-            price: Int!
-          }
-        `);
+                              type Product {
+                                id: ID!
+                                name: String!
+                                price: Int!
+                              }
+                        `);
       });
     });
   });
@@ -603,19 +568,19 @@ describe('composeServices', () => {
 
       const { schema, errors } = composeServices([serviceA, serviceB]);
       expect(errors).toMatchInlineSnapshot(`
-        Array [
-          [GraphQLError: Field "Product.id" already exists in the schema. It cannot also be defined in this type extension.],
-        ]
-      `);
+                        Array [
+                          [GraphQLError: Field "Product.id" already exists in the schema. It cannot also be defined in this type extension.],
+                        ]
+                  `);
       expect(schema).toBeDefined();
 
       expect(schema.getType('Product')).toMatchInlineSnapshot(`
-        type Product implements Item {
-          id: String!
-          sku: String!
-          name: String!
-        }
-      `);
+                        type Product implements Item {
+                          id: String!
+                          sku: String!
+                          name: String!
+                        }
+                  `);
 
       const product = schema.getType('Product') as GraphQLObjectType;
 
@@ -651,15 +616,15 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getQueryType()).toMatchInlineSnapshot(`
-        type Query {
-          products: [ID!]
-          people: [ID!]
-        }
-      `);
+                        type Query {
+                          products: [ID!]
+                          people: [ID!]
+                        }
+                  `);
 
       const query = schema.getQueryType();
 
-      expect(query.federation.serviceName).toEqual(null);
+      expect(query.federation.serviceName).toBeUndefined();
     });
 
     it('treats root Query type definition as an extension, not base definitions', () => {
@@ -692,15 +657,15 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Query')).toMatchInlineSnapshot(`
-        type Query {
-          products: [ID!]
-          people: [ID!]
-        }
-      `);
+                        type Query {
+                          products: [ID!]
+                          people: [ID!]
+                        }
+                  `);
 
       const query = schema.getType('Query') as GraphQLObjectType;
 
-      expect(query.federation.serviceName).toBeNull();
+      expect(query.federation.serviceName).toBeUndefined();
     });
 
     it('allows extension of the Mutation type with no base type definition', () => {
@@ -732,11 +697,11 @@ describe('composeServices', () => {
       expect(schema).toBeDefined();
 
       expect(schema.getType('Mutation')).toMatchInlineSnapshot(`
-        type Mutation {
-          login(credentials: Credentials!): String
-          logout(username: String!): Boolean
-        }
-      `);
+                        type Mutation {
+                          login(credentials: Credentials!): String
+                          logout(username: String!): Boolean
+                        }
+                  `);
     });
 
     it('treats root Mutations type definition as an extension, not base definitions', () => {
@@ -831,28 +796,28 @@ describe('composeServices', () => {
         const product = schema.getType('Product');
 
         expect(product.federation.externals).toMatchInlineSnapshot(`
-          Object {
-            "serviceB--MISSING": Array [
-              Object {
-                "field": sku: String! @external,
-                "parentTypeName": "Product",
-                "serviceName": "serviceB--MISSING",
-              },
-            ],
-            "serviceC--found": Array [
-              Object {
-                "field": sku: String! @external,
-                "parentTypeName": "Product",
-                "serviceName": "serviceC--found",
-              },
-              Object {
-                "field": upc: String! @external,
-                "parentTypeName": "Product",
-                "serviceName": "serviceC--found",
-              },
-            ],
-          }
-        `);
+                              Object {
+                                "serviceB--MISSING": Array [
+                                  Object {
+                                    "field": sku: String! @external,
+                                    "parentTypeName": "Product",
+                                    "serviceName": "serviceB--MISSING",
+                                  },
+                                ],
+                                "serviceC--found": Array [
+                                  Object {
+                                    "field": sku: String! @external,
+                                    "parentTypeName": "Product",
+                                    "serviceName": "serviceC--found",
+                                  },
+                                  Object {
+                                    "field": upc: String! @external,
+                                    "parentTypeName": "Product",
+                                    "serviceName": "serviceC--found",
+                                  },
+                                ],
+                              }
+                        `);
       });
       it('does not redefine fields with @external when composing', () => {
         const serviceA = {
@@ -882,12 +847,12 @@ describe('composeServices', () => {
         const product = schema.getType('Product') as GraphQLObjectType;
 
         expect(product).toMatchInlineSnapshot(`
-          type Product {
-            sku: String!
-            name: String!
-            price: Int!
-          }
-        `);
+                              type Product {
+                                sku: String!
+                                name: String!
+                                price: Int!
+                              }
+                        `);
         expect(product.getFields()['price'].federation.serviceName).toEqual(
           'serviceB',
         );
@@ -956,10 +921,10 @@ describe('composeServices', () => {
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.getFields()['price'].federation.requires)
           .toMatchInlineSnapshot(`
-            sku {
-              id
-            }
-          `);
+                                sku {
+                                  id
+                                }
+                          `);
       });
     });
 
@@ -1035,10 +1000,10 @@ describe('composeServices', () => {
         const review = schema.getType('Review') as GraphQLObjectType;
         expect(review.getFields()['product'].federation.provides)
           .toMatchInlineSnapshot(`
-            sku {
-              id
-            }
-          `);
+                                sku {
+                                  id
+                                }
+                          `);
       });
     });
 
@@ -1069,13 +1034,13 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.federation.keys).toMatchInlineSnapshot(`
-          Object {
-            "serviceA": Array [
-              sku,
-              upc,
-            ],
-          }
-        `);
+                              Object {
+                                "serviceA": Array [
+                                  sku,
+                                  upc,
+                                ],
+                              }
+                        `);
       });
 
       it('adds @key information to types using selection set notation', () => {
@@ -1110,15 +1075,15 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.federation.keys).toMatchInlineSnapshot(`
-          Object {
-            "serviceA": Array [
-              color {
-            id
-            value
-          },
-            ],
-          }
-        `);
+                              Object {
+                                "serviceA": Array [
+                                  color {
+                                id
+                                value
+                              },
+                                ],
+                              }
+                        `);
       });
 
       it('preserves @key information with respect to types across different services', () => {
@@ -1153,18 +1118,18 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product.federation.keys).toMatchInlineSnapshot(`
-          Object {
-            "serviceA": Array [
-              color {
-            id
-            value
-          },
-            ],
-            "serviceB": Array [
-              sku,
-            ],
-          }
-        `);
+                              Object {
+                                "serviceA": Array [
+                                  color {
+                                id
+                                value
+                              },
+                                ],
+                                "serviceB": Array [
+                                  sku,
+                                ],
+                              }
+                        `);
       });
     });
 
@@ -1202,12 +1167,12 @@ describe('composeServices', () => {
 
         const product = schema.getType('Product') as GraphQLObjectType;
         expect(product).toMatchInlineSnapshot(`
-          type Product {
-            sku: String!
-            upc: String!
-            price: Int!
-          }
-        `);
+                              type Product {
+                                sku: String!
+                                upc: String!
+                                price: Int!
+                              }
+                        `);
       });
     });
   });

--- a/packages/apollo-federation/src/composition/__tests__/composeAndValidate.test.ts
+++ b/packages/apollo-federation/src/composition/__tests__/composeAndValidate.test.ts
@@ -111,12 +111,52 @@ it('composes and validates all (24) permutations without error', () => {
     }
 
     expect({ warnings, errors }).toMatchInlineSnapshot(`
-                  Object {
-                    "errors": Array [],
-                    "warnings": Array [],
-                  }
-            `);
+                              Object {
+                                "errors": Array [],
+                                "warnings": Array [],
+                              }
+                    `);
   });
+});
+
+it('errors when a type extension has no base', () => {
+  const serviceA = {
+    typeDefs: gql`
+      schema {
+        query: MyRoot
+      }
+
+      type MyRoot {
+        products: [Product]!
+      }
+
+      type Product @key(fields: "sku") {
+        sku: String!
+        upc: String!
+      }
+    `,
+    name: 'serviceA',
+  };
+
+  const serviceB = {
+    typeDefs: gql`
+      extend type Location {
+        id: ID
+      }
+    `,
+    name: 'serviceB',
+  };
+
+  const { schema, errors } = composeAndValidate([serviceA, serviceB]);
+  expect(errors).toHaveLength(1);
+  expect(errors).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "code": "EXTENSION_WITH_NO_BASE",
+        "message": "[serviceB] Location -> \`Location\` is an extension type, but \`Location\` is not defined in any service",
+      },
+    ]
+  `);
 });
 
 it('treats types with @extends as type extensions', () => {
@@ -149,12 +189,12 @@ it('treats types with @extends as type extensions', () => {
 
   const product = schema.getType('Product') as GraphQLObjectType;
   expect(product).toMatchInlineSnapshot(`
-            type Product {
-              sku: String!
-              upc: String!
-              price: Int!
-            }
-      `);
+                    type Product {
+                      sku: String!
+                      upc: String!
+                      price: Int!
+                    }
+          `);
 });
 
 it('errors on invalid usages of default operation names', () => {
@@ -196,13 +236,13 @@ it('errors on invalid usages of default operation names', () => {
 
   const { errors } = composeAndValidate([serviceA, serviceB]);
   expect(errors).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "code": "ROOT_QUERY_USED",
-        "message": "[serviceA] Query -> Found invalid use of default root operation name \`Query\`. \`Query\` is disallowed when \`Schema.query\` is set to a type other than \`Query\`.",
-      },
-    ]
-  `);
+            Array [
+              Object {
+                "code": "ROOT_QUERY_USED",
+                "message": "[serviceA] Query -> Found invalid use of default root operation name \`Query\`. \`Query\` is disallowed when \`Schema.query\` is set to a type other than \`Query\`.",
+              },
+            ]
+      `);
 });
 
 it.todo('errors on duplicate types where there is a mismatch of field types');

--- a/packages/apollo-federation/src/composition/__tests__/composeAndValidate.test.ts
+++ b/packages/apollo-federation/src/composition/__tests__/composeAndValidate.test.ts
@@ -111,11 +111,11 @@ it('composes and validates all (24) permutations without error', () => {
     }
 
     expect({ warnings, errors }).toMatchInlineSnapshot(`
-                              Object {
-                                "errors": Array [],
-                                "warnings": Array [],
-                              }
-                    `);
+      Object {
+        "errors": Array [],
+        "warnings": Array [],
+      }
+    `);
   });
 });
 
@@ -189,12 +189,12 @@ it('treats types with @extends as type extensions', () => {
 
   const product = schema.getType('Product') as GraphQLObjectType;
   expect(product).toMatchInlineSnapshot(`
-                    type Product {
-                      sku: String!
-                      upc: String!
-                      price: Int!
-                    }
-          `);
+    type Product {
+      sku: String!
+      upc: String!
+      price: Int!
+    }
+  `);
 });
 
 it('errors on invalid usages of default operation names', () => {
@@ -236,13 +236,13 @@ it('errors on invalid usages of default operation names', () => {
 
   const { errors } = composeAndValidate([serviceA, serviceB]);
   expect(errors).toMatchInlineSnapshot(`
-            Array [
-              Object {
-                "code": "ROOT_QUERY_USED",
-                "message": "[serviceA] Query -> Found invalid use of default root operation name \`Query\`. \`Query\` is disallowed when \`Schema.query\` is set to a type other than \`Query\`.",
-              },
-            ]
-      `);
+    Array [
+      Object {
+        "code": "ROOT_QUERY_USED",
+        "message": "[serviceA] Query -> Found invalid use of default root operation name \`Query\`. \`Query\` is disallowed when \`Schema.query\` is set to a type other than \`Query\`.",
+      },
+    ]
+  `);
 });
 
 it.todo('errors on duplicate types where there is a mismatch of field types');

--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -42,13 +42,13 @@ const EmptyQueryDefinition = {
   name: { kind: Kind.NAME, value: 'Query' },
   fields: [],
   serviceName: null,
-}
+};
 const EmptyMutationDefinition = {
   kind: Kind.OBJECT_TYPE_DEFINITION,
   name: { kind: Kind.NAME, value: 'Mutation' },
   fields: [],
   serviceName: null,
-}
+};
 
 // Map of all definitions to eventually be passed to extendSchema
 interface DefinitionsMap {
@@ -247,8 +247,7 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
   // extendSchema will complain about this. We can't add an empty
   // GraphQLObjectType to the schema constructor, so we add an empty definition
   // here. We only add mutation if there is a mutation extension though.
-  if (!definitionsMap.Query)
-    definitionsMap.Query = [EmptyQueryDefinition];
+  if (!definitionsMap.Query) definitionsMap.Query = [EmptyQueryDefinition];
   if (extensionsMap.Mutation && !definitionsMap.Mutation)
     definitionsMap.Mutation = [EmptyMutationDefinition];
 
@@ -390,7 +389,7 @@ export function addFederationMetadataToSchemaNodes({
   }
   // add externals metadata
   for (const field of externalFields) {
-    const namedType = schema.getType(field.parentTypeName)
+    const namedType = schema.getType(field.parentTypeName);
     if (!namedType) continue;
 
     namedType.federation = {

--- a/packages/apollo-federation/src/composition/rules.ts
+++ b/packages/apollo-federation/src/composition/rules.ts
@@ -3,14 +3,20 @@ import { specifiedSDLRules } from 'graphql/validation/specifiedRules';
 import {
   UniqueTypeNamesWithoutEnumsOrScalars,
   MatchingEnums,
+  PossibleTypeExtensions,
 } from './validate/sdl';
 
 const omit = [
   'UniqueDirectivesPerLocation',
   'UniqueTypeNames',
   'UniqueEnumValueNames',
+  'PossibleTypeExtensions',
 ];
 
 export const compositionRules = specifiedSDLRules
   .filter(rule => !omit.includes(rule.name))
-  .concat([UniqueTypeNamesWithoutEnumsOrScalars, MatchingEnums]);
+  .concat([
+    UniqueTypeNamesWithoutEnumsOrScalars,
+    MatchingEnums,
+    PossibleTypeExtensions,
+  ]);

--- a/packages/apollo-federation/src/composition/types.ts
+++ b/packages/apollo-federation/src/composition/types.ts
@@ -3,6 +3,7 @@ import {
   DocumentNode,
   FieldDefinitionNode,
   TypeDefinitionNode,
+  TypeExtensionNode,
 } from 'graphql';
 
 export type ServiceName = string | null;
@@ -81,5 +82,9 @@ declare module 'graphql/type/definition' {
 }
 
 export type FederatedTypeDefinitionNode = TypeDefinitionNode & {
+  serviceName: string | null;
+};
+
+export type FederatedTypeExtensionNode = TypeExtensionNode & {
   serviceName: string | null;
 };

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/possibleTypeExtensions.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/possibleTypeExtensions.test.ts
@@ -1,0 +1,204 @@
+import {
+  GraphQLEnumType,
+  Kind,
+  DocumentNode,
+  validate,
+  GraphQLSchema,
+  specifiedDirectives,
+  extendSchema,
+} from 'graphql';
+import { validateSDL } from 'graphql/validation/validate';
+import gql from 'graphql-tag';
+
+import { composeServices, buildMapsFromServiceList } from '../../../compose';
+import {
+  astSerializer,
+  typeSerializer,
+  selectionSetSerializer,
+  graphqlErrorSerializer,
+} from '../../../../snapshotSerializers';
+import { normalizeTypeDefs } from '../../../normalize';
+import federationDirectives from '../../../../directives';
+import { ServiceDefinition } from '../../../types';
+import { PossibleTypeExtensions } from '../possibleTypeExtensions';
+
+expect.addSnapshotSerializer(graphqlErrorSerializer);
+expect.addSnapshotSerializer(typeSerializer);
+
+// simulate the first half of the composition process
+const createDefinitionsDocumentForServices = (
+  serviceList: ServiceDefinition[],
+): {
+  definitions: DocumentNode;
+  extensions: DocumentNode;
+} => {
+  const { definitionsMap, extensionsMap } = buildMapsFromServiceList(
+    serviceList,
+  );
+  return {
+    definitions: {
+      kind: Kind.DOCUMENT,
+      definitions: Object.values(definitionsMap).flat(),
+    },
+    extensions: {
+      kind: Kind.DOCUMENT,
+      definitions: Object.values(extensionsMap).flat(),
+    },
+  };
+};
+
+describe('PossibleTypeExtensionsType', () => {
+  let schema: GraphQLSchema;
+
+  // create a blank schema for each test
+  beforeEach(() => {
+    schema = new GraphQLSchema({
+      query: undefined,
+      directives: [...specifiedDirectives, ...federationDirectives],
+    });
+  });
+
+  it('does not error with matching enums across services', () => {
+    const serviceList = [
+      {
+        typeDefs: gql`
+          extend type Product {
+            sku: ID
+          }
+        `,
+        name: 'serviceA',
+      },
+
+      {
+        typeDefs: gql`
+          type Product {
+            id: ID!
+          }
+        `,
+        name: 'serviceB',
+      },
+    ];
+
+    const { definitions, extensions } = createDefinitionsDocumentForServices(
+      serviceList,
+    );
+    const errors = validateSDL(definitions, schema, [PossibleTypeExtensions]);
+    schema = extendSchema(schema, definitions, { assumeValidSDL: true });
+    errors.push(...validateSDL(extensions, schema, [PossibleTypeExtensions]));
+    expect(errors).toHaveLength(0);
+  });
+
+  it('errors when there is an extension with no base', () => {
+    const serviceList = [
+      {
+        typeDefs: gql`
+          extend type Product {
+            id: ID!
+          }
+        `,
+        name: 'serviceA',
+      },
+    ];
+
+    const { definitions, extensions } = createDefinitionsDocumentForServices(
+      serviceList,
+    );
+    const errors = validateSDL(definitions, schema, [PossibleTypeExtensions]);
+    schema = extendSchema(schema, definitions, { assumeValidSDL: true });
+    errors.push(...validateSDL(extensions, schema, [PossibleTypeExtensions]));
+
+    expect(errors).toHaveLength(1);
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "EXTENSION_WITH_NO_BASE",
+          "message": "[serviceA] Product -> \`Product\` is an extension type, but \`Product\` is not defined in any service",
+        },
+      ]
+    `);
+  });
+
+  it('errors when trying to extend a type with a different `Kind`', () => {
+    const serviceList = [
+      {
+        typeDefs: gql`
+          extend type Product {
+            sku: ID
+          }
+        `,
+        name: 'serviceA',
+      },
+
+      {
+        typeDefs: gql`
+          input Product {
+            id: ID!
+          }
+        `,
+        name: 'serviceB',
+      },
+    ];
+
+    const { definitions, extensions } = createDefinitionsDocumentForServices(
+      serviceList,
+    );
+    const errors = validateSDL(definitions, schema, [PossibleTypeExtensions]);
+    schema = extendSchema(schema, definitions, { assumeValidSDL: true });
+    errors.push(...validateSDL(extensions, schema, [PossibleTypeExtensions]));
+    expect(errors).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "code": "EXTENSION_OF_WRONG_KIND",
+                "message": "[serviceA] Product -> \`Product\` was originally defined as a InputObjectTypeDefinition and can only be extended by a InputObjectTypeExtension. serviceA defines Product as a ObjectTypeExtension",
+              },
+            ]
+        `);
+  });
+
+  it('does not error', () => {
+    const serviceList = [
+      {
+        typeDefs: gql`
+          extend interface Product {
+            name: String
+          }
+          extend type Book implements Product {
+            sku: ID!
+            name: String
+          }
+        `,
+        name: 'serviceA',
+      },
+
+      {
+        typeDefs: gql`
+          type Book {
+            id: ID!
+          }
+
+          interface Product {
+            sku: ID!
+          }
+        `,
+        name: 'serviceB',
+      },
+    ];
+
+    const { definitions, extensions } = createDefinitionsDocumentForServices(
+      serviceList,
+    );
+    const errors = validateSDL(definitions, schema, [PossibleTypeExtensions]);
+    schema = extendSchema(schema, definitions, { assumeValidSDL: true });
+    errors.push(...validateSDL(extensions, schema, [PossibleTypeExtensions]));
+    schema = extendSchema(schema, extensions, { assumeValidSDL: true });
+
+    expect(schema.getType('Book')).toMatchInlineSnapshot(`
+                  type Book implements Product {
+                    id: ID!
+                    sku: ID!
+                    name: String
+                  }
+            `);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/apollo-federation/src/composition/validate/sdl/index.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/index.ts
@@ -2,3 +2,4 @@ export {
   UniqueTypeNamesWithoutEnumsOrScalars,
 } from './uniqueTypeNamesWithoutEnumsOrScalars';
 export { MatchingEnums } from './matchingEnums';
+export { PossibleTypeExtensions } from './possibleTypeExtensions';

--- a/packages/apollo-federation/src/composition/validate/sdl/possibleTypeExtensions.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/possibleTypeExtensions.ts
@@ -8,11 +8,10 @@ import {
   isEnumType,
   isInputObjectType,
   Kind,
-  // ObjectTypeExtensionNode,
   isTypeDefinitionNode,
   ObjectTypeExtensionNode,
   InterfaceTypeExtensionNode,
-  // TypeExtensionNode,
+  GraphQLNamedType,
 } from 'graphql';
 import { errorWithCode, logServiceAndType } from '../../utils';
 
@@ -22,6 +21,10 @@ type FederatedExtensionNode = (
   serviceName?: string | null;
 };
 
+// This is a variant of the PossibleTypeExtensions validator in graphql-js.
+// it was modified to only check object/interface extensions. A custom error
+// message was also added.
+// original here: https://github.com/graphql/graphql-js/blob/master/src/validation/rules/PossibleTypeExtensions.js
 export function PossibleTypeExtensions(
   context: SDLValidationContext,
 ): ASTVisitor {
@@ -87,7 +90,10 @@ export function PossibleTypeExtensions(
   };
 }
 
-function typeToExtKind(type: any) {
+// These following utility functions/objects are part of the
+// PossibleTypeExtensions validations in graphql-js, but not exported.
+// https://github.com/graphql/graphql-js/blob/d8c1dfdc9dbbdef2400363cb0748d50cbeef39a8/src/validation/rules/PossibleTypeExtensions.js#L110
+function typeToExtKind(type: GraphQLNamedType) {
   if (isScalarType(type)) {
     return Kind.SCALAR_TYPE_EXTENSION;
   } else if (isObjectType(type)) {
@@ -113,7 +119,8 @@ const defKindToExtKind: { [kind: string]: string } = {
   [Kind.INPUT_OBJECT_TYPE_DEFINITION]: Kind.INPUT_OBJECT_TYPE_EXTENSION,
 };
 
-function typeToKind(type: any) {
+// this function is purely for printing out the `Kind` of the base type def.
+function typeToKind(type: GraphQLNamedType) {
   if (isScalarType(type)) {
     return Kind.SCALAR_TYPE_DEFINITION;
   } else if (isObjectType(type)) {

--- a/packages/apollo-federation/src/composition/validate/sdl/possibleTypeExtensions.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/possibleTypeExtensions.ts
@@ -53,9 +53,7 @@ export function PossibleTypeExtensions(
           errorWithCode(
             'EXTENSION_OF_WRONG_KIND',
             logServiceAndType(serviceName, typeName) +
-              `\`${typeName}\` was originally defined as a ${baseKind} and can only be extended by a ${expectedKind}. ${serviceName} defines ${typeName} as a ${
-                node.kind
-              }`,
+              `\`${typeName}\` was originally defined as a ${baseKind} and can only be extended by a ${expectedKind}. ${serviceName} defines ${typeName} as a ${node.kind}`,
           ),
         );
       }
@@ -67,9 +65,7 @@ export function PossibleTypeExtensions(
           errorWithCode(
             'EXTENSION_OF_WRONG_KIND',
             logServiceAndType(serviceName, typeName) +
-              `\`${typeName}\` was originally defined as a ${baseKind} and can only be extended by a ${expectedKind}. ${serviceName} defines ${typeName} as a ${
-                node.kind
-              }`,
+              `\`${typeName}\` was originally defined as a ${baseKind} and can only be extended by a ${expectedKind}. ${serviceName} defines ${typeName} as a ${node.kind}`,
           ),
         );
       }

--- a/packages/apollo-federation/src/composition/validate/sdl/possibleTypeExtensions.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/possibleTypeExtensions.ts
@@ -1,0 +1,131 @@
+import { SDLValidationContext } from 'graphql/validation/ValidationContext';
+import {
+  ASTVisitor,
+  isObjectType,
+  isScalarType,
+  isInterfaceType,
+  isUnionType,
+  isEnumType,
+  isInputObjectType,
+  Kind,
+  // ObjectTypeExtensionNode,
+  isTypeDefinitionNode,
+  ObjectTypeExtensionNode,
+  InterfaceTypeExtensionNode,
+  // TypeExtensionNode,
+} from 'graphql';
+import { errorWithCode, logServiceAndType } from '../../utils';
+
+type FederatedExtensionNode = (
+  | ObjectTypeExtensionNode
+  | InterfaceTypeExtensionNode) & {
+  serviceName?: string | null;
+};
+
+export function PossibleTypeExtensions(
+  context: SDLValidationContext,
+): ASTVisitor {
+  const schema = context.getSchema();
+  const definedTypes = Object.create(null);
+
+  for (const def of context.getDocument().definitions) {
+    if (isTypeDefinitionNode(def)) {
+      definedTypes[def.name.value] = def;
+    }
+  }
+
+  const checkExtension = (node: FederatedExtensionNode) => {
+    const typeName = node.name.value;
+    const defNode = definedTypes[typeName];
+    const existingType = schema && schema.getType(typeName);
+
+    const serviceName = node.serviceName;
+    if (!serviceName) return;
+
+    if (defNode) {
+      const expectedKind = defKindToExtKind[defNode.kind];
+      const baseKind = defNode.kind;
+      if (expectedKind !== node.kind) {
+        context.reportError(
+          errorWithCode(
+            'EXTENSION_OF_WRONG_KIND',
+            logServiceAndType(serviceName, typeName) +
+              `\`${typeName}\` was originally defined as a ${baseKind} and can only be extended by a ${expectedKind}. ${serviceName} defines ${typeName} as a ${
+                node.kind
+              }`,
+          ),
+        );
+      }
+    } else if (existingType) {
+      const expectedKind = typeToExtKind(existingType);
+      const baseKind = typeToKind(existingType);
+      if (expectedKind !== node.kind) {
+        context.reportError(
+          errorWithCode(
+            'EXTENSION_OF_WRONG_KIND',
+            logServiceAndType(serviceName, typeName) +
+              `\`${typeName}\` was originally defined as a ${baseKind} and can only be extended by a ${expectedKind}. ${serviceName} defines ${typeName} as a ${
+                node.kind
+              }`,
+          ),
+        );
+      }
+    } else {
+      context.reportError(
+        errorWithCode(
+          'EXTENSION_WITH_NO_BASE',
+          logServiceAndType(serviceName, typeName) +
+            `\`${typeName}\` is an extension type, but \`${typeName}\` is not defined in any service`,
+        ),
+      );
+    }
+  };
+
+  return {
+    ObjectTypeExtension: checkExtension,
+    InterfaceTypeExtension: checkExtension,
+  };
+}
+
+function typeToExtKind(type: any) {
+  if (isScalarType(type)) {
+    return Kind.SCALAR_TYPE_EXTENSION;
+  } else if (isObjectType(type)) {
+    return Kind.OBJECT_TYPE_EXTENSION;
+  } else if (isInterfaceType(type)) {
+    return Kind.INTERFACE_TYPE_EXTENSION;
+  } else if (isUnionType(type)) {
+    return Kind.UNION_TYPE_EXTENSION;
+  } else if (isEnumType(type)) {
+    return Kind.ENUM_TYPE_EXTENSION;
+  } else if (isInputObjectType(type)) {
+    return Kind.INPUT_OBJECT_TYPE_EXTENSION;
+  }
+  return null;
+}
+
+const defKindToExtKind: { [kind: string]: string } = {
+  [Kind.SCALAR_TYPE_DEFINITION]: Kind.SCALAR_TYPE_EXTENSION,
+  [Kind.OBJECT_TYPE_DEFINITION]: Kind.OBJECT_TYPE_EXTENSION,
+  [Kind.INTERFACE_TYPE_DEFINITION]: Kind.INTERFACE_TYPE_EXTENSION,
+  [Kind.UNION_TYPE_DEFINITION]: Kind.UNION_TYPE_EXTENSION,
+  [Kind.ENUM_TYPE_DEFINITION]: Kind.ENUM_TYPE_EXTENSION,
+  [Kind.INPUT_OBJECT_TYPE_DEFINITION]: Kind.INPUT_OBJECT_TYPE_EXTENSION,
+};
+
+function typeToKind(type: any) {
+  if (isScalarType(type)) {
+    return Kind.SCALAR_TYPE_DEFINITION;
+  } else if (isObjectType(type)) {
+    return Kind.OBJECT_TYPE_DEFINITION;
+  } else if (isInterfaceType(type)) {
+    return Kind.INTERFACE_TYPE_DEFINITION;
+  } else if (isUnionType(type)) {
+    return Kind.UNION_TYPE_DEFINITION;
+  } else if (isEnumType(type)) {
+    return Kind.ENUM_TYPE_DEFINITION;
+  } else if (isInputObjectType(type)) {
+    return Kind.INPUT_OBJECT_TYPE_DEFINITION;
+  }
+  return null;
+}

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -35,14 +35,20 @@ describe('executeQueryPlan', () => {
 
   beforeEach(() => {
     serviceMap = Object.fromEntries(
-      ['accounts', 'product', 'inventory', 'reviews'].map(serviceName => {
-        return [
-          serviceName,
-          buildLocalService([
-            require(path.join(__dirname, '__fixtures__/schemas', serviceName)),
-          ]),
-        ] as [string, LocalGraphQLDataSource];
-      }),
+      ['accounts', 'product', 'inventory', 'reviews', 'books'].map(
+        serviceName => {
+          return [
+            serviceName,
+            buildLocalService([
+              require(path.join(
+                __dirname,
+                '__fixtures__/schemas',
+                serviceName,
+              )),
+            ]),
+          ] as [string, LocalGraphQLDataSource];
+        },
+      ),
     );
 
     let errors: GraphQLError[];


### PR DESCRIPTION
## What is this

Previously, when building federated services, composition allowed you to `extend` a type without ever defining it in another service. This PR removes that :) 

## What was done

There were a few changes that needed to be made to make this work.

1. remove the block of code in `compose.ts` that enabled this behavior to begin with.
2. Add empty `Query` and optional `Mutation` definitions to the `definitionsMap`. This is needed because the old block used to add the query and mutation definitions for us. Query and Mutation definitions found in a service are always treated as _extensions_ to make sure they never have an `owner`.
3. I added a validation rule to make sure this is properly erroring. It checks for 2 things: 
    1. To make sure there is a definition for any extension
    2. make sure the extension is of the same `Kind` (no `type`s extending `interface`s or any of that nonsense
    3. these things only work with types and interfaces at the moment. It's easy to add more though.

## Misc

1. Fixed an integration test that previously left off the `books` service, leading to a validation error because there wasn't a `Book` definition :)
2. Added a test at the `composeAndValidate` level for this, just to make sure nothing was getting swallowed.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
