### PR TITLE
Add createGateway helper function

### DIFF
--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -1,7 +1,7 @@
 import {
-  GraphQLExecutor,
   GraphQLExecutionResult,
   GraphQLRequestContext,
+  GraphQLService,
 } from 'apollo-server-core';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { isObjectType, isIntrospectionType, GraphQLSchema } from 'graphql';
@@ -23,12 +23,6 @@ import { getServiceDefinitionsFromRemoteEndpoint } from './loadServicesFromRemot
 import { serializeQueryPlan, QueryPlan } from './QueryPlan';
 import { GraphQLDataSource } from './datasources/types';
 import { RemoteGraphQLDataSource } from './datasources/RemoteGraphQLDatasource';
-
-export interface GraphQLService {
-  schema?: GraphQLSchema;
-  executor: GraphQLExecutor;
-  isReady: boolean;
-}
 
 export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;
 
@@ -52,7 +46,7 @@ function isLocalConfig(config: GatewayConfig): config is LocalGatewayConfig {
   return 'localServiceList' in config;
 }
 
-export class ApolloGateway implements GraphQLService {
+export class ApolloGateway {
   public schema?: GraphQLSchema;
   public isReady: boolean = false;
   protected serviceMap: ServiceMap = Object.create(null);
@@ -95,7 +89,7 @@ export class ApolloGateway implements GraphQLService {
       this.createSchema(services);
     }
 
-    return { schema: this.schema, executor: this.executor };
+    return { schema: this.schema!, executor: this.executor };
   }
 
   protected createSchema(services: ServiceDefinition[]) {
@@ -264,8 +258,7 @@ export async function createGateway(
   config: GatewayConfig,
 ): Promise<GraphQLService> {
   const gateway = new ApolloGateway(config);
-  await gateway.load();
-  return gateway;
+  return await gateway.load();
 }
 
 export {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -89,7 +89,7 @@ export class ApolloGateway {
       this.createSchema(services);
     }
 
-    return { schema: this.schema!, executor: this.executor }; // TODO: pass apiKey. (dependant on #2915)
+    return { schema: this.schema!, executor: this.executor };
   }
 
   protected createSchema(services: ServiceDefinition[]) {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -89,7 +89,7 @@ export class ApolloGateway {
       this.createSchema(services);
     }
 
-    return { schema: this.schema!, executor: this.executor };
+    return { schema: this.schema!, executor: this.executor }; // TODO: pass apiKey. (dependant on #2915)
   }
 
   protected createSchema(services: ServiceDefinition[]) {
@@ -257,8 +257,7 @@ function wrapSchemaWithAliasResolver(schema: GraphQLSchema): GraphQLSchema {
 export async function createGateway(
   config: GatewayConfig,
 ): Promise<GraphQLService> {
-  const gateway = new ApolloGateway(config);
-  return await gateway.load();
+  return await new ApolloGateway(config).load();
 }
 
 export {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -81,7 +81,7 @@ export class ApolloGateway {
     this.initializeQueryPlanStore();
   }
 
-  public async load() {
+  public async load(): Promise<GraphQLService> {
     if (!this.isReady) {
       this.logger.debug('Loading configuration for Gateway');
       const [services] = await this.loadServiceDefinitions(this.config);

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -134,8 +134,8 @@ export class ApolloGateway implements GraphQLService {
       this.serviceMap[serviceDef.name] = this.config.buildService
         ? this.config.buildService(serviceDef)
         : new RemoteGraphQLDataSource({
-            url: serviceDef.url,
-          });
+          url: serviceDef.url,
+        });
     }
   }
 
@@ -258,6 +258,14 @@ function wrapSchemaWithAliasResolver(schema: GraphQLSchema): GraphQLSchema {
     }
   });
   return schema;
+}
+
+export async function createGateway(
+  config: GatewayConfig,
+): Promise<GraphQLService> {
+  const gateway = new ApolloGateway(config);
+  await gateway.load();
+  return gateway;
 }
 
 export {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -254,12 +254,6 @@ function wrapSchemaWithAliasResolver(schema: GraphQLSchema): GraphQLSchema {
   return schema;
 }
 
-export async function createGateway(
-  config: GatewayConfig,
-): Promise<GraphQLService> {
-  return await new ApolloGateway(config).load();
-}
-
 export {
   buildQueryPlan,
   executeQueryPlan,

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -46,7 +46,7 @@ function isLocalConfig(config: GatewayConfig): config is LocalGatewayConfig {
   return 'localServiceList' in config;
 }
 
-export class ApolloGateway {
+export class ApolloGateway implements GraphQLService {
   public schema?: GraphQLSchema;
   public isReady: boolean = false;
   protected serviceMap: ServiceMap = Object.create(null);
@@ -81,7 +81,7 @@ export class ApolloGateway {
     this.initializeQueryPlanStore();
   }
 
-  public async load(): Promise<GraphQLService> {
+  public async load() {
     if (!this.isReady) {
       this.logger.debug('Loading configuration for Gateway');
       const [services] = await this.loadServiceDefinitions(this.config);

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -134,8 +134,8 @@ export class ApolloGateway implements GraphQLService {
       this.serviceMap[serviceDef.name] = this.config.buildService
         ? this.config.buildService(serviceDef)
         : new RemoteGraphQLDataSource({
-          url: serviceDef.url,
-        });
+            url: serviceDef.url,
+          });
     }
   }
 

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -153,6 +153,7 @@ export class ApolloServerBase {
       uploads,
       playground,
       plugins,
+      gateway,
       ...requestOptions
     } = config;
 
@@ -261,6 +262,9 @@ export class ApolloServerBase {
         throw new Error(errors.map(error => error.message).join('\n\n'));
       }
       this.schema = schema!;
+    } else if (gateway) {
+      this.schema = gateway.schema;
+      this.requestOptions.executor = gateway.executor;
     } else {
       if (!typeDefs) {
         throw Error(

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -61,6 +61,7 @@ import {
 
 import { Headers } from 'apollo-server-env';
 import { buildServiceDefinition } from '@apollographql/apollo-tools';
+import { EngineReportingOptions } from 'apollo-engine-reporting';
 
 const NoIntrospection = (context: ValidationContext) => ({
   Field(node: FieldDefinitionNode) {
@@ -265,6 +266,16 @@ export class ApolloServerBase {
     } else if (gateway) {
       this.schema = gateway.schema;
       this.requestOptions.executor = gateway.executor;
+      if (gateway.apiKey) {
+        if (engine === undefined) {
+          ((engine as unknown) as EngineReportingOptions<object>) = {
+            apiKey: gateway.apiKey,
+          };
+        }
+        if (engine) {
+          engine.apiKey = engine.apiKey || gateway.apiKey;
+        }
+      }
     } else {
       if (!typeDefs) {
         throw Error(

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -68,7 +68,6 @@ type BaseConfig = Pick<
 export interface GraphQLService {
   schema: GraphQLSchema;
   executor: GraphQLExecutor;
-  apiKey?: string;
 }
 
 // This configuration is shared between all integrations and should include
@@ -84,7 +83,7 @@ export interface Config extends BaseConfig {
   introspection?: boolean;
   mocks?: boolean | IMocks;
   mockEntireSchema?: boolean;
-  engine?: false | EngineReportingOptions<Context>;
+  engine?: boolean | EngineReportingOptions<Context>;
   extensions?: Array<() => GraphQLExtension>;
   cacheControl?: CacheControlExtensionOptions | boolean;
   plugins?: PluginDefinition[];

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -66,8 +66,10 @@ type BaseConfig = Pick<
 >;
 
 export interface GraphQLService {
-  schema: GraphQLSchema;
-  executor: GraphQLExecutor;
+  load(): Promise<{
+    schema: GraphQLSchema;
+    executor: GraphQLExecutor;
+  }>;
 }
 
 // This configuration is shared between all integrations and should include

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -26,6 +26,7 @@ import { CacheControlExtensionOptions } from 'apollo-cache-control';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 
 import { GraphQLSchemaModule } from '@apollographql/apollo-tools';
+import { GraphQLExecutor } from 'apollo-server-core/dist/requestPipelineAPI';
 export { GraphQLSchemaModule };
 
 export { KeyValueCache } from 'apollo-server-caching';
@@ -64,6 +65,11 @@ type BaseConfig = Pick<
   | 'cache'
 >;
 
+export interface GraphQLService {
+  schema: GraphQLSchema;
+  executor: GraphQLExecutor;
+}
+
 // This configuration is shared between all integrations and should include
 // fields that are not specific to a single integration
 export interface Config extends BaseConfig {
@@ -86,6 +92,7 @@ export interface Config extends BaseConfig {
   //https://github.com/jaydenseric/graphql-upload#type-uploadoptions
   uploads?: boolean | FileUploadOptions;
   playground?: PlaygroundConfig;
+  gateway?: GraphQLService;
 }
 
 export interface FileUploadOptions {

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -68,6 +68,7 @@ type BaseConfig = Pick<
 export interface GraphQLService {
   schema: GraphQLSchema;
   executor: GraphQLExecutor;
+  apiKey?: string;
 }
 
 // This configuration is shared between all integrations and should include
@@ -83,7 +84,7 @@ export interface Config extends BaseConfig {
   introspection?: boolean;
   mocks?: boolean | IMocks;
   mockEntireSchema?: boolean;
-  engine?: boolean | EngineReportingOptions<Context>;
+  engine?: false | EngineReportingOptions<Context>;
   extensions?: Array<() => GraphQLExtension>;
   cacheControl?: CacheControlExtensionOptions | boolean;
   plugins?: PluginDefinition[];


### PR DESCRIPTION
This is an attempt to implement @glasser's desired API for create gateway. As stated in the comments of AS-105:

```js
import { createGateway } from "@apollo/gateway";
const server = new ApolloServer({
  gateway: await createGateway({ serviceList })
});
console.log(print(server.schema));  // readonly!
```
