### PR TITLE
Add docs for hosted configs and polling

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -45,7 +45,7 @@ module.exports = {
             'federation/advanced-features',
             'federation/errors',
             'federation/migrating-from-stitching',
-            'federation/hosted-gateway-definitions',
+            'federation/managed-federation',
             'federation/federation-spec',
           ],
           // 'Schema stitching': [

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -45,6 +45,7 @@ module.exports = {
             'federation/advanced-features',
             'federation/errors',
             'federation/migrating-from-stitching',
+            'federation/hosted-gateway-definitions',
             'federation/federation-spec',
           ],
           // 'Schema stitching': [

--- a/docs/source/federation/hosted-gateway-definitions.md
+++ b/docs/source/federation/hosted-gateway-definitions.md
@@ -1,0 +1,61 @@
+---
+title: Hosted gateway configurations
+description: Managing gateways at scale
+---
+
+In many cases it is sufficient to define the list of services comprising a federated graph directly within the gateway:
+```javascript
+const gateway = await createGateway({
+    serviceList: [
+      { name: "accounts", url: "http://localhost:4001/graphql" },
+      { name: "products", url: "http://localhost:4002/graphql" },
+      ...
+    ]
+  });
+```
+
+However for larger scale projects it can be helpful to remotely manage service definitions, such that new services may be added or existing services modified at runtime. For these use cases, aApollo Gateway can be configured to pull a remotely hosted service definition from Apollo Engine.
+
+> Currently the hosted federation service is only available for enterprise. Other customers interested in hosted definitions should reach out to sales to discuss expanding their plans.
+
+## Uploading Service Definitions
+
+To begin, ensure all component services are up and running, and the working directory has a `.env` file containing the appropriate  `ENGINE_API_KEY` for your federated service. Then, upload each service to the gateway through the Apollo CLI:
+
+```bash
+apollo service:push       \
+  --serviceURL={{url}}    \
+  --endpoint={{url}}      \
+  --serviceName={{name}}  \
+  --federated
+```
+
+> Each service needs a unique name, this is how you will identify the service for schema updates
+Modify hosted service definitions by rerunning the `apollo service:push` command with the appropriate URL and service name. The service will be queried for it's new schema, which will then be uploaded to Apollo Engine.
+
+## Configuring Apollo Gateway
+
+By default, if no `serviceList` is directly provided at initialization, Apollo Gateway will read from the environment's `ENGINE_API_KEY` and, if found, pull the `current` service definition from Apollo Engine. This can be configured by passing an `apiKey` and/or `tag` to the `createGateway` call:
+
+```javascript
+const gateway = createGateway(
+  {
+    tag: 'staging',
+    apiKey: 'service:MyService:abcd1234'
+  }
+)
+```
+
+### Automatic Updates
+
+By default the gateway will pull the remote service definition only at sartup. This can be changed to a polling-based approach by passing a `onSchemaChange` event handler to the `createGateway` function:
+
+```javascript
+const gateway = createGateway(
+  {
+    onSchemaChange: () => restartServer()
+  }
+)
+```
+
+> We are in the process of developing a zero down-time way to update service definitions without needing to restart the ApolloServer.

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -103,36 +103,32 @@ npm install @apollo/gateway apollo-server graphql
 
 Now we can create a new service that acts as a gateway to the underlying microservices:
 
-```javascript{2,4-9,12}
-const { ApolloServer } = require('apollo-server');
-const { ApolloGateway } = require("@apollo/gateway");
-
-const gateway = new ApolloGateway({
-  serviceList: [
-    { name: 'accounts', url: 'http://localhost:4001' },
-    // more services
-  ],
-});
+```javascript
+const { ApolloServer } = require("apollo-server");
+const { createGateway } = require("@apollo/gateway");
 
 (async () => {
-  const { schema, executor } = await gateway.load();
-
-  const server = new ApolloServer({ schema, executor });
-
-  server.listen().then(({ url }) => {
-    console.log(`🚀 Server ready at ${url}`);
+  const gateway = await createGateway({
+    serviceList: [
+      { name: "accounts", url: "http://localhost:4001/graphql" },
+      { name: "products", url: "http://localhost:4002/graphql" },
+    ]
   });
+
+  const server = new ApolloServer(gateway);
+  const serverInfo = await server.listen();
+  console.log(`🚀 Server ready at ${serverInfo.url}`);
 })();
 ```
 
-In this example, we provide the `serviceList` option to the `ApolloGateway` constructor, which provides a name and endpoint for each of the federated services. The name (an arbitrary string) is primarily used for query planner output, error messages, and logging.
+In this example, we provide the `serviceList` option to the `createGateway` function, which provides a name and endpoint for each of the federated services. The name (an arbitrary string) is primarily used for query planner output, error messages, and logging.
 
 On startup, the gateway will fetch the service capabilities from the running servers and form an overall composed graph. It will accept incoming requests and create query plans which query the underlying services in the service list.
 
-> If there are any composition errors, the `gateway.load()` promise will be rejected with a list of [validation errors](/federation/errors/).
+> If there are any composition errors, the `createGateway()` promise will be rejected with a list of [validation errors](/federation/errors/).
 
 #### Gateway initialization
-The call to `gateway.load()` returns a `Promise` which resolves to a `schema` and `executor`. These are intended to be passed into the constructor of `ApolloServer`.
+The call to `createGateway()` returns a `Promise` which resolves to a `GraphQLService`. This is intended to be passed into the constructor of `ApolloServer`. It has two primary components:
 * The `schema` is the final, composed schema which represents all services.
 * The `executor` handles incoming requests. It uses the query planner to manage the various requests to our services that are necessary to construct the final result.
 
@@ -146,33 +142,30 @@ When the gateway receives a new query, it generates a query plan that defines th
 ## Sharing context across services
 For existing services, it's likely that you've already implemented some form of authentication to convert a request into a user, or require some information passed to the service through request headers. `@apollo/gateway` makes it easy to reuse the context feature of Apollo Server to customize what information is sent to underlying services. Let's see what it looks like to pass user information along from the gateway to its services:
 
-```javascript{9-18,27-36}
+```javascript{10-19,24-32}
 import { ApolloServer } from 'apollo-server';
-import { ApolloGateway, RemoteGraphQLDataSource } from '@apollo/gateway';
-
-const gateway = new ApolloGateway({
-  serviceList: [
-    { name: 'products', url: 'http://localhost:4001' },
-    // other services
-  ],
-  buildService({ name, url }) {
-    return new RemoteGraphQLDataSource({
-      url,
-      willSendRequest({ request, context }) {
-        // pass the user's id from the context to underlying services
-        // as a header called `user-id`
-        request.http.headers.set('user-id', context.userId);
-      },
-    });
-  },
-});
+const { createGateway, RemoteGraphQLDataSource } = require("@apollo/gateway");
 
 (async () => {
-  const { schema, executor } = await gateway.load();
+  const gateway = createGateway({
+    serviceList: [
+      { name: "accounts", url: "http://localhost:4001/graphql" },
+      { name: "products", url: "http://localhost:4002/graphql" },
+    ],
+    buildService({ name, url }) {
+      return new RemoteGraphQLDataSource({
+        url,
+        willSendRequest({ request, context }) {
+          // pass the user's id from the context to underlying services
+          // as a header called `user-id`
+          request.http.headers.set('user-id', context.userId);
+        },
+      });
+    },
+  })
 
   const server = new ApolloServer({
-    schema,
-    executor,
+    ...gateway,
     context: ({ req }) => {
       // get the user token from the headers
       const token = req.headers.authorization || '';
@@ -185,12 +178,42 @@ const gateway = new ApolloGateway({
     },
   });
 
-  server.listen().then(({ url }) => {
-    console.log(`🚀 Server ready at ${url}`);
-  });
+  const serverInfo = await server.listen();
+  console.log(`🚀 Server ready at ${serverInfo.url}`);
 })();
 ```
 
 By leveraging the `buildService` function, we're able to customize how requests are sent to our federated services. In this example, we return a custom `RemoteGraphQLDataSource`. The datasource allows us to modify the outgoing request with information from the Apollo Server `context` before it's sent. Here, we're adding the `user-id` header to pass an authenticated user id to downstream services.
 
 To learn more about `buildService` or `RemoteGraphQLDataSource`, see the [API docs](/api/apollo-gateway/).
+
+## Polling for updates
+
+By default, the gateway will query it's microservices once, at initialization. However, adding support for polling updates is possible by adding a listener to the gateway's `onSchemaChange` event:
+
+```javascript{10,16}
+const { ApolloServer } = require("apollo-server");
+const { createGateway } = require("@apollo/gateway");
+
+const gateway = createGateway(
+  {
+    serviceList: [
+      { name: "accounts", url: "http://localhost:4001/graphql" },
+      { name: "products", url: "http://localhost:4002/graphql" },
+    ],
+    onSchemaChange: () => restartServer()
+  }
+)
+
+let server;
+const restartServer = async () => {
+  if (server) await server.stop()
+  server = new ApolloServer(await gateway);
+  const serverInfo = await server.listen();
+  console.log(`🚀 Server ready at ${serverInfo.url}`);
+}
+
+restartServer();
+```
+
+Here, we add an `onSchemaChange` event listener to the gateway that simply restarts the running server whenever the gateway detects a change in downstream schema. Note that we have moved the call to `createGateway` to the top level. Here, only one gateway is created, and it is reused across the servers.

--- a/docs/source/federation/managed-federation.md
+++ b/docs/source/federation/managed-federation.md
@@ -43,17 +43,3 @@ const gateway = createGateway(
   }
 )
 ```
-
-### Automatic Updates
-
-By default the gateway will pull the remote service definition only at sartup. This can be changed to a polling-based approach by passing a `onSchemaChange` event handler to the `createGateway` function:
-
-```javascript
-const gateway = createGateway(
-  {
-    onSchemaChange: () => restartServer()
-  }
-)
-```
-
-> We are in the process of developing a zero down-time way to update service definitions without needing to restart the ApolloServer.

--- a/docs/source/federation/managed-federation.md
+++ b/docs/source/federation/managed-federation.md
@@ -1,5 +1,5 @@
----
-title: Hosted gateway configurations
+  ---
+title: Using managed federation
 description: Managing gateways at scale
 ---
 
@@ -14,9 +14,7 @@ const gateway = await createGateway({
   });
 ```
 
-However for larger scale projects it can be helpful to remotely manage service definitions, such that new services may be added or existing services modified at runtime. For these use cases, aApollo Gateway can be configured to pull a remotely hosted service definition from Apollo Engine.
-
-> Currently the hosted federation service is only available for enterprise. Other customers interested in hosted definitions should reach out to sales to discuss expanding their plans.
+However for larger scale projects it can be helpful to remotely manage service definitions, such that new services may be added or existing services modified at runtime. For these use cases, an Apollo Gateway can be configured to pull a remotely hosted service definition from Apollo Engine.
 
 ## Uploading Service Definitions
 


### PR DESCRIPTION
This contains docs for varoius features implemented as part of the enterprise/OSS merge, in particular for polling and remote hosted service lists definitions.