### PR TITLE
Add polling support

### DIFF
--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -167,8 +167,8 @@ export class ApolloGateway implements GraphQLService {
       this.serviceMap[serviceDef.name] = this.config.buildService
         ? this.config.buildService(serviceDef)
         : new RemoteGraphQLDataSource({
-          url: serviceDef.url,
-        });
+            url: serviceDef.url,
+          });
     }
   }
 


### PR DESCRIPTION
This adds support for polling. The code is taken, with modifications, from enterprise gateway. Key difference between this and enterprise gateway is the restriction to only one listener, specified at construction, rather than arbitrarily many listeners that can be added or removed dynamically. This change was made in order to simply the code. If there is a benefit to supporting many listeners I cqn add that code back.