### PR TITLE
[Federation] Support __typenames if defined by an incoming operation

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ### vNEXT
 
+* Support __typenames if defined by an incoming operation [#2922](https://github.com/apollographql/apollo-server/pull/2922)
+
 # v0.6.7
 
 * Fix bug in externalUnused validation [#2919](https://github.com/apollographql/apollo-server/pull/2919)
 
 # v0.6.6
+
 * Allow specified directives during validation (@deprecated) [#2823](https://github.com/apollographql/apollo-server/pull/2823)
 
 # v0.6.1

--- a/packages/apollo-federation/src/composition/utils.ts
+++ b/packages/apollo-federation/src/composition/utils.ts
@@ -1,4 +1,5 @@
 import 'apollo-server-env';
+import { isNotNullOrUndefined } from 'apollo-env';
 import {
   ObjectTypeDefinitionNode,
   InterfaceTypeExtensionNode,
@@ -28,12 +29,6 @@ import { ExternalFieldDefinition } from './types';
 
 export function isStringValueNode(node: any): node is StringValueNode {
   return node.kind === Kind.STRING;
-}
-
-export function isNotNullOrUndefined<T>(
-  value: T | null | undefined,
-): value is T {
-  return value !== null && typeof value !== 'undefined';
 }
 
 // Create a map of { fieldName: serviceName } for each field.

--- a/packages/apollo-gateway/src/__tests__/integration/single-service.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/single-service.test.ts
@@ -7,6 +7,10 @@ const accounts = {
     type User @key(fields: "id") {
       id: Int!
       name: String
+      account: Account
+    }
+    type Account {
+      type: String
     }
     extend type Query {
       me: User
@@ -38,6 +42,66 @@ it('executes a query plan over concrete types', async () => {
   });
 
   expect(data).toEqual({ me: { id: 1, name: 'James' } });
+  expect(queryPlan).toCallService('accounts');
+  expect(me).toBeCalled();
+});
+
+it('does not remove __typename on root types', async () => {
+  const query = gql`
+    query GetUser {
+      __typename
+    }
+  `;
+
+  const { data } = await execute([accounts], {
+    query,
+  });
+
+  expect(data).toEqual({ __typename: 'Query' });
+});
+
+it('does not remove __typename if that is all that is requested on an entity', async () => {
+  const me = jest.fn(() => ({ id: 1, name: 'James' }));
+  const localAccounts = overrideResolversInService(accounts, {
+    Query: { me },
+  });
+
+  const query = gql`
+    query GetUser {
+      me {
+        __typename
+      }
+    }
+  `;
+  const { data, queryPlan } = await execute([localAccounts], {
+    query,
+  });
+
+  expect(data).toEqual({ me: { __typename: 'User' } });
+  expect(queryPlan).toCallService('accounts');
+  expect(me).toBeCalled();
+});
+
+it('does not remove __typename if that is all that is requested on a value type', async () => {
+  const me = jest.fn(() => ({ id: 1, name: 'James', account: {} }));
+  const localAccounts = overrideResolversInService(accounts, {
+    Query: { me },
+  });
+
+  const query = gql`
+    query GetUser {
+      me {
+        account {
+          __typename
+        }
+      }
+    }
+  `;
+  const { data, queryPlan } = await execute([localAccounts], {
+    query,
+  });
+
+  expect(data).toEqual({ me: { account: { __typename: 'Account' } } });
   expect(queryPlan).toCallService('accounts');
   expect(me).toBeCalled();
 });

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -1,3 +1,4 @@
+import { isNotNullOrUndefined } from 'apollo-env';
 import {
   DocumentNode,
   FieldNode,
@@ -345,9 +346,17 @@ function splitFields(
       const field = fieldsForParentType[0];
       const { fieldDef } = field;
 
-      // We skip `__typename`.
+      // We skip `__typename` for root types.
       if (fieldDef.name === TypeNameMetaFieldDef.name) {
-        continue;
+        const { schema } = context;
+        const roots = [
+          schema.getQueryType(),
+          schema.getMutationType(),
+          schema.getSubscriptionType(),
+        ]
+          .filter(isNotNullOrUndefined)
+          .map(type => type.name);
+        if (roots.indexOf(parentType.name) > -1) continue;
       }
 
       // We skip introspection fields like `__schema` and `__type`.

--- a/packages/apollo-gateway/src/utilities/array.ts
+++ b/packages/apollo-gateway/src/utilities/array.ts
@@ -1,4 +1,4 @@
-import { isNotNullOrUndefined } from './predicates';
+import { isNotNullOrUndefined } from 'apollo-env';
 
 export function compactMap<T, U>(
   array: T[],

--- a/packages/apollo-gateway/src/utilities/predicates.ts
+++ b/packages/apollo-gateway/src/utilities/predicates.ts
@@ -1,9 +1,3 @@
-export function isNotNullOrUndefined<T>(
-  value: T | null | undefined,
-): value is T {
-  return value !== null && typeof value !== 'undefined';
-}
-
 export function isObject(value: any): value is object {
   return (
     value !== undefined &&


### PR DESCRIPTION
This was a bug with the query planner when collecting fields in a selection set. It would remove __typename even if it was added by the end operation as the only field.