### PR TITLE
gateway: fix @requires bug preventing array and null values

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+- fix @requires bug preventing array and null values [PR #2928](https://github.com/apollographql/apollo-server/pull/2928)
+
 # v0.6.5
 
 * Relax constraints of root operation type names in validation [#2783](ttps://github.com/apollographql/apollo-server/pull/2783)

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-- fix @requires bug preventing array and null values [PR #2928](https://github.com/apollographql/apollo-server/pull/2928)
+- Fix `@requires` bug preventing array and null values. [PR #2928](https://github.com/apollographql/apollo-server/pull/2928)
 
 # v0.6.5
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
@@ -5,6 +5,7 @@ export const name = 'books';
 export const typeDefs = gql`
   extend type Query {
     book(isbn: String!): Book
+    books: [Book]
   }
 
   type Library @key(fields: "id") {
@@ -24,6 +25,7 @@ export const typeDefs = gql`
     isbn: String!
     title: String
     year: Int
+    similarBooks: [Book!]!
   }
 `;
 
@@ -43,6 +45,23 @@ const books = [
     isbn: '0201633612',
     title: 'Design Patterns',
     year: 1995,
+    similarBooks: ['0201633612', '0136291554'],
+  },
+  {
+    isbn: '1234567890',
+    title: 'The Year Was Null',
+    year: null,
+  },
+  {
+    isbn: '404404404',
+    title: '',
+    year: 404,
+  },
+  {
+    isbn: '0987654321',
+    title: 'No Books Like This Book!',
+    year: 2019,
+    similarBooks: ['', null],
   },
 ];
 
@@ -50,6 +69,13 @@ export const resolvers: GraphQLResolverMap<any> = {
   Book: {
     __resolveObject(object) {
       return books.find(book => book.isbn === object.isbn);
+    },
+    similarBooks(object) {
+      return object.similarBooks
+        ? object.similarBooks
+            .map((isbn: string) => books.find(book => book.isbn === isbn))
+            .filter(Boolean)
+        : [];
     },
   },
   Library: {
@@ -60,6 +86,9 @@ export const resolvers: GraphQLResolverMap<any> = {
   Query: {
     book(_, args) {
       return { isbn: args.isbn };
+    },
+    books() {
+      return books;
     },
   },
 };

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
@@ -39,7 +39,6 @@ export const typeDefs = gql`
     year: Int @external
     upc: String!
     sku: String!
-
     name(delimeter: String = " "): String @requires(fields: "title year")
     price: String
   }
@@ -82,6 +81,8 @@ const products = [
   { __typename: 'Book', isbn: '0262510871', price: 39 },
   { __typename: 'Book', isbn: '0136291554', price: 29 },
   { __typename: 'Book', isbn: '0201633612', price: 49 },
+  { __typename: 'Book', isbn: '1234567890', price: 59 },
+  { __typename: 'Book', isbn: '0987654321', price: 29 },
 ];
 
 export const resolvers: GraphQLResolverMap<any> = {

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
@@ -82,6 +82,7 @@ const products = [
   { __typename: 'Book', isbn: '0136291554', price: 29 },
   { __typename: 'Book', isbn: '0201633612', price: 49 },
   { __typename: 'Book', isbn: '1234567890', price: 59 },
+  { __typename: 'Book', isbn: '404404404', price: 0 },
   { __typename: 'Book', isbn: '0987654321', price: 29 },
 ];
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
@@ -38,6 +38,8 @@ export const typeDefs = gql`
   extend type Book implements Product @key(fields: "isbn") {
     isbn: String! @external
     reviews: [Review]
+    similarBooks: [Book!]! @external
+    relatedReviews: [Review!]! @requires(fields: "similarBooks { isbn }")
   }
 
   extend type Mutation {
@@ -101,7 +103,6 @@ export const resolvers: GraphQLResolverMap<any> = {
     review(_, args) {
       return { id: args.id };
     },
-
     topReviews(_, args) {
       return reviews.slice(0, args.first);
     },
@@ -164,6 +165,15 @@ export const resolvers: GraphQLResolverMap<any> = {
   Book: {
     reviews(product) {
       return reviews.filter(review => review.product.isbn === product.isbn);
+    },
+    relatedReviews(book) {
+      return book.similarBooks
+        ? book.similarBooks
+            .map(({ isbn }: any) =>
+              reviews.filter(review => review.product.isbn === isbn),
+            )
+            .flat()
+        : [];
     },
   },
 };

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -222,41 +222,41 @@ describe('executeQueryPlan', () => {
     );
 
     expect(response.data).toMatchInlineSnapshot(`
-                  Object {
-                    "topReviews": Array [
-                      Object {
-                        "author": Object {
-                          "name": "Ada Lovelace",
-                        },
-                        "body": "Love it!",
-                      },
-                      Object {
-                        "author": Object {
-                          "name": "Ada Lovelace",
-                        },
-                        "body": "Too expensive.",
-                      },
-                      Object {
-                        "author": Object {
-                          "name": "Alan Turing",
-                        },
-                        "body": "Could be better.",
-                      },
-                      Object {
-                        "author": Object {
-                          "name": "Alan Turing",
-                        },
-                        "body": "Prefer something else.",
-                      },
-                      Object {
-                        "author": Object {
-                          "name": "Alan Turing",
-                        },
-                        "body": "Wish I had read this before.",
-                      },
-                    ],
-                  }
-            `);
+                                                Object {
+                                                  "topReviews": Array [
+                                                    Object {
+                                                      "author": Object {
+                                                        "name": "Ada Lovelace",
+                                                      },
+                                                      "body": "Love it!",
+                                                    },
+                                                    Object {
+                                                      "author": Object {
+                                                        "name": "Ada Lovelace",
+                                                      },
+                                                      "body": "Too expensive.",
+                                                    },
+                                                    Object {
+                                                      "author": Object {
+                                                        "name": "Alan Turing",
+                                                      },
+                                                      "body": "Could be better.",
+                                                    },
+                                                    Object {
+                                                      "author": Object {
+                                                        "name": "Alan Turing",
+                                                      },
+                                                      "body": "Prefer something else.",
+                                                    },
+                                                    Object {
+                                                      "author": Object {
+                                                        "name": "Alan Turing",
+                                                      },
+                                                      "body": "Wish I had read this before.",
+                                                    },
+                                                  ],
+                                                }
+                                `);
   });
 
   it('should not duplicate variable definitions', async () => {
@@ -291,49 +291,49 @@ describe('executeQueryPlan', () => {
     );
 
     expect(response.data).toMatchInlineSnapshot(`
-      Object {
-        "first": Array [
-          Object {
-            "author": Object {
-              "name": "Ada Lovelace",
-            },
-            "body": "Love it!",
-          },
-          Object {
-            "author": Object {
-              "name": "Ada Lovelace",
-            },
-            "body": "Too expensive.",
-          },
-          Object {
-            "author": Object {
-              "name": "Alan Turing",
-            },
-            "body": "Could be better.",
-          },
-        ],
-        "second": Array [
-          Object {
-            "author": Object {
-              "name": "Ada Lovelace",
-            },
-            "body": "Love it!",
-          },
-          Object {
-            "author": Object {
-              "name": "Ada Lovelace",
-            },
-            "body": "Too expensive.",
-          },
-          Object {
-            "author": Object {
-              "name": "Alan Turing",
-            },
-            "body": "Could be better.",
-          },
-        ],
-      }
-    `);
+                                    Object {
+                                      "first": Array [
+                                        Object {
+                                          "author": Object {
+                                            "name": "Ada Lovelace",
+                                          },
+                                          "body": "Love it!",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "name": "Ada Lovelace",
+                                          },
+                                          "body": "Too expensive.",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "name": "Alan Turing",
+                                          },
+                                          "body": "Could be better.",
+                                        },
+                                      ],
+                                      "second": Array [
+                                        Object {
+                                          "author": Object {
+                                            "name": "Ada Lovelace",
+                                          },
+                                          "body": "Love it!",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "name": "Ada Lovelace",
+                                          },
+                                          "body": "Too expensive.",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "name": "Alan Turing",
+                                          },
+                                          "body": "Could be better.",
+                                        },
+                                      ],
+                                    }
+                        `);
   });
 
   it('should include variables in non-root requests', async () => {
@@ -363,46 +363,46 @@ describe('executeQueryPlan', () => {
     );
 
     expect(response.data).toMatchInlineSnapshot(`
-      Object {
-        "topReviews": Array [
-          Object {
-            "author": Object {
-              "birthDate": "12/10/1815",
-              "name": "Ada Lovelace",
-            },
-            "body": "Love it!",
-          },
-          Object {
-            "author": Object {
-              "birthDate": "12/10/1815",
-              "name": "Ada Lovelace",
-            },
-            "body": "Too expensive.",
-          },
-          Object {
-            "author": Object {
-              "birthDate": "6/23/1912",
-              "name": "Alan Turing",
-            },
-            "body": "Could be better.",
-          },
-          Object {
-            "author": Object {
-              "birthDate": "6/23/1912",
-              "name": "Alan Turing",
-            },
-            "body": "Prefer something else.",
-          },
-          Object {
-            "author": Object {
-              "birthDate": "6/23/1912",
-              "name": "Alan Turing",
-            },
-            "body": "Wish I had read this before.",
-          },
-        ],
-      }
-    `);
+                                    Object {
+                                      "topReviews": Array [
+                                        Object {
+                                          "author": Object {
+                                            "birthDate": "12/10/1815",
+                                            "name": "Ada Lovelace",
+                                          },
+                                          "body": "Love it!",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "birthDate": "12/10/1815",
+                                            "name": "Ada Lovelace",
+                                          },
+                                          "body": "Too expensive.",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "birthDate": "6/23/1912",
+                                            "name": "Alan Turing",
+                                          },
+                                          "body": "Could be better.",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "birthDate": "6/23/1912",
+                                            "name": "Alan Turing",
+                                          },
+                                          "body": "Prefer something else.",
+                                        },
+                                        Object {
+                                          "author": Object {
+                                            "birthDate": "6/23/1912",
+                                            "name": "Alan Turing",
+                                          },
+                                          "body": "Wish I had read this before.",
+                                        },
+                                      ],
+                                    }
+                        `);
   });
 
   it('can execute an introspection query', async () => {
@@ -425,77 +425,91 @@ describe('executeQueryPlan', () => {
     expect(response.errors).toBeUndefined();
   });
 
-  describe('executeSelectionSet', () => {
-    function getSelectionSet(...values: string[]): SelectionSetNode {
-      return {
-        kind: 'SelectionSet',
-        selections: values.map(value => ({
-          kind: 'Field',
-          name: {
-            kind: 'Name',
-            value,
+  it('can execute queries with falsey @requires (except undefined)', async () => {
+    const query = gql`
+      query {
+        books {
+          name # Requires title, year (on Book type)
+        }
+      }
+    `;
+
+    const operationContext = buildOperationContext(schema, query);
+    const queryPlan = buildQueryPlan(operationContext);
+
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
+
+    expect(response.data).toMatchInlineSnapshot(`
+      Object {
+        "books": Array [
+          Object {
+            "name": "Structure and Interpretation of Computer Programs (1996)",
           },
-        })),
-      };
-    }
+          Object {
+            "name": "Object Oriented Software Construction (1997)",
+          },
+          Object {
+            "name": "Design Patterns (1995)",
+          },
+          Object {
+            "name": "The Year Was Null (null)",
+          },
+          Object {
+            "name": " (404)",
+          },
+          Object {
+            "name": "No Books Like This Book! (2019)",
+          },
+        ],
+      }
+    `);
+  });
 
-    const data = {
-      __typename: 'TestSubject',
-      id: '1',
-      nullable: null,
-      emptyString: '',
-      emptyList: [],
-      listOfEmpties: ['', '', ''],
-      listOfNumbers: [1, 2, 3],
-      listOfObjects: [
-        { __typename: 'TestObject', id: 1, nullable: null },
-        { __typename: 'TestObject', id: 2, nullable: null },
-      ],
-    };
+  it('can execute queries with list @requires', async () => {
+    const query = gql`
+      query {
+        book(isbn: "0201633612") {
+          # Requires similarBooks { isbn }
+          relatedReviews {
+            id
+            body
+          }
+        }
+      }
+    `;
 
-    it('handles regular selections and simple edge cases', () => {
-      const result = executeSelectionSet(
-        data,
-        getSelectionSet('__typename', 'id', 'nullable', 'emptyString'),
-      );
+    const operationContext = buildOperationContext(schema, query);
+    const queryPlan = buildQueryPlan(operationContext);
 
-      expect(result).toEqual({
-        __typename: 'TestSubject',
-        id: '1',
-        nullable: null,
-        emptyString: '',
-      });
-    });
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
 
-    it('handles lists', () => {
-      const result = executeSelectionSet(
-        data,
-        getSelectionSet('id', 'emptyList', 'listOfEmpties', 'listOfNumbers'),
-      );
+    expect(response.errors).toMatchInlineSnapshot(`undefined`);
 
-      expect(result).toEqual({
-        id: '1',
-        emptyList: [],
-        listOfEmpties: ['', '', ''],
-        listOfNumbers: [1, 2, 3],
-      });
-    });
-
-    it('list of objects with nested selections', () => {
-      const selectionSet = getSelectionSet('id', 'listOfObjects');
-
-      // Nest another selection set to just pick 'id' and 'nullable' fields
-      // { list { id nullable } }
-      (selectionSet.selections[1] as any).selectionSet = getSelectionSet(
-        'id',
-        'nullable',
-      );
-      const result = executeSelectionSet(data, selectionSet);
-
-      expect(result).toEqual({
-        id: '1',
-        listOfObjects: [{ id: 1, nullable: null }, { id: 2, nullable: null }],
-      });
-    });
+    expect(response.data).toMatchInlineSnapshot(`
+                        Object {
+                          "book": Object {
+                            "relatedReviews": Array [
+                              Object {
+                                "body": "A classic.",
+                                "id": "6",
+                              },
+                              Object {
+                                "body": "A bit outdated.",
+                                "id": "5",
+                              },
+                            ],
+                          },
+                        }
+                `);
   });
 });

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -1,9 +1,4 @@
-import {
-  GraphQLSchema,
-  GraphQLError,
-  getIntrospectionQuery,
-  SelectionSetNode,
-} from 'graphql';
+import { GraphQLSchema, GraphQLError, getIntrospectionQuery } from 'graphql';
 import path from 'path';
 import {
   GraphQLSchemaValidationError,
@@ -16,7 +11,7 @@ import { GraphQLRequestContext } from 'apollo-server-core';
 import { composeServices, buildFederatedSchema } from '@apollo/federation';
 
 import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
-import { executeQueryPlan, executeSelectionSet } from '../executeQueryPlan';
+import { executeQueryPlan } from '../executeQueryPlan';
 import { LocalGraphQLDataSource } from '../datasources/LocalGraphQLDatasource';
 
 function buildLocalService(modules: GraphQLSchemaModule[]) {
@@ -222,41 +217,41 @@ describe('executeQueryPlan', () => {
     );
 
     expect(response.data).toMatchInlineSnapshot(`
-                                                Object {
-                                                  "topReviews": Array [
-                                                    Object {
-                                                      "author": Object {
-                                                        "name": "Ada Lovelace",
-                                                      },
-                                                      "body": "Love it!",
-                                                    },
-                                                    Object {
-                                                      "author": Object {
-                                                        "name": "Ada Lovelace",
-                                                      },
-                                                      "body": "Too expensive.",
-                                                    },
-                                                    Object {
-                                                      "author": Object {
-                                                        "name": "Alan Turing",
-                                                      },
-                                                      "body": "Could be better.",
-                                                    },
-                                                    Object {
-                                                      "author": Object {
-                                                        "name": "Alan Turing",
-                                                      },
-                                                      "body": "Prefer something else.",
-                                                    },
-                                                    Object {
-                                                      "author": Object {
-                                                        "name": "Alan Turing",
-                                                      },
-                                                      "body": "Wish I had read this before.",
-                                                    },
-                                                  ],
-                                                }
-                                `);
+      Object {
+        "topReviews": Array [
+          Object {
+            "author": Object {
+              "name": "Ada Lovelace",
+            },
+            "body": "Love it!",
+          },
+          Object {
+            "author": Object {
+              "name": "Ada Lovelace",
+            },
+            "body": "Too expensive.",
+          },
+          Object {
+            "author": Object {
+              "name": "Alan Turing",
+            },
+            "body": "Could be better.",
+          },
+          Object {
+            "author": Object {
+              "name": "Alan Turing",
+            },
+            "body": "Prefer something else.",
+          },
+          Object {
+            "author": Object {
+              "name": "Alan Turing",
+            },
+            "body": "Wish I had read this before.",
+          },
+        ],
+      }
+    `);
   });
 
   it('should not duplicate variable definitions', async () => {
@@ -291,49 +286,49 @@ describe('executeQueryPlan', () => {
     );
 
     expect(response.data).toMatchInlineSnapshot(`
-                                    Object {
-                                      "first": Array [
-                                        Object {
-                                          "author": Object {
-                                            "name": "Ada Lovelace",
-                                          },
-                                          "body": "Love it!",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "name": "Ada Lovelace",
-                                          },
-                                          "body": "Too expensive.",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "name": "Alan Turing",
-                                          },
-                                          "body": "Could be better.",
-                                        },
-                                      ],
-                                      "second": Array [
-                                        Object {
-                                          "author": Object {
-                                            "name": "Ada Lovelace",
-                                          },
-                                          "body": "Love it!",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "name": "Ada Lovelace",
-                                          },
-                                          "body": "Too expensive.",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "name": "Alan Turing",
-                                          },
-                                          "body": "Could be better.",
-                                        },
-                                      ],
-                                    }
-                        `);
+      Object {
+        "first": Array [
+          Object {
+            "author": Object {
+              "name": "Ada Lovelace",
+            },
+            "body": "Love it!",
+          },
+          Object {
+            "author": Object {
+              "name": "Ada Lovelace",
+            },
+            "body": "Too expensive.",
+          },
+          Object {
+            "author": Object {
+              "name": "Alan Turing",
+            },
+            "body": "Could be better.",
+          },
+        ],
+        "second": Array [
+          Object {
+            "author": Object {
+              "name": "Ada Lovelace",
+            },
+            "body": "Love it!",
+          },
+          Object {
+            "author": Object {
+              "name": "Ada Lovelace",
+            },
+            "body": "Too expensive.",
+          },
+          Object {
+            "author": Object {
+              "name": "Alan Turing",
+            },
+            "body": "Could be better.",
+          },
+        ],
+      }
+    `);
   });
 
   it('should include variables in non-root requests', async () => {
@@ -363,46 +358,46 @@ describe('executeQueryPlan', () => {
     );
 
     expect(response.data).toMatchInlineSnapshot(`
-                                    Object {
-                                      "topReviews": Array [
-                                        Object {
-                                          "author": Object {
-                                            "birthDate": "12/10/1815",
-                                            "name": "Ada Lovelace",
-                                          },
-                                          "body": "Love it!",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "birthDate": "12/10/1815",
-                                            "name": "Ada Lovelace",
-                                          },
-                                          "body": "Too expensive.",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "birthDate": "6/23/1912",
-                                            "name": "Alan Turing",
-                                          },
-                                          "body": "Could be better.",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "birthDate": "6/23/1912",
-                                            "name": "Alan Turing",
-                                          },
-                                          "body": "Prefer something else.",
-                                        },
-                                        Object {
-                                          "author": Object {
-                                            "birthDate": "6/23/1912",
-                                            "name": "Alan Turing",
-                                          },
-                                          "body": "Wish I had read this before.",
-                                        },
-                                      ],
-                                    }
-                        `);
+      Object {
+        "topReviews": Array [
+          Object {
+            "author": Object {
+              "birthDate": "12/10/1815",
+              "name": "Ada Lovelace",
+            },
+            "body": "Love it!",
+          },
+          Object {
+            "author": Object {
+              "birthDate": "12/10/1815",
+              "name": "Ada Lovelace",
+            },
+            "body": "Too expensive.",
+          },
+          Object {
+            "author": Object {
+              "birthDate": "6/23/1912",
+              "name": "Alan Turing",
+            },
+            "body": "Could be better.",
+          },
+          Object {
+            "author": Object {
+              "birthDate": "6/23/1912",
+              "name": "Alan Turing",
+            },
+            "body": "Prefer something else.",
+          },
+          Object {
+            "author": Object {
+              "birthDate": "6/23/1912",
+              "name": "Alan Turing",
+            },
+            "body": "Wish I had read this before.",
+          },
+        ],
+      }
+    `);
   });
 
   it('can execute an introspection query', async () => {

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -484,8 +484,8 @@ describe('executeQueryPlan', () => {
     it('list of objects with nested selections', () => {
       const selectionSet = getSelectionSet('id', 'listOfObjects');
 
-      // Nest another selection set to just pick 'id' field
-      // { list { id } }
+      // Nest another selection set to just pick 'id' and 'nullable' fields
+      // { list { id nullable } }
       (selectionSet.selections[1] as any).selectionSet = getSelectionSet(
         'id',
         'nullable',

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -214,9 +214,7 @@ async function executeFetch<TContext>(
 
     if (receivedEntities.length !== representations.length) {
       throw new Error(
-        `Expected "data._entities" to contain ${
-          representations.length
-        } elements`,
+        `Expected "data._entities" to contain ${representations.length} elements`,
       );
     }
 

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -254,6 +254,11 @@ async function executeFetch<TContext>(
   }
 }
 
+/**
+ *
+ * @param source result of graphql execution
+ * @param selectionSet
+ */
 function executeSelectionSet(
   source: Record<string, any>,
   selectionSet: SelectionSetNode,
@@ -264,13 +269,22 @@ function executeSelectionSet(
     switch (selection.kind) {
       case Kind.FIELD:
         const responseName = getResponseName(selection);
-        if (!source[responseName]) {
+        const selectionSet = selection.selectionSet;
+
+        // Null is a valid value for a response, provided that the types match.
+        // Presumably the underlying service has validated that result, so we
+        // can pass it through here
+        if (source[responseName] === undefined) {
           throw new Error(`Field "${responseName}" was not found in response.`);
         }
-        if (selection.selectionSet) {
+        if (Array.isArray(source[responseName])) {
+          result[responseName] = source[responseName].map((value: any) =>
+            selectionSet ? executeSelectionSet(value, selectionSet) : value,
+          );
+        } else if (selectionSet) {
           result[responseName] = executeSelectionSet(
             source[responseName],
-            selection.selectionSet,
+            selectionSet,
           );
         } else {
           result[responseName] = source[responseName];

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -214,7 +214,9 @@ async function executeFetch<TContext>(
 
     if (receivedEntities.length !== representations.length) {
       throw new Error(
-        `Expected "data._entities" to contain ${representations.length} elements`,
+        `Expected "data._entities" to contain ${
+          representations.length
+        } elements`,
       );
     }
 
@@ -259,7 +261,7 @@ async function executeFetch<TContext>(
  * @param source result of graphql execution
  * @param selectionSet
  */
-function executeSelectionSet(
+export function executeSelectionSet(
   source: Record<string, any>,
   selectionSet: SelectionSetNode,
 ): Record<string, any> {

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -274,7 +274,7 @@ function executeSelectionSet(
         // Null is a valid value for a response, provided that the types match.
         // Presumably the underlying service has validated that result, so we
         // can pass it through here
-        if (source[responseName] === undefined) {
+        if (typeof source[responseName] === 'undefined') {
           throw new Error(`Field "${responseName}" was not found in response.`);
         }
         if (Array.isArray(source[responseName])) {

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -258,7 +258,7 @@ async function executeFetch<TContext>(
 
 /**
  *
- * @param source result of graphql execution
+ * @param source Result of GraphQL execution.
  * @param selectionSet
  */
 export function executeSelectionSet(

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -259,7 +259,7 @@ async function executeFetch<TContext>(
  * @param source Result of GraphQL execution.
  * @param selectionSet
  */
-export function executeSelectionSet(
+function executeSelectionSet(
   source: Record<string, any>,
   selectionSet: SelectionSetNode,
 ): Record<string, any> {


### PR DESCRIPTION
While dogfooding, we ran into an error. Looking into the error with @trevor-scheer, we found that the gateway did not support two use cases we had for `requires`(internally called representations): returning null values and returning arrays. This PR adds the support for those two cases. 

![image](https://user-images.githubusercontent.com/5565407/60208709-d1996a80-980d-11e9-859a-0c69e40a8c03.png)

Fixes #2925
