### PR TITLE
feat(apollo-engine-reportoing): `sendVariableValues` and `sendHeaders`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: The `engine.maskErrorDetails` option, deprecated by `engine.rewriteError` in v2.5.0, now behaves a bit more like the new option: while all error messages will be redacted, they will still show up on the appropriate nodes in a trace. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: By default, send no GraphQL variable values to Apollo's servers instead of sending all variable values. Adding the new EngineReportingOption `maskVariableValues` to send some or all variable values, possibly after transforming them. This replaces the `privateVariables` option, which is now deprecated. [PR #2931](https://github.com/apollographql/apollo-server/pull/2931)
 
+  > Note: In order to keep shipping all GraphQL variable values to Apollo Engine, pass in the option:
+
+  `new ApolloServer({engine: {sendVariableValues: {all: true}}})`.
+
+
 ### v2.6.7
 
 - `apollo-server-core`: Guard against undefined property access in `isDirectiveDefined` which resulted in "Cannot read property 'some' of undefined" error. [PR #2924](https://github.com/apollographql/apollo-server/pull/2924) [Issue #2921](https://github.com/apollographql/apollo-server/issues/2921)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: If the error returned from the `engine.rewriteError` hook has an `extensions` property, that property will be used instead of the original error's extensions. Document that changes to most other `GraphQLError` fields by `engine.rewriteError` are ignored. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: The `engine.maskErrorDetails` option, deprecated by `engine.rewriteError` in v2.5.0, now behaves a bit more like the new option: while all error messages will be redacted, they will still show up on the appropriate nodes in a trace. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
-- `apollo-engine-reporting`: **BEHAVIOR CHANGE**: By default, send no GraphQL variable values to Apollo's servers instead of sending all variable values. Adding the new EngineReportingOption `maskVariableValues` to send some or all variable values, possibly after transforming them. This replaces the `privateVariables` option, which is now deprecated. [PR #2931](https://github.com/apollographql/apollo-server/pull/2931)
+- `apollo-engine-reporting`: **BEHAVIOR CHANGE**: By default, send no GraphQL variable values to Apollo's servers instead of sending all variable values. Adding the new EngineReportingOption `sendVariableValues` to send some or all variable values, possibly after transforming them. This replaces the `privateVariables` option, which is now deprecated. [PR #2931](https://github.com/apollographql/apollo-server/pull/2931)
 
   > Note: In order to keep shipping all GraphQL variable values to Apollo Engine, pass in the option:
-
-  `new ApolloServer({engine: {sendVariableValues: {all: true}}})`.
+  >
+  >  `new ApolloServer({engine: {sendVariableValues: {all: true}}})`.
 
 
 ### v2.6.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: If the error returned from the `engine.rewriteError` hook has an `extensions` property, that property will be used instead of the original error's extensions. Document that changes to most other `GraphQLError` fields by `engine.rewriteError` are ignored. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: The `engine.maskErrorDetails` option, deprecated by `engine.rewriteError` in v2.5.0, now behaves a bit more like the new option: while all error messages will be redacted, they will still show up on the appropriate nodes in a trace. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
+- `apollo-engine-reporting`: **BEHAVIOR CHANGE**: By default, send no GraphQL variable values to Apollo's servers instead of sending all variable values. Adding the new EngineReportingOption `maskVariableValues` to send some or all variable values, possibly after transforming them. This replaces the `privateVariables` option, which is now deprecated. [PR #2847](https://github.com/apollographql/apollo-server/pull/2847)
 
 ### v2.6.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: If the error returned from the `engine.rewriteError` hook has an `extensions` property, that property will be used instead of the original error's extensions. Document that changes to most other `GraphQLError` fields by `engine.rewriteError` are ignored. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
 - `apollo-engine-reporting`: **BEHAVIOR CHANGE**: The `engine.maskErrorDetails` option, deprecated by `engine.rewriteError` in v2.5.0, now behaves a bit more like the new option: while all error messages will be redacted, they will still show up on the appropriate nodes in a trace. [PR #2932](https://github.com/apollographql/apollo-server/pull/2932)
-- `apollo-engine-reporting`: **BEHAVIOR CHANGE**: By default, send no GraphQL variable values to Apollo's servers instead of sending all variable values. Adding the new EngineReportingOption `maskVariableValues` to send some or all variable values, possibly after transforming them. This replaces the `privateVariables` option, which is now deprecated. [PR #2847](https://github.com/apollographql/apollo-server/pull/2847)
+- `apollo-engine-reporting`: **BEHAVIOR CHANGE**: By default, send no GraphQL variable values to Apollo's servers instead of sending all variable values. Adding the new EngineReportingOption `maskVariableValues` to send some or all variable values, possibly after transforming them. This replaces the `privateVariables` option, which is now deprecated. [PR #2931](https://github.com/apollographql/apollo-server/pull/2931)
 
 ### v2.6.7
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -345,19 +345,19 @@ addMockFunctionsToSchema({
    
 * `sendVariableValues`: { transform: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
                      | { exceptNames: Array&lt;String&gt; }
-                     | { includeNames: Array&lt;String&gt; }
+                     | { onlyNames: Array&lt;String&gt; }
                      | { sendNone: true }
                      | { sendAll: true }
     
     By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
     
-    - { sendNone: true }: blocklist all variable values (DEFAULT)
-    - { sendAll: true }: safelist all variable values
+    - { sendNone: true }: don't send any variable values (DEFAULT)
+    - { sendAll: true }: send all variable values
     - { transform: ... }: a custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value. 
     - { exceptNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
-    - { includeNames: ... }: a case-sensitive list of names of variables whose values will be sent to Apollo Servers
+    - { onlyNames: ... }: a case-sensitive list of names of variables whose values will be sent to Apollo Servers
 
-   Defaults to blocklisting all variable values if both this parameter and the to-be-deprecated `privateVariables` are not set. 
+   Defaults to not sending any variable values if both this parameter and the deprecated `privateVariables` are not set. 
    The report will indicate each private variable key whose value was redacted by { sendNone: true } or { exceptNames: [...] }.
    
 *  `privateVariables`: Array&lt;String&gt; | boolean
@@ -370,17 +370,18 @@ addMockFunctionsToSchema({
    
    NOTE: An error will be thrown if both this deprecated option and its replacement, `sendVariableValues` are defined.
     
-* `sendHeaders`: { exceptNames: Array&lt;String&gt; } | { includeNames: Array&lt;String&gt; } | { sendAll: boolean } | { sendNone: boolean }
+* `sendHeaders`: { exceptNames: Array&lt;String&gt; } | { onlyNames: Array&lt;String&gt; } | { sendAll: boolean } | { sendNone: boolean }
    By default, Apollo Server does not send the list of HTTP request headers and values to
    Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
    set this option. This option can take several forms:
    
-  - { sendNone : true }: drop all HTTP request headers (DEFAULT)
-  - { sendAll : true }: send the values of all HTTP request headers
+   - { sendNone: true }: drop all HTTP request headers (DEFAULT)
+   - { sendAll: true }: send the values of all HTTP request headers
    - { exceptNames: ... }: A case-insensitive list of names of HTTP headers whose values should not be
    sent to Apollo servers
-   - { includeNames: ... }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
-  
+   - { onlyNames: ... }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
+   
+   Defaults to not sending any request header names and values if both this parameter and the deprecated `privateHeaders` are not set.
    Unlike with `sendVariableValues`, names of dropped headers are not reported.
    The headers 'authorization', 'cookie', and 'set-cookie' are never reported.
    

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -351,24 +351,23 @@ addMockFunctionsToSchema({
     
     By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
     
-    - { none: true }: don't send any variable values (DEFAULT)
-    - { all: true }: send all variable values
-    - { transform: ... }: a custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value. 
-    - { exceptNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
-    - { onlyNames: ... }: a case-sensitive list of names of variables whose values will be sent to Apollo Servers
+    - `{ none: true }`: Don't send any variable values. **(DEFAULT)**
+    - `{ all: true }`: Send all variable values.
+    - `{ transform: ({ variables, operationString}) => { ... } }`: A custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value. 
+    - `{ exceptNames: [...] }`: A case-sensitive list of names of variables whose values should not be sent to Apollo servers.
+    - `{ onlyNames: [...] }`: A case-sensitive list of names of variables whose values will be sent to Apollo servers.
 
    Defaults to not sending any variable values if both this parameter and the deprecated `privateVariables` are not set. 
-   The report will indicate each private variable key whose value was redacted by { none: true } or { exceptNames: [...] }.
+   The report will indicate each private variable key whose value was redacted by `{ none: true }` or `{ exceptNames: [...]` }.
    
 *  `privateVariables`: Array&lt;String&gt; | boolean
 
-   <!--- TODO(helen): update the version number here --->
-   DEPRECATING IN VERSION XX.XX.XX, to be replaced by the option `sendVariableValues`, which supports the same
-   functionalities but allows for more flexibility. Passing an array into `privateVariables` is equivalent to
+   > Will be deprecated in 3.0. Use the option `sendVariableValues` instead. 
+   Passing an array into `privateVariables` is equivalent to
    passing in `{ exceptNames: array } ` to `sendVariableValues`, and passing in `true` or `false` is equivalent
    to passing ` { none: true } ` or ` { all: true }`, respectively.
    
-   NOTE: An error will be thrown if both this deprecated option and its replacement, `sendVariableValues` are defined.
+   > Note: An error will be thrown if both this deprecated option and its replacement, `sendVariableValues` are defined.
    In order to preserve the old default of `privateVariables`, which sends all variables and their values, pass in the `sendVariableValues` option:
      `new ApolloServer({engine: {sendVariableValues: {all: true}}})`.
     
@@ -377,11 +376,10 @@ addMockFunctionsToSchema({
    Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
    set this option. This option can take several forms:
    
-   - { none: true }: drop all HTTP request headers (DEFAULT)
-   - { all: true }: send the values of all HTTP request headers
-   - { exceptNames: ... }: A case-insensitive list of names of HTTP headers whose values should not be
-   sent to Apollo servers
-   - { onlyNames: ... }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
+   - `{ none: true }`: Drop all HTTP request headers. **(DEFAULT)**
+   - `{ all: true }`: Send the values of all HTTP request headers.
+   - `{ exceptNames: [...] }`: A case-insensitive list of names of HTTP headers whose values should not be sent to Apollo servers.
+   - `{ onlyNames: [...] }`: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers.
    
    Defaults to not sending any request header names and values if both this parameter and the deprecated `privateHeaders` are not set.
    Unlike with `sendVariableValues`, names of dropped headers are not reported.
@@ -389,12 +387,11 @@ addMockFunctionsToSchema({
    
 *  `privateHeaders`: Array&lt;String&gt; | boolean
 
-   <!--- TODO(helen): update the version number here --->
-   DEPRECATING IN VERSION XX.XX.XX, use `sendHeaders` instead.
+   > Will be deprecated in 3.0.  Use the `sendHeaders` option instead.
    Passing an array into `privateHeaders` is equivalent to passing ` { exceptNames: array } ` into `sendHeaders`, and
    passing `true` or `false` is equivalent to passing in ` { none: true } ` and ` { all: true }`, respectively.
    
-   NOTE: An error will be thrown if both this deprecated option and its replacement, `sendHeaders` are defined.
+   > Note: An error will be thrown if both this deprecated option and its replacement, `sendHeaders`, are defined.
    In order to preserve the old default of `privateHeaders`, which sends all request headers and their values, pass in the `sendHeaders` option:
       `new ApolloServer({engine: {sendHeaders: {all: true}}})`.
       

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -119,7 +119,7 @@ new ApolloServer({
 
 * `engine`: <`EngineReportingOptions`> | boolean
 
-  Provided the `ENGINE_API_KEY` environment variable is set, the engine reporting agent will be started automatically. The API key can also be provided as the `apiKey` field in an object passed as the `engine` field. See the [EngineReportingOptions](#enginereportingoptions) section for a full description of how to configure the reporting agent, including how to blacklist variables. When using the Engine proxy, this option should be set to false.
+  Provided the `ENGINE_API_KEY` environment variable is set, the engine reporting agent will be started automatically. The API key can also be provided as the `apiKey` field in an object passed as the `engine` field. See the [EngineReportingOptions](#enginereportingoptions) section for a full description of how to configure the reporting agent, including how to blocklist variables. When using the Engine proxy, this option should be set to false.
 
 * `persistedQueries`: <`Object`> | false
 
@@ -343,14 +343,31 @@ addMockFunctionsToSchema({
    to standard error. Specify this function to process errors in a different
    way.
 
-*  `privateVariables`: Array<String> | boolean
+*  `privateVariables`: Array<String\> | boolean
 
+   DEPRECATING IN VERSION XX.XX.XX for `maskVariableValues`, which will support the same
+   functionalities but allow for more flexibility.
+   
    A case-sensitive list of names of variables whose values should not be sent
    to Apollo servers, or 'true' to leave out all variables. In the former
    case, the report will indicate that each private variable was redacted in
    the latter case, no variables are sent at all.
+   
+* `maskVariableValues`: { valueModifier: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
+                     | { privateVariableNames: Array<String\> }
+                     | { always: boolean }
+    
+    By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
+    
+    - { always: ... }: true to blocklist, or false to whitelist all variable values
+    - { valueModifier: ... }: a custom function for modifying variable values
+    - { privateVariableNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
 
-*  `privateHeaders`: Array<String> | boolean
+    Defaults to blocklisting all variable values if both this parameter and
+    the to-be-deprecated `privateVariables` are not set. The report will also
+    indicate each private variable redacted if set to { always: ... } or { privateVariableNames: ... }
+
+*  `privateHeaders`: Array<String\> | boolean
 
    A case-insensitive list of names of HTTP headers whose values should not be
    sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -345,6 +345,7 @@ addMockFunctionsToSchema({
    
 * `sendVariableValues`: { transform: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
                      | { exceptNames: Array&lt;String&gt; }
+                     | { includeNames: Array&lt;String&gt; }
                      | { sendNone: true }
                      | { sendAll: true }
     
@@ -354,6 +355,7 @@ addMockFunctionsToSchema({
     - { sendAll: true }: safelist all variable values
     - { transform: ... }: a custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value. 
     - { exceptNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
+    - { includeNames: ... }: a case-sensitive list of names of variables whose values will be sent to Apollo Servers
 
    Defaults to blocklisting all variable values if both this parameter and the to-be-deprecated `privateVariables` are not set. 
    The report will indicate each private variable key whose value was redacted by { sendNone: true } or { exceptNames: [...] }.
@@ -368,15 +370,16 @@ addMockFunctionsToSchema({
    
    NOTE: An error will be thrown if both this deprecated option and its replacement, `sendVariableValues` are defined.
     
-* `sendHeaders`: { exceptNames: Array&lt;String&gt; } | { sendAll: boolean } | { sendNone: boolean }
+* `sendHeaders`: { exceptNames: Array&lt;String&gt; } | { includeNames: Array&lt;String&gt; } | { sendAll: boolean } | { sendNone: boolean }
    By default, Apollo Server does not send the list of HTTP request headers and values to
    Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
    set this option. This option can take several forms:
    
-   - { exceptNames: Array&lt;String&gt; } A case-insensitive list of names of HTTP headers whose values should not be
+  - { sendNone : true }: drop all HTTP request headers (DEFAULT)
+  - { sendAll : true }: send the values of all HTTP request headers
+   - { exceptNames: ... }: A case-insensitive list of names of HTTP headers whose values should not be
    sent to Apollo servers
-   - { sendNone : true } to drop all HTTP request headers
-   - { sendAll : true } to send the values of all HTTP request headers
+   - { includeNames: ... }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
   
    Unlike with `sendVariableValues`, names of dropped headers are not reported.
    The headers 'authorization', 'cookie', and 'set-cookie' are never reported.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -346,19 +346,19 @@ addMockFunctionsToSchema({
 * `sendVariableValues`: { transform: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
                      | { exceptNames: Array&lt;String&gt; }
                      | { onlyNames: Array&lt;String&gt; }
-                     | { sendNone: true }
-                     | { sendAll: true }
+                     | { none: true }
+                     | { all: true }
     
     By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
     
-    - { sendNone: true }: don't send any variable values (DEFAULT)
-    - { sendAll: true }: send all variable values
+    - { none: true }: don't send any variable values (DEFAULT)
+    - { all: true }: send all variable values
     - { transform: ... }: a custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value. 
     - { exceptNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
     - { onlyNames: ... }: a case-sensitive list of names of variables whose values will be sent to Apollo Servers
 
    Defaults to not sending any variable values if both this parameter and the deprecated `privateVariables` are not set. 
-   The report will indicate each private variable key whose value was redacted by { sendNone: true } or { exceptNames: [...] }.
+   The report will indicate each private variable key whose value was redacted by { none: true } or { exceptNames: [...] }.
    
 *  `privateVariables`: Array&lt;String&gt; | boolean
 
@@ -366,17 +366,19 @@ addMockFunctionsToSchema({
    DEPRECATING IN VERSION XX.XX.XX, to be replaced by the option `sendVariableValues`, which supports the same
    functionalities but allows for more flexibility. Passing an array into `privateVariables` is equivalent to
    passing in `{ exceptNames: array } ` to `sendVariableValues`, and passing in `true` or `false` is equivalent
-   to passing ` { sendNone: true } ` or ` { sendAll: true }`, respectively.
+   to passing ` { none: true } ` or ` { all: true }`, respectively.
    
    NOTE: An error will be thrown if both this deprecated option and its replacement, `sendVariableValues` are defined.
+   In order to preserve the old default of `privateVariables`, which sends all variables and their values, pass in the `sendVariableValues` option:
+     `new ApolloServer({engine: {sendVariableValues: {all: true}}})`.
     
-* `sendHeaders`: { exceptNames: Array&lt;String&gt; } | { onlyNames: Array&lt;String&gt; } | { sendAll: boolean } | { sendNone: boolean }
+* `sendHeaders`: { exceptNames: Array&lt;String&gt; } | { onlyNames: Array&lt;String&gt; } | { all: boolean } | { none: boolean }
    By default, Apollo Server does not send the list of HTTP request headers and values to
    Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
    set this option. This option can take several forms:
    
-   - { sendNone: true }: drop all HTTP request headers (DEFAULT)
-   - { sendAll: true }: send the values of all HTTP request headers
+   - { none: true }: drop all HTTP request headers (DEFAULT)
+   - { all: true }: send the values of all HTTP request headers
    - { exceptNames: ... }: A case-insensitive list of names of HTTP headers whose values should not be
    sent to Apollo servers
    - { onlyNames: ... }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
@@ -390,10 +392,12 @@ addMockFunctionsToSchema({
    <!--- TODO(helen): update the version number here --->
    DEPRECATING IN VERSION XX.XX.XX, use `sendHeaders` instead.
    Passing an array into `privateHeaders` is equivalent to passing ` { exceptNames: array } ` into `sendHeaders`, and
-   passing `true` or `false` is equivalent to passing in ` { sendNone: true } ` and ` { sendAll: true }`, respectively.
+   passing `true` or `false` is equivalent to passing in ` { none: true } ` and ` { all: true }`, respectively.
    
    NOTE: An error will be thrown if both this deprecated option and its replacement, `sendHeaders` are defined.
-   
+   In order to preserve the old default of `privateHeaders`, which sends all request headers and their values, pass in the `sendHeaders` option:
+      `new ApolloServer({engine: {sendHeaders: {all: true}}})`.
+      
 *  `handleSignals`: boolean
 
    By default, EngineReportingAgent listens for the 'SIGINT' and 'SIGTERM'

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -345,7 +345,7 @@ addMockFunctionsToSchema({
 
 *  `privateVariables`: Array<String\> | boolean
 
-   DEPRECATING IN VERSION XX.XX.XX for `maskVariableValues`, which will support the same
+   DEPRECATING IN VERSION XX.XX.XX for `sendVariableValues`, which will support the same
    functionalities but allow for more flexibility.
    
    A case-sensitive list of names of variables whose values should not be sent
@@ -353,19 +353,19 @@ addMockFunctionsToSchema({
    case, the report will indicate that each private variable was redacted in
    the latter case, no variables are sent at all.
    
-* `maskVariableValues`: { valueModifier: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
-                     | { privateVariableNames: Array<String\> }
-                     | { always: boolean }
+* `sendVariableValues`: { valueModifier: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
+                     | { exceptVariableNames: Array<String\> }
+                     | { whitelistAll: boolean }
     
     By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
     
-    - { always: ... }: true to blocklist, or false to whitelist all variable values
+    - { whitelistAll: ... }: false to blocklist, or true to whitelist all variable values
     - { valueModifier: ... }: a custom function for modifying variable values
-    - { privateVariableNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
+    - { exceptVariableNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
 
     Defaults to blocklisting all variable values if both this parameter and
     the to-be-deprecated `privateVariables` are not set. The report will also
-    indicate each private variable redacted if set to { always: ... } or { privateVariableNames: ... }
+    indicate each private variable key redacted by { whitelistAll: false } or { exceptVariableNames: [...] }.
 
 *  `privateHeaders`: Array<String\> | boolean
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -355,20 +355,32 @@ addMockFunctionsToSchema({
    
 * `sendVariableValues`: { valueModifier: (options: { variables: Record<string, any>, operationString?: string } ) => Record<string, any> }
                      | { exceptVariableNames: Array<String\> }
-                     | { whitelistAll: boolean }
+                     | { safelistAll: boolean }
     
     By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
     
-    - { whitelistAll: ... }: false to blocklist, or true to whitelist all variable values
+    - { safelistAll: ... }: false to blocklist, or true to safelist all variable values
     - { valueModifier: ... }: a custom function for modifying variable values
     - { exceptVariableNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
 
     Defaults to blocklisting all variable values if both this parameter and
     the to-be-deprecated `privateVariables` are not set. The report will also
-    indicate each private variable key redacted by { whitelistAll: false } or { exceptVariableNames: [...] }.
-
+    indicate each private variable key redacted by { safelistAll: false } or { exceptVariableNames: [...] }.
+    
+* `sendHeaders`: { except: Array<String\> } | { safelistAll: boolean }
+   By default, Apollo Server does not send the list of HTTP headers and values to
+   Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
+   set this option. This option can take two forms:
+   
+   - {except: Array<String\>} A case-insensitive list of names of HTTP headers whose values should not be
+   sent to Apollo servers
+   - {safelistAll: true/false} to include or leave out all HTTP headers.
+  
+   Unlike with sendVariableValues, names of dropped headers are not reported.
+   
 *  `privateHeaders`: Array<String\> | boolean
 
+   DEPRECATING IN VERSION XX.XX.XX, use 'sendHeaders' instead.
    A case-insensitive list of names of HTTP headers whose values should not be
    sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike
    with privateVariables, names of dropped headers are not reported.

--- a/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
@@ -1,4 +1,8 @@
-import { signatureCacheKey } from '../agent';
+import {
+  signatureCacheKey,
+  handleLegacyOptions,
+  EngineReportingOptions,
+} from '../agent';
 
 describe('signature cache key', () => {
   it('generates without the operationName', () => {
@@ -9,5 +13,82 @@ describe('signature cache key', () => {
     expect(signatureCacheKey('abc123', 'myOperation')).toEqual(
       'abc123:myOperation',
     );
+  });
+});
+
+describe("test handleLegacyOptions(), which converts the deprecated privateVariable and privateHeaders options to the new options' formats", () => {
+  it('Case 1: privateVariables/privateHeaders == False; same as sendAll', () => {
+    const optionsPrivateFalse: EngineReportingOptions<any> = {
+      privateVariables: false,
+      privateHeaders: false,
+    };
+    handleLegacyOptions(optionsPrivateFalse);
+    expect(optionsPrivateFalse.privateVariables).toBe(undefined);
+    expect(optionsPrivateFalse.sendVariableValues).toEqual({ sendAll: true });
+    expect(optionsPrivateFalse.privateHeaders).toBe(undefined);
+    expect(optionsPrivateFalse.sendHeaders).toEqual({ sendAll: true });
+  });
+
+  it('Case 2: privateVariables/privateHeaders == True; same as sendNone', () => {
+    const optionsPrivateTrue: EngineReportingOptions<any> = {
+      privateVariables: true,
+      privateHeaders: true,
+    };
+    handleLegacyOptions(optionsPrivateTrue);
+    expect(optionsPrivateTrue.privateVariables).toBe(undefined);
+    expect(optionsPrivateTrue.sendVariableValues).toEqual({ sendNone: true });
+    expect(optionsPrivateTrue.privateHeaders).toBe(undefined);
+    expect(optionsPrivateTrue.sendHeaders).toEqual({ sendNone: true });
+  });
+
+  it('Case 3: privateVariables/privateHeaders set to an array', () => {
+    const privateArray: Array<String> = ['t1', 't2'];
+    const optionsPrivateArray: EngineReportingOptions<any> = {
+      privateVariables: privateArray,
+      privateHeaders: privateArray,
+    };
+    handleLegacyOptions(optionsPrivateArray);
+    expect(optionsPrivateArray.privateVariables).toBe(undefined);
+    expect(optionsPrivateArray.sendVariableValues).toEqual({
+      exceptNames: privateArray,
+    });
+    expect(optionsPrivateArray.privateHeaders).toBe(undefined);
+    expect(optionsPrivateArray.sendHeaders).toEqual({
+      exceptNames: privateArray,
+    });
+  });
+
+  it('Case 4: throws error when both the new and old options are set', () => {
+    const optionsBothVariables: EngineReportingOptions<any> = {
+      privateVariables: true,
+      sendVariableValues: { sendNone: true },
+    };
+    expect(() => {
+      handleLegacyOptions(optionsBothVariables);
+    }).toThrow();
+    const optionsBothHeaders: EngineReportingOptions<any> = {
+      privateHeaders: true,
+      sendHeaders: { sendNone: true },
+    };
+    expect(() => {
+      handleLegacyOptions(optionsBothHeaders);
+    }).toThrow();
+  });
+
+  it('Case 5: the passed in options are not modified if deprecated fields were not set', () => {
+    const optionsNotDeprecated: EngineReportingOptions<any> = {
+      sendVariableValues: { exceptNames: ['test'] },
+      sendHeaders: true,
+    };
+    const output: EngineReportingOptions<any> = {
+      sendVariableValues: { exceptNames: ['test'] },
+      sendHeaders: true,
+    };
+    handleLegacyOptions(optionsNotDeprecated);
+    expect(optionsNotDeprecated).toEqual(output);
+
+    const emptyInput: EngineReportingOptions<any> = {};
+    handleLegacyOptions(emptyInput);
+    expect(emptyInput).toEqual({});
   });
 });

--- a/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
@@ -58,7 +58,19 @@ describe("test handleLegacyOptions(), which converts the deprecated privateVaria
     });
   });
 
-  it('Case 4: throws error when both the new and old options are set', () => {
+  it('Case 4: privateVariables/privateHeaders are null or undefined; no change', () => {
+    const optionsPrivateFalse: EngineReportingOptions<any> = {
+      privateVariables: undefined,
+      privateHeaders: null, // null is not a valid TS input, but check the output anyways
+    };
+    handleLegacyOptions(optionsPrivateFalse);
+    expect(optionsPrivateFalse.privateVariables).toBe(undefined);
+    expect(optionsPrivateFalse.sendVariableValues).toBe(undefined);
+    expect(optionsPrivateFalse.privateHeaders).toBe(undefined);
+    expect(optionsPrivateFalse.sendHeaders).toBe(undefined);
+  });
+
+  it('Case 5: throws error when both the new and old options are set', () => {
     const optionsBothVariables: EngineReportingOptions<any> = {
       privateVariables: true,
       sendVariableValues: { none: true },
@@ -75,14 +87,14 @@ describe("test handleLegacyOptions(), which converts the deprecated privateVaria
     }).toThrow();
   });
 
-  it('Case 5: the passed in options are not modified if deprecated fields were not set', () => {
+  it('Case 6: the passed in options are not modified if deprecated fields were not set', () => {
     const optionsNotDeprecated: EngineReportingOptions<any> = {
       sendVariableValues: { exceptNames: ['test'] },
-      sendHeaders: true,
+      sendHeaders: { all: true },
     };
     const output: EngineReportingOptions<any> = {
       sendVariableValues: { exceptNames: ['test'] },
-      sendHeaders: true,
+      sendHeaders: { all: true },
     };
     handleLegacyOptions(optionsNotDeprecated);
     expect(optionsNotDeprecated).toEqual(output);

--- a/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/agent.test.ts
@@ -17,28 +17,28 @@ describe('signature cache key', () => {
 });
 
 describe("test handleLegacyOptions(), which converts the deprecated privateVariable and privateHeaders options to the new options' formats", () => {
-  it('Case 1: privateVariables/privateHeaders == False; same as sendAll', () => {
+  it('Case 1: privateVariables/privateHeaders == False; same as all', () => {
     const optionsPrivateFalse: EngineReportingOptions<any> = {
       privateVariables: false,
       privateHeaders: false,
     };
     handleLegacyOptions(optionsPrivateFalse);
     expect(optionsPrivateFalse.privateVariables).toBe(undefined);
-    expect(optionsPrivateFalse.sendVariableValues).toEqual({ sendAll: true });
+    expect(optionsPrivateFalse.sendVariableValues).toEqual({ all: true });
     expect(optionsPrivateFalse.privateHeaders).toBe(undefined);
-    expect(optionsPrivateFalse.sendHeaders).toEqual({ sendAll: true });
+    expect(optionsPrivateFalse.sendHeaders).toEqual({ all: true });
   });
 
-  it('Case 2: privateVariables/privateHeaders == True; same as sendNone', () => {
+  it('Case 2: privateVariables/privateHeaders == True; same as none', () => {
     const optionsPrivateTrue: EngineReportingOptions<any> = {
       privateVariables: true,
       privateHeaders: true,
     };
     handleLegacyOptions(optionsPrivateTrue);
     expect(optionsPrivateTrue.privateVariables).toBe(undefined);
-    expect(optionsPrivateTrue.sendVariableValues).toEqual({ sendNone: true });
+    expect(optionsPrivateTrue.sendVariableValues).toEqual({ none: true });
     expect(optionsPrivateTrue.privateHeaders).toBe(undefined);
-    expect(optionsPrivateTrue.sendHeaders).toEqual({ sendNone: true });
+    expect(optionsPrivateTrue.sendHeaders).toEqual({ none: true });
   });
 
   it('Case 3: privateVariables/privateHeaders set to an array', () => {
@@ -61,14 +61,14 @@ describe("test handleLegacyOptions(), which converts the deprecated privateVaria
   it('Case 4: throws error when both the new and old options are set', () => {
     const optionsBothVariables: EngineReportingOptions<any> = {
       privateVariables: true,
-      sendVariableValues: { sendNone: true },
+      sendVariableValues: { none: true },
     };
     expect(() => {
       handleLegacyOptions(optionsBothVariables);
     }).toThrow();
     const optionsBothHeaders: EngineReportingOptions<any> = {
       privateHeaders: true,
-      sendHeaders: { sendNone: true },
+      sendHeaders: { none: true },
     };
     expect(() => {
       handleLegacyOptions(optionsBothHeaders);

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -99,146 +99,140 @@ const variables: Record<string, any> = {
   t2: 2,
 };
 
-test('check variableJson output for sendVariableValues null or undefined (default)', () => {
-  // Case 1: No keys/values in variables to be filtered/not filtered
-  const emptyOutput = new Trace.Details();
-  expect(makeTraceDetails({}, null)).toEqual(emptyOutput);
-  expect(makeTraceDetails({}, undefined)).toEqual(emptyOutput);
-  expect(makeTraceDetails({})).toEqual(emptyOutput);
-
-  // Case 2: Filter all variables
-  const filteredOutput = new Trace.Details();
-  Object.keys(variables).forEach(name => {
-    filteredOutput.variablesJson[name] = '';
+describe('check variableJson output for sendVariableValues null or undefined (default)', () => {
+  it('Case 1: No keys/values in variables to be filtered/not filtered', () => {
+    const emptyOutput = new Trace.Details();
+    expect(makeTraceDetails({}, null)).toEqual(emptyOutput);
+    expect(makeTraceDetails({}, undefined)).toEqual(emptyOutput);
+    expect(makeTraceDetails({})).toEqual(emptyOutput);
   });
-  expect(makeTraceDetails(variables)).toEqual(filteredOutput);
-  expect(makeTraceDetails(variables, null)).toEqual(filteredOutput);
-  expect(makeTraceDetails(variables, undefined)).toEqual(filteredOutput);
-});
-
-test('check variableJson output for sendVariableValues safelist type', () => {
-  // Case 1: No keys/values in variables to be filtered/not filtered
-  const emptyOutput = new Trace.Details();
-  expect(makeTraceDetails({}, { safelistAll: true })).toEqual(emptyOutput);
-  expect(makeTraceDetails({}, { safelistAll: false })).toEqual(emptyOutput);
-
-  // Case 2: Filter all variables
-  const filteredOutput = new Trace.Details();
-  Object.keys(variables).forEach(name => {
-    filteredOutput.variablesJson[name] = '';
-  });
-  expect(makeTraceDetails(variables, { safelistAll: false })).toEqual(
-    filteredOutput,
-  );
-
-  // Case 3: Do not filter variables
-  const nonFilteredOutput = new Trace.Details();
-  Object.keys(variables).forEach(name => {
-    nonFilteredOutput.variablesJson[name] = JSON.stringify(variables[name]);
-  });
-  expect(makeTraceDetails(variables, { safelistAll: true })).toEqual(
-    nonFilteredOutput,
-  );
-});
-
-test('variableJson output for privacyEnforcer Array type', () => {
-  const privateVariablesArray: string[] = ['testing', 'notInVariables'];
-  const expectedVariablesJson = {
-    testing: '',
-    t2: JSON.stringify(2),
-  };
-  expect(
-    makeTraceDetails(variables, { exceptVariableNames: privateVariablesArray })
-      .variablesJson,
-  ).toEqual(expectedVariablesJson);
-});
-
-test('variableJson output for privacyEnforcer custom function', () => {
-  // Custom function that redacts every variable to 100;
-  const modifiedValue = 100;
-  const customModifier = (input: {
-    variables: Record<string, any>;
-  }): Record<string, any> => {
-    let out: Record<string, any> = {};
-    Object.keys(input.variables).map((name: string) => {
-      out[name] = modifiedValue;
+  it('Case 2: Filter all variables', () => {
+    const filteredOutput = new Trace.Details();
+    Object.keys(variables).forEach(name => {
+      filteredOutput.variablesJson[name] = '';
     });
-    return out;
-  };
+    expect(makeTraceDetails(variables)).toEqual(filteredOutput);
+    expect(makeTraceDetails(variables, null)).toEqual(filteredOutput);
+    expect(makeTraceDetails(variables, undefined)).toEqual(filteredOutput);
+  });
+});
 
-  // Expected output
-  const output = new Trace.Details();
-  Object.keys(variables).forEach(name => {
-    output.variablesJson[name] = JSON.stringify(modifiedValue);
+describe('check variableJson output for sendVariableValues sendAll/sendNone type', () => {
+  it('Case 1: No keys/values in variables to be filtered/not filtered', () => {
+    const emptyOutput = new Trace.Details();
+    expect(makeTraceDetails({}, { sendAll: true })).toEqual(emptyOutput);
+    expect(makeTraceDetails({}, { sendNone: true })).toEqual(emptyOutput);
   });
 
-  expect(
-    makeTraceDetails(variables, { valueModifier: customModifier }),
-  ).toEqual(output);
+  it('Case 2: Filter all variables', () => {
+    const filteredOutput = new Trace.Details();
+    Object.keys(variables).forEach(name => {
+      filteredOutput.variablesJson[name] = '';
+    });
+    expect(makeTraceDetails(variables, { sendNone: true })).toEqual(
+      filteredOutput,
+    );
+  });
+
+  it('Case 3: Do not filter variables', () => {
+    const nonFilteredOutput = new Trace.Details();
+    Object.keys(variables).forEach(name => {
+      nonFilteredOutput.variablesJson[name] = JSON.stringify(variables[name]);
+    });
+    expect(makeTraceDetails(variables, { sendAll: true })).toEqual(
+      nonFilteredOutput,
+    );
+  });
 });
 
-test('safelist=False equivalent to Array(all variables)', () => {
-  let privateVariablesArray: string[] = ['testing', 't2'];
-  expect(
-    makeTraceDetails(variables, { safelistAll: false }).variablesJson,
-  ).toEqual(
-    makeTraceDetails(variables, { exceptVariableNames: privateVariablesArray })
-      .variablesJson,
-  );
+describe('variableJson output for sendVariableValues exceptNames: Array type', () => {
+  it('array contains some values not in keys', () => {
+    const privateVariablesArray: string[] = ['testing', 'notInVariables'];
+    const expectedVariablesJson = {
+      testing: '',
+      t2: JSON.stringify(2),
+    };
+    expect(
+      makeTraceDetails(variables, { exceptNames: privateVariablesArray })
+        .variablesJson,
+    ).toEqual(expectedVariablesJson);
+  });
+
+  it('sendNone=true equivalent to exceptNames=[all variables]', () => {
+    let privateVariablesArray: string[] = ['testing', 't2'];
+    expect(
+      makeTraceDetails(variables, { sendNone: true }).variablesJson,
+    ).toEqual(
+      makeTraceDetails(variables, { exceptNames: privateVariablesArray })
+        .variablesJson,
+    );
+  });
 });
 
-test('original keys in variables match the modified keys', () => {
+describe('variableJson output for sendVariableValues transform: custom function type', () => {
+  it('test custom function that redacts every variable to some value', () => {
+    const modifiedValue = 100;
+    const customModifier = (input: {
+      variables: Record<string, any>;
+    }): Record<string, any> => {
+      let out: Record<string, any> = {};
+      Object.keys(input.variables).map((name: string) => {
+        out[name] = modifiedValue;
+      });
+      return out;
+    };
+
+    // Expected output
+    const output = new Trace.Details();
+    Object.keys(variables).forEach(name => {
+      output.variablesJson[name] = JSON.stringify(modifiedValue);
+    });
+
+    expect(makeTraceDetails(variables, { transform: customModifier })).toEqual(
+      output,
+    );
+  });
+
   const origKeys = Object.keys(variables);
   const firstKey = origKeys[0];
-  // remove the first key
-  const modifiedKeys = Object.keys(variables).slice(1);
-  // add a key
-  modifiedKeys.push('new v');
+  const secondKey = origKeys[1];
 
   const modifier = (input: {
     variables: Record<string, any>;
   }): Record<string, any> => {
     let out: Record<string, any> = {};
-    Object.keys(modifiedKeys).map((name: string) => {
-      out[name] = 100;
+    Object.keys(input.variables).map((name: string) => {
+      out[name] = null;
     });
+    // remove the first key, and then add a new key
+    delete out[firstKey];
+    out['newkey'] = 'blah';
     return out;
   };
 
-  expect(
-    Object.keys(
-      makeTraceDetails(variables, { valueModifier: modifier }).variablesJson,
-    ).sort(),
-  ).toEqual(origKeys.sort());
+  it('original keys in variables should match the modified keys', () => {
+    expect(
+      Object.keys(
+        makeTraceDetails(variables, { transform: modifier }).variablesJson,
+      ).sort(),
+    ).toEqual(origKeys.sort());
+  });
 
-  // expect empty string for keys removed by the custom modifier
-  expect(
-    makeTraceDetails(variables, { valueModifier: modifier }).variablesJson[
-      firstKey
-    ],
-  ).toEqual('');
-});
+  it('expect empty string for keys removed by the custom modifier', () => {
+    expect(
+      makeTraceDetails(variables, { transform: modifier }).variablesJson[
+        firstKey
+      ],
+    ).toEqual('');
+  });
 
-/**
- * Tests to ensure support of the old privateVariables reporting option
- */
-test('test variableJson output for to-be-deprecated privateVariable option', () => {
-  // Case 1: privateVariables == False; same as safelist all
-  expect(makeTraceDetailsLegacy({}, false)).toEqual(
-    makeTraceDetails({}, { safelistAll: false }),
-  );
-  expect(makeTraceDetailsLegacy(variables, false)).toEqual(
-    makeTraceDetails(variables, { safelistAll: true }),
-  );
-
-  // Case 2: privateVariables is an Array; same as makeTraceDetails
-  const privacyEnforcerArray: string[] = ['testing', 'notInVariables'];
-  expect(
-    makeTraceDetailsLegacy(variables, privacyEnforcerArray).variablesJson,
-  ).toEqual(
-    makeTraceDetails(variables, { exceptVariableNames: privacyEnforcerArray })
-      .variablesJson,
-  );
+  it('expect stringify(null) for values set to null by custom modifier', () => {
+    expect(
+      makeTraceDetails(variables, { transform: modifier }).variablesJson[
+        secondKey
+      ],
+    ).toEqual(JSON.stringify(null));
+  });
 });
 
 function makeTestHTTP(): Trace.HTTP {
@@ -249,71 +243,50 @@ function makeTestHTTP(): Trace.HTTP {
   });
 }
 
+/**
+ * TESTS FOR THE sendHeaders REPORTING OPTION
+ */
 const headers = new Headers();
 headers.append('name', 'value');
 headers.append('authorization', 'blahblah'); // THIS SHOULD NEVER BE SENT
 
 const headersOutput = { name: new Trace.HTTP.Values({ value: ['value'] }) };
 
-/**
- * TESTS FOR sendHeaders REPORTING OPTION
- */
-test('test that sendHeaders defaults to hiding all', () => {
-  const http = makeTestHTTP();
-  makeHTTPRequestHeaders(http, headers, null);
-  expect(http.requestHeaders).toEqual({});
-  makeHTTPRequestHeaders(http, headers, undefined);
-  expect(http.requestHeaders).toEqual({});
-  makeHTTPRequestHeaders(http, headers);
-  expect(http.requestHeaders).toEqual({});
-});
+describe('tests for the sendHeaders reporting option', () => {
+  it('sendHeaders defaults to hiding all', () => {
+    const http = makeTestHTTP();
+    makeHTTPRequestHeaders(http, headers, null);
+    expect(http.requestHeaders).toEqual({});
+    makeHTTPRequestHeaders(http, headers, undefined);
+    expect(http.requestHeaders).toEqual({});
+    makeHTTPRequestHeaders(http, headers);
+    expect(http.requestHeaders).toEqual({});
+  });
 
-test('test sendHeaders.safelistAll', () => {
-  const httpSafelist = makeTestHTTP();
-  makeHTTPRequestHeaders(httpSafelist, headers, { safelistAll: true });
-  expect(httpSafelist.requestHeaders).toEqual(headersOutput);
+  it('sendHeaders.sendAll and sendHeaders.sendNone', () => {
+    const httpSafelist = makeTestHTTP();
+    makeHTTPRequestHeaders(httpSafelist, headers, { sendAll: true });
+    expect(httpSafelist.requestHeaders).toEqual(headersOutput);
 
-  const httpBlocklist = makeTestHTTP();
-  makeHTTPRequestHeaders(httpBlocklist, headers, { safelistAll: false });
-  expect(httpBlocklist.requestHeaders).toEqual({});
-});
+    const httpBlocklist = makeTestHTTP();
+    makeHTTPRequestHeaders(httpBlocklist, headers, { sendNone: true });
+    expect(httpBlocklist.requestHeaders).toEqual({});
+  });
 
-test('test sendHeaders.except', () => {
-  const except: String[] = ['name', 'notinheaders'];
-  const http = makeTestHTTP();
-  makeHTTPRequestHeaders(http, headers, { except: except });
-  expect(http.requestHeaders).toEqual({});
-});
+  it('test sendHeaders.exceptNames', () => {
+    const except: String[] = ['name', 'notinheaders'];
+    const http = makeTestHTTP();
+    makeHTTPRequestHeaders(http, headers, { exceptNames: except });
+    expect(http.requestHeaders).toEqual({});
+  });
 
-/**
- * And test to ensure support of old privateHeaders ooption
- */
-test('test legacy privateHeaders boolean / Array ', () => {
-  // Test Array input
-  const except: String[] = ['name', 'notinheaders'];
-  const httpExcept = makeTestHTTP();
-  makeHTTPRequestHeaders(httpExcept, headers, { except: except });
-  const httpPrivateHeadersArray = makeTestHTTP();
-  makeHTTPRequestHeadersLegacy(httpPrivateHeadersArray, headers, except);
-  expect(httpExcept.requestHeaders).toEqual(
-    httpPrivateHeadersArray.requestHeaders,
-  );
-
-  // Test boolean input safelist vs. privateHeaders false
-  const httpSafelist = makeTestHTTP();
-  makeHTTPRequestHeaders(httpSafelist, headers, { safelistAll: true });
-  const httpPrivateHeadersFalse = makeTestHTTP();
-  makeHTTPRequestHeadersLegacy(httpPrivateHeadersFalse, headers, false);
-  expect(httpSafelist.requestHeaders).toEqual(
-    httpPrivateHeadersFalse.requestHeaders,
-  );
-
-  // Test boolean input blocklist vs. privateHeaders true
-  const httpBlocklist = makeTestHTTP();
-  makeHTTPRequestHeaders(httpBlocklist, headers, { safelistAll: false });
-  const httpPrivateHeadersTrue = makeTestHTTP();
-  makeHTTPRequestHeadersLegacy(httpPrivateHeadersTrue, headers, true);
-  expect(httpBlocklist.requestHeaders).toEqual(
-    httpPrivateHeadersTrue.requestHeaders,
-  );
+  it('authorization, cookie, and set-cookie headers should never be sent', () => {
+    headers.append('cookie', 'blahblah');
+    headers.append('set-cookie', 'blahblah');
+    const http = makeTestHTTP();
+    makeHTTPRequestHeaders(http, headers, { sendAll: true });
+    expect(http.requestHeaders['authorization']).toBe(undefined);
+    expect(http.requestHeaders['cookie']).toBe(undefined);
+    expect(http.requestHeaders['set-cookie']).toBe(undefined);
+  });
 });

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -6,7 +6,11 @@ import {
 import { Trace } from 'apollo-engine-reporting-protobuf';
 import { graphql } from 'graphql';
 import { Request } from 'node-fetch';
-import { EngineReportingExtension } from '../extension';
+import {
+  EngineReportingExtension,
+  makeTraceDetails,
+  makeTraceDetailsLegacy,
+} from '../extension';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 
 test('trace construction', async () => {
@@ -82,4 +86,139 @@ test('trace construction', async () => {
   });
   requestDidEnd();
   // XXX actually write some tests
+});
+
+const variables: Record<string, any> = {
+  testing: 'testing',
+  t2: 2,
+};
+
+test('check variableJson output for privacyEnforcer boolean type', () => {
+  // Case 1: No keys/values in variables to be filtered/not filtered
+  const emptyOutput = new Trace.Details();
+  expect(makeTraceDetails({}, { always: true })).toEqual(emptyOutput);
+  expect(makeTraceDetails({}, { always: false })).toEqual(emptyOutput);
+
+  // Case 2: Filter all variables
+  const filteredOutput = new Trace.Details();
+  Object.keys(variables).forEach(name => {
+    filteredOutput.variablesJson[name] = '';
+  });
+  expect(makeTraceDetails(variables, { always: true })).toEqual(filteredOutput);
+
+  // Case 3: Do not filter variables
+  const nonFilteredOutput = new Trace.Details();
+  Object.keys(variables).forEach(name => {
+    nonFilteredOutput.variablesJson[name] = JSON.stringify(variables[name]);
+  });
+  expect(makeTraceDetails(variables, { always: false })).toEqual(
+    nonFilteredOutput,
+  );
+});
+
+test('variableJson output for privacyEnforcer Array type', () => {
+  const privateVariablesArray: string[] = ['testing', 'notInVariables'];
+  const expectedVariablesJson = {
+    testing: '',
+    t2: JSON.stringify(2),
+  };
+  expect(
+    makeTraceDetails(variables, { privateVariableNames: privateVariablesArray })
+      .variablesJson,
+  ).toEqual(expectedVariablesJson);
+});
+
+test('variableJson output for privacyEnforcer custom function', () => {
+  // Custom function that redacts every variable to 100;
+  const modifiedValue = 100;
+  const customModifier = (input: {
+    variables: Record<string, any>;
+  }): Record<string, any> => {
+    let out: Record<string, any> = {};
+    Object.keys(input.variables).map((name: string) => {
+      out[name] = modifiedValue;
+    });
+    return out;
+  };
+
+  // Expected output
+  const output = new Trace.Details();
+  Object.keys(variables).forEach(name => {
+    output.variablesJson[name] = JSON.stringify(modifiedValue);
+  });
+
+  expect(
+    makeTraceDetails(variables, { valueModifier: customModifier }),
+  ).toEqual(output);
+});
+
+test('privacyEnforcer=True equivalent to privacyEnforcer=Array(all variables)', () => {
+  let privateVariablesArray: string[] = ['testing', 't2'];
+  expect(makeTraceDetails(variables, { always: true }).variablesJson).toEqual(
+    makeTraceDetails(variables, { privateVariableNames: privateVariablesArray })
+      .variablesJson,
+  );
+});
+
+test('original keys in variables match the modified keys', () => {
+  const origKeys = Object.keys(variables);
+  const modifiedKeys = Object.keys(variables).slice(1);
+  modifiedKeys.push('new v');
+
+  const modifier = (input: {
+    variables: Record<string, any>;
+  }): Record<string, any> => {
+    let out: Record<string, any> = {};
+    Object.keys(modifiedKeys).map((name: string) => {
+      out[name] = 100;
+    });
+    return out;
+  };
+
+  expect(
+    Object.keys(
+      makeTraceDetails(variables, { valueModifier: modifier }).variablesJson,
+    ).sort(),
+  ).toEqual(origKeys.sort());
+});
+
+/**
+ * Tests for old privateVariables reporting option
+ */
+
+test('test variableJson output for to-be-deprecated privateVariable option', () => {
+  // Case 1: privateVariables == False; same as makeTraceDetails
+  expect(makeTraceDetailsLegacy({}, false)).toEqual(
+    makeTraceDetails({}, { always: false }),
+  );
+  expect(makeTraceDetailsLegacy(variables, false)).toEqual(
+    makeTraceDetails(variables, { always: false }),
+  );
+
+  // Case 2: privateVariables is an Array; same as makeTraceDetails
+  const privacyEnforcerArray: string[] = ['testing', 'notInVariables'];
+  expect(
+    makeTraceDetailsLegacy(variables, privacyEnforcerArray).variablesJson,
+  ).toEqual(
+    makeTraceDetails(variables, { privateVariableNames: privacyEnforcerArray })
+      .variablesJson,
+  );
+});
+
+test('original keys in variables match the modified keys', () => {
+  const origKeys = Object.keys(variables);
+  const modifiedKeys = Object.keys(variables).slice(1);
+  modifiedKeys.push('new v');
+
+  const enforcer = (input: Record<string, any>): Record<string, any> => {
+    let out: Record<string, any> = {};
+    Object.keys(modifiedKeys).map((name: string) => {
+      out[name] = 100;
+    });
+    return out;
+  };
+
+  expect(
+    Object.keys(makeTraceDetails(variables, enforcer).variablesJson).sort(),
+  ).toEqual(origKeys.sort());
 });

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -117,11 +117,11 @@ describe('check variableJson output for sendVariableValues null or undefined (de
   });
 });
 
-describe('check variableJson output for sendVariableValues sendAll/sendNone type', () => {
+describe('check variableJson output for sendVariableValues all/none type', () => {
   it('Case 1: No keys/values in variables to be filtered/not filtered', () => {
     const emptyOutput = new Trace.Details();
-    expect(makeTraceDetails({}, { sendAll: true })).toEqual(emptyOutput);
-    expect(makeTraceDetails({}, { sendNone: true })).toEqual(emptyOutput);
+    expect(makeTraceDetails({}, { all: true })).toEqual(emptyOutput);
+    expect(makeTraceDetails({}, { none: true })).toEqual(emptyOutput);
   });
 
   const filteredOutput = new Trace.Details();
@@ -135,25 +135,21 @@ describe('check variableJson output for sendVariableValues sendAll/sendNone type
   });
 
   it('Case 2: Filter all variables', () => {
-    expect(makeTraceDetails(variables, { sendNone: true })).toEqual(
-      filteredOutput,
-    );
+    expect(makeTraceDetails(variables, { none: true })).toEqual(filteredOutput);
   });
 
   it('Case 3: Do not filter variables', () => {
-    expect(makeTraceDetails(variables, { sendAll: true })).toEqual(
+    expect(makeTraceDetails(variables, { all: true })).toEqual(
       nonFilteredOutput,
     );
   });
 
   it('Case 4: Check behavior for invalid inputs', () => {
-    expect(makeTraceDetails(variables, { sendNone: false })).toEqual(
+    expect(makeTraceDetails(variables, { none: false })).toEqual(
       nonFilteredOutput,
     );
 
-    expect(makeTraceDetails(variables, { sendAll: false })).toEqual(
-      filteredOutput,
-    );
+    expect(makeTraceDetails(variables, { all: false })).toEqual(filteredOutput);
   });
 });
 
@@ -170,11 +166,9 @@ describe('variableJson output for sendVariableValues exceptNames: Array type', (
     ).toEqual(expectedVariablesJson);
   });
 
-  it('sendNone=true equivalent to exceptNames=[all variables]', () => {
+  it('none=true equivalent to exceptNames=[all variables]', () => {
     let privateVariablesArray: string[] = ['testing', 't2'];
-    expect(
-      makeTraceDetails(variables, { sendNone: true }).variablesJson,
-    ).toEqual(
+    expect(makeTraceDetails(variables, { none: true }).variablesJson).toEqual(
       makeTraceDetails(variables, { exceptNames: privateVariablesArray })
         .variablesJson,
     );
@@ -194,21 +188,17 @@ describe('variableJson output for sendVariableValues onlyNames: Array type', () 
     ).toEqual(expectedVariablesJson);
   });
 
-  it('sendAll=true equivalent to onlyNames=[all variables]', () => {
+  it('all=true equivalent to onlyNames=[all variables]', () => {
     let privateVariablesArray: string[] = ['testing', 't2'];
-    expect(
-      makeTraceDetails(variables, { sendAll: true }).variablesJson,
-    ).toEqual(
+    expect(makeTraceDetails(variables, { all: true }).variablesJson).toEqual(
       makeTraceDetails(variables, { onlyNames: privateVariablesArray })
         .variablesJson,
     );
   });
 
-  it('sendNone=true equivalent to onlyNames=[]', () => {
+  it('none=true equivalent to onlyNames=[]', () => {
     let privateVariablesArray: string[] = [];
-    expect(
-      makeTraceDetails(variables, { sendNone: true }).variablesJson,
-    ).toEqual(
+    expect(makeTraceDetails(variables, { none: true }).variablesJson).toEqual(
       makeTraceDetails(variables, { onlyNames: privateVariablesArray })
         .variablesJson,
     );
@@ -309,23 +299,23 @@ describe('tests for the sendHeaders reporting option', () => {
     expect(http.requestHeaders).toEqual({});
   });
 
-  it('sendHeaders.sendAll and sendHeaders.sendNone', () => {
+  it('sendHeaders.all and sendHeaders.none', () => {
     const httpSafelist = makeTestHTTP();
-    makeHTTPRequestHeaders(httpSafelist, headers, { sendAll: true });
+    makeHTTPRequestHeaders(httpSafelist, headers, { all: true });
     expect(httpSafelist.requestHeaders).toEqual(headersOutput);
 
     const httpBlocklist = makeTestHTTP();
-    makeHTTPRequestHeaders(httpBlocklist, headers, { sendNone: true });
+    makeHTTPRequestHeaders(httpBlocklist, headers, { none: true });
     expect(httpBlocklist.requestHeaders).toEqual({});
   });
 
-  it('invalid inputs for sendHeaders.sendAll and sendHeaders.sendNone', () => {
+  it('invalid inputs for sendHeaders.all and sendHeaders.none', () => {
     const httpSafelist = makeTestHTTP();
-    makeHTTPRequestHeaders(httpSafelist, headers, { sendNone: false });
+    makeHTTPRequestHeaders(httpSafelist, headers, { none: false });
     expect(httpSafelist.requestHeaders).toEqual(headersOutput);
 
     const httpBlocklist = makeTestHTTP();
-    makeHTTPRequestHeaders(httpBlocklist, headers, { sendAll: false });
+    makeHTTPRequestHeaders(httpBlocklist, headers, { all: false });
     expect(httpBlocklist.requestHeaders).toEqual({});
   });
 
@@ -348,7 +338,7 @@ describe('tests for the sendHeaders reporting option', () => {
     headers.append('cookie', 'blahblah');
     headers.append('set-cookie', 'blahblah');
     const http = makeTestHTTP();
-    makeHTTPRequestHeaders(http, headers, { sendAll: true });
+    makeHTTPRequestHeaders(http, headers, { all: true });
     expect(http.requestHeaders['authorization']).toBe(undefined);
     expect(http.requestHeaders['cookie']).toBe(undefined);
     expect(http.requestHeaders['set-cookie']).toBe(undefined);

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -169,6 +169,40 @@ describe('variableJson output for sendVariableValues exceptNames: Array type', (
   });
 });
 
+describe('variableJson output for sendVariableValues includeNames: Array type', () => {
+  it('array contains some values not in keys', () => {
+    const privateVariablesArray: string[] = ['t2', 'notInVariables'];
+    const expectedVariablesJson = {
+      testing: '',
+      t2: JSON.stringify(2),
+    };
+    expect(
+      makeTraceDetails(variables, { includeNames: privateVariablesArray })
+        .variablesJson,
+    ).toEqual(expectedVariablesJson);
+  });
+
+  it('sendAll=true equivalent to includeNames=[all variables]', () => {
+    let privateVariablesArray: string[] = ['testing', 't2'];
+    expect(
+      makeTraceDetails(variables, { sendAll: true }).variablesJson,
+    ).toEqual(
+      makeTraceDetails(variables, { includeNames: privateVariablesArray })
+        .variablesJson,
+    );
+  });
+
+  it('sendNone=true equivalent to includeNames=[]', () => {
+    let privateVariablesArray: string[] = [];
+    expect(
+      makeTraceDetails(variables, { sendNone: true }).variablesJson,
+    ).toEqual(
+      makeTraceDetails(variables, { includeNames: privateVariablesArray })
+        .variablesJson,
+    );
+  });
+});
+
 describe('variableJson output for sendVariableValues transform: custom function type', () => {
   it('test custom function that redacts every variable to some value', () => {
     const modifiedValue = 100;
@@ -278,6 +312,14 @@ describe('tests for the sendHeaders reporting option', () => {
     const http = makeTestHTTP();
     makeHTTPRequestHeaders(http, headers, { exceptNames: except });
     expect(http.requestHeaders).toEqual({});
+  });
+
+  it('test sendHeaders.includeNames', () => {
+    // headers that should never be sent (such as "authorization") should still be removed if in includeHeaders
+    const include: String[] = ['name', 'authorization', 'notinheaders'];
+    const http = makeTestHTTP();
+    makeHTTPRequestHeaders(http, headers, { includeNames: include });
+    expect(http.requestHeaders).toEqual(headersOutput);
   });
 
   it('authorization, cookie, and set-cookie headers should never be sent', () => {

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -271,6 +271,19 @@ describe('variableJson output for sendVariableValues transform: custom function 
   });
 });
 
+describe('Catch circular reference error during JSON.stringify', () => {
+  const circularReference = {};
+  circularReference['this'] = circularReference;
+
+  const circularVariables = {
+    bad: circularReference,
+  };
+
+  expect(
+    makeTraceDetails(circularVariables, { all: true }).variablesJson['bad'],
+  ).toEqual(JSON.stringify('[Unable to convert value to JSON]'));
+});
+
 function makeTestHTTP(): Trace.HTTP {
   return new Trace.HTTP({
     method: Trace.HTTP.Method.UNKNOWN,

--- a/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/extension.test.ts
@@ -167,7 +167,7 @@ describe('variableJson output for sendVariableValues exceptNames: Array type', (
   });
 
   it('none=true equivalent to exceptNames=[all variables]', () => {
-    let privateVariablesArray: string[] = ['testing', 't2'];
+    const privateVariablesArray: string[] = ['testing', 't2'];
     expect(makeTraceDetails(variables, { none: true }).variablesJson).toEqual(
       makeTraceDetails(variables, { exceptNames: privateVariablesArray })
         .variablesJson,
@@ -189,7 +189,7 @@ describe('variableJson output for sendVariableValues onlyNames: Array type', () 
   });
 
   it('all=true equivalent to onlyNames=[all variables]', () => {
-    let privateVariablesArray: string[] = ['testing', 't2'];
+    const privateVariablesArray: string[] = ['testing', 't2'];
     expect(makeTraceDetails(variables, { all: true }).variablesJson).toEqual(
       makeTraceDetails(variables, { onlyNames: privateVariablesArray })
         .variablesJson,
@@ -197,7 +197,7 @@ describe('variableJson output for sendVariableValues onlyNames: Array type', () 
   });
 
   it('none=true equivalent to onlyNames=[]', () => {
-    let privateVariablesArray: string[] = [];
+    const privateVariablesArray: string[] = [];
     expect(makeTraceDetails(variables, { none: true }).variablesJson).toEqual(
       makeTraceDetails(variables, { onlyNames: privateVariablesArray })
         .variablesJson,
@@ -211,7 +211,7 @@ describe('variableJson output for sendVariableValues transform: custom function 
     const customModifier = (input: {
       variables: Record<string, any>;
     }): Record<string, any> => {
-      let out: Record<string, any> = {};
+      const out: Record<string, any> = Object.create(null);
       Object.keys(input.variables).map((name: string) => {
         out[name] = modifiedValue;
       });
@@ -236,7 +236,7 @@ describe('variableJson output for sendVariableValues transform: custom function 
   const modifier = (input: {
     variables: Record<string, any>;
   }): Record<string, any> => {
-    let out: Record<string, any> = {};
+    const out: Record<string, any> = Object.create(null);
     Object.keys(input.variables).map((name: string) => {
       out[name] = null;
     });
@@ -291,6 +291,7 @@ const headersOutput = { name: new Trace.HTTP.Values({ value: ['value'] }) };
 describe('tests for the sendHeaders reporting option', () => {
   it('sendHeaders defaults to hiding all', () => {
     const http = makeTestHTTP();
+    // sendHeaders: null is not a valid TS input, but check the output anyways
     makeHTTPRequestHeaders(http, headers, null);
     expect(http.requestHeaders).toEqual({});
     makeHTTPRequestHeaders(http, headers, undefined);

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -26,7 +26,7 @@ export interface ClientInfo {
 }
 
 export type SendValuesBaseOptions =
-  | { includeNames: Array<String> }
+  | { onlyNames: Array<String> }
   | { exceptNames: Array<String> }
   | { sendAll: true }
   | { sendNone: true };
@@ -104,15 +104,15 @@ export interface EngineReportingOptions<TContext> {
    * By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable
    * values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option.
    * This option can take several forms:
-   * - { sendNone: true }: blocklist all variable values (DEFAULT)
-   * - { sendAll: true}: safelist all variable values
+   * - { sendNone: true }: don't send any variable values (DEFAULT)
+   * - { sendAll: true}: send all variable values
    * - { transform: ... }: a custom function for modifying variable values. Keys added by the custom function will
    *    be removed, and keys removed will be added back with an empty value.
    * - { exceptNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
-   * - { includeNames: ... }: A case-sensitive list of names of variables whose values will be sent to Apollo servers
+   * - { onlyNames: ... }: A case-sensitive list of names of variables whose values will be sent to Apollo servers
    *
-   * Defaults to blocklisting all variable values if both this parameter and
-   * the to-be-deprecated `privateVariables` are not set. The report will
+   * Defaults to not sending any variable values if both this parameter and
+   * the deprecated `privateVariables` are not set. The report will
    * indicate each private variable key whose value was redacted by { sendNone: true } or { exceptNames: [...] }.
    *
    * TODO(helen): Add new flag to the trace details (and modify the protobuf message structure) to indicate the type of modification. Then, add the following description to the docs:
@@ -134,12 +134,14 @@ export interface EngineReportingOptions<TContext> {
    * Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
    * set this option. This option can take several forms:
    *
-   * - { sendNone : true } to drop all HTTP request headers (DEFAULT)
-   * - { sendAll : true } to send the values of all HTTP request headers
+   * - { sendNone: true } to drop all HTTP request headers (DEFAULT)
+   * - { sendAll: true } to send the values of all HTTP request headers
    * - { exceptNames: Array<String> } A case-insensitive list of names of HTTP headers whose values should not be
    *     sent to Apollo servers
-   * - { includeNames: Array<String> }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
+   * - { onlyNames: Array<String> }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
    *
+   * Defaults to not sending any request header names and values if both this parameter and
+   * the deprecated `privateHeaders` are not set.
    * Unlike with sendVariableValues, names of dropped headers are not reported.
    * The headers 'authorization', 'cookie', and 'set-cookie' are never reported.
    */

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -30,6 +30,15 @@ export type VariableValueModifierOptions = {
   operationString?: string;
 };
 
+export type VariableValueOptions =
+  | {
+      valueModifier: (
+        options: VariableValueModifierOptions,
+      ) => Record<string, any>;
+    }
+  | { exceptVariableNames: Array<String> }
+  | { whitelistAll: boolean };
+
 export type GenerateClientInfo<TContext> = (
   requestContext: GraphQLRequestContext<TContext>,
 ) => ClientInfo;
@@ -94,27 +103,22 @@ export interface EngineReportingOptions<TContext> {
    */
   privateVariables?: Array<String> | boolean;
   /**
-   * By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
-   * - true or false to blocklist or whitelist all variable values
-   * - a custom function for modifying variable values
-   * - a case-sensitive list of names of variables whose values should not be sent to Apollo servers
+   * By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable
+   * values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option.
+   * This option can take several forms:
+   * - { whitelistAll: ... }: false to blocklist, or true to whitelist all variable values
+   * - { valueModifier: ... }: a custom function for modifying variable values
+   * - { exceptVariableNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
    *
-   * Will default to blocklisting all variable values if both this parameter and
-   * the to-be-deprecated `privateVariables` were not set. The report will also
-   * indicate each private variable redacted if set to a boolean or array.
+   * Defaults to blocklisting all variable values if both this parameter and
+   * the to-be-deprecated `privateVariables` are not set. The report will also
+   * indicate each private variable key redacted by { whitelistAll: false } or { exceptVariableNames: [...] }.
    *
    * TODO(helen): Add new flag to the trace details (and modify the protobuf message structure) to indicate the type of modification. Then, add the following description to the docs:
    * "The report will indicate that variable values were modified by a custom function, or will list all private variables redacted."
    * TODO(helen): LINK TO EXAMPLE FUNCTION? e.g. a function recursively search for keys to be blocklisted
    */
-  maskVariableValues?:
-    | {
-        valueModifier: (
-          options: VariableValueModifierOptions,
-        ) => Record<string, any>;
-      }
-    | { privateVariableNames: Array<String> }
-    | { always: boolean };
+  sendVariableValues?: VariableValueOptions;
   /**
    * A case-insensitive list of names of HTTP headers whose values should not be
    * sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -551,26 +551,33 @@ export function handleLegacyOptions(
   options: EngineReportingOptions<any>,
 ): void {
   // Handle the legacy option: privateVariables
-  if (options.privateVariables != null && options.sendVariableValues) {
+  if (
+    typeof options.privateVariables !== 'undefined' &&
+    options.sendVariableValues
+  ) {
     throw new Error(
       "You have set both the 'sendVariableValues' and the deprecated 'privateVariables' options. Please only set 'sendVariableValues'.",
     );
-  } else if (options.privateVariables != null) {
-    options.sendVariableValues = makeSendValuesBaseOptionsFromLegacy(
-      options.privateVariables,
-    );
+  } else if (typeof options.privateVariables !== 'undefined') {
+    if (options.privateVariables !== null) {
+      options.sendVariableValues = makeSendValuesBaseOptionsFromLegacy(
+        options.privateVariables,
+      );
+    }
     delete options.privateVariables;
   }
 
   // Handle the legacy option: privateHeaders
-  if (options.privateHeaders != null && options.sendHeaders) {
+  if (typeof options.privateHeaders !== 'undefined' && options.sendHeaders) {
     throw new Error(
       "You have set both the 'sendHeaders' and the deprecated 'privateHeaders' options. Please only set 'sendHeaders'.",
     );
-  } else if (options.privateHeaders != null) {
-    options.sendHeaders = makeSendValuesBaseOptionsFromLegacy(
-      options.privateHeaders,
-    );
+  } else if (typeof options.privateHeaders !== 'undefined') {
+    if (options.privateHeaders !== null) {
+      options.sendHeaders = makeSendValuesBaseOptionsFromLegacy(
+        options.privateHeaders,
+      );
+    }
     delete options.privateHeaders;
   }
 }

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -25,6 +25,11 @@ export interface ClientInfo {
   clientReferenceId?: string;
 }
 
+export type VariableValueModifierOptions = {
+  variables: Record<string, any>;
+  operationString?: string;
+};
+
 export type GenerateClientInfo<TContext> = (
   requestContext: GraphQLRequestContext<TContext>,
 ) => ClientInfo;
@@ -82,12 +87,34 @@ export interface EngineReportingOptions<TContext> {
    */
   reportErrorFunction?: (err: Error) => void;
   /**
-   * A case-sensitive list of names of variables whose values should not be sent
-   * to Apollo servers, or 'true' to leave out all variables. In the former
+   * [TO-BE-DEPRECATED] A case-sensitive list of names of variables whose values should
+   * not be sent to Apollo servers, or 'true' to leave out all variables. In the former
    * case, the report will indicate that each private variable was redacted; in
    * the latter case, no variables are sent at all.
    */
   privateVariables?: Array<String> | boolean;
+  /**
+   * By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option. This option can take several forms:
+   * - true or false to blocklist or whitelist all variable values
+   * - a custom function for modifying variable values
+   * - a case-sensitive list of names of variables whose values should not be sent to Apollo servers
+   *
+   * Will default to blocklisting all variable values if both this parameter and
+   * the to-be-deprecated `privateVariables` were not set. The report will also
+   * indicate each private variable redacted if set to a boolean or array.
+   *
+   * TODO(helen): Add new flag to the trace details (and modify the protobuf message structure) to indicate the type of modification. Then, add the following description to the docs:
+   * "The report will indicate that variable values were modified by a custom function, or will list all private variables redacted."
+   * TODO(helen): LINK TO EXAMPLE FUNCTION? e.g. a function recursively search for keys to be blocklisted
+   */
+  maskVariableValues?:
+    | {
+        valueModifier: (
+          options: VariableValueModifierOptions,
+        ) => Record<string, any>;
+      }
+    | { privateVariableNames: Array<String> }
+    | { always: boolean };
   /**
    * A case-insensitive list of names of HTTP headers whose values should not be
    * sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -28,8 +28,8 @@ export interface ClientInfo {
 export type SendValuesBaseOptions =
   | { onlyNames: Array<String> }
   | { exceptNames: Array<String> }
-  | { sendAll: true }
-  | { sendNone: true };
+  | { all: true }
+  | { none: true };
 
 type VariableValueTransformOptions = {
   variables: Record<string, any>;
@@ -104,8 +104,8 @@ export interface EngineReportingOptions<TContext> {
    * By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable
    * values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option.
    * This option can take several forms:
-   * - { sendNone: true }: don't send any variable values (DEFAULT)
-   * - { sendAll: true}: send all variable values
+   * - { none: true }: don't send any variable values (DEFAULT)
+   * - { all: true}: send all variable values
    * - { transform: ... }: a custom function for modifying variable values. Keys added by the custom function will
    *    be removed, and keys removed will be added back with an empty value.
    * - { exceptNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
@@ -113,7 +113,7 @@ export interface EngineReportingOptions<TContext> {
    *
    * Defaults to not sending any variable values if both this parameter and
    * the deprecated `privateVariables` are not set. The report will
-   * indicate each private variable key whose value was redacted by { sendNone: true } or { exceptNames: [...] }.
+   * indicate each private variable key whose value was redacted by { none: true } or { exceptNames: [...] }.
    *
    * TODO(helen): Add new flag to the trace details (and modify the protobuf message structure) to indicate the type of modification. Then, add the following description to the docs:
    * "The report will indicate that variable values were modified by a custom function, or will list all private variables redacted."
@@ -123,8 +123,8 @@ export interface EngineReportingOptions<TContext> {
   /**
    * [DEPRECATED] Use sendVariableValues
    * Passing an array into privateVariables is equivalent to passing { exceptNames: array } into
-   * sendVariableValues, and passing in `true` or `false` is equivalent to passing { sendNone: true } or
-   * { sendAll: true }, respectively.
+   * sendVariableValues, and passing in `true` or `false` is equivalent to passing { none: true } or
+   * { all: true }, respectively.
    *
    * An error will be thrown if both this deprecated option and its replacement, sendVariableValues are defined.
    */
@@ -134,8 +134,8 @@ export interface EngineReportingOptions<TContext> {
    * Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
    * set this option. This option can take several forms:
    *
-   * - { sendNone: true } to drop all HTTP request headers (DEFAULT)
-   * - { sendAll: true } to send the values of all HTTP request headers
+   * - { none: true } to drop all HTTP request headers (DEFAULT)
+   * - { all: true } to send the values of all HTTP request headers
    * - { exceptNames: Array<String> } A case-insensitive list of names of HTTP headers whose values should not be
    *     sent to Apollo servers
    * - { onlyNames: Array<String> }: A case-insensitive list of names of HTTP headers whose values will be sent to Apollo servers
@@ -149,7 +149,7 @@ export interface EngineReportingOptions<TContext> {
   /**
    * [DEPRECATED] Use sendHeaders
    * Passing an array into privateHeaders is equivalent to passing { exceptNames: array } into sendHeaders, and
-   * passing `true` or `false` is equivalent to passing in { sendNone: true } and { sendAll: true }, respectively.
+   * passing `true` or `false` is equivalent to passing in { none: true } and { all: true }, respectively.
    *
    * An error will be thrown if both this deprecated option and its replacement, sendHeaders are defined.
    */
@@ -585,6 +585,6 @@ function makeSendValuesBaseOptionsFromLegacy(
         exceptNames: legacyPrivateOption,
       }
     : legacyPrivateOption
-    ? { sendNone: true }
-    : { sendAll: true };
+    ? { none: true }
+    : { all: true };
 }

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -37,7 +37,7 @@ export type VariableValueOptions =
       ) => Record<string, any>;
     }
   | { exceptVariableNames: Array<String> }
-  | { whitelistAll: boolean };
+  | { safelistAll: boolean };
 
 export type GenerateClientInfo<TContext> = (
   requestContext: GraphQLRequestContext<TContext>,
@@ -96,7 +96,8 @@ export interface EngineReportingOptions<TContext> {
    */
   reportErrorFunction?: (err: Error) => void;
   /**
-   * [TO-BE-DEPRECATED] A case-sensitive list of names of variables whose values should
+   * [TO-BE-DEPRECATED] Use sendVariableValues
+   * A case-sensitive list of names of variables whose values should
    * not be sent to Apollo servers, or 'true' to leave out all variables. In the former
    * case, the report will indicate that each private variable was redacted; in
    * the latter case, no variables are sent at all.
@@ -106,13 +107,13 @@ export interface EngineReportingOptions<TContext> {
    * By default, Apollo Server does not send the values of any GraphQL variables to Apollo's servers, because variable
    * values often contain the private data of your app's users. If you'd like variable values to be included in traces, set this option.
    * This option can take several forms:
-   * - { whitelistAll: ... }: false to blocklist, or true to whitelist all variable values
+   * - { safelistAll: ... }: false to blocklist, or true to safelist all variable values
    * - { valueModifier: ... }: a custom function for modifying variable values
    * - { exceptVariableNames: ... }: a case-sensitive list of names of variables whose values should not be sent to Apollo servers
    *
    * Defaults to blocklisting all variable values if both this parameter and
    * the to-be-deprecated `privateVariables` are not set. The report will also
-   * indicate each private variable key redacted by { whitelistAll: false } or { exceptVariableNames: [...] }.
+   * indicate each private variable key redacted by { safelistAll: false } or { exceptVariableNames: [...] }.
    *
    * TODO(helen): Add new flag to the trace details (and modify the protobuf message structure) to indicate the type of modification. Then, add the following description to the docs:
    * "The report will indicate that variable values were modified by a custom function, or will list all private variables redacted."
@@ -120,6 +121,19 @@ export interface EngineReportingOptions<TContext> {
    */
   sendVariableValues?: VariableValueOptions;
   /**
+   * By default, Apollo Server does not send the list of HTTP headers and values to
+   * Apollo's servers, to protect private data of your app's users. If you'd like this information included in traces,
+   * set this option. This option can take two forms:
+   *
+   * - {except: Array<String>} A case-insensitive list of names of HTTP headers whose values should not be
+   * sent to Apollo servers
+   * - {safelistAll: 'true'/'false'} to include or leave out all HTTP headers.
+   *
+   * Unlike with sendVariableValues, names of dropped headers are not reported.
+   */
+  sendHeaders?: { except: Array<String> } | { safelistAll: boolean };
+  /**
+   * [TO-BE-DEPRECATED] Use sendHeaders
    * A case-insensitive list of names of HTTP headers whose values should not be
    * sent to Apollo servers, or 'true' to leave out all HTTP headers. Unlike
    * with privateVariables, names of dropped headers are not reported.

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -16,7 +16,7 @@ import {
   GenerateClientInfo,
   AddTraceArgs,
   VariableValueOptions,
-  BlocklistValuesBaseOptions,
+  SendValuesBaseOptions,
 } from './agent';
 import { GraphQLRequestContext } from 'apollo-server-core/dist/requestPipelineAPI';
 
@@ -418,7 +418,9 @@ export function makeTraceDetails(
         // We assume that most users will have only a few variables values to hide,
         // or will just set {sendNone: true}; we can change this
         // linear-time operation if it causes real performance issues.
-        sendVariableValues.exceptNames.includes(name))
+        sendVariableValues.exceptNames.includes(name)) ||
+      ('includeNames' in sendVariableValues &&
+        !sendVariableValues.includeNames.includes(name))
     ) {
       // Special case for private variables. Note that this is a different
       // representation from a variable containing the empty string, as that
@@ -459,22 +461,25 @@ function cleanModifiedVariables(
 export function makeHTTPRequestHeaders(
   http: Trace.IHTTP,
   headers: Headers,
-  sendHeaders?: BlocklistValuesBaseOptions,
+  sendHeaders?: SendValuesBaseOptions,
 ): void {
   if (!sendHeaders || 'sendNone' in sendHeaders) {
     return;
   }
   for (const [key, value] of headers) {
     if (
-      sendHeaders &&
-      'exceptNames' in sendHeaders &&
-      // We assume that most users only have a few headers to hide, or will
-      // just set {sendNone: true} ; we can change this linear-time
-      // operation if it causes real performance issues.
-      sendHeaders.exceptNames.some(exceptHeader => {
-        // Headers are case-insensitive, and should be compared as such.
-        return exceptHeader.toLowerCase() === key.toLowerCase();
-      })
+      ('exceptNames' in sendHeaders &&
+        // We assume that most users only have a few headers to hide, or will
+        // just set {sendNone: true} ; we can change this linear-time
+        // operation if it causes real performance issues.
+        sendHeaders.exceptNames.some(exceptHeader => {
+          // Headers are case-insensitive, and should be compared as such.
+          return exceptHeader.toLowerCase() === key.toLowerCase();
+        })) ||
+      ('includeNames' in sendHeaders &&
+        !sendHeaders.includeNames.some(header => {
+          return header.toLowerCase() === key.toLowerCase();
+        }))
     ) {
       continue;
     }

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -434,24 +434,9 @@ export function makeTraceDetails(
             ? ''
             : JSON.stringify(variablesToRecord[name]);
       } catch (e) {
-        if (
-          // The apollo-engine-reporting package currently only runs on Node.js
-          // and Node.js 6, 8, 10 and 12 all pass this criteria.  For what it's
-          // worth, changes in error message text are considered major breaking
-          // changes to Node.js.   In the future, hopefully all of these will
-          // be guarded by error `code` properties, but that will take some
-          // upstream V8 work to standardize.
-          e.name === 'TypeError' &&
-          e.message.startsWith('Converting circular structure to JSON')
-        ) {
-          details.variablesJson![name] = JSON.stringify(
-            '[Unable to convert value to JSON]',
-          );
-        } else {
-          // Re-throw when it doesn't meet our expectation so we don't
-          // inadvertently swallow anything as a "cycle error" when its not.
-          throw e;
-        }
+        details.variablesJson![name] = JSON.stringify(
+          '[Unable to convert value to JSON]',
+        );
       }
     }
   });

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -413,14 +413,15 @@ export function makeTraceDetails(
   Object.keys(variablesToRecord).forEach(name => {
     if (
       !sendVariableValues ||
-      'sendNone' in sendVariableValues ||
+      ('sendNone' in sendVariableValues && sendVariableValues.sendNone) ||
+      ('sendAll' in sendVariableValues && !sendVariableValues.sendAll) ||
       ('exceptNames' in sendVariableValues &&
         // We assume that most users will have only a few variables values to hide,
         // or will just set {sendNone: true}; we can change this
         // linear-time operation if it causes real performance issues.
         sendVariableValues.exceptNames.includes(name)) ||
-      ('includeNames' in sendVariableValues &&
-        !sendVariableValues.includeNames.includes(name))
+      ('onlyNames' in sendVariableValues &&
+        !sendVariableValues.onlyNames.includes(name))
     ) {
       // Special case for private variables. Note that this is a different
       // representation from a variable containing the empty string, as that
@@ -463,10 +464,15 @@ export function makeHTTPRequestHeaders(
   headers: Headers,
   sendHeaders?: SendValuesBaseOptions,
 ): void {
-  if (!sendHeaders || 'sendNone' in sendHeaders) {
+  if (
+    !sendHeaders ||
+    ('sendNone' in sendHeaders && sendHeaders.sendNone) ||
+    ('sendAll' in sendHeaders && !sendHeaders.sendAll)
+  ) {
     return;
   }
   for (const [key, value] of headers) {
+    const lowercaseKey = key.toLowerCase();
     if (
       ('exceptNames' in sendHeaders &&
         // We assume that most users only have a few headers to hide, or will
@@ -474,11 +480,11 @@ export function makeHTTPRequestHeaders(
         // operation if it causes real performance issues.
         sendHeaders.exceptNames.some(exceptHeader => {
           // Headers are case-insensitive, and should be compared as such.
-          return exceptHeader.toLowerCase() === key.toLowerCase();
+          return exceptHeader.toLowerCase() === lowercaseKey;
         })) ||
-      ('includeNames' in sendHeaders &&
-        !sendHeaders.includeNames.some(header => {
-          return header.toLowerCase() === key.toLowerCase();
+      ('onlyNames' in sendHeaders &&
+        !sendHeaders.onlyNames.some(header => {
+          return header.toLowerCase() === lowercaseKey;
         }))
     ) {
       continue;

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -413,11 +413,11 @@ export function makeTraceDetails(
   Object.keys(variablesToRecord).forEach(name => {
     if (
       !sendVariableValues ||
-      ('sendNone' in sendVariableValues && sendVariableValues.sendNone) ||
-      ('sendAll' in sendVariableValues && !sendVariableValues.sendAll) ||
+      ('none' in sendVariableValues && sendVariableValues.none) ||
+      ('all' in sendVariableValues && !sendVariableValues.all) ||
       ('exceptNames' in sendVariableValues &&
         // We assume that most users will have only a few variables values to hide,
-        // or will just set {sendNone: true}; we can change this
+        // or will just set {none: true}; we can change this
         // linear-time operation if it causes real performance issues.
         sendVariableValues.exceptNames.includes(name)) ||
       ('onlyNames' in sendVariableValues &&
@@ -466,8 +466,8 @@ export function makeHTTPRequestHeaders(
 ): void {
   if (
     !sendHeaders ||
-    ('sendNone' in sendHeaders && sendHeaders.sendNone) ||
-    ('sendAll' in sendHeaders && !sendHeaders.sendAll)
+    ('none' in sendHeaders && sendHeaders.none) ||
+    ('all' in sendHeaders && !sendHeaders.all)
   ) {
     return;
   }
@@ -476,7 +476,7 @@ export function makeHTTPRequestHeaders(
     if (
       ('exceptNames' in sendHeaders &&
         // We assume that most users only have a few headers to hide, or will
-        // just set {sendNone: true} ; we can change this linear-time
+        // just set {none: true} ; we can change this linear-time
         // operation if it causes real performance issues.
         sendHeaders.exceptNames.some(exceptHeader => {
           // Headers are case-insensitive, and should be compared as such.

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -15,8 +15,11 @@ import {
   EngineReportingOptions,
   GenerateClientInfo,
   AddTraceArgs,
+  VariableValueModifier,
+  VariableValueModifierOptions,
 } from './agent';
 import { GraphQLRequestContext } from 'apollo-server-core/dist/requestPipelineAPI';
+import { operation } from 'retry';
 
 const clientNameHeaderKey = 'apollographql-client-name';
 const clientReferenceIdHeaderKey = 'apollographql-client-reference-id';
@@ -127,41 +130,25 @@ export class EngineReportingExtension<TContext = any>
       }
     }
 
-    if (this.options.privateVariables !== true && o.variables) {
-      // Note: we explicitly do *not* include the details.rawQuery field. The
-      // Engine web app currently does nothing with this other than store it in
-      // the database and offer it up via its GraphQL API, and sending it means
-      // that using calculateSignature to hide sensitive data in the query
-      // string is ineffective.
-      this.trace.details = new Trace.Details();
-      Object.keys(o.variables).forEach(name => {
-        if (
-          this.options.privateVariables &&
-          Array.isArray(this.options.privateVariables) &&
-          // We assume that most users will have only a few private variables,
-          // or will just set privateVariables to true; we can change this
-          // linear-time operation if it causes real performance issues.
-          this.options.privateVariables.includes(name)
-        ) {
-          // Special case for private variables. Note that this is a different
-          // representation from a variable containing the empty string, as that
-          // will be sent as '""'.
-          this.trace.details!.variablesJson![name] = '';
-        } else {
-          try {
-            this.trace.details!.variablesJson![name] = JSON.stringify(
-              o.variables![name],
-            );
-          } catch (e) {
-            // This probably means that the value contains a circular reference,
-            // causing `JSON.stringify()` to throw a TypeError:
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Issue_with_JSON.stringify()_when_serializing_circular_references
-            this.trace.details!.variablesJson![name] = JSON.stringify(
-              '[Unable to convert value to JSON]',
-            );
-          }
-        }
-      });
+    if (o.variables) {
+      if (
+        this.options.maskVariableValues !== undefined ||
+        this.options.privateVariables == null
+      ) {
+        // The new option maskVariableValues will take precendence over the deprecated privateVariables option
+        this.trace.details = makeTraceDetails(
+          o.variables,
+          this.options.maskVariableValues,
+          o.queryString,
+        );
+      } else {
+        // DEPRECATED: privateVariables
+        // But keep supporting if it has been set.
+        this.trace.details = makeTraceDetailsLegacy(
+          o.variables,
+          this.options.privateVariables,
+        );
+      }
     }
 
     const clientInfo = this.generateClientInfo(o.requestContext);
@@ -423,4 +410,107 @@ function defaultGenerateClientInfo({ request }: GraphQLRequestContext) {
   } else {
     return {};
   }
+}
+
+// Creates trace details from request variables, given a specification for modifying
+// values of private or sensitive variables.
+// The details include the variables in the request, TODO(helen): and the modifier type.
+// If maskVariableValues is a bool or Array, it will act similarly to
+// to the to-be-deprecated options.privateVariables, except that the redacted variable
+// names will still be visible in the UI when 'true.'
+// If maskVariableValues is null, the policy will default to the 'true' case.
+export function makeTraceDetails(
+  variables: Record<string, any>,
+  maskVariableValues?:
+    | {
+        valueModifier: (
+          options: VariableValueModifierOptions,
+        ) => Record<string, any>;
+      }
+    | { privateVariableNames: Array<String> }
+    | { always: boolean },
+  operationString?: string,
+): Trace.Details {
+  const details = new Trace.Details();
+  const variablesToRecord = (() => {
+    if (maskVariableValues && 'valueModifier' in maskVariableValues) {
+      // Custom function to allow user to specify what variablesJson will look like
+      const originalKeys = Object.keys(variables);
+      const modifiedVariables = maskVariableValues.valueModifier({
+        variables: variables,
+        operationString: operationString,
+      });
+      return cleanModifiedVariables(originalKeys, modifiedVariables);
+    } else {
+      return variables;
+    }
+  })();
+
+  // Note: we explicitly do *not* include the details.rawQuery field. The
+  // Engine web app currently does nothing with this other than store it in
+  // the database and offer it up via its GraphQL API, and sending it means
+  // that using calculateSignature to hide sensitive data in the query
+  // string is ineffective.
+  Object.keys(variablesToRecord).forEach(name => {
+    if (
+      maskVariableValues == null ||
+      ('always' in maskVariableValues && maskVariableValues.always) ||
+      ('privateVariableNames' in maskVariableValues &&
+        // We assume that most users will have only a few private variables,
+        // or will just set privateVariables to true; we can change this
+        // linear-time operation if it causes real performance issues.
+        maskVariableValues.privateVariableNames.includes(name))
+    ) {
+      // Special case for private variables. Note that this is a different
+      // representation from a variable containing the empty string, as that
+      // will be sent as '""'.
+      details.variablesJson![name] = '';
+    } else {
+      try {
+        details.variablesJson![name] =
+          variablesToRecord[name] == null
+            ? ''
+            : JSON.stringify(variablesToRecord[name]);
+      } catch (e) {
+        // This probably means that the value contains a circular reference,
+        // causing `JSON.stringify()` to throw a TypeError:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Issue_with_JSON.stringify()_when_serializing_circular_references
+        details.variablesJson![name] = JSON.stringify(
+          '[Unable to convert value to JSON]',
+        );
+      }
+    }
+  });
+
+  return details;
+}
+
+// Creates trace details when privateVariables [DEPRECATED] was set.
+// Wraps privateVariable into a format that can be passed into makeTraceDetails(),
+// which also handles the new replacement option maskVariableValues.
+export function makeTraceDetailsLegacy(
+  variables: Record<string, any>,
+  privateVariables: Array<String> | boolean,
+): Trace.Details | undefined {
+  const newArguments = Array.isArray(privateVariables)
+    ? {
+        privateVariableNames: privateVariables,
+      }
+    : {
+        always: privateVariables,
+      };
+  return makeTraceDetails(variables, newArguments);
+}
+
+// Helper for makeTraceDetails() to enforce that the keys of a modified 'variables'
+// matches that of the original 'variables'
+function cleanModifiedVariables(
+  originalKeys: Array<string>,
+  modifiedVariables: Record<string, any>,
+): Record<string, any> {
+  let cleanedVariables: Record<string, any> = {};
+  originalKeys.forEach(name => {
+    cleanedVariables[name] = modifiedVariables[name];
+  });
+  return cleanedVariables;
 }

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -436,9 +436,15 @@ export function makeTraceDetails(
       } catch (e) {
         if (
           e.name === 'TypeError' &&
-          e.message === 'Converting circular structure to JSON'
+          (e.message === 'cyclic object value' ||
+            e.message === 'Converting circular structure to JSON' ||
+            e.message === 'Circular reference in value argument not supported')
+          // Not sure how to determine the standardized error message... so checking the ones listed here:
+          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Message
         ) {
-          details.variablesJson![name] = JSON.stringify(e.message);
+          details.variablesJson![name] = JSON.stringify(
+            '[Unable to convert value to JSON]',
+          );
         } else {
           // Re-throw when it doesn't meet our expectation so we don't
           // inadvertently swallow anything as a "cycle error" when its not.

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -435,12 +435,14 @@ export function makeTraceDetails(
             : JSON.stringify(variablesToRecord[name]);
       } catch (e) {
         if (
+          // The apollo-engine-reporting package currently only runs on Node.js
+          // and Node.js 6, 8, 10 and 12 all pass this criteria.  For what it's
+          // worth, changes in error message text are considered major breaking
+          // changes to Node.js.   In the future, hopefully all of these will
+          // be guarded by error `code` properties, but that will take some
+          // upstream V8 work to standardize.
           e.name === 'TypeError' &&
-          (e.message === 'cyclic object value' ||
-            e.message === 'Converting circular structure to JSON' ||
-            e.message === 'Circular reference in value argument not supported')
-          // Not sure how to determine the standardized error message... so checking the ones listed here:
-          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Message
+          e.message.startsWith('Converting circular structure to JSON')
         ) {
           details.variablesJson![name] = JSON.stringify(
             '[Unable to convert value to JSON]',

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -16,6 +16,7 @@ import {
   GenerateClientInfo,
   AddTraceArgs,
   VariableValueOptions,
+  BlocklistValuesBaseOptions,
 } from './agent';
 import { GraphQLRequestContext } from 'apollo-server-core/dist/requestPipelineAPI';
 
@@ -93,20 +94,12 @@ export class EngineReportingExtension<TContext = any>
       path: null,
     });
 
-    if (this.options.sendHeaders || this.options.privateHeaders != null) {
-      if (this.options.sendHeaders) {
-        makeHTTPRequestHeaders(
-          this.trace.http,
-          o.request.headers,
-          this.options.sendHeaders,
-        );
-      } else if (this.options.privateHeaders != null) {
-        makeHTTPRequestHeadersLegacy(
-          this.trace.http,
-          o.request.headers,
-          this.options.privateHeaders,
-        );
-      }
+    if (this.options.sendHeaders) {
+      makeHTTPRequestHeaders(
+        this.trace.http,
+        o.request.headers,
+        this.options.sendHeaders,
+      );
 
       if (o.requestContext.metrics.persistedQueryHit) {
         this.trace.persistedQueryHit = true;
@@ -117,24 +110,11 @@ export class EngineReportingExtension<TContext = any>
     }
 
     if (o.variables) {
-      if (
-        this.options.sendVariableValues !== undefined ||
-        this.options.privateVariables == null
-      ) {
-        // The new option sendVariableValues will take precendence over the deprecated privateVariables option
-        this.trace.details = makeTraceDetails(
-          o.variables,
-          this.options.sendVariableValues,
-          o.queryString,
-        );
-      } else {
-        // privateVariables will be DEPRECATED
-        // But keep supporting if it has been set.
-        this.trace.details = makeTraceDetailsLegacy(
-          o.variables,
-          this.options.privateVariables,
-        );
-      }
+      this.trace.details = makeTraceDetails(
+        o.variables,
+        this.options.sendVariableValues,
+        o.queryString,
+      );
     }
 
     const clientInfo = this.generateClientInfo(o.requestContext);
@@ -412,10 +392,10 @@ export function makeTraceDetails(
 ): Trace.Details {
   const details = new Trace.Details();
   const variablesToRecord = (() => {
-    if (sendVariableValues && 'valueModifier' in sendVariableValues) {
+    if (sendVariableValues && 'transform' in sendVariableValues) {
       // Custom function to allow user to specify what variablesJson will look like
       const originalKeys = Object.keys(variables);
-      const modifiedVariables = sendVariableValues.valueModifier({
+      const modifiedVariables = sendVariableValues.transform({
         variables: variables,
         operationString: operationString,
       });
@@ -432,14 +412,13 @@ export function makeTraceDetails(
   // string is ineffective.
   Object.keys(variablesToRecord).forEach(name => {
     if (
-      sendVariableValues == null ||
-      ('safelistAll' in sendVariableValues &&
-        !sendVariableValues.safelistAll) ||
-      ('exceptVariableNames' in sendVariableValues &&
-        // We assume that most users will have only a few private variables,
-        // or will just set privateVariables to true; we can change this
+      !sendVariableValues ||
+      'sendNone' in sendVariableValues ||
+      ('exceptNames' in sendVariableValues &&
+        // We assume that most users will have only a few variables values to hide,
+        // or will just set {sendNone: true}; we can change this
         // linear-time operation if it causes real performance issues.
-        sendVariableValues.exceptVariableNames.includes(name))
+        sendVariableValues.exceptNames.includes(name))
     ) {
       // Special case for private variables. Note that this is a different
       // representation from a variable containing the empty string, as that
@@ -448,7 +427,7 @@ export function makeTraceDetails(
     } else {
       try {
         details.variablesJson![name] =
-          variablesToRecord[name] == null
+          variablesToRecord[name] === undefined
             ? ''
             : JSON.stringify(variablesToRecord[name]);
       } catch (e) {
@@ -461,25 +440,7 @@ export function makeTraceDetails(
       }
     }
   });
-
   return details;
-}
-
-// Creates trace details when privateVariables [DEPRECATED] was set.
-// Wraps privateVariable into a format that can be passed into makeTraceDetails(),
-// which handles the new option sendVariableValues.
-export function makeTraceDetailsLegacy(
-  variables: Record<string, any>,
-  privateVariables: Array<String> | boolean,
-): Trace.Details {
-  const newArguments = Array.isArray(privateVariables)
-    ? {
-        exceptVariableNames: privateVariables,
-      }
-    : {
-        safelistAll: !privateVariables,
-      };
-  return makeTraceDetails(variables, newArguments);
 }
 
 // Helper for makeTraceDetails() to enforce that the keys of a modified 'variables'
@@ -498,22 +459,19 @@ function cleanModifiedVariables(
 export function makeHTTPRequestHeaders(
   http: Trace.IHTTP,
   headers: Headers,
-  sendHeaders?: { except: Array<String> } | { safelistAll: boolean },
+  sendHeaders?: BlocklistValuesBaseOptions,
 ): void {
-  if (sendHeaders == null) {
-    return;
-  }
-  if ('safelistAll' in sendHeaders && !sendHeaders.safelistAll) {
+  if (!sendHeaders || 'sendNone' in sendHeaders) {
     return;
   }
   for (const [key, value] of headers) {
     if (
       sendHeaders &&
-      'except' in sendHeaders &&
-      // We assume that most users only have a few private headers, or will
-      // just set privateHeaders to true; we can change this linear-time
+      'exceptNames' in sendHeaders &&
+      // We assume that most users only have a few headers to hide, or will
+      // just set {sendNone: true} ; we can change this linear-time
       // operation if it causes real performance issues.
-      sendHeaders.except.some(exceptHeader => {
+      sendHeaders.exceptNames.some(exceptHeader => {
         // Headers are case-insensitive, and should be compared as such.
         return exceptHeader.toLowerCase() === key.toLowerCase();
       })
@@ -532,18 +490,4 @@ export function makeHTTPRequestHeaders(
         });
     }
   }
-}
-
-// Creates request headers when privateHeaders [DEPRECATED] was previously set.
-// Wraps privateHeaders into an object that can be passed into makeTraceDetails(),
-// which handles handles the new reporting option sendHeaders.
-export function makeHTTPRequestHeadersLegacy(
-  http: Trace.IHTTP,
-  headers: Headers,
-  privateHeaders: Array<String> | boolean,
-): void {
-  const sendHeaders = Array.isArray(privateHeaders)
-    ? { except: privateHeaders }
-    : { safelistAll: !privateHeaders };
-  makeHTTPRequestHeaders(http, headers, sendHeaders);
 }


### PR DESCRIPTION
Reopening: https://github.com/apollographql/apollo-server/pull/2847
After the revert: https://github.com/apollographql/apollo-server/pull/2930