### PR TITLE
docs: fix typo in authentication.md

### DIFF
--- a/docs/source/features/authentication.md
+++ b/docs/source/features/authentication.md
@@ -164,7 +164,7 @@ context: ({ req }) => {
 
  // optionally block the user
  // we could also check user roles/permissions here
- if (!user) throw new AuthorizationError('you must be logged in to query this schema');  
+ if (!user) throw new AuthenticationError('you must be logged in to query this schema');  
 
  // add the user to the context
  return {


### PR DESCRIPTION
This PR replaces `AuthorizationError` (which doesn't exist) with `AuthenticationError`. It's the same fix as https://github.com/apollographql/apollo-server/pull/2763 except that this PR is for another instance of `AuthorizationError`.