### PR TITLE
add test for @key referencing list

### DIFF
--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/keyFieldsSelectInvalidType.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/keyFieldsSelectInvalidType.test.ts
@@ -72,13 +72,13 @@ describe('keyFieldsSelectInvalidType', () => {
 
     const warnings = validateKeyFieldsSelectInvalidType(schema);
     expect(warnings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "code": "KEY_FIELDS_SELECT_INVALID_TYPE",
-          "message": "[serviceA] Product -> A @key selects Product.featuredItem, which is an interface type. Keys cannot select interfaces.",
-        },
-      ]
-    `);
+            Array [
+              Object {
+                "code": "KEY_FIELDS_SELECT_INVALID_TYPE",
+                "message": "[serviceA] Product -> A @key selects Product.featuredItem, which is an interface type. Keys cannot select interfaces.",
+              },
+            ]
+        `);
   });
 
   it('warns if @key references fields of a union type', () => {
@@ -109,12 +109,45 @@ describe('keyFieldsSelectInvalidType', () => {
 
     const warnings = validateKeyFieldsSelectInvalidType(schema);
     expect(warnings).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "code": "KEY_FIELDS_SELECT_INVALID_TYPE",
-          "message": "[serviceA] Product -> A @key selects Product.price, which is a union type. Keys cannot select union types.",
-        },
-      ]
-    `);
+            Array [
+              Object {
+                "code": "KEY_FIELDS_SELECT_INVALID_TYPE",
+                "message": "[serviceA] Product -> A @key selects Product.price, which is a union type. Keys cannot select union types.",
+              },
+            ]
+        `);
+  });
+
+  it('warns if @key references fields of a list type', () => {
+    const serviceA = {
+      typeDefs: gql`
+        type Product @key(fields: "price") {
+          sku: String!
+          price: [Numeric]!
+        }
+
+        type Numeric {
+          euro: Int
+          usd: Int
+        }
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        extend type Product {
+          sku: String! @external
+          name: String!
+        }
+      `,
+      name: 'serviceB',
+    };
+
+    const { schema, errors } = composeServices([serviceA, serviceB]);
+    expect(errors).toHaveLength(0);
+
+    const warnings = validateKeyFieldsSelectInvalidType(schema);
+    expect(warnings).toMatchInlineSnapshot(`Array []`);
   });
 });


### PR DESCRIPTION
This PR demonstrates a lack of validation errors for array types in the @-key directive. 

Expected: validations provide a warning when list types are referenced by a @-key directive.

https://github.com/apollographql/apollo-server/compare/evans/broken-requires-list?expand=1#diff-80ddba2f8f972a6873ae15bd107da23eR151 should have values inside of the array printed in the snapshot

## TODO

- [ ] fix arrays as keys, either explicitly banning them or supporting them as references