### PR TITLE
@apollo/gateway: flatten SequenceNodes and ParallelNodes

### DIFF
--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -117,41 +117,39 @@ describe('buildQueryPlan', () => {
                                                     }
                                                   }
                                                 },
-                                                Sequence {
-                                                  Flatten(path: "topProducts.@") {
-                                                    Fetch(service: "books") {
-                                                      {
-                                                        ... on Book {
-                                                          __typename
-                                                          isbn
-                                                        }
-                                                      } =>
-                                                      {
-                                                        ... on Book {
-                                                          __typename
-                                                          isbn
-                                                          title
-                                                          year
-                                                        }
+                                                Flatten(path: "topProducts.@") {
+                                                  Fetch(service: "books") {
+                                                    {
+                                                      ... on Book {
+                                                        __typename
+                                                        isbn
                                                       }
-                                                    },
+                                                    } =>
+                                                    {
+                                                      ... on Book {
+                                                        __typename
+                                                        isbn
+                                                        title
+                                                        year
+                                                      }
+                                                    }
                                                   },
-                                                  Flatten(path: "topProducts.@") {
-                                                    Fetch(service: "product") {
-                                                      {
-                                                        ... on Book {
-                                                          __typename
-                                                          isbn
-                                                          title
-                                                          year
-                                                        }
-                                                      } =>
-                                                      {
-                                                        ... on Book {
-                                                          name
-                                                        }
+                                                },
+                                                Flatten(path: "topProducts.@") {
+                                                  Fetch(service: "product") {
+                                                    {
+                                                      ... on Book {
+                                                        __typename
+                                                        isbn
+                                                        title
+                                                        year
                                                       }
-                                                    },
+                                                    } =>
+                                                    {
+                                                      ... on Book {
+                                                        name
+                                                      }
+                                                    }
                                                   },
                                                 },
                                               },

--- a/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts
@@ -239,57 +239,53 @@ it('multiple root mutations with correct service order', async () => {
             }
           }
         },
-        Sequence {
-          Fetch(service: "accounts") {
+        Fetch(service: "accounts") {
+          {
+            login(username: $username, password: $password) {
+              __typename
+              id
+            }
+          }
+        },
+        Flatten(path: "login") {
+          Fetch(service: "reviews") {
             {
-              login(username: $username, password: $password) {
+              ... on User {
                 __typename
                 id
               }
-            }
-          },
-          Sequence {
-            Flatten(path: "login") {
-              Fetch(service: "reviews") {
-                {
-                  ... on User {
+            } =>
+            {
+              ... on User {
+                reviews {
+                  product {
                     __typename
-                    id
-                  }
-                } =>
-                {
-                  ... on User {
-                    reviews {
-                      product {
-                        __typename
-                        ... on Book {
-                          __typename
-                          isbn
-                        }
-                        ... on Furniture {
-                          upc
-                        }
-                      }
+                    ... on Book {
+                      __typename
+                      isbn
+                    }
+                    ... on Furniture {
+                      upc
                     }
                   }
                 }
-              },
-            },
-            Flatten(path: "login.reviews.@.product") {
-              Fetch(service: "product") {
-                {
-                  ... on Book {
-                    __typename
-                    isbn
-                  }
-                } =>
-                {
-                  ... on Book {
-                    upc
-                  }
-                }
-              },
-            },
+              }
+            }
+          },
+        },
+        Flatten(path: "login.reviews.@.product") {
+          Fetch(service: "product") {
+            {
+              ... on Book {
+                __typename
+                isbn
+              }
+            } =>
+            {
+              ... on Book {
+                upc
+              }
+            }
           },
         },
         Fetch(service: "reviews") {

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -37,7 +37,9 @@ import {
 } from './FieldSet';
 import {
   FetchNode,
+  ParallelNode,
   PlanNode,
+  SequenceNode,
   QueryPlan,
   ResponsePath,
   VariableUsage,
@@ -87,9 +89,9 @@ export function buildQueryPlan(operationContext: OperationContext): QueryPlan {
 
   return {
     kind: 'QueryPlan',
-    node: isMutation
-      ? wrapInSequenceNodeIfNeeded(nodes)
-      : wrapInParallelNodeIfNeeded(nodes),
+    node: nodes.length
+      ? flatWrap(isMutation ? 'Sequence' : 'Parallel', nodes)
+      : undefined,
   };
 }
 
@@ -124,31 +126,32 @@ function executionNodeForGroup(
     const dependentNodes = group.dependentGroups.map(dependentGroup =>
       executionNodeForGroup(context, dependentGroup),
     );
-    return {
-      kind: 'Sequence',
-      nodes: [node, wrapInParallelNodeIfNeeded(dependentNodes)],
-    };
+
+    return flatWrap('Sequence', [node, flatWrap('Parallel', dependentNodes)]);
   } else {
     return node;
   }
 }
 
-function wrapInParallelNodeIfNeeded(nodes: PlanNode[]): PlanNode {
-  return nodes.length > 1
-    ? {
-        kind: 'Parallel',
-        nodes: nodes,
-      }
-    : nodes[0];
-}
-
-function wrapInSequenceNodeIfNeeded(nodes: PlanNode[]): PlanNode {
-  return nodes.length > 1
-    ? {
-        kind: 'Sequence',
-        nodes: nodes,
-      }
-    : nodes[0];
+// Wraps the given nodes in a ParallelNode or SequenceNode, unless there's only
+// one node, in which case it is returned directly. Any nodes of the same kind
+// in the given list have their sub-nodes flattened into the list: ie,
+// flatWrap('Sequence', [a, flatWrap('Sequence', b, c), d]) returns a SequenceNode
+// with four children.
+function flatWrap(
+  kind: ParallelNode['kind'] | SequenceNode['kind'],
+  nodes: PlanNode[],
+): PlanNode {
+  if (nodes.length === 0) {
+    throw Error('programming error: should always be called with nodes');
+  }
+  if (nodes.length === 1) {
+    return nodes[0];
+  }
+  return {
+    kind,
+    nodes: nodes.flatMap(n => (n.kind === kind ? n.nodes : [n])),
+  } as PlanNode;
 }
 
 function splitRootFields(


### PR DESCRIPTION
It's easier to read a query plan if four steps that'll go in sequence are
written Sequence(a, b, c, d) rather than Sequence(a, Sequence(b, Sequence(c,
d))).
