### PR TITLE
Add experimental observability functions

### DIFF
--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -290,7 +290,6 @@ export function buildSchemaFromDefinitionsAndExtensions({
   };
 
   errors.push(...validateSDL(extensionsDocument, schema, compositionRules));
-
   schema = extendSchema(schema, extensionsDocument, { assumeValidSDL: true });
 
   return { schema, errors };

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -1,0 +1,170 @@
+import { ApolloServer } from 'apollo-server';
+
+import { getServiceDefinitionsFromRemoteEndpoint } from '../../loadServicesFromRemoteEndpoint';
+import { ApolloGateway, GatewayConfig } from '../../index';
+import * as accounts from '../__fixtures__/schemas/accounts';
+import * as books from '../__fixtures__/schemas/books';
+import * as inventory from '../__fixtures__/schemas/inventory';
+import * as product from '../__fixtures__/schemas/product';
+import * as reviews from '../__fixtures__/schemas/reviews';
+import { buildFederatedSchema } from '@apollo/federation';
+import gql from 'graphql-tag';
+
+const services = [product, reviews, inventory, accounts, books];
+
+const booksReplacement = {
+  name: 'books',
+  typeDefs: gql`
+    extend type Query {
+      book(isbn: String): Book
+    }
+    type Book {
+      isbn: String!
+    }
+  `,
+  resolvers: {
+    Query: {
+      book: () => ({ isbn: 0 }),
+    },
+  },
+};
+
+describe('lifecycle hooks', () => {
+  let serviceDefinitions;
+  let apolloServers: { port: number; server: ApolloServer }[] = [];
+
+  // takes a service and a port and starts an apolloServer
+  // if no port is passed, it'll start it at a random one (0)
+  const startServerFromDefinition = (service, portToStartFrom) => {
+    const server = new ApolloServer({
+      schema: buildFederatedSchema([service]),
+      introspection: true,
+    });
+    // apolloServers.push(server);
+    return server.listen({ port: portToStartFrom || 0 }).then(({ port }) => {
+      apolloServers.push({ server, port });
+      return { ...service, port };
+    });
+  };
+
+  beforeEach(async () => {
+    serviceDefinitions = await Promise.all(
+      services.map(startServerFromDefinition),
+    );
+  });
+  afterEach(() => {
+    apolloServers.forEach(server => server.server.stop());
+    apolloServers = [];
+  });
+
+  it('uses updateServiceDefinitions override', async () => {
+    const update = jest.fn(async (config: GatewayConfig) => {
+      const [definitions] = await getServiceDefinitionsFromRemoteEndpoint({
+        serviceList: config.serviceList,
+      });
+      return definitions;
+    });
+
+    const experimental_didUpdateComputedFederationConfig = jest.fn();
+
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions.map(service => ({
+        name: service.name,
+        url: `http://localhost:${service.port}`,
+      })),
+      experimental_updateServiceDefinitions: update,
+      // experimental_didUpdateComputedFederationConfig,
+    });
+
+    const interval = await gateway.loadAndPoll();
+
+    expect(update).toBeCalled();
+    clearInterval(interval);
+  });
+
+  it('calls experimental_didFailComposition with a bad config', async () => {
+    // const experimental_updateServiceDefinitions = () => [];
+    const update = jest.fn(async (config: GatewayConfig) => {
+      const [definitions] = await getServiceDefinitionsFromRemoteEndpoint({
+        serviceList: config.serviceList,
+      });
+      return [definitions[0]];
+    });
+    const experimental_didFailComposition = jest.fn();
+
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions.map(service => ({
+        name: service.name,
+        url: `http://localhost:${service.port}`,
+      })),
+      experimental_updateServiceDefinitions: update,
+      experimental_didFailComposition,
+    });
+
+    const interval = await gateway.loadAndPoll();
+
+    const callbackArgs = experimental_didFailComposition.mock.calls[0][0];
+
+    expect(callbackArgs.serviceList).toHaveLength(1);
+    expect(callbackArgs.errors).toMatchInlineSnapshot(`
+      Array [
+        [GraphQLError: [product] Book -> \`Book\` is an extension type, but \`Book\` is not defined in any service],
+      ]
+    `);
+    clearInterval(interval);
+  });
+
+  fit('calls experimental_didUpdateComputedFederationConfig on schema update', async done => {
+    const update = jest.fn(async (config: GatewayConfig) => {
+      const [definitions] = await getServiceDefinitionsFromRemoteEndpoint({
+        serviceList: config.serviceList,
+      });
+      return definitions;
+    });
+
+    const experimental_didUpdateComputedFederationConfig = jest.fn();
+
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions.map(service => ({
+        name: service.name,
+        url: `http://localhost:${service.port}`,
+      })),
+      experimental_updateServiceDefinitions: update,
+      experimental_pollInterval: 1000,
+      experimental_didUpdateComputedFederationConfig,
+    });
+
+    const interval = await gateway.loadAndPoll();
+    new Promise(resolve => setTimeout(resolve, 2000));
+
+    // find the service definition that is for the "books" service.
+    const booksDefinition = serviceDefinitions.find(s => s.name === 'books');
+    // keep the port of that service so we can start a replacement book service
+    const booksPort = booksDefinition.port;
+    // find the apollo server instance using this port
+    const existingBooksServer = apolloServers.find(s => s.port === booksPort);
+    // stop the existing server
+    existingBooksServer.server.stop();
+
+    // start a replacement books service
+    const newBooksService = await startServerFromDefinition(
+      booksReplacement,
+      booksPort,
+    );
+
+    // wait for 3 seconds
+    new Promise(resolve => setTimeout(resolve, 3000));
+
+    // after now, the service should have polled and updated the config based
+    // off the new book service schema
+    // expect(experimental_didUpdateComputedFederationConfig).toHaveBeenCalledWith(
+    //   {},
+    // );
+    clearInterval(interval);
+  });
+});
+
+it.todo('changing schema after poll');
+it.todo('without overriding fetcher');
+
+it.todo('');

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -52,10 +52,10 @@ describe('lifecycle hooks', () => {
 
     expect(callbackArgs.serviceList).toHaveLength(1);
     expect(callbackArgs.errors).toMatchInlineSnapshot(`
-      Array [
-        [GraphQLError: [product] Book -> \`Book\` is an extension type, but \`Book\` is not defined in any service],
-      ]
-    `);
+                        Array [
+                          [GraphQLError: [product] Book -> \`Book\` is an extension type, but \`Book\` is not defined in any service],
+                        ]
+                `);
     clearInterval(interval);
   });
 
@@ -121,5 +121,31 @@ describe('lifecycle hooks', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it.todo('warns when polling on the default fetcher');
+  it('warns when polling on the default fetcher', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions,
+      experimental_pollInterval: 10,
+    });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. Use with caution.",
+      ]
+    `);
+  });
+
+  it('warns when polling using a custom serviceList fetcher', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
+    const gateway = new ApolloGateway({
+      experimental_updateServiceDefinitions: jest.fn(),
+      experimental_pollInterval: 10,
+    });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. Use with caution.",
+      ]
+    `);
+  });
 });

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -154,10 +154,16 @@ export class ApolloGateway implements GraphQLService {
       config.experimental_didUpdateComposition;
     this.experimental_pollInterval = config.experimental_pollInterval;
 
-    // TODO: warn if user may be polling an endpoint. ie if they have a pollinterval and a custom loader
+    // TODO: warn if user may be polling an endpoint.
+    // ie if they have a pollinterval and a custom loader or a serviceList
     if (config.experimental_pollInterval) {
-      if (config.experimental_updateServiceDefinitions) {
-        console.warn('be careful tho');
+      if (config.experimental_updateServiceDefinitions || config.serviceList) {
+        console.warn(
+          'Polling running services is dangerous and not recommended in production.',
+        );
+        console.warn(
+          'Polling should only be used against a registry. Use with caution.',
+        );
       }
     }
   }

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -161,7 +161,6 @@ export class ApolloGateway implements GraphQLService {
 
   public async loadAndPoll() {
     const load = async () => {
-      console.log('LOAD');
       // Preserve old service defs for observability cb
       const previousServiceDefinitions = this.serviceDefinitions;
       const previousSchema = this.schema;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -159,10 +159,7 @@ export class ApolloGateway implements GraphQLService {
     if (config.experimental_pollInterval) {
       if (config.experimental_updateServiceDefinitions || config.serviceList) {
         console.warn(
-          'Polling running services is dangerous and not recommended in production.',
-        );
-        console.warn(
-          'Polling should only be used against a registry. Use with caution.',
+          'Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. Use with caution.',
         );
       }
     }


### PR DESCRIPTION
## What this is

This pull request adds the following functions designed to offer additional observability features to apollo-gateway.


## Todo

- [x] Add tests

Each of these functions can be passed to the `ApolloGateway` constructor. The keys in the constructor correspond to the function names. They all are prefixed with the `experimental_` key.

The first function, `experimental_updateServiceDefinitions`, is used to replace the existing logic for fetching service lists. The rest are purely observability related.

