### PR TITLE
Make `Error`'s returned by formatError printable

### DIFF
--- a/packages/apollo-server-core/src/__tests__/errors.test.ts
+++ b/packages/apollo-server-core/src/__tests__/errors.test.ts
@@ -115,6 +115,11 @@ describe('Errors', () => {
       expect(error instanceof ApolloError).toBe(true);
       expect(formatter).toHaveBeenCalledTimes(1);
     });
+    it('Formats native Errors in a JSON-compatible way', () => {
+      const error = new Error('Hello');
+      const [formattedError] = formatApolloErrors([error]);
+      expect(JSON.parse(JSON.stringify(formattedError)).message).toBe('Hello');
+    });
   });
   describe('Named Errors', () => {
     const message = 'message';

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -243,6 +243,19 @@ export function formatApolloErrors(
   // }
 
   const enrichedErrors = errors.map(error => enrichError(error, debug));
+  const makePrintable = error => {
+    if (error instanceof Error) {
+      // Error defines its `message` and other fields as non-enumerable, meaning JSON.stringigfy does not print them.
+      const graphQLError = error as GraphQLFormattedError;
+      return {
+        message: graphQLError.message,
+        ...(graphQLError.locations && { locations: graphQLError.locations }),
+        ...(graphQLError.path && { path: graphQLError.path }),
+        ...(graphQLError.extensions && { extensions: graphQLError.extensions }),
+      };
+    }
+    return error;
+  };
 
   if (!formatter) {
     return enrichedErrors;
@@ -250,7 +263,7 @@ export function formatApolloErrors(
 
   return enrichedErrors.map(error => {
     try {
-      return formatter(error);
+      return makePrintable(formatter(error));
     } catch (err) {
       if (debug) {
         return enrichError(err, debug);


### PR DESCRIPTION
Fixes #1456.
Can't seem to find a way to test this, as `apolloFetch` does it's own formatting of errors that circumvents the issue.

Test:
```
formatError: error => {
    return new Error("hello");
}
```

previously, the error would be rendered as `{}`, now, the message is preserved.