### PR TITLE
docs(error-handling): add originalError property description

### DIFF
--- a/docs/source/features/errors.md
+++ b/docs/source/features/errors.md
@@ -150,9 +150,19 @@ server.listen().then(({ url }) => {
 });
 ```
 
-The original error instance thrown in the resolver is in `err.originalError`,
-it can be used to check error type, e.g `AuthenticationError` or
-`ValidationError`
+The error instance received by `formatError` (a `GraphQLError`) contains an `originalError` property which represents the original error thrown within the resolver.  This can be used to `instanceof` check against a specific error class, such as `AuthenticationError`, `ValidationError`, etc.:
+
+```js
+  /* ... */
+  formatError(err) {
+    if (err.originalError instanceof AuthenticationError) {
+      return new Error('Different authentication error message!');
+    }
+  },
+  /* ... */
+```
+
+> To make context-specific adjustments to the error received by `formatError` (e.g. localization or personalization), consider using the `didEncounterErrors` life-cycle hook to attach additional properties to the error, which can be accessed andn utilized within `formatError`.
 
 ### For Apollo Engine reporting
 

--- a/docs/source/features/errors.md
+++ b/docs/source/features/errors.md
@@ -150,6 +150,10 @@ server.listen().then(({ url }) => {
 });
 ```
 
+The original error instance thrown in the resolver is in `err.originalError`,
+it can be used to check error type, e.g `AuthenticationError` or
+`ValidationError`
+
 ### For Apollo Engine reporting
 
 With the Apollo Platform, it's possible to observe error rates within Apollo


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
Fixes #2898
There is no info in docs about what `formatError` [function](https://www.apollographql.com/docs/apollo-server/features/errors/#masking-and-logging-errors) argument is.

 `err` argument type is `GraphQLError`, which doesn't allow checks like `instanceof AuthenticationError`, because it is not an original error thrown in resolver.
 I think it should be explicitly said about that in docs. 
