### PR TITLE
[docs]: Update Deploying with Netlify Functions

### DIFF
--- a/docs/source/deployment/netlify.md
+++ b/docs/source/deployment/netlify.md
@@ -82,14 +82,15 @@ const resolvers = {
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers,
-  playground: true
+  resolvers
 });
 
 exports.handler = server.createHandler();
 ```
 
-Now, make sure you've run `npm run start:lambda`, and navigate to `localhost:9000/graphql` in your browser. You should see GraphQL Playground, where you can run queries against your API!
+Now, make sure you've run `NODE_ENV=development npm run start:lambda`, and navigate to `localhost:9000/graphql` in your browser. You should see GraphQL Playground, where you can run queries against your API!
+
+*Note - The GraphQL Playground will only run if your `NODE_ENV` is set to `development`. If you don't pass this, or your `NODE_ENV` is set to `production`, you will not see the GraphQL Playground.* 
 
 ![Local GraphQL Server](../images/graphql.png)
 

--- a/docs/source/deployment/netlify.md
+++ b/docs/source/deployment/netlify.md
@@ -82,7 +82,8 @@ const resolvers = {
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers
+  resolvers,
+  playground: true
 });
 
 exports.handler = server.createHandler();


### PR DESCRIPTION
While going through [this section](https://www.apollographql.com/docs/apollo-server/deployment/netlify/#set-up-apollo-server), I couldn't get the GraphQL Playground to show up until I added `playground: true` on the ApolloServer options object (thanks to this [thread on Spectrum](https://spectrum.chat/zeit/general/apollo-server-get-query-missing~ae8d5ca5-2faf-4c8d-8097-c3f6e25cad56)).

I thought I'd add this to the docs so others don't get stuck.