### PR TITLE
[DataSource] Add missing class property context

### DIFF
--- a/packages/apollo-datasource/src/index.ts
+++ b/packages/apollo-datasource/src/index.ts
@@ -6,5 +6,6 @@ export interface DataSourceConfig<TContext> {
 }
 
 export abstract class DataSource<TContext = any> {
+  context!: TContext;
   initialize?(config: DataSourceConfig<TContext>): void;
 }


### PR DESCRIPTION
According to the JS tutorial, we should be able to access to the `context` property inside a datasource https://github.com/apollographql/fullstack-tutorial/blob/master/final/server/src/datasources/user.js

So here ya go ;)

Here's the small use-case I have used (tested with TS 3.5.2)
```
export class TestAPI extends DataSource<any> {
  initialize(config: DataSourceConfig<any>) {
    this.context = config.context
  }
}
```

Close #2617