### PR TITLE
gateway: proxy downstream service errors

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* Proxy errors from downstream services [#3019](https://github.com/apollographql/apollo-server/pull/3019)
 * Handle schema defaultVariables correctly within downstream fetches [#2963](https://github.com/apollographql/apollo-server/pull/2963)
 
 # v0.6.12

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -7,7 +7,7 @@ import {
   GraphQLResolverMap,
 } from 'apollo-graphql';
 import gql from 'graphql-tag';
-import { GraphQLRequestContext } from 'apollo-server-core';
+import { GraphQLRequestContext, AuthenticationError } from 'apollo-server-core';
 import { composeServices, buildFederatedSchema } from '@apollo/federation';
 
 import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
@@ -101,7 +101,7 @@ describe('executeQueryPlan', () => {
       overrideResolversInService('accounts', {
         Query: {
           me() {
-            throw new Error('Something went wrong');
+            throw new AuthenticationError('Something went wrong');
           },
         },
       });
@@ -126,9 +126,22 @@ describe('executeQueryPlan', () => {
 
       expect(response).toHaveProperty('data.me', null);
       expect(response).toHaveProperty(
-        'errors.0.extensions.downstreamErrors.0.message',
+        'errors.0.message',
         'Something went wrong',
       );
+      expect(response).toHaveProperty(
+        'errors.0.extensions.code',
+        'UNAUTHENTICATED',
+      );
+      expect(response).toHaveProperty(
+        'errors.0.extensions.serviceName',
+        'accounts',
+      );
+      expect(response).toHaveProperty(
+        'errors.0.extensions.query',
+        '{\n  me {\n    name\n  }\n}',
+      );
+      expect(response).toHaveProperty('errors.0.extensions.variables', {});
     });
 
     it(`should still include other root-level results if one root-level field errors out`, async () => {


### PR DESCRIPTION
In the gateway, we currently squash all errors from a single service
into a single `Error` with a generic message, such as `Error while
fetching subquery from service "registry"`. In other words, the gateway
globally overwrites errors from the underlying services and the original
errors are appended to `Error.extensions.downstreamErrors`.

https://github.com/apollographql/apollo-server/blob/9208e14ba1b96aea663f101e1089b40ca17790c2/packages/apollo-gateway/src/executeQueryPlan.ts#L242

This changes to behavior, so that the errors are proxied in their same
form rather than nested into a single error. Ultimately the underlying
services are better equipped than the gateway to expose/mask their own
errors with `formatErrors` and this removes the gateway as the
bottleneck of configuration. The original desire with the message mask
was to retain service info / context. To accomplish this, we add the
`serviceName` to the `Error.extensions` object for each. so users can
investigate the results.

