### PR TITLE
Add introspectionHeaders documentation to gateway

### DIFF
--- a/docs/source/api/apollo-gateway.mdx
+++ b/docs/source/api/apollo-gateway.mdx
@@ -49,7 +49,19 @@ The core of the federated gateway implementation. For an example, see the ["impl
       },
     });
     ```
-
+  * `introspectionHeaders`: `{ [key: string]: string }`
+    
+    An object containing headers sent with introspection queries
+    
+    ```js{3-5}
+    const gateway = new ApolloGateway({
+      ...
+      introspectionHeaders: {
+        Authorization: 'my-header'
+      }
+    });
+    ```
+   
   * `debug`: `Boolean`
 
     With debug enabled, the server will log startup messages as well as query plans during incoming requests.


### PR DESCRIPTION
## In this PR
* Add the `introspectionHeaders` option documentation for `ApolloGateway`


