### PR TITLE
gateway: proxy downstream service errors

### DIFF
--- a/packages/apollo-federation/package.json
+++ b/packages/apollo-federation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Apollo Federation Utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* Proxy errors from downstream services [#3019](https://github.com/apollographql/apollo-server/pull/3019)
 * Handle schema defaultVariables correctly within downstream fetches [#2963](https://github.com/apollographql/apollo-server/pull/2963)
 
 # v0.6.12

--- a/packages/apollo-gateway/package.json
+++ b/packages/apollo-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/gateway",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Apollo Gateway",
   "author": "opensource@apollographql.com",
   "main": "dist/index.js",

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -7,7 +7,7 @@ import {
   GraphQLResolverMap,
 } from 'apollo-graphql';
 import gql from 'graphql-tag';
-import { GraphQLRequestContext } from 'apollo-server-core';
+import { GraphQLRequestContext, AuthenticationError } from 'apollo-server-core';
 import { composeServices, buildFederatedSchema } from '@apollo/federation';
 
 import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
@@ -101,7 +101,7 @@ describe('executeQueryPlan', () => {
       overrideResolversInService('accounts', {
         Query: {
           me() {
-            throw new Error('Something went wrong');
+            throw new AuthenticationError('Something went wrong');
           },
         },
       });
@@ -126,9 +126,22 @@ describe('executeQueryPlan', () => {
 
       expect(response).toHaveProperty('data.me', null);
       expect(response).toHaveProperty(
-        'errors.0.extensions.downstreamErrors.0.message',
+        'errors.0.message',
         'Something went wrong',
       );
+      expect(response).toHaveProperty(
+        'errors.0.extensions.code',
+        'UNAUTHENTICATED',
+      );
+      expect(response).toHaveProperty(
+        'errors.0.extensions.serviceName',
+        'accounts',
+      );
+      expect(response).toHaveProperty(
+        'errors.0.extensions.query',
+        '{\n  me {\n    name\n  }\n}',
+      );
+      expect(response).toHaveProperty('errors.0.extensions.variables', {});
     });
 
     it(`should still include other root-level results if one root-level field errors out`, async () => {

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "2.6.7",
+	"version": "2.6.8",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-base",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Apollo Server plugin base classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-response-cache",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Apollo Server full query response cache",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-testing",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Test utils for apollo-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Production ready GraphQL Server",
   "author": "opensource@apollographql.com",
   "main": "dist/index.js",


### PR DESCRIPTION
* gateway: proxy downstream service errors (#3019)

In the gateway, we currently squash all errors from a single service
into a single `Error` with a generic message, such as `Error while
fetching subquery from service "registry"`. In other words, the gateway
globally overwrites errors from the underlying services and the original
errors are appended to `Error.extensions.downstreamErrors`.

https://github.com/apollographql/apollo-server/blob/9208e14ba1b96aea663f101e1089b40ca17790c2/packages/apollo-gateway/src/executeQueryPlan.ts#L242

This changes to behavior, so that the errors are proxied in their same
form rather than nested into a single error. Ultimately the underlying
services are better equipped than the gateway to expose/mask their own
errors with `formatErrors` and this removes the gateway as the
bottleneck of configuration. The original desire with the message mask
was to retain service info / context. To accomplish this, we add the
`serviceName` to the `Error.extensions` object for each. so users can
investigate the results.
