### PR TITLE
apollo-engine-reporting: fix reporting errors from backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
+- `apollo-engine-reporting`: fix reporting errors from backend. (The support for federated metrics introduced in v2.7.0 did not properly handle GraphQL errors from the backend; all users of federated metrics should upgrade to this version.) [PR #3056](https://github.com/apollographql/apollo-server/pull/3056) [Issue #3052](https://github.com/apollographql/apollo-server/issues/3052)
 - `apollo-engine-reporting`: clean up `SIGINT` and `SIGTERM` handlers when `EngineReportingAgent` is stopped; fixes 'Possible EventEmitter memory leak detected' log. [PR #3090](https://github.com/apollographql/apollo-server/pull/3090)
 
 ### v2.7.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
       "dependencies": {
         "apollo-env": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
-          "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
+          "bundled": true,
           "requires": {
             "core-js": "^3.0.1",
             "node-fetch": "^2.2.0",
@@ -23,8 +22,7 @@
         },
         "core-js": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.3.tgz",
-          "integrity": "sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA=="
+          "bundled": true
         }
       }
     },
@@ -46,8 +44,7 @@
       "dependencies": {
         "apollo-env": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
-          "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
+          "bundled": true,
           "requires": {
             "core-js": "^3.0.1",
             "node-fetch": "^2.2.0",
@@ -56,8 +53,7 @@
         },
         "core-js": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.3.tgz",
-          "integrity": "sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA=="
+          "bundled": true
         }
       }
     },
@@ -3216,8 +3212,7 @@
       "dependencies": {
         "apollo-env": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.5.1.tgz",
-          "integrity": "sha512-fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==",
+          "bundled": true,
           "requires": {
             "core-js": "^3.0.1",
             "node-fetch": "^2.2.0",
@@ -3226,8 +3221,7 @@
         },
         "core-js": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.3.tgz",
-          "integrity": "sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA=="
+          "bundled": true
         }
       }
     },
@@ -3352,8 +3346,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },
@@ -3376,16 +3369,14 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "bundled": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ioredis": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.2.0.tgz",
-          "integrity": "sha512-PdxZGNJBfPiR2RI6DkqmiacL1+ML3gaqEiaC5QXWQt9eSTlGj+BwDCct0s8irn1ed8GyzAHTzcjvU9fmnl6D7A==",
+          "bundled": true,
           "requires": {
             "cluster-key-slot": "^1.0.6",
             "debug": "^3.1.0",
@@ -3401,8 +3392,7 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "bundled": true
         }
       }
     },
@@ -3424,8 +3414,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },
@@ -3464,8 +3453,7 @@
       "dependencies": {
         "subscriptions-transport-ws": {
           "version": "0.9.16",
-          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-          "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+          "bundled": true,
           "requires": {
             "backo2": "^1.0.2",
             "eventemitter3": "^3.1.0",
@@ -3476,8 +3464,7 @@
           "dependencies": {
             "ws": {
               "version": "5.2.2",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-              "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+              "bundled": true,
               "requires": {
                 "async-limiter": "~1.0.0"
               }
@@ -3517,13 +3504,11 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         },
         "@types/express": {
           "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
-          "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+          "bundled": true,
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "*",
@@ -3546,8 +3531,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },
@@ -3565,8 +3549,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },
@@ -3601,8 +3584,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },
@@ -3618,8 +3600,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },
@@ -3635,8 +3616,7 @@
       "dependencies": {
         "@apollographql/graphql-playground-html": {
           "version": "1.6.24",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.24.tgz",
-          "integrity": "sha512-8GqG48m1XqyXh4mIZrtB5xOhUwSsh1WsrrsaZQOEYYql3YN9DEu9OOSg0ILzXHZo/h2Q74777YE4YzlArQzQEQ=="
+          "bundled": true
         }
       }
     },

--- a/packages/apollo-engine-reporting/src/federatedExtension.ts
+++ b/packages/apollo-engine-reporting/src/federatedExtension.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo, GraphQLError } from 'graphql';
-import { GraphQLExtension, EndHandler } from 'graphql-extensions';
+import { GraphQLExtension } from 'graphql-extensions';
 import { Trace } from 'apollo-engine-reporting-protobuf';
 import { GraphQLRequestContext } from 'apollo-server-types';
 
@@ -53,30 +53,27 @@ export class EngineFederatedTracingExtension<TContext = any>
     }
   }
 
-  public executionDidStart(): EndHandler | void {
-    if (this.enabled) {
-      // It's a little odd that we record the end time after execution rather than
-      // at the end of the whole request, but because we need to include our
-      // formatted trace in the request itself, we have to record it before the
-      // request is over!  It's also odd that we don't do traces for parse or
-      // validation errors, but runQuery doesn't currently support that, as
-      // format() is only invoked after execution.
-      return () => {
-        this.treeBuilder.stopTiming();
-        this.done = true;
-      };
-    }
-  }
-
   // The ftv1 extension is a base64'd Trace protobuf containing only the
   // durationNs, startTime, endTime, and root fields.
+  //
+  // Note: format() is only called after executing an operation, and
+  // specifically isn't called for parse or validation errors. Parse and validation
+  // errors in a federated backend will get reported to the end user as a downstream
+  // error but will not get reported to Engine (because Engine filters out downstream
+  // errors)! See #3091.
   public format(): [string, string] | undefined {
     if (!this.enabled) {
       return;
     }
-    if (!this.done) {
-      throw Error('format called before end of execution?');
+    if (this.done) {
+      throw Error('format called twice?');
     }
+
+    // We record the end time at the latest possible time: right before serializing the trace.
+    // If we wait any longer, the time we record won't actually be sent anywhere!
+    this.treeBuilder.stopTiming();
+    this.done = true;
+
     const encodedUint8Array = Trace.encode(this.treeBuilder.trace).finish();
     const encodedBuffer = Buffer.from(
       encodedUint8Array,

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -2027,6 +2027,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
         type Query {
           books: [Book]
           movies: [Movie]
+          error: String
         }
       `;
 
@@ -2042,6 +2043,9 @@ export function testApolloServer<AS extends ApolloServerBase>(
             new Promise(resolve =>
               setTimeout(() => resolve([{ title: 'H' }]), 12),
             ),
+          error: () => {
+            throw new GraphQLError('It broke');
+          },
         },
       };
 
@@ -2089,10 +2093,6 @@ export function testApolloServer<AS extends ApolloServerBase>(
         });
 
         const apolloFetch = createApolloFetchAsIfFromGateway(uri);
-        apolloFetch.use(({ options }, next) => {
-          options.headers = { 'apollo-federation-include-trace': 'ftv1' };
-          next();
-        });
 
         const result = await apolloFetch({
           query: `{ books { title author } }`,
@@ -2128,6 +2128,43 @@ export function testApolloServer<AS extends ApolloServerBase>(
             trace.endTime.nanos,
           );
         }
+      });
+
+      it('includes errors in federated trace', async () => {
+        const { url: uri } = await createApolloServer({
+          typeDefs: allTypeDefs,
+          resolvers,
+          formatError(err) {
+            err.message = `Formatted: ${err.message}`;
+            return err;
+          },
+          engine: {
+            rewriteError(err) {
+              err.message = `Rewritten for Engine: ${err.message}`;
+              return err;
+            },
+          },
+        });
+
+        const apolloFetch = createApolloFetchAsIfFromGateway(uri);
+
+        const result = await apolloFetch({
+          query: `{ error }`,
+        });
+
+        expect(result.data).toStrictEqual({ error: null });
+        expect(result.errors).toBeTruthy();
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0].message).toBe('Formatted: It broke');
+
+        const ftv1: string = result.extensions.ftv1;
+
+        expect(ftv1).toBeTruthy();
+        const encoded = Buffer.from(ftv1, 'base64');
+        const trace = Trace.decode(encoded);
+        expect(trace.root.child[0].error[0].message).toBe(
+          'Rewritten for Engine: It broke',
+        );
       });
     });
 


### PR DESCRIPTION
The extension stack executionDidEnd method gets called before didEncounterErrors
for GraphQL errors returned from execution (although confusingly the plugin
executionDidEnd method gets called after), which caused the assertion that
nothing gets added to the EngineReportingTreeBuilder after stopTiming to
fail. Fix by moving stopTiming to the last possible moment: format().

Actually test error reporting, including both kinds of rewriting.

Add a comment noting that backend parse and validation errors don't get
reported.

Fixes #3052.
