### PR TITLE
Docs: Federation Implementation Touchups

### DIFF
--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -122,7 +122,7 @@ const gateway = new ApolloGateway({
   ],
 });
 
-const server = new ApolloServer({ gateway });
+const server = new ApolloServer({ gateway, subscriptions: false });
 
 server.listen().then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`);
@@ -165,6 +165,7 @@ const gateway = new ApolloGateway({
 
 const server = new ApolloServer({
   gateway,
+  subscriptions: false,
   context: ({ req }) => {
     // get the user token from the headers
     const token = req.headers.authorization || '';

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -122,7 +122,15 @@ const gateway = new ApolloGateway({
   ],
 });
 
-const server = new ApolloServer({ gateway, subscriptions: false });
+const server = new ApolloServer({
+  gateway,
+  
+  // Currently, subscriptions are enabled by default with Apollo Server, however,
+  // subscriptions are not compatible with the gateway.  We hope to resolve this
+  // limitation in future versions of Apollo Server.  Please reach out to us on
+  // https://spectrum.chat/apollo/apollo-server if this is critical to your adoption!
+  subscriptions: false,
+});
 
 server.listen().then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`);
@@ -140,6 +148,7 @@ On startup, the gateway will fetch the service capabilities from the running ser
 > If there are any composition errors, the `new ApolloServer` call will throw with a list of [validation errors](/federation/errors/).
 
 ## Sharing context across services
+
 For existing services, it's likely that you've already implemented some form of authentication to convert a request into a user, or require some information passed to the service through request headers. `@apollo/gateway` makes it easy to reuse the context feature of Apollo Server to customize what information is sent to underlying services. Let's see what it looks like to pass user information along from the gateway to its services:
 
 ```javascript{9-18,23-32}
@@ -165,7 +174,13 @@ const gateway = new ApolloGateway({
 
 const server = new ApolloServer({
   gateway,
+  
+  // As noted above, subscriptions are enabled by default with Apollo Server, however,
+  // subscriptions are not compatible with the gateway.  We hope to resolve this
+  // limitation in future versions of Apollo Server.  Please reach out to us on
+  // https://spectrum.chat/apollo/apollo-server if this is critical to your adoption!
   subscriptions: false,
+  
   context: ({ req }) => {
     // get the user token from the headers
     const token = req.headers.authorization || '';

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -143,8 +143,8 @@ On startup, the gateway will fetch the service capabilities from the running ser
 For existing services, it's likely that you've already implemented some form of authentication to convert a request into a user, or require some information passed to the service through request headers. `@apollo/gateway` makes it easy to reuse the context feature of Apollo Server to customize what information is sent to underlying services. Let's see what it looks like to pass user information along from the gateway to its services:
 
 ```javascript{9-18,23-32}
-import { ApolloServer } from 'apollo-server';
-import { ApolloGateway, RemoteGraphQLDataSource } from '@apollo/gateway';
+const { ApolloServer } = require('apollo-server');
+const { ApolloGateway, RemoteGraphQLDataSource } = require('@apollo/gateway');
 
 const gateway = new ApolloGateway({
   serviceList: [

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -44,6 +44,10 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
 });
+
+server.listen(4001).then(({ url }) => {
+    console.log(`🚀 Server ready at ${url}`);
+});
 ```
 
 If you're already familiar with [setting up an Apollo Server](/essentials/server/#creating-a-server), this should look pretty familiar. If not, we recommend you first take a moment to get comfortable with this topic before jumping in to federation.
@@ -87,6 +91,10 @@ const resolvers = {
 
 const server = new ApolloServer({
   schema: buildFederatedSchema([{ typeDefs, resolvers }])
+});
+
+server.listen(4001).then(({ url }) => {
+    console.log(`🚀 Server ready at ${url}`);
 });
 ```
 > Note: we're now providing a `schema` to the `ApolloServer` constructor, rather than `typeDefs` and `resolvers`.


### PR DESCRIPTION
Hello There 👋 

First off all: thank you for the documentation. It makes getting started with Apollo a lot easier! 

I'm playing around with the Federation product at the moment and found some minor copy & paste code improvements on the Federation implementation docs. Let me know what you think :)

### What has been done:
- The example federated service does not have a "start server" statement. I've added that
- Later-on in the docs we assume that the server is running on port 4001, so I added the port to the federated service :)
- When first starting the Gateway service you are presented with an error: 
```
Error: Cannot define both `subscriptions` and `gateway`. Set `subscriptions: false` in Apollo Server's config to use gateway.
```
I've applied the fix in the code. Hope this is the right workaround 🙈 
- The last example uses `import` statements which error in my local setup. I think this requires typescript 🤔 so I changed it back to a `const` for consistency reasons. 
 
Thanks again!