### PR TITLE
chore: Mock `yup` error shape in tests in lieu of full dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -227,15 +227,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -3058,12 +3049,6 @@
       "version": "12.0.9",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.9.tgz",
       "integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA=="
-    },
-    "@types/yup": {
-      "version": "0.26.22",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.22.tgz",
-      "integrity": "sha512-AhUPifCc7j2BEfp+wye3Mj7v3mMhbtu5BbO7n0zpwC/NVSETc8+MHENRmoxjE8wLC8AmFr5+uEhg5cvqusaRFQ==",
-      "dev": true
     },
     "@wry/equality": {
       "version": "0.1.9",
@@ -6257,12 +6242,6 @@
           }
         }
       }
-    },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -12518,12 +12497,6 @@
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
-    "property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
-      "dev": true
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -12847,12 +12820,6 @@
       "requires": {
         "redis-errors": "^1.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -13850,12 +13817,6 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
-    "synchronous-promise": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.6.tgz",
-      "integrity": "sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==",
-      "dev": true
-    },
     "tar": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
@@ -14049,12 +14010,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "toposort": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=",
-      "dev": true
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -14736,20 +14691,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
       "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ=="
-    },
-    "yup": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
-      "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.11",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.6",
-        "toposort": "^2.0.2"
-      }
     },
     "zen-observable": {
       "version": "0.8.14",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@types/test-listen": "1.1.0",
     "@types/type-is": "1.6.2",
     "@types/ws": "6.0.1",
-    "@types/yup": "0.26.22",
     "apollo-fetch": "0.7.0",
     "apollo-link": "1.2.12",
     "apollo-link-http": "1.5.15",
@@ -139,8 +138,7 @@
     "ts-jest": "24.0.2",
     "tslint": "5.18.0",
     "typescript": "3.5.3",
-    "ws": "6.2.1",
-    "yup": "0.27.0"
+    "ws": "6.2.1"
   },
   "jest": {
     "projects": [


### PR DESCRIPTION
It shouldn't be necessary to bring this entire `yup` dependency just to test
compatibility with the shape of a `yup` (https://npm.im/yup) error.

Ref: https://github.com/apollographql/apollo-server/pull/1288
