### PR TITLE
[docs] Remove undefined component

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -22,6 +22,6 @@ import {ButtonWrapper, ButtonLink} from 'gatsby-theme-apollo-docs';
 
 <ButtonWrapper>
   <ButtonLink size="large" to="/getting-started/">
-    <Button>Get started</Button>
+    Get started
   </ButtonLink>
 </ButtonWrapper>


### PR DESCRIPTION
This branch removes an undefined `Button` component within the `ButtonLink` on the docs index page.