### PR TITLE
[docs] Give the docs a package.json name field

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "apollo-server-docs",
   "scripts": {
     "start": "rm -rf .cache && gatsby develop",
     "build": "gatsby build",


### PR DESCRIPTION
This branch adds a `name` field to the docs' package.json