### PR TITLE
add interval parameter on startPollingServices and define it as prote…

### DIFF
--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -172,7 +172,7 @@ export class ApolloGateway implements GraphQLService {
     };
   }
 
-  private startPollingServices() {
+  protected startPollingServices(interval) {
     if (this.pollingTimer) clearInterval(this.pollingTimer);
 
     this.pollingTimer = setInterval(async () => {
@@ -205,7 +205,7 @@ export class ApolloGateway implements GraphQLService {
           e,
         );
       }
-    }, 10 * 1000);
+    }, interval || (10 * 1000));
   }
 
   protected createServices(services: ServiceEndpointDefinition[]) {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -205,7 +205,7 @@ export class ApolloGateway implements GraphQLService {
           e,
         );
       }
-    }, interval || (10 * 1000));
+    }, interval || 10 * 1000);
   }
 
   protected createServices(services: ServiceEndpointDefinition[]) {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -172,7 +172,7 @@ export class ApolloGateway implements GraphQLService {
     };
   }
 
-  protected startPollingServices(interval) {
+  protected startPollingServices(interval?: number) {
     if (this.pollingTimer) clearInterval(this.pollingTimer);
 
     this.pollingTimer = setInterval(async () => {


### PR DESCRIPTION
New internal feature :
The startPollingServices function is very interesting, but the interval between polling is hard coded to 10s which seems to me a little beat agressive. I've added an optional parameter on it to customize this value. Also, as I use it from a class which inherits from ApolloGateway, this function is redefined protected instead of private.

Do you agree with these modifications?

Thank in advance