### PR TITLE
fix(@apollo/gateway) Call `unref` on the federated gateway's `setInterval`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet!_
+- `@apollo/gateway`: Change the `setInterval` timer, which is used to continuously check for updates to a federated graph from the Apollo Graph Manager, to be an `unref`'d timer.  Without this change, the server wouldn't terminate properly once polling had started since the event-loop would continue to have unprocessed events on it. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO);
 
 ### v2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- `@apollo/gateway`: Change the `setInterval` timer, which is used to continuously check for updates to a federated graph from the Apollo Graph Manager, to be an `unref`'d timer.  Without this change, the server wouldn't terminate properly once polling had started since the event-loop would continue to have unprocessed events on it. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO);
+- `@apollo/gateway`: Change the `setInterval` timer, which is used to continuously check for updates to a federated graph from the Apollo Graph Manager, to be an `unref`'d timer.  Without this change, the server wouldn't terminate properly once polling had started since the event-loop would continue to have unprocessed events on it. [PR #3105](https://github.com/apollographql/apollo-server/pull/3105)
 
 ### v2.8.0
 

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -206,6 +206,11 @@ export class ApolloGateway implements GraphQLService {
         );
       }
     }, 10 * 1000);
+
+    // Prevent the Node.js event loop from remaining active (and preventing,
+    // e.g. process shutdown) by calling `unref` on the `Timeout`.  For more
+    // information, see https://nodejs.org/api/timers.html#timers_timeout_unref.
+    this.pollingTimer.unref();
   }
 
   protected createServices(services: ServiceEndpointDefinition[]) {


### PR DESCRIPTION
When the Apollo Gateway is configured in so-called "managed mode", it uses a
`setInterval` timer to periodically check for updates from the Apollo Graph
Manager (also known as Apollo Engine).

However, since the Timer's `unref` method wasn't invoked, the timer would
continue to place tasks on the event loop, even when the server had been
requested to be shutdown.  By calling `unref`, Node.js switches the timer to
an internal timer which doesn't block the event-loop.

While we could alternatively use a `process.on` event to detect when a
shutdown signal had been received and invoke the Gateway's `stop` method
accordingly, this should be sufficient for this particular implementation.
(As opposed to the implementation in `apollo-engine-reporting`  which does
exactly this since it needs to ensure that all queued traces are transmitted
to the cloud prior to process exit.