### PR TITLE
Fix bug for not import correct packages after (#3089)

### DIFF
--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -1,5 +1,5 @@
 import hapi from 'hapi';
-import { parseAll } from 'accept';
+import { parseAll } from '@hapi/accept';
 import {
   renderPlaygroundPage,
   RenderPageOptions as PlaygroundRenderPageOptions,

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,4 +1,4 @@
-import Boom from 'boom';
+import Boom from '@hapi/boom';
 import { Server, Request, RouteOptions } from 'hapi';
 import {
   GraphQLOptions,


### PR DESCRIPTION
Fixing my stupid bug that do not import correct package name after rename accept & boom to new namespace (PR #3089)