### PR TITLE
Add `schemaTag` option to Engine setup example

### DIFF
--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -11,17 +11,34 @@ Understanding the behavior of GraphQL execution inside of Apollo Server is criti
 
 Apollo Engine provides an integrated hub for all GraphQL performance data that is free for one million queries per month. With an API key from the [Engine UI](https://engine.apollographql.com/), Apollo Server reports performance and error data out-of-band. Apollo Engine then aggregates and displays information for [queries](https://www.apollographql.com/docs/engine/features/query-tracking.html), [requests](https://www.apollographql.com/docs/engine/performance.html), the [schema](https://www.apollographql.com/docs/engine/features/performance.html), and [errors](https://www.apollographql.com/docs/engine/features/error-tracking.html). By leveraging this data, Apollo Engine offers [alerts](https://www.apollographql.com/docs/engine/features/alerts.html) via [Slack](https://www.apollographql.com/docs/engine/integrations/slack.html) and [Datadog](https://www.apollographql.com/docs/engine/integrations/datadog.html) integrations.
 
-To set up Apollo Server with Engine, [click here](https://engine.apollographql.com/) to get an Engine API key. This API key can be passed directly to the Apollo Server constructor.
+To set up Apollo Server with Engine, [click here](https://engine.apollographql.com/) to get an Engine API key.
 
-```js{6-8}
+The API key can be specified in two ways:
+
+1. Within the `ApolloServer` constructor options.
+2. Using environment variables.
+
+### Configuring within the `ApolloServer` constructor options
+
+```js{6-15}
 const { ApolloServer } = require("apollo-server");
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   engine: {
+    // The Apollo Engine API key.
+    //
+    // This may also be set via the `ENGINE_API_KEY` environment variable.
     apiKey: "YOUR API KEY HERE",
-    schemaTag: "production"
+
+    // A tag for this specific environment (e.g. `development` or `production`).
+    //
+    // This may also be set via the `ENGINE_SCHEMA_TAG` environment variable.
+    // For more information on schema tags/variants, see the documentation in
+    // our Platform documentation on associating metrics with variants:
+    // https://www.apollographql.com/docs/platform/schema-registry/#associating-metrics-with-a-variant
+    schemaTag: 'development',
   }
 });
 
@@ -30,35 +47,61 @@ server.listen().then(({ url }) => {
 });
 ```
 
-The API key can also be set with the `ENGINE_API_KEY` environment variable. Setting an environment variable can be done in commandline as seen below or with the [dotenv npm package](https://www.npmjs.com/package/dotenv).
+### Configuration via environment variables
+
+The API key can also be set with the `ENGINE_API_KEY` environment variable and the schema tag can be set similarly with `ENGINE_SCHEMA_TAG`.
+
+Setting an environment variable can be done on the command line as seen below or using the [`dotenv` npm package](https://www.npmjs.com/package/dotenv) (or similar).
 
 ```bash
-# Replace YOUR_API_KEY with the API key provided within Apollo Engine.
-ENGINE_API_KEY=YOUR_API_KEY node start-server.js
+# Replace the example values below with values specific to your use case.
+ENGINE_API_KEY=YOUR_API_KEY ENGINE_SCHEMA_TAG=development node start-server.js
 ```
 
 ### Client awareness
 
-Apollo Engine accepts metrics annotated with client information. The Engine UI
-is then able to filter metrics and usage patterns by these names and versions. To provide metrics to the Engine, pass a `generateClientInfo` function into the `ApolloServer` constructor, like so:
+> For additional information on client awareness, please see the section in our Apollo Platform documentation on [client awareness](https://www.apollographql.com/docs/platform/client-awareness).
 
-```js{8-23}
+Setting up client awareness enables client-based filtering of metrics and usage patterns within Apollo Engine.  A client's identity has three configurable dimensions:
+
+* Name (e.g. "Android App")
+* Version (e.g. `1.0.1`)
+* Reference ID (e.g. A Git reference or other supporting identifier)
+
+There are two ways to configure client awareness:
+
+1. By setting specific headers on the client which are automatically picked up by Apollo Server.
+2. Defining a custom `generateClientInfo` implementation within Apollo Server, allowing the use of different headers or other information from the request context.
+
+#### Default client identification headers
+
+By default, Apollo Server will automatically recognize the following headers on incoming requests and associate them with a client's identity on a trace automatically:
+
+* `apollographql-client-name`
+* `apollographql-client-version`
+* `apollographql-client-reference-id`
+
+#### Custom client identification
+
+For more advanced cases, or to use custom headers, pass a `generateClientInfo` function into the `ApolloServer` constructor:
+
+```js{9-24}
 const { ApolloServer } = require("apollo-server");
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   engine: {
-    apiKey: "YOUR API KEY HERE",
-    schemaTag: "production",
+    /* Other, existing `engine` configuration should remain the same. */
+
     generateClientInfo: ({
       request
     }) => {
       const headers = request.http && request.http.headers;
       if(headers) {
         return {
-          clientName: headers['apollo-client-name'],
-          clientVersion: headers['apollo-client-version'],
+          clientName: headers['apollographql-client-name'],
+          clientVersion: headers['apollographql-client-version'],
         };
       } else {
         return {
@@ -67,6 +110,7 @@ const server = new ApolloServer({
         };
       }
     },
+
   }
 });
 

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -20,7 +20,8 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   engine: {
-    apiKey: "YOUR API KEY HERE"
+    apiKey: "YOUR API KEY HERE",
+    schemaTag: "production"
   }
 });
 
@@ -49,6 +50,7 @@ const server = new ApolloServer({
   resolvers,
   engine: {
     apiKey: "YOUR API KEY HERE",
+    schemaTag: "production",
     generateClientInfo: ({
       request
     }) => {


### PR DESCRIPTION
Schema tags (variants) have become a central part of interacting with the data in Engine. This helps users set up tags more easily, earlier in their process.