### PR TITLE
[gateway] Adds experimental observability functions

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+* Add experimental observability functions [#3110](https://github.com/apollographql/apollo-server/pull/3110)
+
 # v0.8.2
 
 * Handle `null` @requires selections correctly during execution [#3138](https://github.com/apollographql/apollo-server/pull/3138)

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -62,7 +62,7 @@ describe('lifecycle hooks', () => {
 
   it('calls experimental_didUpdateComposition on schema update', async done => {
     const update = jest.fn();
-    update.mockImplementationOnce(async (config: GatewayConfig) => {
+    update.mockImplementation(async (config: GatewayConfig) => {
       return [serviceDefinitions, true];
     });
     update.mockImplementationOnce(async (config: GatewayConfig) => {
@@ -81,7 +81,7 @@ describe('lifecycle hooks', () => {
       ];
     });
 
-    const experimental_didUpdateComposition = jest.fn();
+    const experimental_didUpdateComposition = jest.fn(() => {});
 
     const gateway = new ApolloGateway({
       experimental_updateServiceDefinitions: update,
@@ -89,9 +89,8 @@ describe('lifecycle hooks', () => {
       experimental_didUpdateComposition,
     });
 
-    jest.useFakeTimers();
     await gateway.load();
-    await jest.advanceTimersByTime(15);
+    await new Promise(resolve => setTimeout(resolve, 10));
 
     expect(update).toBeCalledTimes(2);
 

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -1,0 +1,151 @@
+import { ApolloGateway, GatewayConfig } from '../../index';
+import * as accounts from '../__fixtures__/schemas/accounts';
+import * as books from '../__fixtures__/schemas/books';
+import * as inventory from '../__fixtures__/schemas/inventory';
+import * as product from '../__fixtures__/schemas/product';
+import * as reviews from '../__fixtures__/schemas/reviews';
+
+const services = [product, reviews, inventory, accounts, books];
+const serviceDefinitions = services.map((s, i) => ({
+  name: s.name,
+  typeDefs: s.typeDefs,
+  url: `http://localhost:${i}`,
+}));
+
+describe('lifecycle hooks', () => {
+  it('uses updateServiceDefinitions override', async () => {
+    const experimental_updateServiceDefinitions = jest.fn(
+      async (config: GatewayConfig) => {
+        return serviceDefinitions;
+      },
+    );
+
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions,
+      experimental_updateServiceDefinitions,
+      experimental_didUpdateComputedFederationConfig: jest.fn(),
+    });
+
+    const { interval } = await gateway.load();
+
+    expect(experimental_updateServiceDefinitions).toBeCalled();
+    clearInterval(interval);
+  });
+
+  it('calls experimental_didFailComposition with a bad config', async () => {
+    // const experimental_updateServiceDefinitions = () => [];
+    const update = jest.fn(async (config: GatewayConfig) => {
+      return [serviceDefinitions[0]];
+    });
+
+    const experimental_didFailComposition = jest.fn();
+
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions,
+      experimental_updateServiceDefinitions: update,
+      experimental_didFailComposition,
+    });
+
+    const { interval } = await gateway.load();
+
+    const callbackArgs = experimental_didFailComposition.mock.calls[0][0];
+
+    expect(callbackArgs.serviceList).toHaveLength(1);
+    expect(callbackArgs.errors).toMatchInlineSnapshot(`
+                        Array [
+                          [GraphQLError: [product] Book -> \`Book\` is an extension type, but \`Book\` is not defined in any service],
+                        ]
+                `);
+    clearInterval(interval);
+  });
+
+  it('calls experimental_didUpdateComposition on schema update', async done => {
+    const update = jest.fn();
+    update.mockImplementationOnce(async (config: GatewayConfig) => {
+      return serviceDefinitions;
+    });
+    update.mockImplementationOnce(async (config: GatewayConfig) => {
+      // remove first item and use rest
+      const services = serviceDefinitions.filter(s => s.name !== 'books');
+      // overwrite books service with a similar 'book' service
+      return [
+        ...services,
+        {
+          name: 'book',
+          typeDefs: books.typeDefs,
+          url: 'http://localhost:32542',
+        },
+      ];
+    });
+
+    const experimental_didUpdateComposition = jest.fn();
+
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions,
+      experimental_updateServiceDefinitions: update,
+      experimental_pollInterval: 10,
+      experimental_didUpdateComposition,
+    });
+
+    const { interval } = await gateway.load();
+
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    const {
+      calls: [firstCall, secondCall],
+    } = experimental_didUpdateComposition.mock;
+
+    expect(experimental_didUpdateComposition).toHaveBeenCalledTimes(2);
+
+    // first call's `current` arg should have a schema
+    expect(firstCall[0].schema).toBeDefined();
+    expect(firstCall[1]).toBeUndefined();
+
+    expect(secondCall[0].schema).toBeDefined();
+    // second call should have a previous schema
+    expect(secondCall[1].schema).toBeDefined();
+
+    clearInterval(interval);
+
+    done();
+  });
+
+  it('uses default service definition updater', async () => {
+    const gateway = new ApolloGateway({
+      localServiceList: serviceDefinitions,
+    });
+
+    const spy = jest.spyOn(gateway, 'updateServiceDefinitions');
+
+    const { interval } = await gateway.load();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when polling on the default fetcher', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
+    const gateway = new ApolloGateway({
+      serviceList: serviceDefinitions,
+      experimental_pollInterval: 10,
+    });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. Use with caution.",
+      ]
+    `);
+  });
+
+  it('warns when polling using a custom serviceList fetcher', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
+    const gateway = new ApolloGateway({
+      experimental_updateServiceDefinitions: jest.fn(),
+      experimental_pollInterval: 10,
+    });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. Use with caution.",
+      ]
+    `);
+  });
+});

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -166,18 +166,4 @@ describe('lifecycle hooks', () => {
                 `);
     consoleSpy.mockRestore();
   });
-
-  it('warns when polling using a custom serviceList fetcher', async () => {
-    const consoleSpy = jest.spyOn(console, 'warn');
-    new ApolloGateway({
-      experimental_updateServiceDefinitions: jest.fn(),
-      experimental_pollInterval: 10,
-    });
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
-                        Array [
-                          "Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. If you are polling running services, use with caution.",
-                        ]
-                `);
-  });
 });

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -29,6 +29,7 @@ describe('lifecycle hooks', () => {
     await gateway.load();
 
     expect(experimental_updateServiceDefinitions).toBeCalled();
+    expect(gateway.schema.getType('Furniture')).toBeDefined();
   });
 
   it('calls experimental_didFailComposition with a bad config', async done => {
@@ -88,10 +89,12 @@ describe('lifecycle hooks', () => {
       experimental_didUpdateComposition,
     });
 
-    const { interval } = await gateway.load();
-    await new Promise(resolve => setTimeout(resolve, 20));
+    jest.useFakeTimers();
+    await gateway.load();
+    await jest.advanceTimersByTime(15);
 
-    clearInterval(interval);
+    expect(update).toBeCalledTimes(2);
+
     const {
       calls: [firstCall, secondCall],
     } = experimental_didUpdateComposition.mock;

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -90,7 +90,7 @@ describe('lifecycle hooks', () => {
     });
 
     await gateway.load();
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await new Promise(resolve => setTimeout(resolve, 19));
 
     expect(update).toBeCalledTimes(2);
 

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -44,7 +44,7 @@ describe('lifecycle hooks', () => {
       async experimental_updateServiceDefinitions(_config: GatewayConfig) {
         return {
           serviceDefinitions: [serviceDefinitions[0]],
-          compositionInfo: {
+          compositionMetadata: {
             formatVersion: 1,
             id: 'abc',
             implementingServiceLocations: [],
@@ -65,7 +65,7 @@ describe('lifecycle hooks', () => {
     expect(callbackArgs.errors[0]).toMatchInlineSnapshot(
       `[GraphQLError: [product] Book -> \`Book\` is an extension type, but \`Book\` is not defined in any service]`,
     );
-    expect(callbackArgs.compositionInfo.id).toEqual('abc');
+    expect(callbackArgs.compositionMetadata.id).toEqual('abc');
     expect(experimental_didFailComposition).toBeCalled();
     done();
   });
@@ -73,7 +73,7 @@ describe('lifecycle hooks', () => {
   it('calls experimental_didUpdateComposition on schema update', async () => {
     jest.useFakeTimers();
 
-    const compositionInfo = {
+    const compositionMetadata = {
       formatVersion: 1,
       id: 'abc',
       implementingServiceLocations: [],
@@ -85,8 +85,8 @@ describe('lifecycle hooks', () => {
     ) => ({
       serviceDefinitions,
       isNewSchema: true,
-      compositionInfo: {
-        ...compositionInfo,
+      compositionMetadata: {
+        ...compositionMetadata,
         id: '123',
         schemaHash: 'hash2',
       },
@@ -109,7 +109,7 @@ describe('lifecycle hooks', () => {
           },
         ],
         isNewSchema: true,
-        compositionInfo,
+        compositionMetadata,
       };
     });
 
@@ -138,15 +138,15 @@ describe('lifecycle hooks', () => {
     const [firstCall, secondCall] = mockDidUpdate.mock.calls;
 
     expect(firstCall[0]!.schema).toBeDefined();
-    expect(firstCall[0].compositionInfo!.schemaHash).toEqual('hash1');
+    expect(firstCall[0].compositionMetadata!.schemaHash).toEqual('hash1');
     // first call should have no second "previous" argument
     expect(firstCall[1]).toBeUndefined();
 
     expect(secondCall[0].schema).toBeDefined();
-    expect(secondCall[0].compositionInfo!.schemaHash).toEqual('hash2');
+    expect(secondCall[0].compositionMetadata!.schemaHash).toEqual('hash2');
     // second call should have previous info in the second arg
     expect(secondCall[1]!.schema).toBeDefined();
-    expect(secondCall[1]!.compositionInfo!.schemaHash).toEqual('hash1');
+    expect(secondCall[1]!.compositionMetadata!.schemaHash).toEqual('hash1');
 
     jest.useRealTimers();
   });

--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -95,7 +95,8 @@ describe('lifecycle hooks', () => {
     // This is the simplest way I could find to achieve mocked functions that leverage our types
     const mockUpdate = jest.fn(update);
 
-    // We want to return a different composition across two ticks,
+    // We want to return a different composition across two ticks, so we mock it
+    // slightly differenty
     mockUpdate.mockImplementationOnce(async (_config: GatewayConfig) => {
       const services = serviceDefinitions.filter(s => s.name !== 'books');
       return {
@@ -127,8 +128,8 @@ describe('lifecycle hooks', () => {
     expect(mockDidUpdate).toBeCalledTimes(1);
 
     jest.runOnlyPendingTimers();
-    // XXX This allows the ApolloGateway.loader() Promise to resolve after the poll ticks,
-    // and is necessary for allowing mockDidUpdate to see the expected calls.
+    // XXX This allows the ApolloGateway.updateComposition() Promise to resolve
+    // after the poll ticks, and is necessary for allowing mockDidUpdate to see the expected calls.
     await Promise.resolve();
 
     expect(mockUpdate).toBeCalledTimes(2);
@@ -171,11 +172,9 @@ describe('lifecycle hooks', () => {
       experimental_pollInterval: 10,
     });
     expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
-      Array [
-        "Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. If you are polling running services, use with caution.",
-      ]
-    `);
+    expect(consoleSpy.mock.calls[0][0]).toMatch(
+      'Polling running services is dangerous and not recommended in production. Polling should only be used against a registry. If you are polling running services, use with caution.',
+    );
     consoleSpy.mockRestore();
   });
 });

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -18,6 +18,7 @@ afterEach(() => {
   expect(nock.isDone()).toBeTruthy();
   nock.cleanAll();
   nock.restore();
+  jest.useRealTimers();
 });
 
 it('Queries remote endpoints for their SDLs', async () => {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -82,7 +82,7 @@ function isRemoteConfig(config: GatewayConfig): config is RemoteGatewayConfig {
 function isManagedConfig(
   config: GatewayConfig,
 ): config is ManagedGatewayConfig {
-  return 'federationVersion' in config;
+  return !isRemoteConfig(config) && !isLocalConfig(config);
 }
 
 type DidResolveQueryPlanCallback = ({

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -82,7 +82,7 @@ function isRemoteConfig(config: GatewayConfig): config is RemoteGatewayConfig {
 function isManagedConfig(
   config: GatewayConfig,
 ): config is ManagedGatewayConfig {
-  return !isRemoteConfig(config) && !isLocalConfig(config);
+  return 'federationVersion' in config;
 }
 
 type DidResolveQueryPlanCallback = ({

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -128,13 +128,19 @@ export class ApolloGateway implements GraphQLService {
   private onSchemaChangeListeners = new Set<SchemaChangeCallback>();
   private serviceDefinitions: ServiceDefinition[] = [];
 
-  // Observe query plan, service info, and operation info prior to execution. The information made available here will give insight into the resulting query plan and the inputs that generated it.
+  // Observe query plan, service info, and operation info prior to execution.
+  // The information made available here will give insight into the resulting
+  // query plan and the inputs that generated it.
   protected experimental_didResolveQueryPlan?: DidResolveQueryPlanCallback;
-  // Observe composition failures and the ServiceList that caused them. This enables reporting any issues that occur during composition. Implementors will be interested in addressing these immediately.
+  // Observe composition failures and the ServiceList that caused them. This
+  // enables reporting any issues that occur during composition. Implementors
+  // will be interested in addressing these immediately.
   protected experimental_didFailComposition?: DidFailCompositionCallback;
-  // Used to communicated composition changes, and what definitions caused those updates
+  // Used to communicated composition changes, and what definitions caused
+  // those updates
   protected experimental_didUpdateComposition?: DidUpdateCompositionCallback;
-  // Used for overriding the default service list fetcher. This should return an array of ServiceDefinition. *This function must be awaited.*
+  // Used for overriding the default service list fetcher. This should return
+  // an array of ServiceDefinition. *This function must be awaited.*
   protected updateServiceDefinitions: UpdateServiceDefinitions;
   // how often service defs should be loaded/updated (in ms)
   protected experimental_pollInterval?: number;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -203,18 +203,13 @@ export class ApolloGateway implements GraphQLService {
         config.experimental_didUpdateComposition;
       this.experimental_pollInterval = config.experimental_pollInterval;
 
-      // ie if they have a pollinterval and a custom loader or a serviceList
-      if (config.experimental_pollInterval) {
-        if (
-          config.experimental_updateServiceDefinitions ||
-          (config as RemoteGatewayConfig).serviceList
-        ) {
-          console.warn(
-            'Polling running services is dangerous and not recommended in production. ' +
-              'Polling should only be used against a registry. ' +
-              'If you are polling running services, use with caution.',
-          );
-        }
+      // Warn against using the pollInterval and a serviceList simulatenously
+      if (config.experimental_pollInterval && isRemoteConfig(config)) {
+        console.warn(
+          'Polling running services is dangerous and not recommended in production. ' +
+            'Polling should only be used against a registry. ' +
+            'If you are polling running services, use with caution.',
+        );
       }
     }
   }

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -224,7 +224,8 @@ export class ApolloGateway implements GraphQLService {
     }
 
     return {
-      // we know this will be here since we're awaiting loader before here which sets this.schema
+      // we know this will be here since we're awaiting this.updateComposition
+      // before here which sets this.schema
       schema: this.schema!,
       executor: this.executor,
     };

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -114,7 +114,7 @@ interface CompositionInfo {
   compositionInfo?: CompositionMetadata;
 }
 
-type DidUpdateCompositionCallback = (
+export type DidUpdateCompositionCallback = (
   currentConfig: CompositionInfo,
   previousConfig?: CompositionInfo,
 ) => void;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -101,17 +101,17 @@ type DidResolveQueryPlanCallback = ({
 type DidFailCompositionCallback = ({
   errors,
   serviceList,
-  compositionInfo,
+  compositionMetadata,
 }: {
   readonly errors: GraphQLError[];
   readonly serviceList: ServiceDefinition[];
-  readonly compositionInfo?: CompositionMetadata;
+  readonly compositionMetadata?: CompositionMetadata;
 }) => void;
 
 interface CompositionInfo {
   serviceDefinitions: ServiceDefinition[];
   schema: GraphQLSchema;
-  compositionInfo?: CompositionMetadata;
+  compositionMetadata?: CompositionMetadata;
 }
 
 export type DidUpdateCompositionCallback = (
@@ -124,7 +124,7 @@ export type UpdateServiceDefinitions = (
 ) => Promise<
   | {
       serviceDefinitions: ServiceDefinition[];
-      compositionInfo?: CompositionMetadata;
+      compositionMetadata?: CompositionMetadata;
       isNewSchema: true;
     }
   | { isNewSchema: false }
@@ -142,7 +142,7 @@ export class ApolloGateway implements GraphQLService {
   private pollingTimer?: NodeJS.Timer;
   private onSchemaChangeListeners = new Set<SchemaChangeCallback>();
   private serviceDefinitions: ServiceDefinition[] = [];
-  private compositionInfo?: CompositionMetadata;
+  private compositionMetadata?: CompositionMetadata;
 
   // Observe query plan, service info, and operation info prior to execution.
   // The information made available here will give insight into the resulting
@@ -236,7 +236,7 @@ export class ApolloGateway implements GraphQLService {
   }) {
     const previousSchema = this.schema;
     const previousServiceDefinitions = this.serviceDefinitions;
-    const previousCompositionInfo = this.compositionInfo;
+    const previousCompositionMetadata = this.compositionMetadata;
 
     if (options && options.engine) {
       if (!options.engine.graphVariant)
@@ -260,7 +260,7 @@ export class ApolloGateway implements GraphQLService {
       this.serviceDefinitions = result.serviceDefinitions;
     }
 
-    this.compositionInfo = result.compositionInfo;
+    this.compositionMetadata = result.compositionMetadata;
     this.schema = this.createSchema(result.serviceDefinitions);
 
     if (this.experimental_didUpdateComposition) {
@@ -268,16 +268,16 @@ export class ApolloGateway implements GraphQLService {
         {
           serviceDefinitions: result.serviceDefinitions,
           schema: this.schema,
-          ...(this.compositionInfo && {
-            compositionInfo: this.compositionInfo,
+          ...(this.compositionMetadata && {
+            compositionMetadata: this.compositionMetadata,
           }),
         },
         previousServiceDefinitions &&
           previousSchema && {
             serviceDefinitions: previousServiceDefinitions,
             schema: previousSchema,
-            ...(previousCompositionInfo && {
-              compositionInfo: previousCompositionInfo,
+            ...(previousCompositionMetadata && {
+              compositionMetadata: previousCompositionMetadata,
             }),
           },
       );
@@ -298,8 +298,8 @@ export class ApolloGateway implements GraphQLService {
         this.experimental_didFailComposition({
           errors,
           serviceList,
-          ...(this.compositionInfo && {
-            compositionInfo: this.compositionInfo,
+          ...(this.compositionMetadata && {
+            compositionMetadata: this.compositionMetadata,
           }),
         });
       }

--- a/packages/apollo-gateway/src/loadServicesFromStorage.ts
+++ b/packages/apollo-gateway/src/loadServicesFromStorage.ts
@@ -95,10 +95,12 @@ export async function getServiceDefinitionsFromStorage({
     `${urlPartialSchemaBase}/${parsedLink.configPath}`,
   );
 
-  const compositionInfo = JSON.parse(configFileResult) as CompositionMetadata;
+  const compositionMetadata = JSON.parse(
+    configFileResult,
+  ) as CompositionMetadata;
 
   const serviceDefinitions = await fetchServiceDefinitions(
-    compositionInfo.implementingServiceLocations,
+    compositionMetadata.implementingServiceLocations,
   );
 
   // explicity return that this is a new schema, as the link file has changed.
@@ -107,7 +109,7 @@ export async function getServiceDefinitionsFromStorage({
   // (for instance if a partial schema is removed or a partial schema is rolled back to a prior version, which is still in cache)
   return {
     serviceDefinitions,
-    compositionInfo,
+    compositionMetadata,
     isNewSchema: true,
   };
 }

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -70,6 +70,7 @@ export type SchemaChangeCallback = (schema: GraphQLSchema) => void;
 export type GraphQLServiceConfig = {
   schema: GraphQLSchema;
   executor: GraphQLExecutor;
+  interval?: NodeJS.Timer;
 };
 
 /**

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -70,7 +70,6 @@ export type SchemaChangeCallback = (schema: GraphQLSchema) => void;
 export type GraphQLServiceConfig = {
   schema: GraphQLSchema;
   executor: GraphQLExecutor;
-  interval?: NodeJS.Timer;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR aims to add experimental observability functions to `@apollo/gateway` and add the ability to poll/overwrite service fetching logic. These abilities are not intended for production usage, as they are still experimental and APIs may change in future versions.

The following functions can all be used as additions to the `ApolloGateway` constructor.

## Additions

- `experimental_pollInterval`
  - used to add polling to any service definition lookup. This can be used with the default lookup logic or with a custom service definition lookup function, defined below.
  - it is NOT recommended to use this interval when fetching sdl from a running endpoint. 

- `experimental_updateServiceDefinitions`
  - This allows users to provide their own means of preparing the information necessary to run the gateway. It’s agnostic as to where or how the list is built (i.e. from filesystem, network request(s), etc).
  - Note: this function will warn if used in conjunction with `experimental_pollInterval`, since it could be used to poll a running service.

```
async experimental_updateServiceDefinitions (
  config: GatewayConfig
):PromiseOrValue<ServiceDefinition[]>
```

- `experimental_didUpdateComposition`
  - Used to communicated composition changes, and what definitions caused those updates.

```
interface CompositionInfo {
  serviceDefinitions: ServiceDefinition[];
  schema: GraphQLSchema;
}

type DidUpdateCompositionCallback = (
  currentConfig: CompositionInfo,
  previousConfig?: CompositionInfo,
) => void;

experimental_didUpdateComposition: DidUpdateCompositionCallback;
```

- `experimental_didFailComposition`
  - Observe composition failures and the ServiceDefinition[] that caused them. Pretty straightforward, this enables reporting any issues that occur during composition. Implementors will be interested in addressing these immediately.

```
experimental_didFailComposition({
  errors: GraphQLError[],
  serviceDefinitions: ServiceDefinition[],
}): void
```

- `experimental_didResolveQueryPlan`
  - Observe query plan, service info, and operation info prior to execution. The information made available here will give insight into the resulting query plan and the inputs that generated it.

```
experimental_didResolveQueryPlan({
  queryPlan: QueryPlan;
  serviceMap: ServiceMap;
  operationContext: OperationContext,
}): void
```

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->