### PR TITLE
Allow federated schema polling for non-managed gateways

### DIFF
--- a/packages/apollo-gateway/src/__tests__/gateway/pollForSchemaChanges.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/pollForSchemaChanges.test.ts
@@ -1,18 +1,18 @@
 jest.mock('node-fetch');
-import fetch, {Response} from 'node-fetch';
+import fetch, { Response } from 'node-fetch';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 
 import { ApolloGateway } from '../../';
 
 beforeEach(() => {
-  jest.mock('node-fetch', ()=>jest.fn())
+  jest.mock('node-fetch', () => jest.fn());
 });
 
 it('checks for changes to a federated schema on a default polling schedule', async () => {
-  jest.useFakeTimers()
+  jest.useFakeTimers();
 
   const gateway = new ApolloGateway({
-    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo'}],
+    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo' }],
     pollForSchemaChanges: true,
   });
 
@@ -23,8 +23,10 @@ it('checks for changes to a federated schema on a default polling schedule', asy
     type Query {
       foo: String
     }
-  `
-  fetch.mockReturnValue(Promise.resolve({ json: () => ({ data: { _service: { sdl } } }) }));
+  `;
+  fetch.mockReturnValue(
+    Promise.resolve({ json: () => ({ data: { _service: { sdl } } }) }),
+  );
 
   await gateway.load();
 
@@ -43,15 +45,17 @@ it('checks for changes to a federated schema on a default polling schedule', asy
 });
 
 it('allows for a custom polling schedule', async () => {
-  jest.useFakeTimers()
+  jest.useFakeTimers();
 
   const gateway = new ApolloGateway({
-    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo'}],
+    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo' }],
     pollForSchemaChanges: true,
-    schemaChangePollingPeriod: 600 * 1000
+    schemaChangePollingPeriod: 600 * 1000,
   });
 
   expect(setInterval).toHaveBeenCalledTimes(1);
-  expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 600 * 1000);
+  expect(setInterval).toHaveBeenLastCalledWith(
+    expect.any(Function),
+    600 * 1000,
+  );
 });
-

--- a/packages/apollo-gateway/src/__tests__/gateway/pollForSchemaChanges.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/pollForSchemaChanges.test.ts
@@ -1,0 +1,57 @@
+jest.mock('node-fetch');
+import fetch, {Response} from 'node-fetch';
+import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
+
+import { ApolloGateway } from '../../';
+
+beforeEach(() => {
+  jest.mock('node-fetch', ()=>jest.fn())
+});
+
+it('checks for changes to a federated schema on a default polling schedule', async () => {
+  jest.useFakeTimers()
+
+  const gateway = new ApolloGateway({
+    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo'}],
+    pollForSchemaChanges: true,
+  });
+
+  expect(setInterval).toHaveBeenCalledTimes(1);
+  expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 10 * 1000);
+
+  const sdl = `
+    type Query {
+      foo: String
+    }
+  `
+  fetch.mockReturnValue(Promise.resolve({ json: () => ({ data: { _service: { sdl } } }) }));
+
+  await gateway.load();
+
+  expect(fetch).toBeCalledTimes(1);
+
+  jest.advanceTimersByTime(31 * 1000);
+
+  expect(fetch).toBeCalledTimes(4);
+  expect(fetch).toHaveBeenCalledWith('https://api.example.com/foo', {
+    method: 'POST',
+    body: '{"query":"query GetServiceDefinition { _service { sdl } }"}',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+});
+
+it('allows for a custom polling schedule', async () => {
+  jest.useFakeTimers()
+
+  const gateway = new ApolloGateway({
+    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo'}],
+    pollForSchemaChanges: true,
+    schemaChangePollingPeriod: 600 * 1000
+  });
+
+  expect(setInterval).toHaveBeenCalledTimes(1);
+  expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 600 * 1000);
+});
+


### PR DESCRIPTION
Currently the option to poll for schema changes is restricted to managed schemas. This functionality would also be very useful for unmanaged schemas as well. There does not seem to be any technical reason why you would not be able to poll for schema changes in any configuration so this PR removes that restriction. It also gives the ability to turn polling and set the polling schedule during creation.

It solves this issue: #3082