### PR TITLE
[Federation] Handle `null` @requires selections correctly during execution

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Proxy errors from downstream services [#3019](https://github.com/apollographql/apollo-server/pull/3019)
 * Handle schema defaultVariables correctly within downstream fetches [#2963](https://github.com/apollographql/apollo-server/pull/2963)
+* Handle `null` @requires selections correctly during execution [#3138](https://github.com/apollographql/apollo-server/pull/3138)
 
 # v0.6.12
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
@@ -26,7 +26,7 @@ export const typeDefs = gql`
     isbn: String!
     title: String
     year: Int
-    similarBooks: [Book!]!
+    similarBooks: [Book]!
   }
 `;
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
@@ -44,7 +44,7 @@ export const typeDefs = gql`
   extend type Book implements Product @key(fields: "isbn") {
     isbn: String! @external
     reviews: [Review]
-    similarBooks: [Book!]! @external
+    similarBooks: [Book]! @external
     relatedReviews: [Review!]! @requires(fields: "similarBooks { isbn }")
   }
 

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -521,4 +521,38 @@ describe('executeQueryPlan', () => {
                         }
                 `);
   });
+
+  it('can execute queries with selections on null @requires fields', async () => {
+    const query = gql`
+      query {
+        book(isbn: "0987654321") {
+          # Requires similarBooks { isbn }
+          relatedReviews {
+            id
+            body
+          }
+        }
+      }
+    `;
+
+    const operationContext = buildOperationContext(schema, query);
+    const queryPlan = buildQueryPlan(operationContext);
+
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
+
+    expect(response.errors).toBeUndefined();
+
+    expect(response.data).toMatchInlineSnapshot(`
+      Object {
+        "book": Object {
+          "relatedReviews": Array [],
+        },
+      }
+    `);
+  });
 });

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -505,21 +505,21 @@ describe('executeQueryPlan', () => {
     expect(response.errors).toMatchInlineSnapshot(`undefined`);
 
     expect(response.data).toMatchInlineSnapshot(`
-                        Object {
-                          "book": Object {
-                            "relatedReviews": Array [
-                              Object {
-                                "body": "A classic.",
-                                "id": "6",
-                              },
-                              Object {
-                                "body": "A bit outdated.",
-                                "id": "5",
-                              },
-                            ],
-                          },
-                        }
-                `);
+      Object {
+        "book": Object {
+          "relatedReviews": Array [
+            Object {
+              "body": "A classic.",
+              "id": "6",
+            },
+            Object {
+              "body": "A bit outdated.",
+              "id": "5",
+            },
+          ],
+        },
+      }
+    `);
   });
 
   it('can execute queries with selections on null @requires fields', async () => {

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -395,6 +395,7 @@ function executeSelectionSet(
         // Null is a valid value for a response, provided that the types match.
         // Presumably the underlying service has validated that result, so we
         // can pass it through here
+        // Note: undefined is unexpected here due to GraphQL's type coercion / nullability rules
         if (source === null) {
           result[responseName] = null;
           break;

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -381,7 +381,7 @@ async function executeFetch<TContext>(
  * @param selectionSet
  */
 function executeSelectionSet(
-  source: Record<string, any>,
+  source: Record<string, any> | null,
   selectionSet: SelectionSetNode,
 ): Record<string, any> {
   const result: Record<string, any> = Object.create(null);
@@ -395,6 +395,10 @@ function executeSelectionSet(
         // Null is a valid value for a response, provided that the types match.
         // Presumably the underlying service has validated that result, so we
         // can pass it through here
+        if (source === null) {
+          result[responseName] = null;
+          break;
+        }
         if (typeof source[responseName] === 'undefined') {
           throw new Error(`Field "${responseName}" was not found in response.`);
         }


### PR DESCRIPTION
This is a follow-up / additional fix to PR #2928.

This resolves an oversight (of my own) in handling the case where source is null.

1) The `source` parameter was typed incorrectly (missing `| null`)
2) We tried to access a key on source in various locations within that code
   path that resulted in a runtime error when `source === null`

This PR also adds a test case in order to exercise the new `source === null` code path.