### PR TITLE
Fix stack trace when using apollo-server-testing

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -83,6 +83,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
 
   extensions?: Array<() => GraphQLExtension>;
   tracing?: boolean;
+  debug?: boolean;
   persistedQueries?: PersistedQueryOptions;
   cacheControl?: CacheControlExtensionOptions;
 
@@ -535,7 +536,7 @@ export async function processGraphQLRequest<TContext>(
   ): ReadonlyArray<GraphQLFormattedError> {
     return formatApolloErrors(errors, {
       formatter: config.formatError,
-      debug: requestContext.debug,
+      debug: requestContext.debug != null ? requestContext.debug : config.debug,
     });
   }
 


### PR DESCRIPTION
Using apollo-server-testing, I'm running into an issue where an error thrown in a resolver function while executing a query provides no stack trace. My test code that call's `apollo-server-testing`'s `query()` gets a response with `response.errors` present, but there is no stack trace in the response. Additionally, my ApolloServer's `formatError()` function gets called, but `error.extensions.exception.stacktrace` is not present.

I'm using apollo-server-testing v2.8.1 (latest as of writing).

## Reproducible example

This example demonstrates the current problem. Save the following as `test.js`:

<details>

```js
const { ApolloServer, gql } = require('apollo-server-express');
const { createTestClient } = require('apollo-server-testing');

const server = new ApolloServer({
  debug: true,
  typeDefs: gql`
    type Query {
      test: String
    }
  `,
  resolvers: {
    Query: {
      test: () => {
        throw new Error('Some error');
      },
    },
  },
  formatError: error => {
    console.log(`Apollo Server error: ${error.message}`);
    console.log(error);
    if (error.extensions.exception) {
      console.log(error.extensions.exception.stacktrace);
    }
  },
});


const main = async () => {
  const { query } = createTestClient(server);
  const result = await query({
    query: gql`
      {
        test
      }
    `,
  });
  console.log('result', result);
}

main();
```

</details>

Then run:

```
$ npm i apollo-server-express apollo-server-testing graphql
$ node test.js
```

### Expected behavior

If a resolver throws an error, I expect my `formatError()` function to be called with `error.extensions.exception.stacktrace` present.

### Actual behavior

`error.extensions.exception.stacktrace` is not present. Program output:

<details>

```
$ node test.js
Apollo Server error: Some error
error { [GraphQLError: Some error]
  message: 'Some error',
  locations: [ { line: 2, column: 3 } ],
  path: [ 'test' ],
  extensions: { code: 'INTERNAL_SERVER_ERROR' } }
result { http:
   { headers: Headers { [Symbol(map)]: [Object: null prototype] {} } },
  errors: [ undefined ],
  data: [Object: null prototype] { test: null },
  extensions: undefined }
```

</details>

### Actual behavior when fixed

And here's the behavior I get after I apply one of the fixes I describe below:

<details>

```
$ node test.js
Apollo Server error: Some error
error { [GraphQLError: Some error]
  message: 'Some error',
  locations: [ { line: 2, column: 3 } ],
  path: [ 'test' ],
  extensions:
   { code: 'INTERNAL_SERVER_ERROR',
     exception: { stacktrace: [Array] } } }
[ 'Error: Some error',
  '    at test (/private/tmp/apollo-testing-stacktrace-test/test.js:14:15)',
  '    at field.resolve (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql-extensions/dist/index.js:133:26)',
  '    at resolveFieldValueOrError (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql/execution/execute.js:503:18)',
  '    at resolveField (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql/execution/execute.js:470:16)',
  '    at executeFields (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql/execution/execute.js:311:18)',
  '    at executeOperation (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql/execution/execute.js:255:122)',
  '    at executeImpl (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql/execution/execute.js:102:14)',
  '    at Object.execute (/private/tmp/apollo-testing-stacktrace-test/node_modules/graphql/execution/execute.js:62:35)',
  '    at /private/tmp/apollo-testing-stacktrace-test/node_modules/apollo-server-core/dist/requestPipeline.js:239:46',
  '    at Generator.next (<anonymous>)' ]
result { http:
   { headers: Headers { [Symbol(map)]: [Object: null prototype] {} } },
  errors: [ undefined ],
  data: [Object: null prototype] { test: null },
  extensions: undefined }
```

</details>

## What I'm trying to accomplish

My schema test code uses this approach to execute queries against the schema during tests. If there's a programming error in a resolver that results in an error being thrown, I want the developer running tests to see the resolver error and its stack trace.

I'm wondering if, aside from this issue, logging `error.extensions.exception.stacktrace` in `formatError()` the best approach to accomplish this in the first place?


## What I've found so far

<details>

The reason `extensions.exception.stacktrace` gets omitted is because `requestContext.debug` if falsy here: https://github.com/apollographql/apollo-server/blob/d5015f4ea00cadb2a74b09956344e6f65c084629/packages/apollo-server-core/src/requestPipeline.ts#L533-L536

However, `config.debug` is in the same scope `true`.

The call site that's passing `requestContext` into that scope does not pass `debug` at all: https://github.com/apollographql/apollo-server/blob/d5015f4ea00cadb2a74b09956344e6f65c084629/packages/apollo-server-core/src/ApolloServer.ts#L769-L780

I'm not sure what would be setting `requestContext.debug` or why the function looks there, I'd expect `debug` to be present in the server `config` object, not `requestContext`.

</details>

## Potential solutions

I came across two straightforward ways to fix this:

<details>

### 1) Read from `config.debug`

Change the following line: https://github.com/apollographql/apollo-server/blob/d5015f4ea00cadb2a74b09956344e6f65c084629/packages/apollo-server-core/src/requestPipeline.ts#L535

To:

```patch
- debug: requestContext.debug,
+ debug: requestContext.debug != null ? requestContext.debug : config.debug,
```

### 2) Pass `requestContext.debug`

Alternatively, pass `debug` from the call site that creates `requestContext`: https://github.com/apollographql/apollo-server/blob/d5015f4ea00cadb2a74b09956344e6f65c084629/packages/apollo-server-core/src/ApolloServer.ts#L780

```patch
  const requestCtx: GraphQLRequestContext = {
    request,
    context: options.context || Object.create(null),
    cache: options.cache!,
    response: {
      http: {
        headers: new Headers(),
      },
    },
+   debug: options.debug,
  };

  return processGraphQLRequest(options, requestCtx);
```

</details>

## This PR

This PR applies the first fix described above. I'm looking for:

* Feedback on the fix
* Feedback on whether logging `error.extensions.exception.stacktrace` in `formatError()` the best approach to get stack traces in the first place