### PR TITLE
Add the context parameter to the `didEncounterErrors` handler

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -236,7 +236,7 @@ export async function processGraphQLRequest<TContext>(
         parsingDidEnd();
       } catch (syntaxError) {
         parsingDidEnd(syntaxError);
-        await didEncounterErrors(syntaxError, requestContext.context)
+        await didEncounterErrors(syntaxError, requestContext.context);
         return await sendErrorResponse(syntaxError, SyntaxError);
       }
 
@@ -254,7 +254,7 @@ export async function processGraphQLRequest<TContext>(
         validationDidEnd();
       } else {
         validationDidEnd(validationErrors);
-        await didEncounterErrors(validationErrors, requestContext.context)
+        await didEncounterErrors(validationErrors, requestContext.context);
         return await sendErrorResponse(validationErrors, ValidationError);
       }
 
@@ -314,7 +314,7 @@ export async function processGraphQLRequest<TContext>(
       if (err instanceof HttpQueryError) {
         throw err;
       }
-      await didEncounterErrors(err, requestContext.context)
+      await didEncounterErrors(err, requestContext.context);
       return await sendErrorResponse(err);
     }
 
@@ -362,7 +362,7 @@ export async function processGraphQLRequest<TContext>(
         executionDidEnd();
       } catch (executionError) {
         executionDidEnd(executionError);
-        await didEncounterErrors(executionError, requestContext.context)
+        await didEncounterErrors(executionError, requestContext.context);
         return await sendErrorResponse(executionError);
       }
     }
@@ -498,9 +498,9 @@ export async function processGraphQLRequest<TContext>(
 
   async function didEncounterErrors(
     errorOrErrors: ReadonlyArray<GraphQLError> | GraphQLError,
-    context: TContext
+    context: TContext,
   ) {
-    const errors = ensureErrorArray(errorOrErrors)
+    const errors = ensureErrorArray(errorOrErrors);
     requestContext.errors = errors;
     extensionStack.didEncounterErrors(errors, context);
 
@@ -518,7 +518,7 @@ export async function processGraphQLRequest<TContext>(
     errorClass?: typeof ApolloError,
   ) {
     // If a single error is passed, it should still be encapsulated in an array.
-    const errors = ensureErrorArray(errorOrErrors)
+    const errors = ensureErrorArray(errorOrErrors);
 
     return sendResponse({
       errors: formatErrors(
@@ -544,11 +544,9 @@ export async function processGraphQLRequest<TContext>(
   }
 
   function ensureErrorArray(
-    errorOrErrors: ReadonlyArray<GraphQLError> | GraphQLError
+    errorOrErrors: ReadonlyArray<GraphQLError> | GraphQLError,
   ): ReadonlyArray<GraphQLError> {
-    return Array.isArray(errorOrErrors)
-      ? errorOrErrors
-      : [errorOrErrors]
+    return Array.isArray(errorOrErrors) ? errorOrErrors : [errorOrErrors];
   }
 
   function initializeRequestListenerDispatcher(): Dispatcher<

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -46,7 +46,10 @@ export class GraphQLExtension<TContext = any> {
     executionArgs: ExecutionArgs;
   }): EndHandler | void;
 
-  public didEncounterErrors?(errors: ReadonlyArray<GraphQLError>): void;
+  public didEncounterErrors?(
+    errors: ReadonlyArray<GraphQLError>,
+    context: TContext
+  ): void;
 
   public willSendResponse?(o: {
     graphqlResponse: GraphQLResponse;
@@ -107,10 +110,13 @@ export class GraphQLExtensionStack<TContext = any> {
     );
   }
 
-  public didEncounterErrors(errors: ReadonlyArray<GraphQLError>) {
+  public didEncounterErrors(
+    errors: ReadonlyArray<GraphQLError>,
+    context: TContext
+  ) {
     this.extensions.forEach(extension => {
       if (extension.didEncounterErrors) {
-        extension.didEncounterErrors(errors);
+        extension.didEncounterErrors(errors, context);
       }
     });
   }

--- a/packages/graphql-extensions/src/index.ts
+++ b/packages/graphql-extensions/src/index.ts
@@ -48,7 +48,7 @@ export class GraphQLExtension<TContext = any> {
 
   public didEncounterErrors?(
     errors: ReadonlyArray<GraphQLError>,
-    context: TContext
+    context: TContext,
   ): void;
 
   public willSendResponse?(o: {
@@ -112,7 +112,7 @@ export class GraphQLExtensionStack<TContext = any> {
 
   public didEncounterErrors(
     errors: ReadonlyArray<GraphQLError>,
-    context: TContext
+    context: TContext,
   ) {
     this.extensions.forEach(extension => {
       if (extension.didEncounterErrors) {


### PR DESCRIPTION
This change enables us to use the current `Context` when handling errors via the `didEncounterErrors` handler.

Consider this scenario, where the `Context` is relevant to send the user information to an error reporting tool:

```typescript

class MyErrorHandler extends GraphQLExtension<Context> {

    didEncounterErrors(errors: ReadonlyArray<GraphQLError>, context: Context) {
        for (const error of errors) {
            if (isUnexpected(error)) {
                reportError(error, context.user)
            }
            // ...
        }
    }

}
```

Fixes #2702