### PR TITLE
Example for the rootValue field documentation was incorrect

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -61,10 +61,10 @@ new ApolloServer({
 new ApolloServer({
   typeDefs,
   resolvers,
-  rootValue: (documentAST) => ({
+  rootValue: (documentAST) => {
     const op = getOperationAST(documentNode)
     return op === 'mutation' ? mutationRoot : queryRoot;
-  })
+  }
 });
 ```
 


### PR DESCRIPTION
# Example code on the rootValue field was incorrect

The JavaScript example for the `rootValue` field was syntactically incorrect, the original example tried to return an object inside a closure (exactly how one would do so, if they were trying to return an object from an arrow function), like so:
```js
const server = new ApolloServer({
  typeDefs,
  resolvers,
  rootValue: (documentAST) => ({
    const op = getOperationAST(documentNode)
    return op === 'mutation' ? mutationRoot : queryRoot;
  }),
});
```
when in-fact the intent - as apparent from the code inside the `{}` - was to have said code inside the body of the arrow function. The correct syntax would be as follows:
```js
const server = new ApolloServer({
  typeDefs,
  resolvers,
  rootValue: (documentAST) => {
    const op = getOperationAST(documentNode)
    return op === 'mutation' ? mutationRoot : queryRoot;
  },
});
```
Removing the `()` around the `{}` solves the issue.

Thank you for considering my PR.