### PR TITLE
Removed broken link from Getting Started page

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -169,10 +169,6 @@ This application should be a great starting point for any GraphQL server, but th
 
 ## More information
 
-### GitHub Repository
-
-The code from the above examples can be accessed in our [getting started example repository](https://github.com/apollographql/graphql-server-example) on GitHub
-
 ### Online Playground
 
 It's also possible to play with this example on Glitch, by remixing the repository.


### PR DESCRIPTION
## Description

I just checked Getting Started page and noticed page contains link to repo that doesn't exist:

<img width="1152" alt="Screenshot 2019-08-18 at 11 17 40" src="https://user-images.githubusercontent.com/950216/63221992-1ad0bf80-c1aa-11e9-9bdb-160f460f7152.png">

This PR removed obsolete section but maybe it's better to update a link to existing repo.