### PR TITLE
Change instances of Engine to Graph Manager

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -98,7 +98,7 @@ new ApolloServer({
 
 * `tracing`, `cacheControl`: <`Boolean`>
 
-  If set to true, adds tracing or cacheControl meta data to the GraphQL response. This is primarily intended for use with the deprecated Engine proxy.  `cacheControl` can also be set to an object to specify arguments to the `apollo-cache-control` package, including `defaultMaxAge`, `calculateHttpHeaders`, and `stripFormattedExtensions`.
+  If set to `true`, adds tracing or cacheControl metadata to the GraphQL response. This is primarily intended for use with the deprecated Engine proxy.  `cacheControl` can also be set to an object to specify arguments to the `apollo-cache-control` package, including `defaultMaxAge`, `calculateHttpHeaders`, and `stripFormattedExtensions`.
 
 * `formatError`, `formatResponse`: <`Function`>
 
@@ -119,7 +119,7 @@ new ApolloServer({
 
 * `engine`: <`EngineReportingOptions`> | boolean
 
-  Provided the `ENGINE_API_KEY` environment variable is set, the engine reporting agent will be started automatically. The API key can also be provided as the `apiKey` field in an object passed as the `engine` field. See the [EngineReportingOptions](#enginereportingoptions) section for a full description of how to configure the reporting agent, including how to include variable values and HTTP headers. When using the Engine proxy, this option should be set to false.
+  Provided the `ENGINE_API_KEY` environment variable is set, the Graph Manager reporting agent will be started automatically. The API key can also be provided as the `apiKey` field in an object passed as the `engine` field. See the [EngineReportingOptions](#enginereportingoptions) section for a full description of how to configure the reporting agent, including how to include variable values and HTTP headers. When using the Engine proxy, this option should be set to `false`.
 
 * `persistedQueries`: <`Object`> | false
 
@@ -296,10 +296,10 @@ addMockFunctionsToSchema({
 
 *  `apiKey`: string __(required)__
 
-  API key for the service. Get this from
-  [Engine](https://engine.apollographql.com) by logging in and creating
-  a service. You may also specify this with the `ENGINE_API_KEY`
-  environment variable the option takes precedence.
+  API key for the service. Obtain an API key from
+  [Graph Manager](https://engine.apollographql.com) by logging in and creating
+  a service. You can also specify an API key with the `ENGINE_API_KEY`
+  environment variable. This option takes precedence over the environment variable.
 
 *  `calculateSignature`: (ast: DocumentNode, operationName: string) => string
 
@@ -310,23 +310,23 @@ addMockFunctionsToSchema({
 
 *  `reportIntervalMs`: number
 
-   How often to send reports to the Engine server. We'll also send reports
-   when the report gets big see maxUncompressedReportSize.
+   How often to send reports to Graph Manager, in milliseconds. We'll also send reports
+   when the report reaches a size threshold specified by `maxUncompressedReportSize`.
 
 *  `maxUncompressedReportSize`: number
 
-   We send a report when the report size will become bigger than this size in
-   bytes (default: 4MB).  (This is a rough limit --- we ignore the size of the
-   report header and some other top level bytes. We just add up the lengths of
-   the serialized traces and signatures.)
+   In addition to interval-based reporting, Apollo Server sends a report to
+   Graph Manager whenever the report's size exceeds this value in
+   bytes (default: 4MB). Note that this is a rough limit. The size of the
+   report's header and some other top-level bytes are ignored. We just add up the lengths of the serialized traces and signatures.
 
 *  `endpointUrl`: string
 
-   The URL of the Engine report ingress server.
+   The URL of the Graph Manager report ingress server.
 
 *  `requestAgent`: `http.Agent | https.Agent | false`
 
-   HTTP(s) agent to be used for Apollo Engine metrics reporting.  This accepts either an [`http.Agent`](https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_agent) or [`https.Agent`](https://nodejs.org/docs/latest-v10.x/api/https.html#https_class_https_agent) and behaves the same as the `agent` parameter to Node.js' [`http.request`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_http_request_options_callback).
+   HTTP(s) agent to be used for Apollo Graph Manager metrics reporting.  This accepts either an [`http.Agent`](https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_agent) or [`https.Agent`](https://nodejs.org/docs/latest-v10.x/api/https.html#https_class_https_agent) and behaves the same as the `agent` parameter to Node.js' [`http.request`](https://nodejs.org/docs/latest-v8.x/api/http.html#http_http_request_options_callback).
 
 *  `debugPrintReports`: boolean
 
@@ -343,7 +343,7 @@ addMockFunctionsToSchema({
 
 *  `reportErrorFunction`: (err: Error) => void
 
-   By default, errors sending reports to Engine servers will be logged
+   By default, any errors encountered while sending reports to Graph Manager will be logged
    to standard error. Specify this function to process errors in a different
    way.
 
@@ -409,13 +409,13 @@ addMockFunctionsToSchema({
 
 *  `rewriteError`: (err: GraphQLError) => GraphQLError | null
 
-   By default, all errors are reported to Apollo Engine.  This function
+   By default, all errors are reported to Apollo Graph Manager.  This function
    can be used to exclude specific errors from being reported.  This function
    receives a copy of the `GraphQLError` and can manipulate it for the
-   purposes of Apollo Engine reporting.  The modified error (e.g. after changing
+   purposes of Graph Manager reporting.  The modified error (e.g., after changing
    the `err.message` property) should be returned or the function should return
    an explicit `null` to avoid reporting the error entirely.  It is not
-   permissable to return `undefined`. Note that most `GraphQLError` fields,
+   permissible to return `undefined`. Note that most `GraphQLError` fields,
    like `path`, will get copied from the original error to the new error: this
    way, you can just `return new GraphQLError("message")` without having to
    explicitly keep it associated with the same node. Specifically, only the
@@ -432,7 +432,7 @@ addMockFunctionsToSchema({
    Creates a client context(ClientInfo) based on the request pipeline's
    context, which contains values like the request, response, cache, and
    context. This generated client information will be provided to Apollo
-   Engine and can be used to filter metrics. Set `clientName` to identify a
+   Graph Manager and can be used to filter metrics. Set `clientName` to identify a
    particular client. Use `clientVersion` to specify a version for a client
    name.  The default function will use the `clientInfo` field inside of
    GraphQL Query `extensions`.
@@ -444,6 +444,6 @@ addMockFunctionsToSchema({
    for cross-correspondence, so names and reference ids should have a one to
    one relationship.
 
-   > [WARNING] If you specify a `clientReferenceId`, Engine will treat the
+   > [WARNING] If you specify a `clientReferenceId`, Graph Manager will treat the
    > `clientName` as a secondary lookup, so changing a `clientName` may result
    > in an unwanted experience.

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -299,7 +299,7 @@ addMockFunctionsToSchema({
   API key for the service. Obtain an API key from
   [Graph Manager](https://engine.apollographql.com) by logging in and creating
   a service. You can also specify an API key with the `ENGINE_API_KEY`
-  environment variable. This option takes precedence over the environment variable.
+  environment variable, although the `apiKey` option takes precedence.
 
 *  `calculateSignature`: (ast: DocumentNode, operationName: string) => string
 
@@ -318,7 +318,8 @@ addMockFunctionsToSchema({
    In addition to interval-based reporting, Apollo Server sends a report to
    Graph Manager whenever the report's size exceeds this value in
    bytes (default: 4MB). Note that this is a rough limit. The size of the
-   report's header and some other top-level bytes are ignored. We just add up the lengths of the serialized traces and signatures.
+   report's header and some other top-level bytes are ignored. The report size is
+   limited to the sum of the lengths of serialized traces and signatures.
 
 *  `endpointUrl`: string
 
@@ -416,7 +417,7 @@ addMockFunctionsToSchema({
    the `err.message` property) should be returned or the function should return
    an explicit `null` to avoid reporting the error entirely.  It is not
    permissible to return `undefined`. Note that most `GraphQLError` fields,
-   like `path`, will get copied from the original error to the new error: this
+   like `path`, will be copied from the original error to the new error: this
    way, you can just `return new GraphQLError("message")` without having to
    explicitly keep it associated with the same node. Specifically, only the
    `message` and `extensions` properties on the returned `GraphQLError` are
@@ -431,7 +432,7 @@ addMockFunctionsToSchema({
 
    Creates a client context(ClientInfo) based on the request pipeline's
    context, which contains values like the request, response, cache, and
-   context. This generated client information will be provided to Apollo
+   context. This generated client information will be provided to
    Graph Manager and can be used to filter metrics. Set `clientName` to identify a
    particular client. Use `clientVersion` to specify a version for a client
    name.  The default function will use the `clientInfo` field inside of

--- a/docs/source/deployment/heroku.md
+++ b/docs/source/deployment/heroku.md
@@ -15,19 +15,19 @@ The following must be done before following this guide:
 
 ## Set up a new Heroku application
 
-Before deploying, a new application must be setup. To do this, log into the [Heroku dashboard](https://dashboard.heroku.com/apps). Then click `New > Create New App` in the top right. The name you choose will be referred to later as `<HEROKU_APP_NAME>`, so be sure to replace it in the later sections.
+Before deploying, a new application must be set up. To do this, log in to the [Heroku dashboard](https://dashboard.heroku.com/apps). Then click `New > Create New App` in the top right. The name you choose will be referred to later as `<HEROKU_APP_NAME>`, so be sure to replace it in the later sections.
 
 ![New App Screenshot](../images/deployment/heroku/new-app.png)
 
-Name your app and hit "Create app"
+Name your app and click "Create app"
 
 ![Create App Screenshot](../images/deployment/heroku/create-app.png)
 
 ## Setting up the project
 
-For Heroku, projects can be setup using any of the `apollo-server` HTTP variants (like express, hapi, etc).
+For Heroku, projects can be set up using any of the `apollo-server` HTTP variants (like express, hapi, etc).
 
-The only special consideration that needs to be made is to allow heroku to choose the port that the server is deployed to. Otherwise, there may be errors, such as a request timeout.
+The only special consideration that needs to be made is to allow Heroku to choose the port that the server is deployed to. Otherwise, there may be errors, such as a request timeout.
 
 To configure `apollo-server` to use a port defined by Heroku at runtime, the `listen` function in your setup file can be called with a port defined by the `PORT` environment variable:
 
@@ -39,11 +39,11 @@ server.listen({ port: process.env.PORT || 4000 }).then(({ url }) => {
 
 ## Deploying the project
 
-There are a couple of ways to push projects to Heroku. Automatically, with GitHub integration, or manually using Heroku push.
+There are a couple of ways to push projects to Heroku. Automatically, with GitHub integration, or manually using `git push`.
 
 ### Deploying with Heroku push
 
-Install the [Heroku Cli](https://devcenter.heroku.com/articles/heroku-cli), then inside of your project, run:
+Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli), then inside of your project, run:
 
 ```shell
 $ git init #existing git repositories can skip this
@@ -58,20 +58,20 @@ Send a query to your GraphQL service at your Heroku Application at `<HEROKU_APP_
 
 ### Automatically deploying with GitHub
 
-If the project is already pushed to GitHub, it may be easier to setup automatic deployments from the project's repository
+If the project is already pushed to GitHub, it may be easier to setup automatic deployments from the project's repository.
 
 On the Heroku dashboard, click on the name of the app that will be deployed from GitHub.
 
-Then, on the app detail page, there is a tab bar at the top, with a "Deploy" option. On that page, the deployment method can be chosen and setup to integrate with GitHub.
+Then, on the app detail page, there is a tab bar at the top, with a "Deploy" option. On that page, the deployment method can be chosen and configured to integrate with GitHub.
 
 ![github deployment instructions](../images/deployment/heroku/heroku-github-instructions.png)
 
 ## Configuring environment variables
 
-In order to enable the production mode of Apollo Server, you will need to set the `NODE_ENV` variable to production. To ensure you have visibility into your GraphQL performance in Apollo Server, you'll want to add the `ENGINE_API_KEY` environment variable to Heroku. For the API key, log into the [Engine UI](https://engine.apollographql.com) and navigate to your service or create a new one.
+To enable the production mode of Apollo Server, you need to set the `NODE_ENV` variable to `production`. To ensure you have visibility into your GraphQL performance in Apollo Server, you'll want to add the `ENGINE_API_KEY` environment variable to Heroku. For the API key, log in to the [Graph Manager UI](https://engine.apollographql.com) and navigate to your service or create a new one.
 
-Then under the “Settings” tab, click “Reveal Config Vars". Next set `NODE_ENV` to `production` and copy your key from the [Engine UI](http://engine.apollographql.com/) as the value for `ENGINE_API_KEY`.
+Under the “Settings” tab, click **Reveal Config Vars**. Next, set `NODE_ENV` to `production` and copy your key from the [Graph Manager UI](http://engine.apollographql.com/) as the value for `ENGINE_API_KEY`.
 
-![Add Engine Api Key Screenshot](../images/deployment/heroku/add-env-vars.png)
+![Add Graph Manager API Key Screenshot](../images/deployment/heroku/add-env-vars.png)
 
-Send a query to your GraphQL service at your Heroku Application at `<HEROKU_APP_NAME>.herokuapp.com` and then check out the tracing data in the [Engine UI](http://engine.apollographql.com/).
+Send a query to your Heroku app's GraphQL service at `<HEROKU_APP_NAME>.herokuapp.com` and then check out the tracing data in the [Graph Manager UI](http://engine.apollographql.com/).

--- a/docs/source/deployment/heroku.md
+++ b/docs/source/deployment/heroku.md
@@ -41,7 +41,7 @@ server.listen({ port: process.env.PORT || 4000 }).then(({ url }) => {
 
 There are a couple of ways to push projects to Heroku. Automatically, with GitHub integration, or manually using `git push`.
 
-### Deploying with Heroku push
+### Deploying with Git
 
 Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli), then inside of your project, run:
 

--- a/docs/source/deployment/now.md
+++ b/docs/source/deployment/now.md
@@ -62,7 +62,7 @@ The `now` command deploys right away and attempts to start the server. This spec
 
 [Now](https://zeit.co/now) supports automatic deployment from GitHub on pull requests.
 
-To set up automatic deployment, visit [https://zeit.co/github](https://zeit.co/github) and click on the "Setup Now" button.
+To set up automatic deployment, visit [https://zeit.co/github](https://zeit.co/github) and click **Setup Now**.
 
 After signing in with GitHub, the [Now](https://zeit.co/now) GitHub app can be added to any account or organization. Once installed, it's possible to choose which repositories that [Now](https://zeit.co/now) can run on, allowing new deployments on Pull Requests.
 
@@ -70,7 +70,7 @@ After signing in with GitHub, the [Now](https://zeit.co/now) GitHub app can be a
 
 ## Setting environment variables
 
-The `graphql-server-example` project requires environment variables to enable reporting to Apollo Engine. To deploy to Now with environment variables, the `-e` flag can be used followed by the variables like so:
+The `graphql-server-example` project requires environment variables to enable reporting to Apollo Graph Manager. To deploy to Now with environment variables, the `-e` flag can be used followed by the variables like so:
 
 ```shell
 $ now -e ENGINE_API_KEY=xxxxxxxxx apollographql/graphql-server-example

--- a/docs/source/essentials/data.md
+++ b/docs/source/essentials/data.md
@@ -206,7 +206,7 @@ Once your resolver map is complete, it's time to start testing out your queries 
 
 ### Naming operations
 
-When sending the queries and mutations in the above examples, we've used either `query { ... }` or `mutation { ... }` respectively.  While this is fine, and particularly convenient when running queries by hand, it makes sense to name the operation in order to quickly identify operations during debugging or to aggregate similar operations together for application performance metrics, for example, when using [Apollo Engine](https://engine.apollographql.com/) to monitor an API.
+When sending the queries and mutations in the above examples, we've used either `query { ... }` or `mutation { ... }` respectively.  While this is fine, and particularly convenient when running queries by hand, it makes sense to name the operation in order to quickly identify operations during debugging or to aggregate similar operations together for application performance metrics, for example, when using [Apollo Graph Manager](https://engine.apollographql.com/) to monitor an API.
 
 Operations can be named by placing an identifier after the `query` or `mutation` keyword, as we've done with `HomeBookListing` here:
 

--- a/docs/source/features/errors.md
+++ b/docs/source/features/errors.md
@@ -182,7 +182,7 @@ reporting the error entirely.
 
 The following sections give some examples of various use-cases for `rewriteError`.
 
-#### Avoid reporting lower-severity predefined errors
+#### Avoid reporting lower-severity, predefined errors
 
 If an application is using the predefined errors noted above (`AuthenticationError`, `ForbiddenError`, `UserInputError`, etc.), these can
 be used with `rewriteError`.

--- a/docs/source/features/errors.md
+++ b/docs/source/features/errors.md
@@ -3,15 +3,15 @@ title: Error handling
 description: Making errors actionable on the client and server
 ---
 
-Apollo server provides a couple predefined errors, including
-`AuthenticationError`, `ForbiddenError`, `UserInputError` and a generic
-`ApolloError`. These errors are designed to enhance errors thrown before and during GraphQL execution. The provided errors focus on debugging a Apollo server as well as enabling the client to take specific action based on an error.
+Apollo Server provides a collection of predefined errors, including
+`AuthenticationError`, `ForbiddenError`, `UserInputError`, and a generic
+`ApolloError`. These errors are designed to enhance errors thrown before and during GraphQL execution, making it easier to debug your Apollo Server integration and enabling clients to take specific actions based on an error.
 
-When an error occurs in Apollo server both inside and outside of resolvers, each error inside of the `errors` array will contain an object at `extensions` that contains the information added by Apollo server.
+When an error occurs in Apollo Server both inside and outside of resolvers, each error inside of the `errors` array contains an `extensions` object that contains the information added by Apollo Server.
 
 ## Default information
 
-The first step to improving the usability of a server is providing the error stack trace by default. The following example demonstrates the response returned from Apollo server with a resolver that throws a node [`SystemError`](https://nodejs.org/api/errors.html#errors_system_errors).
+The first step to improving the usability of a server is providing the error stack trace by default. The following example demonstrates the response returned from Apollo Server with a resolver that throws a node [`SystemError`](https://nodejs.org/api/errors.html#errors_system_errors).
 
 ```js{14-16}
 const {
@@ -38,7 +38,7 @@ The response will return:
 
 ![Screenshot demonstrating an error stacktrace and additional](../images/features/error-stacktrace.png)
 
-> To disable stacktraces for production, pass `debug: false` to the Apollo server constructor or set the `NODE_ENV` environment variable to 'production' or 'test'. Note that this will make the stacktrace unavailable to your application. If you want to log the stacktrace, but not send it in the response to the client, see [Masking and logging errors](#masking-and-logging-errors) below.
+> To disable stacktraces for production, pass `debug: false` to the Apollo Server constructor or set the `NODE_ENV` environment variable to 'production' or 'test'. Note that this will make the stacktrace unavailable to your application. If you want to log the stacktrace, but not send it in the response to the client, see [Masking and logging errors](#masking-and-logging-errors) below.
 
 ## Codes
 
@@ -120,11 +120,11 @@ new ApolloError(message, code, additionalProperties);
 
 ### For the client response
 
-The Apollo server constructor accepts a `formatError` function that is run on each error passed back to the client. This can be used to mask errors as well as for logging.
+The Apollo Server constructor accepts a `formatError` function that is run on each error passed back to the client. This can be used to mask errors as well as for logging.
 
 > Note that while this changes the error which is sent to the client, it
-> doesn't change the error which is sent to Apollo Engine.  See the
-> `rewriteError` function in the _For Apollo Engine reporting_ section below
+> doesn't change the error that is sent to Apollo Graph Manager.  See the
+> `rewriteError` function in the _For Apollo Graph Manager reporting_ section below
 > if this behavior is desired.
 
 This example demonstrates throwing a different error when the error's message starts with `Database Error: `:
@@ -164,34 +164,32 @@ The error instance received by `formatError` (a `GraphQLError`) contains an `ori
 
 > To make context-specific adjustments to the error received by `formatError` (e.g. localization or personalization), consider using the `didEncounterErrors` lifecycle hook to attach additional properties to the error, which can be accessed and utilized within `formatError`.
 
-### For Apollo Engine reporting
+### For Apollo Graph Manager reporting
 
-With the Apollo Platform, it's possible to observe error rates within Apollo
-Engine, rather than simply logging them to the console. While all errors are
-sent to Apollo Engine by default, depending on the severity of the error, it
-may be desirable to not send particular errors which may be caused by a
-user's actions. Alternatively, it may be necessary to modify or redact errors
-before transmitting them.
+You can use Apollo Graph Manager to analyze error rates instead of simply logging
+errors to the console. If you connect Apollo Server to Graph Manager, all errors are 
+sent to Graph Manager by default. If you _don't_ want certain error information to be 
+sent to Graph Manager (either because the error is unimportant or because certain information is confidential), you can modify or redact errors entirely
+before they're transmitted.
 
 To account for these needs, a `rewriteError` function can be provided within
 the `engine` settings to Apollo Server. At a high-level, the function will
-receive the error to be reported (i.e. a `GraphQLError` or an `ApolloError`)
+receive the error to be reported (i.e., a `GraphQLError` or an `ApolloError`)
 as the first argument. The function should then return a modified form of
-that error (e.g. after changing the `err.message` to remove potentially
+that error (e.g., after changing the `err.message` to remove potentially
 sensitive information), or should return an explicit `null` in order to avoid
 reporting the error entirely.
 
 The following sections give some examples of various use-cases for `rewriteError`.
 
-#### Avoid reporting lower-severity predefined errors.
+#### Avoid reporting lower-severity predefined errors
 
-If an application is utilizing the predefined errors noted above (e.g.
-`AuthenticationError`, `ForbiddenError`, `UserInputError`, etc.), these can
+If an application is using the predefined errors noted above (`AuthenticationError`, `ForbiddenError`, `UserInputError`, etc.), these can
 be used with `rewriteError`.
 
 For example, if the current server is `throw`ing the `AuthenticationError`
 when a mis-typed password is supplied, an implementor can avoid reporting
-this to Apollo Engine by defining `rewriteError` as follows:
+this to Apollo Graph Manager by defining `rewriteError` as follows:
 
 ```js{5-15}
 const { ApolloServer, AuthenticationError } = require("apollo-server");
@@ -212,18 +210,16 @@ const server = new ApolloServer({
 });
 ```
 
-This example configuration would ensure that any `AuthenticationError` which
-was thrown within a resolver would only be reported to the client, and never
-sent to Apollo Engine. All other errors would be transmitted to Apollo Engine
+This example configuration ensures that any `AuthenticationError` that's
+ thrown within a resolver is only reported to the client, and never
+sent to Apollo Graph Manager. All other errors are transmitted to Graph Manager
 normally.
 
-#### Avoid reporting an error based on other properties.
+#### Avoid reporting an error based on other properties
 
-When generating an error (e.g. `new ApolloError("Failure!")`), the `message`
-is the most common property (i.e. `err.message`, which is `Failure!` in this
-case). However, any number of properties can be attached to the error (e.g.
-adding a `code` property). These properties can be checked when determining
-whether an error should be reported to Apollo Engine using the `rewriteError`
+When generating an error (e.g., `new ApolloError("Failure!")`), the `message`
+is the most common property (in this case it's `Failure!`). However, any number of properties can be attached to the error (such as a `code` property). These properties can be checked when determining
+whether an error should be reported to Apollo Graph Manager using the `rewriteError`
 function as follows:
 
 ```js{5-16}
@@ -246,15 +242,15 @@ const server = new ApolloServer({
 });
 ```
 
-This example configuration would ensure that any error which started with
-`Known error message` was not transmitted to Apollo Engine, but all other
-errors would continue to be sent.
+This example configuration ensures that any error that starts with
+`Known error message` is not transmitted to Apollo Graph Manager, but all other
+errors are sent as normal.
 
-#### Redacting the error message.
+#### Redacting the error message
 
-If it is necessary to change the error prior to reporting it to Apollo Engine
-– for example, if there is personally identifiable information in the error
-`message` — the `rewriteError` function can also help.
+If it is necessary to change an error prior to reporting it to Apollo Graph Manager
+(for example, if there is personally identifiable information in the error
+`message`), the `rewriteError` function can also help.
 
 Consider an example where the error contains a piece of information like
 an API key:
@@ -264,7 +260,7 @@ throw new ApolloError("The x-api-key:12345 doesn't have sufficient privileges.")
 ```
 
 The `rewriteError` function can be used to ensure
-such information is not sent to Apollo Engine and potentially revealed outside
+such information is not sent to Apollo Graph Manager and potentially revealed outside
 its intended scope:
 
 ```js{5-11}
@@ -282,7 +278,7 @@ const server = new ApolloServer({
 });
 ```
 
-In this case, the example error used above would be reported in Apollo Engine as:
+In this case, the error above is reported to Apollo Graph Manager as:
 
 ```
 The REDACTED doesn't have sufficient privileges.

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -3,40 +3,38 @@ title: Monitoring and metrics
 description: How to monitor Apollo Server's performance
 ---
 
-Understanding the behavior of GraphQL execution inside of Apollo Server is critical to developing and running a production GraphQL layer. Apollo Server enables GraphQL monitoring in Apollo Engine and provides more primitive native mechanisms to log each phase of a GraphQL request.
+Understanding GraphQL execution inside of Apollo Server is critical to developing and running a production GraphQL layer. Apollo Server provides sophisticated GraphQL monitoring via integration with Apollo Graph Manager, along with native mechanisms for logging each phase of a GraphQL request.
 
 > Using Federation? Check out the documentation for [federated tracing](/federation/metrics/)
 
-## Apollo Engine
+## Apollo Graph Manager
 
-Apollo Engine provides an integrated hub for all GraphQL performance data that is free for one million queries per month. With an API key from the [Engine UI](https://engine.apollographql.com/), Apollo Server reports performance and error data out-of-band. Apollo Engine then aggregates and displays information for [queries](https://www.apollographql.com/docs/engine/features/query-tracking.html), [requests](https://www.apollographql.com/docs/engine/performance.html), the [schema](https://www.apollographql.com/docs/engine/features/performance.html), and [errors](https://www.apollographql.com/docs/engine/features/error-tracking.html). By leveraging this data, Apollo Engine offers [alerts](https://www.apollographql.com/docs/engine/features/alerts.html) via [Slack](https://www.apollographql.com/docs/engine/integrations/slack.html) and [Datadog](https://www.apollographql.com/docs/engine/integrations/datadog.html) integrations.
+[Apollo Graph Manager](https://www.apollographql.com/docs/platform/graph-manager-overview/) provides an integrated hub for all of your GraphQL performance data. Obtain an API key from the [Graph Manager UI](https://engine.apollographql.com/) and provide it to Apollo Server to enable automatic reporting of performance and error data. Graph Manager aggregates and displays information for your [schema](https://www.apollographql.com/docs/engine/features/performance.html), [queries](https://www.apollographql.com/docs/engine/features/query-tracking.html), [requests](https://www.apollographql.com/docs/engine/performance.html), and [errors](https://www.apollographql.com/docs/engine/features/error-tracking.html). You can also configure [alerts](https://www.apollographql.com/docs/engine/features/alerts.html) that support [Slack](https://www.apollographql.com/docs/engine/integrations/slack.html) and [Datadog](https://www.apollographql.com/docs/engine/integrations/datadog.html) integrations.
 
-To set up Apollo Server with Engine, [click here](https://engine.apollographql.com/) to get an Engine API key.
+To set connect Apollo Server to Graph Manager, first [visit the Graph Manager UI](https://engine.apollographql.com/) to get a Graph Manager API key.
 
-The API key can be specified in two ways:
+You can provide the API key to Apollo Server in any of the following ways:
 
-1. Within the `ApolloServer` constructor options.
-2. Using environment variables.
+* Include the API key in the constructor options for `ApolloServer`
+* Assign the API key to the `ENGINE_API_KEY` environment variable
 
-### Configuring within the `ApolloServer` constructor options
+### Providing an API key via the `ApolloServer` constructor
 
-```js{6-15}
+You can provide your Graph Manager API key as an option to the `ApolloServer`
+constructor like so:
+
+```js{6-14}
 const { ApolloServer } = require("apollo-server");
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   engine: {
-    // The Apollo Engine API key.
-    //
-    // This may also be set via the `ENGINE_API_KEY` environment variable.
-    apiKey: "YOUR API KEY HERE",
+    // The Graph Manager API key
+    apiKey: "YOUR_API_KEY_HERE",
 
     // A tag for this specific environment (e.g. `development` or `production`).
-    //
-    // This may also be set via the `ENGINE_SCHEMA_TAG` environment variable.
-    // For more information on schema tags/variants, see the documentation in
-    // our Platform documentation on associating metrics with variants:
+    // For more information on schema tags/variants, see
     // https://www.apollographql.com/docs/platform/schema-registry/#associating-metrics-with-a-variant
     schemaTag: 'development',
   }
@@ -47,11 +45,12 @@ server.listen().then(({ url }) => {
 });
 ```
 
-### Configuration via environment variables
+### Providing an API key via environment variables
 
-The API key can also be set with the `ENGINE_API_KEY` environment variable and the schema tag can be set similarly with `ENGINE_SCHEMA_TAG`.
+You can provide your Graph Manager API key to Apollo Server via the `ENGINE_API_KEY` environment variable. Similarly, you can assign a particular [variant](https://www.apollographql.com/docs/platform/schema-registry/#managing-environments)
+to an Apollo Server instance via the `ENGINE_SCHEMA_TAG` environment variable.
 
-Setting an environment variable can be done on the command line as seen below or using the [`dotenv` npm package](https://www.npmjs.com/package/dotenv) (or similar).
+You can set environment variable values on the command line as seen below, or by using the [`dotenv` npm package](https://www.npmjs.com/package/dotenv) (or similar).
 
 ```bash
 # Replace the example values below with values specific to your use case.
@@ -62,7 +61,7 @@ ENGINE_API_KEY=YOUR_API_KEY ENGINE_SCHEMA_TAG=development node start-server.js
 
 > For additional information on client awareness, please see the section in our Apollo Platform documentation on [client awareness](https://www.apollographql.com/docs/platform/client-awareness).
 
-Setting up client awareness enables client-based filtering of metrics and usage patterns within Apollo Engine.  A client's identity has three configurable dimensions:
+Setting up client awareness enables client-based filtering of metrics and usage patterns within Apollo Graph Manager.  A client's identity has three configurable dimensions:
 
 * Name (e.g. "Android App")
 * Version (e.g. `1.0.1`)
@@ -75,7 +74,7 @@ There are two ways to configure client awareness:
 
 #### Default client identification headers
 
-By default, Apollo Server will automatically recognize the following headers on incoming requests and associate them with a client's identity on a trace automatically:
+By default, Apollo Server automatically recognizes the following headers on incoming requests and associates them with a client's identity on a trace automatically:
 
 * `apollographql-client-name`
 * `apollographql-client-version`
@@ -153,7 +152,7 @@ server.listen().then(({ url }) => {
 
 ### Granular logs
 
-For more advanced cases, Apollo Server provides an experimental api that accepts an array of `graphql-extensions` to the `extensions` field. These extensions receive a variety of lifecycle calls for each phase of a GraphQL request and can keep state, such as the request headers.
+For more advanced cases, Apollo Server provides an experimental API that accepts an array of `graphql-extensions` to the `extensions` field. These extensions receive a variety of lifecycle calls for each phase of a GraphQL request and can keep state, such as the request headers.
 
 ```js
 const { ApolloServer }  = require('apollo-server');
@@ -170,4 +169,4 @@ server.listen().then(({ url }) => {
 });
 ```
 
-For example the `logFunction` from Apollo Server 1 can be implemented as an [extension](https://github.com/apollographql/apollo-server/blob/8914b135df9840051fe81cc9224b444cfc5b61ab/packages/apollo-server-core/src/logging.ts) and could be modified to add additional state or functionality.
+For example, the `logFunction` from Apollo Server 1 can be implemented as an [extension](https://github.com/apollographql/apollo-server/blob/8914b135df9840051fe81cc9224b444cfc5b61ab/packages/apollo-server-core/src/logging.ts) and could be modified to add additional state or functionality.

--- a/docs/source/features/metrics.md
+++ b/docs/source/features/metrics.md
@@ -11,7 +11,7 @@ Understanding GraphQL execution inside of Apollo Server is critical to developin
 
 [Apollo Graph Manager](https://www.apollographql.com/docs/platform/graph-manager-overview/) provides an integrated hub for all of your GraphQL performance data. Obtain an API key from the [Graph Manager UI](https://engine.apollographql.com/) and provide it to Apollo Server to enable automatic reporting of performance and error data. Graph Manager aggregates and displays information for your [schema](https://www.apollographql.com/docs/engine/features/performance.html), [queries](https://www.apollographql.com/docs/engine/features/query-tracking.html), [requests](https://www.apollographql.com/docs/engine/performance.html), and [errors](https://www.apollographql.com/docs/engine/features/error-tracking.html). You can also configure [alerts](https://www.apollographql.com/docs/engine/features/alerts.html) that support [Slack](https://www.apollographql.com/docs/engine/integrations/slack.html) and [Datadog](https://www.apollographql.com/docs/engine/integrations/datadog.html) integrations.
 
-To set connect Apollo Server to Graph Manager, first [visit the Graph Manager UI](https://engine.apollographql.com/) to get a Graph Manager API key.
+To connect Apollo Server to Graph Manager, first [visit the Graph Manager UI](https://engine.apollographql.com/) to get a Graph Manager API key.
 
 You can provide the API key to Apollo Server in any of the following ways:
 

--- a/docs/source/migration-engine.md
+++ b/docs/source/migration-engine.md
@@ -1,13 +1,13 @@
 ---
-title: Using Engine with v2.0
-description: How to use Engine with Apollo Server 2.0
+title: Using Graph Manager with v2.0
+description: How to use Graph Manager with Apollo Server 2.0
 ---
 
 Apollo Server provides reporting, persisted queries, and cache-control headers in native javascript by default, so often times moving to Apollo Server 2 without the Engine proxy is possible. For services that already contain the Engine proxy and depend on its full response caching, Apollo Server continues to support it with first class functionality. With Apollo Server 2, the Engine proxy can be started by the same node process. If the Engine proxy is running in a dedicated machine, Apollo Server 2 supports the cache-control and tracing extensions, used to communicate with the proxy.
 
 ## Stand-alone Apollo Server
 
-Apollo Server 2 is able to replace all the metrics-reporting functionality which once required the Apollo Engine Proxy. To enable metrics reporting in Apollo Server 2, add `ENGINE_API_KEY` as an environment variable.  With this setting enabled, Apollo Server 2 will automatically send execution traces directly to Apollo Engine. In addition, by default, Apollo Server supports [persisted queries](https://www.apollographql.com/docs/guides/performance/#automatic-persisted-queried) without needing the proxy's cache. Apollo Server also sets `Cache-Control` headers for consumption by a CDN.  Integrating a CDN provides an alternative to the full response caching inside of Engine proxy.
+Apollo Server 2 is able to replace all the metrics-reporting functionality which once required the Apollo Engine Proxy. To enable metrics reporting in Apollo Server 2, add `ENGINE_API_KEY` as an environment variable.  With this setting enabled, Apollo Server 2 will automatically send execution traces directly to Apollo Graph Manager. In addition, by default, Apollo Server supports [persisted queries](https://www.apollographql.com/docs/guides/performance/#automatic-persisted-queried) without needing the proxy's cache. Apollo Server also sets `Cache-Control` headers for consumption by a CDN.  Integrating a CDN provides an alternative to the full response caching inside of Engine proxy.
 
 ```js
 const { ApolloServer } = require('apollo-server');

--- a/docs/source/whats-new.md
+++ b/docs/source/whats-new.md
@@ -154,16 +154,16 @@ For more information, check out the [feature explanation about mocking](/feature
 
 ### Performance monitoring
 
-Apollo Server 2.0 enables GraphQL monitoring out of the box. It reports performance and error data out-of-band to Apollo Engine. And Apollo Engine displays information about every query and schema present in your GraphQL service.
+Apollo Server 2.0 enables GraphQL monitoring out of the box. It reports performance and error data out-of-band to Apollo Graph Manager. And Apollo Graph Manager displays information about every query and schema present in your GraphQL service.
 
-To set up Apollo Server with Engine, [click here](https://engine.apollographql.com/) to get an Engine API key and provide it to the `ENGINE_API_KEY` environment variable. Setting an environment variable can be done on the command-line as seen below, or with the [`dotenv` npm package](https://www.npmjs.com/package/dotenv).
+To set up Apollo Server with Graph Manager, [click here](https://engine.apollographql.com/) to get a Graph Manager API key and provide it to the `ENGINE_API_KEY` environment variable. Setting an environment variable can be done on the command-line as seen below, or with the [`dotenv` npm package](https://www.npmjs.com/package/dotenv).
 
 ```bash
-#Replace YOUR_API_KEY with the api key for you service in the Engine UI
+#Replace YOUR_API_KEY with the api key for you service in the Graph Manager UI
 ENGINE_API_KEY=YOUR_API_KEY node start-server.js
 ```
 
-The simplest option is to pass the Engine API Key directly to the Apollo Server constructor.
+The simplest option is to pass the Graph Manager API Key directly to the Apollo Server constructor.
 
 ```js{6-8}
 const { ApolloServer } = require('apollo-server');


### PR DESCRIPTION
Doesn't change option/variable names (for obvious reasons), nor does it rename the deprecated "engine proxy".
