### PR TITLE
types: Try to avoid runtime cost of `apollo-engine-reporting-protobuf`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-core`: Make `formatError` available to subscriptions in the same spirit as the existing `formatResponse`. [PR #2942](https://github.com/apollographql/apollo-server/pull/2942)
+- `apollo-server-types`: Attempt to avoid runtime cost involved with evaluating `apollo-engine-reporting-protobuf` by importing the `ITrace` interface rather than the `Trace` implementation. [PR #3210](https://github.com/apollographql/apollo-server/pull/3210)
 
 ### v2.9.0
 

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -11,7 +11,7 @@ import {
 
 // This seems like it could live in this package too.
 import { KeyValueCache } from 'apollo-server-caching';
-import { Trace } from 'apollo-engine-reporting-protobuf';
+import { ITrace } from 'apollo-engine-reporting-protobuf/dist/protobuf';
 
 export type ValueOrPromise<T> = T | Promise<T>;
 export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
@@ -55,7 +55,7 @@ export interface GraphQLRequestMetrics {
   forbiddenOperation?: boolean;
   registeredOperation?: boolean;
   startHrTime?: [number, number];
-  queryPlanTrace?: Trace.QueryPlanNode;
+  queryPlanTrace?: ITrace['queryPlan'];
 }
 
 export interface GraphQLRequestContext<TContext = Record<string, any>> {


### PR DESCRIPTION
This is an experiment, but hopefully will resolve the runtime cost noted in:

https://github.com/apollographql/apollo-server/issues/2162#issuecomment-520238106

We'll do this by importing the `ITrace` interface and borrowing its `queryPlan` property type, rather than leveraging the implementation (`Trace`).

cc @aaronplummeridgelumira @hotgazpacho @kyeotic 