### PR TITLE
 Add Context to ApolloServer Constructor as optional, generic argument

### DIFF
--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -79,12 +79,12 @@ export interface ExpressContext {
   connection?: ExecutionParams;
 }
 
-export interface ApolloServerExpressConfig extends Config {
-  context?: ContextFunction<ExpressContext, Context> | Context;
+export interface ApolloServerExpressConfig<TContext> extends Config {
+  context?: ContextFunction<ExpressContext, Context<TContext>> | Context<TContext>;
 }
 
-export class ApolloServer extends ApolloServerBase {
-  constructor(config: ApolloServerExpressConfig) {
+export class ApolloServer<TContext> extends ApolloServerBase {
+  constructor(config: ApolloServerExpressConfig<TContext>) {
     super(config);
   }
 

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -79,11 +79,11 @@ export interface ExpressContext {
   connection?: ExecutionParams;
 }
 
-export interface ApolloServerExpressConfig<TContext> extends Config {
+export interface ApolloServerExpressConfig<TContext extends {}> extends Config {
   context?: ContextFunction<ExpressContext, Context<TContext>> | Context<TContext>;
 }
 
-export class ApolloServer<TContext> extends ApolloServerBase {
+export class ApolloServer<TContext extends {} = {}> extends ApolloServerBase {
   constructor(config: ApolloServerExpressConfig<TContext>) {
     super(config);
   }

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -22,7 +22,7 @@ export interface ServerInfo {
   server: http.Server;
 }
 
-export class ApolloServer<TContext> extends ApolloServerBase {
+export class ApolloServer<TContext extends {} = {}> extends ApolloServerBase {
   private httpServer?: http.Server;
   private cors?: CorsOptions | boolean;
   private onHealthCheck?: (req: express.Request) => Promise<any>;

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -22,13 +22,13 @@ export interface ServerInfo {
   server: http.Server;
 }
 
-export class ApolloServer extends ApolloServerBase {
+export class ApolloServer<TContext> extends ApolloServerBase {
   private httpServer?: http.Server;
   private cors?: CorsOptions | boolean;
   private onHealthCheck?: (req: express.Request) => Promise<any>;
 
   constructor(
-    config: ApolloServerExpressConfig & {
+    config: ApolloServerExpressConfig<TContext> & {
       cors?: CorsOptions | boolean;
       onHealthCheck?: (req: express.Request) => Promise<any>;
     },


### PR DESCRIPTION
This PR allows users to define the type of the context object when using 'apollo-server' or 'apollo-server-express'.