### PR TITLE
apollo-engine-reporting: fix maxAttempts parameter, log 5xx body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-core`: Make `formatError` available to subscriptions in the same spirit as the existing `formatResponse`. [PR #2942](https://github.com/apollographql/apollo-server/pull/2942)
+- `apollo-engine-reporting`: The behavior of the `engine.maxAttempts` parameter previously did not match its documentation. It is documented as being the max number of attempts *including* the initial attempt, but until this release it was actually the number of retries *excluding* the initial attempt. The behavior has been changed to match the documentation (and the literal reading of the option name). [PR #3218](https://github.com/apollographql/apollo-server/pull/3218)
+- `apollo-engine-reporting`: When sending the report fails with a server-side 5xx error, include the full error from the server in the logs. [PR #3218](https://github.com/apollographql/apollo-server/pull/3218)
 
 ### v2.9.0
 

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -403,27 +403,32 @@ export class EngineReportingAgent<TContext = any> {
         });
 
         if (curResponse.status >= 500 && curResponse.status < 600) {
-          throw new Error(`${curResponse.status}: ${curResponse.statusText}`);
+          throw new Error(
+            `HTTP status ${curResponse.status}, ${(await curResponse.text()) ||
+              '(no body)'}`,
+          );
         } else {
           return curResponse;
         }
       },
       {
-        retries: this.options.maxAttempts || 5,
+        retries: (this.options.maxAttempts || 5) - 1,
         minTimeout: this.options.minimumRetryDelayMs || 100,
         factor: 2,
       },
     ).catch((err: Error) => {
-      throw new Error(`Error sending report to Apollo Engine servers: ${err}`);
+      throw new Error(
+        `Error sending report to Apollo Engine servers: ${err.message}`,
+      );
     });
 
     if (response.status < 200 || response.status >= 300) {
       // Note that we don't expect to see a 3xx here because request follows
       // redirects.
       throw new Error(
-        `Error sending report to Apollo Engine servers (HTTP status ${
+        `Error sending report to Apollo Engine servers: HTTP status ${
           response.status
-        }): ${await response.text()}`,
+        }, ${(await response.text()) || '(no body)'}`,
       );
     }
     if (this.options.debugPrintReports) {


### PR DESCRIPTION
- The behavior of maxAttempts previously failed to match its documentation or
  the literal reading of its name. Previously, setting maxAttempts=1 would
  actually result in one retry after the initial attempt. This change fixes
  the behavior to match the docs and the name.

- We intend the bodies of Engine report endpoint errors to be useful in error
  logs, even 5xx errors. This change returns to including them in the reported
  error.

PR #1274 (merged before the initial release of apollo-engine-reporting)
regressed both of these issues.
