### PR TITLE
Update Playground to fix #2529.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-server-core`: Make `formatError` available to subscriptions in the same spirit as the existing `formatResponse`. [PR #2942](https://github.com/apollographql/apollo-server/pull/2942)
 - `apollo-engine-reporting`: The behavior of the `engine.maxAttempts` parameter previously did not match its documentation. It is documented as being the max number of attempts *including* the initial attempt, but until this release it was actually the number of retries *excluding* the initial attempt. The behavior has been changed to match the documentation (and the literal reading of the option name). [PR #3218](https://github.com/apollographql/apollo-server/pull/3218)
 - `apollo-engine-reporting`: When sending the report fails with a server-side 5xx error, include the full error from the server in the logs. [PR #3218](https://github.com/apollographql/apollo-server/pull/3218)
+- `apollo-server-core`: Fix regression which prevented the resizing of the schema panel in GraphQL Playground. [PR #3224](https://github.com/apollographql/apollo-server/pull/3224) and [upstream](https://github.com/apollographql/graphql-playground/pull/19)
 
 ### v2.9.0
 

--- a/packages/apollo-server-core/src/playground.ts
+++ b/packages/apollo-server-core/src/playground.ts
@@ -10,7 +10,7 @@ export {
 // This specifies the version of `graphql-playground-react` that will be served
 // from `graphql-playground-html`.  It's passed to ``graphql-playground-html`'s
 // renderPlaygroundPage` via the integration packages' playground configuration.
-const playgroundVersion = '1.7.30';
+const playgroundVersion = '1.7.31';
 
 // https://stackoverflow.com/a/51365037
 type RecursivePartial<T> = {


### PR DESCRIPTION
Via an upstream PR provided by @spencersteers, this fixes a regression in
GraphQL Playground which prevented the resizing of the schema panel.  This
regression seems to have been introduced by
https://github.com/prisma/graphql-playground/pull/1001, which removed the
relevant binding.

See referenced issues for additional details into the change.

Ref: https://github.com/apollographql/graphql-playground/pull/19
Fixes: https://github.com/apollographql/apollo-server/issues/2529