### PR TITLE
Fixup typings for graphql@>14.4.5

### DIFF
--- a/packages/apollo-federation/src/service/printFederatedSchema.ts
+++ b/packages/apollo-federation/src/service/printFederatedSchema.ts
@@ -295,7 +295,7 @@ function printArgs(args: GraphQLArgument[], indentation = '') {
   );
 }
 
-function printInputValue(arg: GraphQLArgument) {
+function printInputValue(arg: GraphQLInputField | GraphQLArgument) {
   const defaultAST = astFromValue(arg.defaultValue, arg.type);
   let argDecl = arg.name + ': ' + String(arg.type);
   if (defaultAST) {

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -57,7 +57,7 @@ export async function executeQueryPlan<TContext>(
     errors,
   };
 
-  let data: ResultMap | undefined = Object.create(null);
+  let data: ResultMap | undefined | null = Object.create(null);
 
   const captureTraces = !!(
     requestContext.metrics && requestContext.metrics.captureTraces
@@ -288,7 +288,7 @@ async function executeFetch<TContext>(
     context: ExecutionContext<TContext>,
     operation: OperationDefinitionNode,
     variables: Record<string, any>,
-  ): Promise<ResultMap | void> {
+  ): Promise<ResultMap | void | null> {
     const source = print(operation);
     // We declare this as 'any' because it is missing url and method, which
     // GraphQLRequest.http is supposed to have if it exists.

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -41,7 +41,7 @@ export interface GraphQLRequest {
 export type VariableValues = { [name: string]: any };
 
 export interface GraphQLResponse {
-  data?: Record<string, any>;
+  data?: Record<string, any> | null;
   errors?: ReadonlyArray<GraphQLFormattedError>;
   extensions?: Record<string, any>;
   http?: Pick<Response, 'headers'> & Partial<Pick<Mutable<Response>, 'status'>>;
@@ -103,7 +103,7 @@ export type GraphQLExecutor<TContext = Record<string, any>> = (
 ) => ValueOrPromise<GraphQLExecutionResult>;
 
 export type GraphQLExecutionResult = {
-  data?: Record<string, any>;
+  data?: Record<string, any> | null;
   errors?: ReadonlyArray<GraphQLError>;
   extensions?: Record<string, any>;
 };


### PR DESCRIPTION
We previously assumed an execution result's value would never be null. This is not true, and enforced in graphql@>14.5.4