### PR TITLE
Update koa-bodyparser to ^4.2.1 (Fixes content-length mismatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- Nothing yet! Stay tuned!
+- `apollo-server-koa`: Update `koa-bodyparser` dependency from `v3.0.0` to `v4.2.1` to fix inaccurate `Content-length` calculation. [PR #3229](https://github.com/apollographql/apollo-server/pull/3229)
 
 ### v2.9.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4243,7 +4243,7 @@
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0",
         "koa": "2.8.1",
-        "koa-bodyparser": "^3.0.0",
+        "koa-bodyparser": "^4.2.1",
         "koa-router": "^7.4.0",
         "type-is": "^1.6.16"
       }

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -39,7 +39,7 @@
     "graphql-subscriptions": "^1.0.0",
     "graphql-tools": "^4.0.0",
     "koa": "2.8.1",
-    "koa-bodyparser": "^3.0.0",
+    "koa-bodyparser": "^4.2.1",
     "koa-router": "^7.4.0",
     "type-is": "^1.6.16"
   },


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
## Issue:
`apollo-server-koa` will incorrectly throw `request size did not match content length` from `raw-body` dependency when a well form request with `content-length` header is followed by well formed request without a `content-length` header i.e. (chunked encoding) 

## Cause:
`koa-bodyparser` creates singleton options objects for `co-body` [on this line](https://github.com/koajs/bodyparser/blob/master/index.js#L62), the version of `co-body` that Apollo server koa resolves to will mutate that options object [fixed in this commit](https://github.com/cojs/co-body/commit/39d2e74b6e112a26607009cdf53d1060cf4099ba) when `content-length` header is present the value is persisted in the singleton. So _any_ follow-up request that might not contain `content-length` will use the previous value.

## Reproduction
1. Make _any_ request to `apollo-server-koa` with a valid body and correct `content-length` header.
2. Make _another_ request to `apollo-server-koa` with `transfer-encoding: chunked` with a **different** body so the resultant length is different to the first request
3. `request size did not match content length` will be thrown

## Fix:
The `co-body` dependency has been fixed (in 2017!). Updating the `koa-bodyparser` to a version that supports the fix will resolve the issue.

