### PR TITLE
types: Use explicit return type of `express.Router` on `getMiddleware`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- Nothing yet! Stay tuned!
+- `apollo-server-express`: Use explicit return type for new `getMiddleware` method, in an effort to resolve [Issue #3222](https://github.com/apollographql/apollo-server/issues/3222) [PR #3230](https://github.com/apollographql/apollo-server/pull/3230)
 
 ### v2.9.1
 

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -119,7 +119,7 @@ export class ApolloServer extends ApolloServerBase {
     bodyParserConfig,
     disableHealthCheck,
     onHealthCheck,
-  }: GetMiddlewareOptions = {}) {
+  }: GetMiddlewareOptions = {}): express.Router {
     if (!path) path = '/graphql';
 
     const router = express.Router();


### PR DESCRIPTION
The TypeScript compiler is inferring the return type of this method
accurately, but emitting `import("express-serve-static-core")` directly into
the `apollo-server-express` type definitions.

Looking at the `package-lock.json` for the Apollo Server repository, I have
a working theory that there are multple `@types/express`'s within this project
and that, when resolving the imports in the delcarations, a copy of
`express-serve-static-core` is not quite in the right resolution path —
potentially due to some package hoisting and module resolution.

To be honest, it's just a theory and I only spent about 3 or 4 minutes
looking at this, but I hope that this will address #3222 (intentionally not
using the keyword "Fixes" here because we'll wait for validation!)

cc @CallMeLaNN