### PR TITLE
apollo-server-express: Add direct dependency on `express`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4176,6 +4176,7 @@
         "apollo-server-types": "file:packages/apollo-server-types",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
+        "express": "^4.17.1",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0",
         "parseurl": "^1.3.2",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -36,6 +36,7 @@
     "apollo-server-types": "file:../apollo-server-types",
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
+    "express": "^4.17.1",
     "graphql-subscriptions": "^1.0.0",
     "graphql-tools": "^4.0.0",
     "parseurl": "^1.3.2",


### PR DESCRIPTION
The [literal `import`-ing of `express` in `ApolloServer.ts`][1] isn't new but, prior to #3047, it had only been a typing dependency — not an actual runtime dependency — since the TypeScript compiler doesn't emit `require`s when only types are utilized.

To see this first hand, see [the emitted `dist/ApolloServer.js` in `apollo-server-express@2.8.2`][2] compared to [the same file in `apollo-server-express@2.9.0`][3].  (Hard to decipher, but check around like 15 and search for `"express"` in the second link.)

Now that we actually utilize `express.Router` to build the composition of middleware in #3047 , it's true that `express` is no longer just a type dependency, but does warrant being a regular dependency as well!

Since this has never been the case before during the entirety of the v2 line, I'm a bit concerned about introducing it now, but it seems other integrations like `apollo-server-koa` already have similar requirements going back to its introduction in [#1282][4]

https://github.com/apollographql/apollo-server/blob/92ea402a90bf9817c9b887707abbd77dcf5edcb4/packages/apollo-server-koa/package.json#L41

Furthermore, we already have similar direct dependencies on other packages which we use directly, like [`cors`][5] and [`body-parser`][6]:

https://github.com/apollographql/apollo-server/blob/ff3af66a0f3c63bfb056feca82fc7e7b7592b4a5/packages/apollo-server-express/package.json

If this turns out to be problematic, we could consider declaring it only in `peerDependencies`, but those come with their own [share of confusion][7].

[1]: https://github.com/apollographql/apollo-server/blob/6d9c3b8c97/packages/apollo-server-express/src/ApolloServer.ts#L1
[2]: https://unpkg.com/apollo-server-express@2.8.2/dist/ApolloServer.js
[3]: https://unpkg.com/apollo-server-express@2.9.0/dist/ApolloServer.js
[4]: https://github.com/apollographql/apollo-server/pull/1282:
[5]: https://npm.im/cors
[6]: https://npm.im/body-parser
[7]: https://github.com/npm/rfcs/pull/43
Fixes: #3238