### PR TITLE
Stop testing Koa on Node.js v6 in order to update `koa-bodyparser`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > [See complete versioning details.](https://github.com/apollographql/apollo-server/commit/92ea402a90bf9817c9b887707abbd77dcf5edcb4)
 
-- `apollo-server-koa`: Update `koa-bodyparser` dependency from `v3.0.0` to `v4.2.1` to fix inaccurate `Content-length` calculation. [PR #3229](https://github.com/apollographql/apollo-server/pull/3229)
+- `apollo-server-koa`: **Drop support for Node.js v6 within the Apollo Server Koa integration in order to update `koa-bodyparser` dependency from `v3.0.0` to `v4.2.1`.** [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO) [Issue #3050](https://github.com/apollographql/apollo-server/issues/3050) [PR #3229](https://github.com/apollographql/apollo-server/pull/3229)
 - `apollo-server-express`: Use explicit return type for new `getMiddleware` method, in an effort to resolve [Issue #3222](https://github.com/apollographql/apollo-server/issues/3222) [PR #3230](https://github.com/apollographql/apollo-server/pull/3230)
 
 ### v2.9.1

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -1,5 +1,3 @@
-import Koa from 'koa';
-
 import http from 'http';
 
 import request from 'request';
@@ -8,7 +6,7 @@ import fs from 'fs';
 import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError, Config } from 'apollo-server-core';
-import { ApolloServer, ServerRegistration } from '../ApolloServer';
+import { ServerRegistration } from '../ApolloServer';
 
 import {
   NODE_MAJOR_VERSION,
@@ -28,9 +26,20 @@ const resolvers = {
   },
 };
 
-describe('apollo-server-koa', () => {
-  let server;
-  let httpServer;
+// If we're on Node.js v6, skip this test, since `koa-bodyparser` has dropped
+// support for it and there was an important update to it which we brought in
+// through https://github.com/apollographql/apollo-server/pull/3229.
+// It's worth noting that Node.js v6 has been out of Long-Term-Support status
+// for four months and is no longer recommended by the Node.js Foundation.
+(
+  NODE_MAJOR_VERSION === 6 ?
+  describe.skip :
+  describe
+)('apollo-server-koa', () => {
+  const { ApolloServer } = require('../ApolloServer');
+  const Koa = require('koa');
+  let server: ApolloServer;
+  let httpServer: http.Server;
   testApolloServer(
     async options => {
       server = new ApolloServer(options);
@@ -48,23 +57,33 @@ describe('apollo-server-koa', () => {
   );
 });
 
-describe('apollo-server-koa', () => {
-  let server: ApolloServer;
-
-  let app: Koa;
+// If we're on Node.js v6, skip this test, since `koa-bodyparser` has dropped
+// support for it and there was an important update to it which we brought in
+// through https://github.com/apollographql/apollo-server/pull/3229.
+// It's worth noting that Node.js v6 has been out of Long-Term-Support status
+// for four months and is no longer recommended by the Node.js Foundation.
+(
+  NODE_MAJOR_VERSION === 6 ?
+  describe.skip :
+  describe
+)('apollo-server-koa', () => {
+  const Koa = require('koa');
+  const { ApolloServer } = require('../ApolloServer');
+  let server: import('../ApolloServer').ApolloServer;
+  let app: import('koa');
   let httpServer: http.Server;
 
   async function createServer(
     serverOptions: Config,
-    options: Partial<ServerRegistration> = {},
+    options: Partial<import('../ApolloServer').ServerRegistration> = {},
   ) {
     server = new ApolloServer(serverOptions);
     app = new Koa();
 
     server.applyMiddleware({ ...options, app });
 
-    httpServer = await new Promise<http.Server>(resolve => {
-      const l = app.listen({ port: 0 }, () => resolve(l));
+    httpServer = await new Promise(resolve => {
+      const l: http.Server = app.listen({ port: 0 }, () => resolve(l));
     });
 
     return createServerInfo(server, httpServer);

--- a/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
@@ -1,12 +1,13 @@
-import Koa from 'koa';
-import { ApolloServer } from '../ApolloServer';
 import testSuite, {
+  NODE_MAJOR_VERSION,
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
 import { GraphQLOptions, Config } from 'apollo-server-core';
 
 function createApp(options: CreateAppOptions = {}) {
+  const Koa = require('koa');
+  const { ApolloServer } = require('../ApolloServer');
   const app = new Koa();
 
   const server = new ApolloServer(
@@ -23,7 +24,17 @@ async function destroyApp(app) {
   await new Promise(resolve => app.close(resolve));
 }
 
-describe('koaApollo', () => {
+// If we're on Node.js v6, skip this test, since `koa-bodyparser` has dropped
+// support for it and there was an important update to it which we brought in
+// through https://github.com/apollographql/apollo-server/pull/3229.
+// It's worth noting that Node.js v6 has been out of Long-Term-Support status
+// for four months and is no longer recommended by the Node.js Foundation.
+(
+  NODE_MAJOR_VERSION === 6 ?
+  describe.skip :
+  describe
+)('koaApollo', () => {
+  const { ApolloServer } = require('../ApolloServer');
   it('throws error if called without schema', function() {
     expect(() => new ApolloServer(undefined as GraphQLOptions)).toThrow(
       'ApolloServer requires options.',
@@ -31,6 +42,15 @@ describe('koaApollo', () => {
   });
 });
 
-describe('integration:Koa', () => {
+// If we're on Node.js v6, skip this test, since `koa-bodyparser` has dropped
+// support for it and there was an important update to it which we brought in
+// through https://github.com/apollographql/apollo-server/pull/3229.
+// It's worth noting that Node.js v6 has been out of Long-Term-Support status
+// for four months and is no longer recommended by the Node.js Foundation.
+(
+  NODE_MAJOR_VERSION === 6 ?
+  describe.skip :
+  describe
+)('integration:Koa', () => {
   testSuite(createApp, destroyApp);
 });


### PR DESCRIPTION
**Support for Koa on Node.js v6 was dropped as of `apollo-server-koa@2.9.2` when `koa-bodyparser` was updated in #3229.**   _This PR only stops **testing** Koa on Node.js v6, which took a bit more work in order to continue testing on Koa on newer versions of Node.js while maintaining testing Node.js v6 for non-Koa frameworks._

Since Node.js v6 is no longer supported by the Node.js Foundation, it was going to come to this sooner or later since transitive packages are inching their ECMAScript compilation targets to more and more recent versions of the language.

While Apollo Server itself will drop support for Node.js v6 in 3.x, the current Koa integration necessitates a more immediate exception since, after bringing #3229 (2dd0592e), the `koa-bodyparser` package was updated to a new major version which, itself, dropped Node.js 6 support.

That update to `koa-bodyparser`, which fixes an incorrect/malformed `Content-length` header calculation is important enough on its own, but there's also a [CVE][1] for the [`qs`][2] dependency, which makes it even more pressing.

We should make sure both of those are included in Apollo Server, which currently drives the underlying version of `koa-bodyparser` (and `koa`, itself) for all users because of its close coupling within the `apollo-server-koa` package).

This doesn't necessarily mean that those who are still on Node.js v6 are completely out of luck, since they could probably modify their `package-lock.json` files to use an older copy of `koa-bodyparser`, but anyone still using Node.js v6 should certainly make considerations - sooner rather than later — about upgrading to more recent and more supported versions of Node.js!

Luckily, this micro-framework-management will soon no longer be a concern with Apollo Server, particularly because of the introduction of a transport abstraction, which is proposed in #3184.

Ref: https://github.com/apollographql/apollo-server/issues/3184

[1]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000048
[2]: https://npm.im/qs

Fixes: https://github.com/apollographql/apollo-server/issues/3050