### PR TITLE
types: Add `@types/aws-lambda` as a dependency of `apollo-server-lambda`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-express`: Add direct dependency on `express` to allow for usage of `express.Router` for `getMiddleware` functionality (from [#2435](https://github.com/apollographql/apollo-server/pull/2435)).  Previously, unlike other server integration packages, `apollo-server-express` did not directly need `express` as a dependency since it only relied on `express` for TypeScript typings. [Issue #3238](https://github.com/apollographql/apollo-server/issues/3238) [PR #3239](https://github.com/apollographql/apollo-server/pull/3239)
+- `apollo-server-lambda`: Add `@types/aws-lambda` as a direct dependency to `apollo-server-express` to allow usage of its typings without needing to separately install it. [Issue #2351](https://github.com/apollographql/apollo-server/issue/2351) [PR #3242](https://github.com/apollographql/apollo-server/pull/3242)
 
 ### v2.9.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3235,8 +3235,7 @@
     "@types/aws-lambda": {
       "version": "8.10.31",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.31.tgz",
-      "integrity": "sha512-xcmOvzVILQoex1oR+vjKnBP3OJn+g92r3yVzeTSmRgLQwBvSOghRPRSx3rVMQivLzAIR6atxlVu3AV9bxc/hQw==",
-      "dev": true
+      "integrity": "sha512-xcmOvzVILQoex1oR+vjKnBP3OJn+g92r3yVzeTSmRgLQwBvSOghRPRSx3rVMQivLzAIR6atxlVu3AV9bxc/hQw=="
     },
     "@types/babel__core": {
       "version": "7.1.0",
@@ -4266,6 +4265,7 @@
       "version": "file:packages/apollo-server-lambda",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
+        "@types/aws-lambda": "^8.10.31",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "apollo-server-types": "file:packages/apollo-server-types",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.24",
+    "@types/aws-lambda": "^8.10.31",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "apollo-server-types": "file:../apollo-server-types",


### PR DESCRIPTION
The typings provided by `aws-types` are used on public methods within the `apollo-server-express` package and, therefore, must be included as direct (not development) dependencies to ensure they are available to packages which utilize it since we don't publish types separately (e.g. via DefinitelyTyped).

For example, these usages:

https://github.com/apollographql/apollo-server/blob/aa3e23de9fbcde41a1bd3cca9c2eacf734bae582/packages/apollo-server-lambda/src/lambdaApollo.ts#L16-L18

https://github.com/apollographql/apollo-server/blob/aa3e23de9fbcde41a1bd3cca9c2eacf734bae582/packages/apollo-server-lambda/src/ApolloServer.ts#L100-L104

And seen in the emitted type declarations here:

https://unpkg.com/apollo-server-lambda@2.9.0/dist/ApolloServer.d.ts
https://unpkg.com/apollo-server-lambda@2.9.0/dist/lambdaApollo.d.ts

(Note the `import` statements, which must be resolvable by TypeScript!)

Fixes: https://github.com/apollographql/apollo-server/issues/2351