### PR TITLE
Add missing variable assignment.

### DIFF
--- a/docs/source/features/apq.md
+++ b/docs/source/features/apq.md
@@ -145,7 +145,7 @@ import { InMemoryCache } from "apollo-cache-inmemory";
 import { ApolloLink } from "apollo-link";
 import ApolloClient from "apollo-client";
 
-ApolloLink.from([
+const link = ApolloLink.from([
   createPersistedQueryLink({ useGETForHashedQueries: true }),
   createHttpLink({ uri: "/graphql" })
 ]);


### PR DESCRIPTION
It seems as if the actual `link` variable declaration is missing.