### PR TITLE
Bug/#3267 hapi upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4564,6 +4564,15 @@
       "integrity": "sha512-DdeXyzAbx632bwNs/+xp6meXWHvKpHCC2647Trfzs48QtEgsxEUB+0Jz4W5J4SNs4k640lWE6431ITOuPsSgpQ==",
       "dev": true
     },
+    "b64": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/b64/-/b64-4.1.2.tgz",
+      "integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ==",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x"
+      }
+    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -5432,6 +5441,15 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
+    },
+    "content": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/content/-/content-4.0.6.tgz",
+      "integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==",
+      "dev": true,
+      "requires": {
+        "boom": "7.x.x"
+      }
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -12712,6 +12730,16 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nigel": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
+      "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x",
+        "vise": "3.x.x"
+      }
+    },
     "nock": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
@@ -13410,6 +13438,19 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "pez": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.5.tgz",
+      "integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ==",
+      "dev": true,
+      "requires": {
+        "b64": "4.x.x",
+        "boom": "7.x.x",
+        "content": "4.x.x",
+        "hoek": "6.x.x",
+        "nigel": "3.x.x"
+      }
     },
     "pify": {
       "version": "3.0.0",
@@ -14795,6 +14836,20 @@
         }
       }
     },
+    "subtext": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.12.tgz",
+      "integrity": "sha512-yT1wCDWVgqvL9BIkWzWqgj5spUSYo/Enu09iUV8t2ZvHcr2tKGTGg2kc9tUpVEsdhp1ihsZeTAiDqh0TQciTPQ==",
+      "dev": true,
+      "requires": {
+        "boom": "7.x.x",
+        "bourne": "1.x.x",
+        "content": "4.x.x",
+        "hoek": "6.x.x",
+        "pez": "4.x.x",
+        "wreck": "14.x.x"
+      }
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -15473,6 +15528,15 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vise": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.2.tgz",
+      "integrity": "sha512-X52VtdRQbSBXdjcazRiY3eRgV3vTQ0B+7Wh8uC9cVv7lKfML5m9+9NHlbcgCY0R9EAqD1v/v7o9mhGh2A3ANFg==",
+      "dev": true,
+      "requires": {
+        "hoek": "6.x.x"
+      }
+    },
     "w3c-hr-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
@@ -15640,6 +15704,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "wreck": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.2.0.tgz",
+      "integrity": "sha512-NFFft3SMgqrJbXEVfYifh+QDWFxni+98/I7ut7rLbz3F0XOypluHsdo3mdEYssGSirMobM3fGlqhyikbWKDn2Q==",
+      "dev": true,
+      "requires": {
+        "boom": "7.x.x",
+        "bourne": "1.x.x",
+        "hoek": "6.x.x"
+      }
     },
     "write-file-atomic": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "request": "2.88.0",
     "request-promise": "4.2.4",
     "subscriptions-transport-ws": "0.9.16",
+    "subtext": "^6.0.12",
     "supertest": "4.0.2",
     "test-listen": "1.1.0",
     "ts-jest": "24.0.2",

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -8,30 +8,7 @@ import {
 import { graphqlHapi } from './hapiApollo';
 
 export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
-import {
-  ApolloServerBase,
-  GraphQLOptions,
-  FileUploadOptions,
-  processFileUploads,
-} from 'apollo-server-core';
-
-function handleFileUploads(uploadsConfig: FileUploadOptions) {
-  return async (request: hapi.Request, _h?: hapi.ResponseToolkit) => {
-    if (
-      typeof processFileUploads === 'function' &&
-      request.mime === 'multipart/form-data'
-    ) {
-      Object.defineProperty(request, 'payload', {
-        value: await processFileUploads(
-          request.raw.req,
-          request.raw.res,
-          uploadsConfig,
-        ),
-        writable: false,
-      });
-    }
-  };
-}
+import { ApolloServerBase, GraphQLOptions } from 'apollo-server-core';
 
 export class ApolloServer extends ApolloServerBase {
   // This translates the arguments from the middleware into graphQL options It
@@ -69,10 +46,6 @@ export class ApolloServer extends ApolloServerBase {
       method: async function(request, h) {
         if (request.path !== path) {
           return h.continue;
-        }
-
-        if (this.uploadsConfig && typeof processFileUploads === 'function') {
-          await handleFileUploads(this.uploadsConfig)(request);
         }
 
         if (this.playgroundOptions && request.method === 'get') {
@@ -138,6 +111,7 @@ export class ApolloServer extends ApolloServerBase {
             : {
                 cors: cors !== undefined ? cors : true,
               },
+        uploadsConfig: this.uploadsConfig,
       },
     });
 

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -409,7 +409,7 @@ const port = 0;
         });
       });
       describe('file uploads', () => {
-        xit('enabled uploads', async () => {
+        it('enabled uploads', async () => {
           server = new ApolloServer({
             typeDefs: gql`
               type File {

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,5 +1,6 @@
 import Boom from 'boom';
-import { Server, Request, RouteOptions } from 'hapi';
+import { Server, Request, RouteOptions, ServerRoute } from 'hapi';
+import Subtext from 'subtext';
 import {
   FileUploadOptions,
   GraphQLOptions,
@@ -39,74 +40,99 @@ const graphqlHapi: IPlugin = {
       throw new Error('Apollo Server requires options.');
     }
 
-    server.route({
-      method: ['GET', 'POST'],
-      path: options.path || '/graphql',
-      vhost: options.vhost || undefined,
-      options: options.route || {},
-      handler: async (request, h) => {
-        try {
-          let query: HttpQueryRequest['query'];
+    const isUploadEnabled =
+      options.uploadsConfig && typeof processFileUploads === 'function';
+    const path = options.path || '/graphql';
 
-          if (request.method === 'get') {
-            // TODO: Don't cast as `any`
-            query = request.query as any;
-          } else {
-            if (
-              request.mime === 'multipart/form-data' &&
-              options.uploadsConfig &&
-              typeof processFileUploads === 'function'
-            ) {
-              query = await processFileUploads(
-                request.raw.req,
-                request.raw.res,
-                options.uploadsConfig,
-              );
-            } else {
-              // TODO: Don't cast as `any`
-              query = request.payload as any;
-            }
-          }
+    const handler: ServerRoute['handler'] = async (request, h) => {
+      try {
+        let query: HttpQueryRequest;
 
-          const { graphqlResponse, responseInit } = await runHttpQuery(
-            [request, h],
-            {
-              method: request.method.toUpperCase(),
-              options: options.graphqlOptions,
-              query,
-              request: convertNodeHttpToRequest(request.raw.req),
-            },
-          );
-
-          const response = h.response(graphqlResponse);
-          Object.keys(responseInit.headers).forEach(key =>
-            response.header(key, responseInit.headers[key]),
-          );
-          return response;
-        } catch (error) {
-          if ('HttpQueryError' !== error.name) {
-            throw Boom.boomify(error);
-          }
-
-          if (true === error.isGraphQLError) {
-            const response = h.response(error.message);
-            response.code(error.statusCode);
-            response.type('application/json');
-            return response;
-          }
-
-          const err = new Boom(error.message, { statusCode: error.statusCode });
-          if (error.headers) {
-            Object.keys(error.headers).forEach(header => {
-              err.output.headers[header] = error.headers[header];
-            });
-          }
-          // Boom hides the error when status code is 500
-          err.output.payload.message = error.message;
-          throw err;
+        if (request.method === 'get') {
+          query = request.query as any;
+        } else if (isUploadEnabled && request.mime === 'multipart/form-data') {
+          query = (await processFileUploads(
+            request.raw.req,
+            request.raw.res,
+            options.uploadsConfig,
+          )) as any;
+        } else {
+          // The request is unparsed due to the 'POST' route's config. Use
+          // Subtext, hapi's default parser, to parse the request.
+          // https://github.com/hapijs/subtext
+          const { payload } = await Subtext.parse(request.raw.req, null, {
+            parse: true,
+            output: 'data',
+          });
+          query = payload;
         }
+
+        const { graphqlResponse, responseInit } = await runHttpQuery(
+          [request, h],
+          {
+            method: request.method.toUpperCase(),
+            options: options.graphqlOptions,
+            query,
+            request: convertNodeHttpToRequest(request.raw.req),
+          },
+        );
+
+        const response = h.response(graphqlResponse);
+        Object.keys(responseInit.headers).forEach(key =>
+          response.header(key, responseInit.headers[key]),
+        );
+        return response;
+      } catch (error) {
+        if ('HttpQueryError' !== error.name) {
+          throw Boom.boomify(error);
+        }
+
+        if (true === error.isGraphQLError) {
+          const response = h.response(error.message);
+          response.code(error.statusCode);
+          response.type('application/json');
+          return response;
+        }
+
+        const err = new Boom(error.message, { statusCode: error.statusCode });
+        if (error.headers) {
+          Object.keys(error.headers).forEach(header => {
+            err.output.headers[header] = error.headers[header];
+          });
+        }
+        // Boom hides the error when status code is 500
+        err.output.payload.message = error.message;
+        throw err;
+      }
+    };
+
+    // hapi doesn't allow `options.payload` configuration to non-POST routes.
+    // Register two routes to apply the necessary `options.payload`
+    // configuration to the POST handler.
+    server.route([
+      {
+        method: 'GET',
+        path,
+        vhost: options.vhost || undefined,
+        options: options.route || {},
+        handler,
       },
-    });
+      {
+        method: 'POST',
+        path,
+        vhost: options.vhost || undefined,
+        handler,
+        options: {
+          ...options.route,
+          // Don't parse the incoming `http.IncomingMessage` to permit passing the
+          // un-parsed request to graphql-upload for upload parsing
+          payload: {
+            output: 'stream',
+            parse: false,
+          },
+        },
+      },
+    ]);
 
     if (next) {
       next();

--- a/types/subtext/index.d.ts
+++ b/types/subtext/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'subtext' {
+  import { IncomingMessage } from 'http'
+  import stream from 'stream'
+
+  export interface SubtextParseOptions {
+    parse: boolean
+    output: 'data' | 'file' | 'stream'
+  }
+
+  export function parse(
+    request: IncomingMessage,
+    tap: stream,
+    options: SubtextParseOptions
+  ): Promise<{
+    mime: string,
+    payload: any
+  }>
+}


### PR DESCRIPTION
* **Problem:** File uploads in apollo-server-hapi appear broken (see #3267). This appears to be due to `request.mime` not being set here: https://github.com/apollographql/apollo-server/blob/10402c46013920b5c9cd64d5ae1cc41f5fe5ceb5/packages/apollo-server-hapi/src/ApolloServer.ts#L22, which is _probably_ due to the hapi not fully parsing the request on `onRequest` extensions.
* **Solution:** Move the file upload handling to the route registered in the hapi plugin.
* **Testing:** Just run the relevant tests:
    ```shell
    $ npx jest packages/apollo-server-hapi/src/__tests__/*.ts
    ```
