### PR TITLE
Upgrade hapi package

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -167,7 +167,7 @@ The `applyMiddleware` method is provided by the `apollo-server-{integration}` pa
 
     Specify a custom path. It defaults to `/graphql` if no path is specified.
 
-  * `cors`: <`Object` | `boolean`> ([express](https://github.com/expressjs/cors#cors), [hapi](https://hapijs.com/api#-routeoptionscors), [koa](https://github.com/koajs/cors/))
+  * `cors`: <`Object` | `boolean`> ([express](https://github.com/expressjs/cors#cors), [hapi](https://hapi.dev/api/?v=18.3.2#route.options.cors), [koa](https://github.com/koajs/cors/))
 
     Pass the integration-specific cors options. False removes the cors middleware and true uses the defaults.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -384,6 +384,316 @@
         }
       }
     },
+    "@hapi/accept": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
+      "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/address": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.1.tgz",
+      "integrity": "sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==",
+      "dev": true
+    },
+    "@hapi/ammo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
+      "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/b64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.3.tgz",
+      "integrity": "sha512-3di+R+BcGS7HKy67Zi6mIga8orf67GdR0ubDEVBG1oqz3y9B70LewsuCMCSvWWLKlI6V1+266zqhYzjMrPGvZw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.1.tgz",
+      "integrity": "sha512-/ecFQTRBom2MEbjMHvKKE6FZ/e1gYK72CeUIFzz++dKK1kYJ0KbRJ72mXroWoTT2hIv+8H0ua/eOkO0+hRdHcw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/call": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
+      "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/catbox": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.2.tgz",
+      "integrity": "sha512-a4KejaKqDOMdwo/PIYoAaObVMmkfkG3RS85kPqNTTURjWnIV1+rrZ938f6RCz5EbrroKbuNC0bcvAt7lAD5LNg==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/podium": "3.x.x"
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/content": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
+      "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
+      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
+      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ==",
+      "dev": true
+    },
+    "@hapi/hapi": {
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.2.tgz",
+      "integrity": "sha512-UJogSyMPe4VFfzjQW5v2ixLvTLZLSfPs1XV/DRnAl2znzsGCaNJI+tgNxjM9lszOjEEkMfxLgoXZadk9exnIxw==",
+      "dev": true,
+      "requires": {
+        "@hapi/accept": "3.x.x",
+        "@hapi/ammo": "3.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/call": "5.x.x",
+        "@hapi/catbox": "10.x.x",
+        "@hapi/catbox-memory": "4.x.x",
+        "@hapi/heavy": "6.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/mimos": "4.x.x",
+        "@hapi/podium": "3.x.x",
+        "@hapi/shot": "4.x.x",
+        "@hapi/somever": "2.x.x",
+        "@hapi/statehood": "6.x.x",
+        "@hapi/subtext": "6.x.x",
+        "@hapi/teamwork": "3.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/heavy": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.1.tgz",
+      "integrity": "sha512-uaEyC4AtGCGKt/LLBbdDQxJP1bFAbxiot6n/fwa4kyo6w8ULpXXCh8FxLlJ5mC06lqbAxQv45JyozIB6P4Dsig==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+      "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==",
+      "dev": true
+    },
+    "@hapi/iron": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.1.tgz",
+      "integrity": "sha512-QYfm6nofZ19pIxm8LR0lsANBabrdxqe0vUYKKI+0w9VdCetoove+dxfbLfduVDM72kh/RNOQG6E5/xyI826PcA==",
+      "dev": true,
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/mimos": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "@hapi/nigel": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/vise": "3.x.x"
+      }
+    },
+    "@hapi/pez": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
+      "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
+      "dev": true,
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/content": "4.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/nigel": "3.x.x"
+      }
+    },
+    "@hapi/podium": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.1.tgz",
+      "integrity": "sha512-WbwYr5nK+GIrCdgEbN8R7Mh7z+j9AgntOLQ/YQdeLtBp+uScVmW9FoycKdNS5uweO74xwICr28Ob0DU74a2zmg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/shot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.1.tgz",
+      "integrity": "sha512-TrsqCyaq24XcdvD0bSi26hjwyQQy5q/nzpasbPNgPLoGnxW3sCWE7ws3ba6dd6Atb8TEh9QBD7mBQDCrMMz2Ig==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/somever": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+      "dev": true,
+      "requires": {
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/statehood": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.1.tgz",
+      "integrity": "sha512-tMfS6B8QdrqTaKRUhHv6Ur7oPK6kcEZcnnvBK4IuaPZA9ma5UsyprTXkzbiB0V+0E56dMg3RabO1SABeZkzy6g==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/iron": "5.x.x",
+        "@hapi/joi": "15.x.x"
+      }
+    },
+    "@hapi/subtext": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
+      "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/content": "4.x.x",
+        "@hapi/file": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/pez": "4.x.x",
+        "@hapi/wreck": "15.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
+      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+      "integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/vise": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.2.tgz",
+      "integrity": "sha512-D/7sGmx3XxxkaMWHZDKTMai8rIEfIgE+DnoZeKfmxhKGgvIpMu1f8BBmLADbdniccGer79w74IWWdXleNrT1Rw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
@@ -3293,22 +3603,10 @@
         "@types/node": "*"
       }
     },
-    "@types/boom": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@types/boom/-/boom-7.2.1.tgz",
-      "integrity": "sha512-kOiap+kSa4DPoookJXQGQyKy1rjZ55tgfKAh9F0m1NUdukkcwVzpSnXPMH42a5L+U++ugdQlh/xFJu/WAdr1aw==",
-      "dev": true
-    },
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
-    },
-    "@types/catbox": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/catbox/-/catbox-10.0.6.tgz",
-      "integrity": "sha512-qS0VHlL6eBUUoUeBnI/ASCffoniS62zdV6IUtLSIjGKmRhZNawotaOMsTYivZOTZVktfe9koAJkD9XFac7tEEg==",
       "dev": true
     },
     "@types/connect": {
@@ -3426,20 +3724,74 @@
         "graphql": "^14.5.3"
       }
     },
-    "@types/hapi": {
-      "version": "17.8.6",
-      "resolved": "https://registry.npmjs.org/@types/hapi/-/hapi-17.8.6.tgz",
-      "integrity": "sha512-8xfvwsfZmQCSognkNDMAkyNlnQwfpGdIP1Y7h/EMgcEzrVHB6lmuDHc8TEMhOJ6lt40TKGBA1e9z9htb/KSbOA==",
+    "@types/hapi__boom": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/hapi__boom/-/hapi__boom-7.4.1.tgz",
+      "integrity": "sha512-x/ZK824GomII7Yoei/nMoB46NQcSfGe0iVpZK3uUivxIAfUUSzRvu8RQO7ZkKapIgzgshHZc+GR+z/BQ8l2VLg==",
+      "dev": true
+    },
+    "@types/hapi__catbox": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.2.tgz",
+      "integrity": "sha512-AWK70LgRsRWL1TNw+aT0IlS56E0pobvFdr/en0K8XazyK4Ey6T/jXhQqv/iQ6FJAAU+somMzgmt9fWq2TaaOkA==",
+      "dev": true
+    },
+    "@types/hapi__hapi": {
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-18.2.5.tgz",
+      "integrity": "sha512-hCAQVtE3OZCihJrn5SxQYmAkIdtE1BwAyvGkxwnPwP+IIe0MQxqbP2s0cwlAwimGOdDQ/ArH+7i6FGDKPlZhFQ==",
       "dev": true,
       "requires": {
-        "@types/boom": "*",
-        "@types/catbox": "*",
-        "@types/iron": "*",
-        "@types/joi": "*",
-        "@types/mimos": "*",
-        "@types/node": "*",
-        "@types/podium": "*",
-        "@types/shot": "*"
+        "@types/hapi__boom": "*",
+        "@types/hapi__catbox": "*",
+        "@types/hapi__iron": "*",
+        "@types/hapi__joi": "*",
+        "@types/hapi__mimos": "*",
+        "@types/hapi__podium": "*",
+        "@types/hapi__shot": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/hapi__iron": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/hapi__iron/-/hapi__iron-5.1.0.tgz",
+      "integrity": "sha512-RxYHIc8wFe8M1jMwgovskoHNVjuP1q0tUGCNnbHnhA4SBMyYg+JHIAz8yFibSwgF4gWYh5yHMpbmK5kmnG4HRA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/hapi__joi": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-15.0.4.tgz",
+      "integrity": "sha512-VSS6zc7AIOdHVXmqKaGNPYl8eGrMvWi0R5pt3evJL3UdxO8XS28/XAkBXNyLQoymHxhMd4bF3o1U9mZkWDeN8w==",
+      "dev": true,
+      "requires": {
+        "@types/hapi__joi": "*"
+      }
+    },
+    "@types/hapi__mimos": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.0.tgz",
+      "integrity": "sha512-hcdSoYa32wcP+sEfyf85ieGwElwokcZ/mma8eyqQ4OTHeCAGwfaoiGxjG4z1Dm+RGhIYLHlW54ji5FFwahH12A==",
+      "dev": true,
+      "requires": {
+        "@types/mime-db": "*"
+      }
+    },
+    "@types/hapi__podium": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/hapi__podium/-/hapi__podium-3.4.0.tgz",
+      "integrity": "sha512-LE85jLgqR5HscGQ7SaSz6FMRsKlQ1wHVbYc9u0yq7NKDRvZiQFIrr3Pl1RPzK7QNUdZP8zmJibe8q0JcafTAJQ==",
+      "dev": true
+    },
+    "@types/hapi__shot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.0.tgz",
+      "integrity": "sha512-vIySJYkwIGXMB5eFaZu3U8dS9CAZmteJfmkRn9bYH5uNcSvVgiwDROiwAkD7ej88qA+RZPkUK70KmeDs3LRHvw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/http-assert": {
@@ -3451,15 +3803,6 @@
       "version": "4.0.17",
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.0.17.tgz",
       "integrity": "sha512-Lq/lG64wTc6A3uu4tj8zKtVHZw2GPLIJgmWweMbMLwwIx34KycyyQJtbeUZBOtD4a8K5RCPr1kWau0x81rKQNw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/iron": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/iron/-/iron-5.0.1.tgz",
-      "integrity": "sha512-Ng5BkVGPt7Tw9k1OJ6qYwuD9+dmnWgActmsnnrdvs4075N8V2go1f6Pz8omG3q5rbHjXN6yzzZDYo3JOgAE/Ug==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3500,12 +3843,6 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
-      "dev": true
-    },
-    "@types/joi": {
-      "version": "14.3.3",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.3.tgz",
-      "integrity": "sha512-6gAT/UkIzYb7zZulAbcof3lFxpiD5EI6xBeTvkL1wYN12pnFQ+y/+xl9BvnVgxkmaIDN89xWhGZLD9CvuOtZ9g==",
       "dev": true
     },
     "@types/keygrip": {
@@ -3636,15 +3973,6 @@
       "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
       "dev": true
     },
-    "@types/mimos": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mimos/-/mimos-3.0.1.tgz",
-      "integrity": "sha512-MATIRH4VMIJki8lcYUZdNQEHuAG7iQ1FWwoLgxV+4fUOly2xZYdhHtGgvQyWiTeJqq2tZbE0nOOgZD6pR0FpNQ==",
-      "dev": true,
-      "requires": {
-        "@types/mime-db": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3683,12 +4011,6 @@
         "@types/events": "*",
         "@types/node": "*"
       }
-    },
-    "@types/podium": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/podium/-/podium-1.0.0.tgz",
-      "integrity": "sha1-v6ohUb4rHWEJzGn3+qnawsujuyA=",
-      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -3730,15 +4052,6 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
-      }
-    },
-    "@types/shot": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/shot/-/shot-4.0.0.tgz",
-      "integrity": "sha512-Xv+n8yfccuicMlwBY58K5PVVNtXRm7uDzcwwmCarBxMP+XxGfnh1BI06YiVAsPbTAzcnYsrzpoS5QHeyV7LS8A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -8265,315 +8578,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "hapi": {
-      "version": "17.8.5",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.8.5.tgz",
-      "integrity": "sha512-+RnMWK/HI3VCvzfy0vO28YycMX19OiY8h9tYaDzjjOJ1eTh/HY2URvhFNkcqxZ1R1uoUdiB+pnjGi9e+vkaPEw==",
-      "dev": true,
-      "requires": {
-        "accept": "3.x.x",
-        "ammo": "3.x.x",
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "call": "5.x.x",
-        "catbox": "10.x.x",
-        "catbox-memory": "3.x.x",
-        "heavy": "6.x.x",
-        "hoek": "6.x.x",
-        "joi": "14.x.x",
-        "mimos": "4.x.x",
-        "podium": "3.x.x",
-        "shot": "4.x.x",
-        "somever": "2.x.x",
-        "statehood": "6.x.x",
-        "subtext": "6.x.x",
-        "teamwork": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "dependencies": {
-        "accept": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-          "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "ammo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.3.tgz",
-          "integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "b64": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/b64/-/b64-4.1.2.tgz",
-          "integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "big-time": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.1.tgz",
-          "integrity": "sha512-qtwYYoocwpiAxTXC5sIpB6nH5j6ckt+n/jhD7J5OEiFHnUZEFn0Xk8STUaE5s10LdazN/87bTDMe+fSihaW7Kg==",
-          "dev": true
-        },
-        "boom": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
-          "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "bounce": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.2.tgz",
-          "integrity": "sha512-1LPcXg3fkGVhjdA/P3DcR5cDktKEYtDpruJv9Nhmy36RoYaoxZfC82Zr2JmS3vysDJKqMtP0qJw3/P6iisTASg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "bourne": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.1.tgz",
-          "integrity": "sha512-Ou0l3W8+n1FuTOoIfIrCk9oF9WVWc+9fKoAl67XQr9Ws0z7LgILRZ7qtc9xdT4BveSKtnYXfKPgn8pFAqeQRew==",
-          "dev": true
-        },
-        "call": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/call/-/call-5.0.3.tgz",
-          "integrity": "sha512-eX16KHiAYXugbFu6VifstSdwH6aMuWWb4s0qvpq1nR1b+Sf+u68jjttg8ixDBEldPqBi30bDU35OJQWKeTLKxg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "catbox": {
-          "version": "10.0.5",
-          "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.5.tgz",
-          "integrity": "sha512-5SpI/tEP3SiLE1qkkV+/hdVW48sHVBEbzPX4jBiwl6hsZh/gkl4bqfGLkvh7mjpMK5evJ0Rm/6NRlhF/Jsy9ow==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "catbox-memory": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.4.tgz",
-          "integrity": "sha512-1tDnll066au0HXBSDHS/YQ34MQ2omBsmnA9g/jseyq/M3m7UPrajVtPDZK/rXgikSC1dfjo9Pa+kQ1qcyG2d3g==",
-          "dev": true,
-          "requires": {
-            "big-time": "2.x.x",
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "content": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/content/-/content-4.0.6.tgz",
-          "integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x"
-          }
-        },
-        "cryptiles": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x"
-          }
-        },
-        "heavy": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.2.tgz",
-          "integrity": "sha512-cJp884bqhiebNcEHydW0g6V1MUGYOXRPw9c7MFiHQnuGxtbWuSZpsbojwb2kxb3AA1/Rfs8CNiV9MMOF8pFRDg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "hoek": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-          "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw==",
-          "dev": true
-        },
-        "iron": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
-          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
-          "dev": true,
-          "requires": {
-            "b64": "4.x.x",
-            "boom": "7.x.x",
-            "cryptiles": "4.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "joi": {
-          "version": "14.0.4",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-14.0.4.tgz",
-          "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "isemail": "3.x.x",
-            "topo": "3.x.x"
-          }
-        },
-        "mime-db": {
-          "version": "1.37.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-          "dev": true
-        },
-        "mimos": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.2.tgz",
-          "integrity": "sha512-5XBsDqBqzSN88XPPH/TFpOalWOjHJM5Z2d3AMx/30iq+qXvYKd/8MPhqBwZDOLtoaIWInR3nLzMQcxfGK9djXA==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "mime-db": "1.x.x"
-          }
-        },
-        "nigel": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
-          "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "vise": "3.x.x"
-          }
-        },
-        "pez": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.5.tgz",
-          "integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ==",
-          "dev": true,
-          "requires": {
-            "b64": "4.x.x",
-            "boom": "7.x.x",
-            "content": "4.x.x",
-            "hoek": "6.x.x",
-            "nigel": "3.x.x"
-          }
-        },
-        "podium": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.5.tgz",
-          "integrity": "sha512-+fAPmAj3d5fWKx5oSjQKeBIcl46/qZnGLhzyi/dJ/HzNiOpuxyX/Y4091LiVxZQ4ALdf/LCS7siV6ai5nNLlOg==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "shot": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.7.tgz",
-          "integrity": "sha512-RKaKAGKxJ11EjJl0cf2fYVSsd4KB5Cncb9J0v7w+0iIaXpxNqFWTYNDNhBX7f0XSyDrjOH9a4OWZ9Gp/ZML+ew==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "somever": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/somever/-/somever-2.0.0.tgz",
-          "integrity": "sha512-9JaIPP+HxwYGqCDqqK3tRaTqdtQHoK6Qy3IrXhIt2q5x8fs8RcfU7BMWlFTCOgFazK8p88zIv1tHQXvAwtXMyw==",
-          "dev": true,
-          "requires": {
-            "bounce": "1.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "statehood": {
-          "version": "6.0.9",
-          "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.9.tgz",
-          "integrity": "sha512-jbFg1+MYEqfC7ABAoWZoeF4cQUtp3LUvMDUGExL76cMmleBHG7I6xlZFsE8hRi7nEySIvutHmVlLmBe9+2R5LQ==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "bounce": "1.x.x",
-            "bourne": "1.x.x",
-            "cryptiles": "4.x.x",
-            "hoek": "6.x.x",
-            "iron": "5.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "subtext": {
-          "version": "6.0.12",
-          "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.12.tgz",
-          "integrity": "sha512-yT1wCDWVgqvL9BIkWzWqgj5spUSYo/Enu09iUV8t2ZvHcr2tKGTGg2kc9tUpVEsdhp1ihsZeTAiDqh0TQciTPQ==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "bourne": "1.x.x",
-            "content": "4.x.x",
-            "hoek": "6.x.x",
-            "pez": "4.x.x",
-            "wreck": "14.x.x"
-          }
-        },
-        "teamwork": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.2.tgz",
-          "integrity": "sha512-tpG01+9Qws/oGhMBiZN3BnB32gn5QeKY84AmLxxaCJw4mNeRzhEZ6jEj/vBhKerHD7Hgq9/vOZ58pyryYSn9gA==",
-          "dev": true
-        },
-        "topo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "vise": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.1.tgz",
-          "integrity": "sha512-7BJNjsv2o83+E6AHAFSnjQF324UTgypsR/Sw/iFmLvr7RgJrEXF1xNBvb5LJfi+1FvWQXjJK4X41WMuHMeunPQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "wreck": {
-          "version": "14.1.3",
-          "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.3.tgz",
-          "integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -9244,15 +9248,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "dev": true,
-      "requires": {
-        "punycode": "2.x.x"
-      }
     },
     "isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -58,13 +58,14 @@
     "graphql-extensions": "file:packages/graphql-extensions"
   },
   "devDependencies": {
+    "@hapi/hapi": "^18.3.2",
     "@types/async-retry": "1.4.1",
     "@types/aws-lambda": "8.10.31",
     "@types/body-parser": "1.17.1",
     "@types/connect": "3.4.32",
     "@types/fast-json-stable-stringify": "2.0.0",
     "@types/graphql": "14.2.3",
-    "@types/hapi": "17.8.6",
+    "@types/hapi__hapi": "^18.2.5",
     "@types/ioredis": "4.0.17",
     "@types/jest": "24.0.18",
     "@types/koa-router": "7.0.42",
@@ -99,7 +100,6 @@
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "2.10.1",
     "graphql-tools": "4.0.5",
-    "hapi": "17.8.5",
     "ioredis": "4.14.0",
     "jest": "24.9.0",
     "jest-config": "24.9.0",

--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -9,11 +9,11 @@ npm install apollo-server-hapi
 
 ## Usage
 
-The code below requires Hapi 17 or higher.
+The code below requires Hapi 18 or higher.
 
 ```js
 const { ApolloServer, gql } = require('apollo-server-hapi');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 async function StartServer() {
   const server = new ApolloServer({ typeDefs, resolvers });

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -37,6 +37,7 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
+    "@hapi/hapi": "^18.2.0",
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   }
 }

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import hapi from 'hapi';
+import hapi from '@hapi/hapi';
 import { parseAll } from 'accept';
 import {
   renderPlaygroundPage,

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -21,10 +21,10 @@ const port = 0;
   () => {
     let server: ApolloServer;
 
-    let app: import('hapi').Server;
+    let app: import('@hapi/hapi').Server;
     let httpServer: http.Server;
 
-    const { Server } = require('hapi');
+    const { Server } = require('@hapi/hapi');
 
     testApolloServer(
       async options => {

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -15,7 +15,7 @@ import { ApolloServer } from '../ApolloServer';
 
 const port = 0;
 
-// NODE: Intentionally skip for Node.js < 8 since Hapi 17 doesn't support those.
+// NODE: Intentionally skip for Node.js < 8 since Hapi 18 doesn't support those.
 (NODE_MAJOR_VERSION < 8 ? describe.skip : describe)(
   'apollo-server-hapi',
   () => {

--- a/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
@@ -7,7 +7,7 @@ import testSuite, {
   NODE_MAJOR_VERSION,
 } from 'apollo-server-integration-testsuite';
 
-// NODE: Intentionally skip on Node.js < 8 since Hapi 17 doesn't support less
+// NODE: Intentionally skip on Node.js < 8 since Hapi 18 doesn't support less
 (NODE_MAJOR_VERSION < 8 ? describe.skip : describe)('integration:Hapi', () => {
   async function createApp(options: CreateAppOptions = {}) {
     const { Server } = require('@hapi/hapi');

--- a/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
@@ -10,9 +10,9 @@ import testSuite, {
 // NODE: Intentionally skip on Node.js < 8 since Hapi 17 doesn't support less
 (NODE_MAJOR_VERSION < 8 ? describe.skip : describe)('integration:Hapi', () => {
   async function createApp(options: CreateAppOptions = {}) {
-    const { Server } = require('hapi');
+    const { Server } = require('@hapi/hapi');
 
-    const app: import('hapi').Server = new Server({
+    const app: import('@hapi/hapi').Server = new Server({
       host: 'localhost',
       port: 8000,
     });

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,5 +1,5 @@
 import Boom from 'boom';
-import { Server, Request, RouteOptions } from 'hapi';
+import { Server, Request, RouteOptions } from '@hapi/hapi';
 import {
   GraphQLOptions,
   runHttpQuery,

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,8 +33,8 @@
       "allowedVersions": "<3"
     },
     {
-      "packageNames": ["hapi", "@types/hapi"],
-      "allowedVersions": "<18"
+      "packageNames": ["@hapi/hapi", "@types/hapi__hapi"],
+      "allowedVersions": "<19"
     },
     {
       "packageNames": ["ws"],


### PR DESCRIPTION
* **Type:** Integration (upgrade a supported framework)
* **Problem:**
  * Apollo-server is 1 major version behind on hapi (current is v18)
  * The [hapi 17 license](https://github.com/hapijs/hapi/tree/v17-commercial) requires users purchase a commercial license (ref: https://blog.sideway.com/hapi-enterprise-support-22aa77a8158e). While the version currently used to test hapi in this repository (`hapi@17.8.5`) doesn't contain this license, a renovate upgrade may unwittingly put this project in a licensing issue. Also, Apollo users should probably upgrade if they want to avoid the commercial license and keep up with the latest and greatest stuff. The package rename makes this difficult.
* **Solution:**
  * Upgrade apollo-server-hapi to the `@hapi/hapi` packages
  * Update documentation, comments
  * Add `@hapi/hapi` as an explicit peer dependency in apollo-server-hapi
* **Testing:** Let's see if CI tests pass 🤞 