### PR TITLE
Change all broken redirect destinations to real pages

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -6,21 +6,21 @@
 
 # Redirects associated with revamp of Apollo Server information architecture
 /docs/apollo-server/whats-new https://github.com/apollographql/apollo-server/blob/master/CHANGELOG.md
-/docs/apollo-server/essentials/data/ /docs/apollo-server/serving/data/
+/docs/apollo-server/essentials/data/ /docs/apollo-server/data/data/
 /docs/apollo-server/essentials/schema/ /docs/apollo-server/schema/schema/
 /docs/apollo-server/essentials/server /docs/apollo-server/getting-started/
 /docs/apollo-server/features/apq/ /docs/apollo-server/performance/apq/
-/docs/apollo-server/features/authentication/ /docs/apollo-server/serving/authentication/
+/docs/apollo-server/features/authentication/ /docs/apollo-server/security/authentication/
 /docs/apollo-server/features/caching/ /docs/apollo-server/performance/caching/
 /docs/apollo-server/features/creating-directives/ /docs/apollo-server/schema/creating-directives/
-/docs/apollo-server/features/data-sources/ /docs/apollo-server/serving/data-sources/
-/docs/apollo-server/features/directives/ /docs/apollo-server/schema/directives/schema/scalars-enums/
-/docs/apollo-server/features/file-uploads/ /docs/apollo-server/serving/file-uploads/
-/docs/apollo-server/features/graphql-playground/ /docs/apollo-server/graphql-playground/
+/docs/apollo-server/features/data-sources/ /docs/apollo-server/data/data-sources/
+/docs/apollo-server/features/directives/ /docs/apollo-server/schema/directives/
+/docs/apollo-server/features/file-uploads/ /docs/apollo-server/data/file-uploads/
+/docs/apollo-server/features/graphql-playground/ /docs/apollo-server/testing/graphql-playground/
 /docs/apollo-server/features/health-checks/ /docs/apollo-server/monitoring/health-checks/
 /docs/apollo-server/features/metrics/ /docs/apollo-server/monitoring/metrics/
 /docs/apollo-server/features/mocking/ /docs/apollo-server/testing/mocking/
 /docs/apollo-server/features/scalars-enums/ /docs/apollo-server/
-/docs/apollo-server/features/subscriptions/ /docs/apollo-server/serving/subscriptions/
+/docs/apollo-server/features/subscriptions/ /docs/apollo-server/data/subscriptions/
 /docs/apollo-server/features/testing/ /docs/apollo-server/testing/testing/
 /docs/apollo-server/features/unions-interfaces/ /docs/apollo-server/schema/unions-interfaces/


### PR DESCRIPTION
This branch fixes a number of broken redirect destinations in the docs' `_redirects` file.