### PR TITLE
Remove deprecated `registerServer` function.

### DIFF
--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -227,9 +227,3 @@ export class ApolloServer extends ApolloServerBase {
     return router;
   }
 }
-
-export const registerServer = () => {
-  throw new Error(
-    'Please use server.applyMiddleware instead of registerServer. This warning will be removed in the next release',
-  );
-};

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -24,7 +24,6 @@ export * from 'graphql-subscriptions';
 // ApolloServer integration.
 export {
   ApolloServer,
-  registerServer,
   ServerRegistration,
   ApolloServerExpressConfig,
 } from './ApolloServer';

--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -184,9 +184,3 @@ export class ApolloServer extends ApolloServerBase {
     };
   }
 }
-
-export const registerServer = () => {
-  throw new Error(
-    'Please use server.createHandler instead of registerServer. This warning will be removed in the next release',
-  );
-};

--- a/packages/apollo-server-fastify/src/index.ts
+++ b/packages/apollo-server-fastify/src/index.ts
@@ -24,6 +24,5 @@ export * from 'graphql-subscriptions';
 // ApolloServer integration.
 export {
   ApolloServer,
-  registerServer,
   ServerRegistration,
 } from './ApolloServer';

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -154,9 +154,3 @@ export interface ServerRegistration {
   disableHealthCheck?: boolean;
   uploads?: boolean | Record<string, any>;
 }
-
-export const registerServer = () => {
-  throw new Error(
-    'Please use server.applyMiddleware instead of registerServer. This warning will be removed in the next release',
-  );
-};

--- a/packages/apollo-server-hapi/src/index.ts
+++ b/packages/apollo-server-hapi/src/index.ts
@@ -24,6 +24,5 @@ export * from 'graphql-subscriptions';
 // ApolloServer integration.
 export {
   ApolloServer,
-  registerServer,
   ServerRegistration,
 } from './ApolloServer';

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -210,9 +210,3 @@ export class ApolloServer extends ApolloServerBase {
     return compose(middlewares);
   }
 }
-
-export const registerServer = () => {
-  throw new Error(
-    'Please use server.applyMiddleware instead of registerServer. This warning will be removed in the next release',
-  );
-};

--- a/packages/apollo-server-koa/src/index.ts
+++ b/packages/apollo-server-koa/src/index.ts
@@ -24,6 +24,5 @@ export * from 'graphql-subscriptions';
 // ApolloServer integration.
 export {
   ApolloServer,
-  registerServer,
   ServerRegistration,
 } from './ApolloServer';


### PR DESCRIPTION
This cleans up some pre-release cruft which is no longer necessary.

The `registerServer` method was the pre-release name for today's `applyMiddleware` method in early (again, pre-release) versions of Apollo Server.

It's been `throw`ing since the first _stable_ release of Apollo Server so this isn't a breaking change.