### PR TITLE
Remove local `fast-json-stable-stringify` types installed via DefinitelyTyped.

### DIFF
--- a/types/fast-json-stable-stringify/index.d.ts
+++ b/types/fast-json-stable-stringify/index.d.ts
@@ -1,1 +1,0 @@
-export default function stringify(obj: any): string;


### PR DESCRIPTION
This merely removes the unnecessary local (and incomplete) set of the types which were already being installed from DefinitelyTyped since 90572878561.