### PR TITLE
Stub out `it.todo` tests representing future work for transport abstraction

### DIFF
--- a/packages/apollo-server-core/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-core/src/__tests__/ApolloServer.test.ts
@@ -1,0 +1,15 @@
+describe("ApolloServer", () => {
+  it.todo("errors when called without any parameters");
+  it.todo("accepts 'typeDefs' and 'resolvers'");
+  describe("accepts context", () => {
+    it.todo("permits context to be a simple object");
+    it.todo("permits context to be a function that returns an object");
+  });
+  describe("mocks", () => {
+    it.todo("allows mocks to be boolean true");
+    it.todo("allows mocks as an object");
+    it.todo("allows mocks as an object and preserves existing resolvers");
+    // Not sure about this, but see existing test by the same name.
+    it.todo("skipped allows mocks as an object with overriding the existing resolvers");
+  });
+});

--- a/packages/apollo-server-core/src/__tests__/requestPipeline.test.ts
+++ b/packages/apollo-server-core/src/__tests__/requestPipeline.test.ts
@@ -1,0 +1,124 @@
+describe("requestPipeline", () => {
+  describe("queries", () => {
+    it.todo("can run a simple query");
+    it.todo("can run a query with variables");
+    it.todo("raises a syntax error when one is encountered in the operation document")
+    // Reconsider this test.
+    it.todo("does not call console.error if an error occurs and debug mode is set");
+    // Reconsider this test.
+    it.todo("does not call console.error if an error occurs and not in debug mode");
+    it.todo("returns a validation error if the query does not validate");
+    it.todo("errors when variables are malformed");
+    it.todo("throws an error when there are missing variables");
+    it.todo("allows a resolver to yield");
+    it.todo("executes the correct operation when 'operationName' is specified");
+    it.todo("errors out when an 'operationName' does not match an operation in the document");
+    it.todo("returns an IntrospectionResult when performing an IntrospectionQuery");
+    // I don't understand this test.  It seems to me that we'd just
+    // want to ensure that we're receiving a JSON string value for 'query', but
+    // this seems to make a specific test for DocumentNode?
+    it.todo("does not accept a DocumentNode as a 'query' body");
+  });
+
+  describe("Mutations", () => {
+    it.todo("can run a simple mutation");
+  });
+
+  describe("errors", () => {
+    it.todo("propagates errors, WITH their stack and code, to the 'errors' response in non-production");
+    it.todo("propagates errors, WITHOUT their stack and code, to the 'errors' response in production");
+  });
+
+  describe("formatResponse", () => {
+    it.todo("applies formatResponse");
+  });
+
+  describe("formatError", () => {
+    it.todo("applies formatError");
+    it.todo("receives an error that is an instance of GraphQLError and Error");
+    it.todo("allows the sanitization of an error");
+    it.todo("permits the return of an object");
+    it.todo("guards against exceptions within a user's formatError implementation");
+  });
+
+  describe("Context", () => {
+    it.todo("passes the context to the resolver");
+    it.todo("propagates contextual errors to the 'errors' response");
+    // Maybe.  This might be tested elsewhere, but I needed to log this here
+    // to at least acknowledge it did exist before.
+    it.todo("receives transport-specific properties");
+  });
+
+  describe("Plugins", () => {
+    // Each of these should be tested more thoroughly, paying close attention to
+    // timing and ordering, including whether they properly await other hooks.
+    it.todo("requestDidStart");
+    describe("parsingDidStart", () => {
+      // There are existing tests, but they don't seem to be named correctly
+      // considering this life-cycle hook would be a _before_ parse hook.
+      // That said, they were on the `graphql-extensions` implementation, not
+      // the new request pipeline, so maybe the behavior has changed.
+      it.todo("is invoked when parsing will result in an error");
+      it.todo("is invoked when a successful parse happens")
+    });
+    it.todo("validationDidStart");
+    it.todo("didResolveOperation");
+    describe("didEncounterErrors", () => {
+      it.todo("is invoked when an error occurs during parsing");
+      it.todo("is invoked when an error occurs during validation");
+      it.todo("is invoked when an error occurs during prior life-cycle hooks");
+      it.todo("is invoked when an error occurs during execution");
+    });
+    it.todo("responseForOperation");
+    it.todo("executionDidStart");
+    it.todo("willSendResponse");
+  });
+
+  describe("parsing and validation cache", () => {
+    it.todo("validates each time when the documentStore is not configured");
+    it.todo("caches the DocumentNode in the documentStore when configured");
+  });
+
+  // We may not support rootValue in AS3, so these may not need to be implemented.
+  describe("rootValue", () => {
+    it.todo("passes the rootValue to the resolver");
+    it.todo("passes the rootValue function result to the resolver");
+  });
+
+  // We may not support fieldResolver in AS3, so these may not need to be implemented.
+  describe("fieldResolver", () => {
+    it.todo("runs a custom fieldResolver");
+  });
+
+  describe("validationRules", () => {
+    it.todo("applies user-provided validation rules");
+  });
+
+  describe("Batches", () => {
+    it.todo("returns an array response when an array of operations is sent");
+    it.todo("returns an array response when an array of operations is sent and one of the operations contains multiple operations with an 'operationName' specified");
+    it.todo("can process the requests in parallel");
+    // TODO what _should_ this do?
+    it.todo("does something properly with the context when doing batched operations");
+  });
+
+  describe("Cache Control", () => {
+    it.todo("returns cacheControl extensions when cacheControl is enabled");
+    it.todo("returns default maxAge when no specific hints are provided");
+  });
+
+  describe("Persisted Queries", () => {
+    it.todo("normalizes operations to the same hash");
+    it.todo("errors with 'PersistedQueryNotSupported' when persisted queries are disabled");
+    it.todo("errors with 'PersistedQueryNotSupported' when persisted queries are disabled");
+    it.todo("errors with 'PersistedQueryNotFound' when query is not persisted");
+    it.todo("uses DocumentNode from persisted operation when it is available");
+    it.todo("behaves properly for batched operations");
+    it.todo("errors when the hash provided doesn't match the operation provided");
+  });
+
+  // TODO Possibly remove these or put them somewhere else.
+  describe("Misc", () => {
+    it.todo("does not break async_hook call stack");
+  });
+});

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -1323,5 +1323,34 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
         expect(result.body.data).toEqual({ testString: 'it works' });
       });
     });
+
+    /**
+     * This is the beginning of tests which are directly related to HTTP
+     * transport-related functionality.
+     */
+    describe("transport specific", () => {
+      it.todo("returns a 500 if the body of the request is missing");
+      it.todo("returns a 405 if the HTTP method was not 'POST' or 'GET'");
+      it.todo("returns a 400 if the 'query' is missing when the 'GET' method is used");
+      it.todo("returns a 200 when GraphQL execution completes");
+      it.todo("returns a 405 when attempting a 'mutation' when the 'GET' method is used");
+      it.todo("ensure that 'extensions' are properly returned in the response");
+      it.todo("ensure that 'errors' is properly returned in the response");
+      it.todo("ensure that 'data' is properly returned in the response");
+      it.todo("returns a 400 when 'query' is malformed");
+      it.todo("returns a 400 when 'variables' is malformed");
+      it.todo("returns a 400 when the GraphQL operation does not validate");
+      // I'm not sure if this next one is relevant anymore since we'll be
+      // specifically leaving that binding up to the user and it would be
+      // outside of our knowledge/concern.
+      it.todo("returns a 404 on other routes");
+      it.todo("invokes 'serverWillStart' life-cycle hook before serving a request");
+
+      // TODO Consider Persisted Queries.
+      // The HTTP status codes for persisted queries should be generated
+      // within the transport based on the error codes that are related to
+      // persisted queries (i.e. PersistedQueryNotFound)
+      it.todo("returns 400 when persisted query hash is mismatched with the document")
+    });
   });
 };


### PR DESCRIPTION
> This PR closely relates to the transports work from #3184.

Historically, most of the testing within Apollo Server has occurred within a monolithic (local) package called `apollo-server-integration-testsuite` which exercisizes complete end-to-end tests across several HTTP framework integrations (e.g. Express, Koa, Hapi).

After some extensive analysis of existing tests (literally, going through each and every file and test with a notepad), from not only `apollo-server-integration-testsuite` but across the entirety of the Apollo Server monorepo, this PR introduces a proposal via **incomplete** tests (using `it.todo` tests, rather than `it` to indicate their lack of implementation!).  I hope this represents a natural grouping which is more appropriate for the soon-to-be-realized world where HTTP transport functionality is separated from that of GraphQL execution. (See #3184)

In making this proposal whole, many of the existing tests (by often similar names) should be used as inspiration when filling out these `it.todo` tests.  Once complete, it will allow us to sunset the `apollo-server-integration-testsuite` package, though there are some additional TODO items which are not covered by this PR that should be addressed before that can happen (currently tracked internally).

Some of the additional destructuring of the existing testing monolith also applies more granular concerns which more closely wraps the code that implements the behavior being tested.  For example, consider the `ApolloServerBase` class within `apollo-server-core` and adjacent `requestPipeline.ts` (which wraps all GraphQL execution within Apollo Server): previously, any testing of `requestPipeline.ts`' `processGraphQLRequest` only occurred from `apollo-server-integration-testsuite`.

Not only does that pattern make the tests seem like an afterthought since the tests were so distant from the features they were testing, but it also mixes in a lot of other complications which are not related to the function being tested.  For example, new tests were being introduced to `apollo-server-integration-testsuite` in an end-to-end HTTP test fashion when smaller unit-tests would have sufficed, just because that was the status quo of the existing tests.  Technically, that also proved to be quite painful since we'd open and close the same TCP ports hundreds of times during a test run.

Having better separation of concerns with more appropriate co-located tests should speed up tests and provide more scalable testing patterns which are simpler to reason about, and that's what this foundation is aiming to do.

For now, this PR still places the proposal for some of this new grouping within the existing `apollo-server-integration-testsuite`, but this is not meant to be their final home.  That home will only be determined once the work on Apollo Server 3.x is further along and the strucutre of that package solidifies.

Ref: https://github.com/apollographql/apollo-server/issues/3184