### PR TITLE
Adding `reporting` to the type of BaseConfig

### DIFF
--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -62,6 +62,7 @@ type BaseConfig = Pick<
   | 'tracing'
   | 'dataSources'
   | 'cache'
+  | 'reporting'
 >;
 
 export type Unsubscriber = () => void;


### PR DESCRIPTION
The Typescript complains about the missing property `reporting` of ApolloServer constructor options. It should be part of the BaseConfig type.