### PR TITLE
Federation page redirect

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -25,3 +25,5 @@
 /docs/apollo-server/features/subscriptions/ /docs/apollo-server/data/subscriptions/
 /docs/apollo-server/features/testing/ /docs/apollo-server/testing/testing/
 /docs/apollo-server/features/unions-interfaces/ /docs/apollo-server/schema/unions-interfaces/
+
+/docs/apollo-server/federation/managed-federation /docs/graph-manager/federation/#connecting-apollo-server-to-the-graph-manager


### PR DESCRIPTION
Adds a redirect from a former federation page to the one on the graph manager docs