### PR TITLE
Fix debug query plan logging

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- Nothing yet! Stay tuned!
+* Fix debug query plan logging [#3376](https://github.com/apollographql/apollo-server/pull/3376)
 
 # v0.10.1
 

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -510,6 +510,12 @@ export class ApolloGateway implements GraphQLService {
       operationContext,
     );
 
+    const serializedQueryPlan = serializeQueryPlan(queryPlan);
+
+    // Log the query plan if it's non-empty
+    if (queryPlan.node) this.logger.debug(serializedQueryPlan);
+
+
     const shouldShowQueryPlan =
       this.config.__exposeQueryPlanExperimental &&
       request.http &&
@@ -517,9 +523,6 @@ export class ApolloGateway implements GraphQLService {
       request.http.headers.get('Apollo-Query-Plan-Experimental');
 
     if (shouldShowQueryPlan) {
-      const serializedQueryPlan = serializeQueryPlan(queryPlan);
-      this.logger.debug(serializedQueryPlan);
-
       // TODO: expose the query plan in a more flexible JSON format in the future
       // and rename this to `queryPlan`. Playground should cutover to use the new
       // option once we've built a way to print that representation.


### PR DESCRIPTION
This PR fixes a bug where query plan logging only occurred
if `shouldShowQueryPlan` was true. This boolean is only true
under certain conditions during _introspection_, meaning that
this debug log was disabled for all regular queries.

This PR opts to only serialize the query plan if _either_ debugging is enabled, _or_ if the `Apollo-Query-Plan-Experimental` header is set. We then log and/or respond with the query plan as appropriate.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
