### PR TITLE
Fix double instantiation of DataSources

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-* Add export for experimental observability functions types.
+* Add export for experimental observability functions types. [#3371](https://github.com/apollographql/apollo-server/pull/3371)
+* Fix double instantiation of DataSources [#3388](https://github.com/apollographql/apollo-server/pull/3388)
 
 # v0.10.2
 

--- a/packages/apollo-gateway/src/__tests__/gateway/buildService.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/buildService.test.ts
@@ -1,9 +1,7 @@
 import gql from 'graphql-tag';
-import { print } from 'graphql';
 import { fetch } from '__mocks__/apollo-server-env';
 import { createTestClient } from 'apollo-server-testing';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
-import { buildFederatedSchema } from '@apollo/federation';
 
 import { RemoteGraphQLDataSource } from '../../datasources/RemoteGraphQLDataSource';
 import { ApolloGateway } from '../../';

--- a/packages/apollo-gateway/src/__tests__/gateway/buildService.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/buildService.test.ts
@@ -19,20 +19,24 @@ beforeEach(() => {
 });
 
 it('calls buildService only once per service', async () => {
+  fetch.mockJSONResponseOnce({
+    data: { _service: { sdl: `extend type Query { thing: String }` } },
+  });
+
   const buildServiceSpy = jest.fn(() => {
     return new RemoteGraphQLDataSource({
-      url: 'https://api.example.com/foo'
+      url: 'https://api.example.com/foo',
     });
   });
 
   const gateway = new ApolloGateway({
-    localServiceList: [accounts, books, inventory, product, reviews],
+    serviceList: [{ name: 'foo', url: 'https://api.example.com/foo' }],
     buildService: buildServiceSpy
   });
 
   await gateway.load();
 
-  expect(buildServiceSpy).toHaveBeenCalledTimes(5);
+  expect(buildServiceSpy).toHaveBeenCalledTimes(1);
 });
 
 it('correctly passes the context from ApolloServer to datasources', async () => {

--- a/packages/apollo-gateway/src/__tests__/gateway/buildService.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/buildService.test.ts
@@ -18,6 +18,23 @@ beforeEach(() => {
   fetch.mockReset();
 });
 
+it('calls buildService only once per service', async () => {
+  const buildServiceSpy = jest.fn(() => {
+    return new RemoteGraphQLDataSource({
+      url: 'https://api.example.com/foo'
+    });
+  });
+
+  const gateway = new ApolloGateway({
+    localServiceList: [accounts, books, inventory, product, reviews],
+    buildService: buildServiceSpy
+  });
+
+  await gateway.load();
+
+  expect(buildServiceSpy).toHaveBeenCalledTimes(5);
+});
+
 it('correctly passes the context from ApolloServer to datasources', async () => {
   const gateway = new ApolloGateway({
     localServiceList: [accounts, books, inventory, product, reviews],


### PR DESCRIPTION
Currently, buildService is being called twice for each service on
gateway startup. While we _are_ caching the datasources,
we're failing to utilize the cache.

This commit places the creation and caching of datasources in one
place, and indicates this more clearly with an updated function
name.

Fixes #3367 

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
