### PR TITLE
Gateway schema change listener bug + refactor

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-* Gateway schema change listener bug + refactor [#3411](https://github.com/apollographql/apollo-server/pull/3411)
+* Gateway schema change listener bug + refactor [#3411](https://github.com/apollographql/apollo-server/pull/3411) introduces a change to the `experimental_didUpdateComposition` hook and `experimental_pollInterval` configuration behavior.
+1. Previously, the `experimental_didUpdateComposition` hook wouldn't be reliably called unless the `experimental_pollInterval` was set. If it _was_ called, it was sporadic and didn't necessarily mark the timing of an actual composition update. After this change, the `dUC` hook is called on a successful composition update.
+2. The `experimental_pollInterval` configuration option now affects both the GCS polling interval when gateway is configured for managed federation, as well as the polling interval of services. The former being newly introduced behavior.
 
 # v.0.10.7
 

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -5,7 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
 * Gateway schema change listener bug + refactor [#3411](https://github.com/apollographql/apollo-server/pull/3411) introduces a change to the `experimental_didUpdateComposition` hook and `experimental_pollInterval` configuration behavior.
-1. Previously, the `experimental_didUpdateComposition` hook wouldn't be reliably called unless the `experimental_pollInterval` was set. If it _was_ called, it was sporadic and didn't necessarily mark the timing of an actual composition update. After this change, the `dUC` hook is called on a successful composition update.
+  1. Previously, the `experimental_didUpdateComposition` hook wouldn't be reliably called unless the `experimental_pollInterval` was set. If it _was_ called, it was sporadic and didn't necessarily mark the timing of an actual composition update. After this change, the hook is called on a successful composition update.
 2. The `experimental_pollInterval` configuration option now affects both the GCS polling interval when gateway is configured for managed federation, as well as the polling interval of services. The former being newly introduced behavior.
 
 # v.0.10.7

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-* _Nothing yet! Stay tuned!_
+* Gateway schema change listener bug + refactor [#3411](https://github.com/apollographql/apollo-server/pull/3411)
 
 # v.0.10.7
 

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Gateway schema change listener bug + refactor [#3411](https://github.com/apollographql/apollo-server/pull/3411) introduces a change to the `experimental_didUpdateComposition` hook and `experimental_pollInterval` configuration behavior.
   1. Previously, the `experimental_didUpdateComposition` hook wouldn't be reliably called unless the `experimental_pollInterval` was set. If it _was_ called, it was sporadic and didn't necessarily mark the timing of an actual composition update. After this change, the hook is called on a successful composition update.
-2. The `experimental_pollInterval` configuration option now affects both the GCS polling interval when gateway is configured for managed federation, as well as the polling interval of services. The former being newly introduced behavior.
+  2. The `experimental_pollInterval` configuration option now affects both the GCS polling interval when gateway is configured for managed federation, as well as the polling interval of services. The former being newly introduced behavior.
 
 # v.0.10.7
 

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -260,11 +260,14 @@ it('Rollsback to a previous schema when triggered', async () => {
   jest.useFakeTimers();
 
   const onChange = jest.fn();
+
   const gateway = new ApolloGateway();
+
   await gateway.load({ engine: { apiKeyHash, graphId: serviceName } });
 
   gateway.onSchemaChange(onChange);
 
+  // 10000 ms is the default pollInterval
   jest.advanceTimersByTime(10000);
 
   // This useReal/useFake is challenging to explain the need for, and I probably

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -260,11 +260,8 @@ it('Rollsback to a previous schema when triggered', async () => {
   jest.useFakeTimers();
 
   const onChange = jest.fn();
-
   const gateway = new ApolloGateway();
-
   await gateway.load({ engine: { apiKeyHash, graphId: serviceName } });
-
   gateway.onSchemaChange(onChange);
 
   // 10000 ms is the default pollInterval

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -262,20 +262,23 @@ it('Rollsback to a previous schema when triggered', async () => {
   const onChange = jest.fn();
   const gateway = new ApolloGateway();
   await gateway.load({ engine: { apiKeyHash, graphId: serviceName } });
+
   gateway.onSchemaChange(onChange);
-  jest.runOnlyPendingTimers();
+
+  jest.advanceTimersByTime(10000);
 
   jest.useRealTimers();
-  await new Promise(resolve => setTimeout(resolve, 100));
+  await new Promise(resolve => setTimeout(resolve, 10));
   jest.useFakeTimers();
 
   expect(onChange.mock.calls.length).toBe(1);
 
-  jest.runOnlyPendingTimers();
+  jest.advanceTimersByTime(10000);
 
   jest.useRealTimers();
-  await new Promise(resolve => setTimeout(resolve, 100));
+  await new Promise(resolve => setTimeout(resolve, 10));
   jest.useFakeTimers();
+
 
   expect(onChange.mock.calls.length).toBe(2);
 });

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -267,6 +267,9 @@ it('Rollsback to a previous schema when triggered', async () => {
 
   jest.advanceTimersByTime(10000);
 
+  // This useReal/useFake is challenging to explain the need for, and I probably
+  // don't have the _correct_ answer here, but it seems that pushing this process
+  // to the back of the task queue is insufficient.
   jest.useRealTimers();
   await new Promise(resolve => setTimeout(resolve, 10));
   jest.useFakeTimers();
@@ -278,7 +281,6 @@ it('Rollsback to a previous schema when triggered', async () => {
   jest.useRealTimers();
   await new Promise(resolve => setTimeout(resolve, 10));
   jest.useFakeTimers();
-
 
   expect(onChange.mock.calls.length).toBe(2);
 });

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -255,8 +255,8 @@ export class ApolloGateway implements GraphQLService {
     const previousCompositionMetadata = this.compositionMetadata;
 
     let result: Await<ReturnType<Experimental_UpdateServiceDefinitions>>;
+    this.logger.debug('Loading configuration for gateway');
     try {
-      this.logger.debug('Loading configuration for gateway');
       result = await this.updateServiceDefinitions(this.config);
     } catch (e) {
       this.logger.warn(

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -209,7 +209,19 @@ export class ApolloGateway implements GraphQLService {
         config.experimental_didFailComposition;
       this.experimental_didUpdateComposition =
         config.experimental_didUpdateComposition;
-      this.experimental_pollInterval = config.experimental_pollInterval;
+
+      if (
+        isManagedConfig(config) &&
+        config.experimental_pollInterval &&
+        config.experimental_pollInterval < 10000
+      ) {
+        this.experimental_pollInterval = 10000;
+        this.logger.warn(
+          'Polling Apollo services at a frequency of less than once per 10 seconds (10000) is disallowed. Instead, the minimum allowed pollInterval of 10000 will be used. Please reconfigure your experimental_pollInterval accordingly. If this is problematic for your team, please contact support.',
+        );
+      } else {
+        this.experimental_pollInterval = config.experimental_pollInterval;
+      }
 
       // Warn against using the pollInterval and a serviceList simulatenously
       if (config.experimental_pollInterval && isRemoteConfig(config)) {
@@ -269,7 +281,7 @@ export class ApolloGateway implements GraphQLService {
     if (
       !('serviceDefinitions' in result) ||
       JSON.stringify(this.serviceDefinitions) ===
-      JSON.stringify(result.serviceDefinitions)
+        JSON.stringify(result.serviceDefinitions)
     ) {
       this.logger.debug('No change in service definitions since last check');
       return;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -262,7 +262,10 @@ export class ApolloGateway implements GraphQLService {
       return;
     }
 
-    if (!('serviceDefinitions' in result)) return;
+    if (!('serviceDefinitions' in result)) {
+      this.logger.trace('No changes to service definitions.');
+      return;
+    }
 
     if (
       JSON.stringify(this.serviceDefinitions) ===

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -262,10 +262,11 @@ export class ApolloGateway implements GraphQLService {
       return;
     }
 
+    if (!('serviceDefinitions' in result)) return;
+
     if (
-      !result.serviceDefinitions ||
       JSON.stringify(this.serviceDefinitions) ===
-        JSON.stringify(result.serviceDefinitions)
+      JSON.stringify(result.serviceDefinitions)
     ) {
       this.logger.debug('No change in service definitions since last check');
       return;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -266,12 +266,8 @@ export class ApolloGateway implements GraphQLService {
       return;
     }
 
-    if (!('serviceDefinitions' in result)) {
-      this.logger.trace('No changes to service definitions.');
-      return;
-    }
-
     if (
+      !('serviceDefinitions' in result) ||
       JSON.stringify(this.serviceDefinitions) ===
       JSON.stringify(result.serviceDefinitions)
     ) {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -223,16 +223,10 @@ export class ApolloGateway implements GraphQLService {
   }
 
   public async load(options?: { engine?: GraphQLServiceEngineConfig }) {
-    if (options && options.engine) {
-      if (!options.engine.graphVariant)
-        console.warn('No graph variant provided. Defaulting to `current`.');
-      this.engineConfig = options.engine;
-    }
-
-    await this.updateComposition();
+    await this.updateComposition(options);
     if (this.experimental_pollInterval) {
       setInterval(
-        () => this.updateComposition(),
+        () => this.updateComposition(options),
         this.experimental_pollInterval,
       );
     }
@@ -245,7 +239,17 @@ export class ApolloGateway implements GraphQLService {
     };
   }
 
-  private async updateComposition(): Promise<void> {
+  protected async updateComposition(options?: {
+    engine?: GraphQLServiceEngineConfig;
+  }): Promise<void> {
+    // The options argument and internal config update coule be handled by this.load()
+    // instead of here. We can remove this as a breaking change in the future.
+    if (options && options.engine) {
+      if (!options.engine.graphVariant)
+        console.warn('No graph variant provided. Defaulting to `current`.');
+      this.engineConfig = options.engine;
+    }
+
     const previousSchema = this.schema;
     const previousServiceDefinitions = this.serviceDefinitions;
     const previousCompositionMetadata = this.compositionMetadata;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -245,7 +245,7 @@ export class ApolloGateway implements GraphQLService {
     };
   }
 
-  private async updateComposition() {
+  private async updateComposition(): Promise<void> {
     const previousSchema = this.schema;
     const previousServiceDefinitions = this.serviceDefinitions;
     const previousCompositionMetadata = this.compositionMetadata;


### PR DESCRIPTION
This PR removes quite a bit of duplication around the `updateComposition` function of `ApolloGateway`. This consolidates two very similar functions, one anonymous async function being used for polling and the original updateComposition function.

This consolidation fixes a bug where the gateway didn't notify its `onSchemaChange` listeners when the composition was updated.

Behavioral differences as a result of these changes:
1. Previously, the `experimental_didUpdateComposition` hook wouldn't be reliably called unless the `experimental_pollInterval` was set. If it _was_ called, it was sporadic and didn't necessarily mark the timing of an actual composition update. After this change, the `dUC` hook is called on a successful composition update.
2. The `experimental_pollInterval` configuration option now affects both the GCS polling interval when gateway is configured for managed federation, as well as the polling interval of services. The former being newly introduced behavior.

Note:
This is broken out from its original PR: https://github.com/apollographql/apollo-server/pull/3409
In order to separate two unrelated changes and cleanup some unnecessary git madness that I introduced by moving `updateComposition` around within the `ApolloGateway` class.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
