### PR TITLE
Gateway cached DataSource bug

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Gateway schema change listener bug + refactor [#3411](https://github.com/apollographql/apollo-server/pull/3411) introduces a change to the `experimental_didUpdateComposition` hook and `experimental_pollInterval` configuration behavior.
   1. Previously, the `experimental_didUpdateComposition` hook wouldn't be reliably called unless the `experimental_pollInterval` was set. If it _was_ called, it was sporadic and didn't necessarily mark the timing of an actual composition update. After this change, the hook is called on a successful composition update.
   2. The `experimental_pollInterval` configuration option now affects both the GCS polling interval when gateway is configured for managed federation, as well as the polling interval of services. The former being newly introduced behavior.
+* Gateway cached DataSource bug [#3412](https://github.com/apollographql/apollo-server/pull/3412) introduces a fix for managed federation users where `DataSource`s wouldn't update correctly if a service's url changed. This bug was introduced with heavier DataSource caching in [#3388](https://github.com/apollographql/apollo-server/pull/3388). By inspecting the `url` as well, `DataSource`s will now update correctly when a composition update occurs.
 
 # v.0.10.7
 

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -406,9 +406,7 @@ export class ApolloGateway implements GraphQLService {
       return this.serviceMap[serviceDef.name].dataSource;
 
     if (!serviceDef.url && !isLocalConfig(this.config)) {
-      throw new Error(
-        `Service definition for service ${serviceDef.name} is missing a url`,
-      );
+      this.logger.error(`Service definition for service ${serviceDef.name} is missing a url`)
     }
 
     const dataSource = this.config.buildService
@@ -523,7 +521,7 @@ export class ApolloGateway implements GraphQLService {
         serviceDataSources[serviceName] = dataSource;
         return serviceDataSources;
       },
-      {} as ServiceMap,
+      Object.create(null) as ServiceMap,
     );
 
     if (this.experimental_didResolveQueryPlan) {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -76,6 +76,10 @@ export type GatewayConfig =
   | LocalGatewayConfig
   | ManagedGatewayConfig;
 
+type DataSourceCache = {
+  [serviceName: string]: { url?: string; dataSource: GraphQLDataSource };
+};
+
 function isLocalConfig(config: GatewayConfig): config is LocalGatewayConfig {
   return 'localServiceList' in config;
 }
@@ -121,16 +125,17 @@ export type Experimental_DidUpdateCompositionCallback = (
   previousConfig?: Experimental_CompositionInfo,
 ) => void;
 
+/**
+ * Note: it's possible for a schema to be the same with serviceDefinitions that
+ * have changed. For example, during type migration.
+ */
 export type Experimental_UpdateServiceDefinitions = (
   config: GatewayConfig,
-) => Promise<
-  | {
-      serviceDefinitions: ServiceDefinition[];
-      compositionMetadata?: CompositionMetadata;
-      isNewSchema: true;
-    }
-  | { isNewSchema: false }
->;
+) => Promise<{
+  serviceDefinitions?: ServiceDefinition[];
+  compositionMetadata?: CompositionMetadata;
+  isNewSchema: boolean;
+}>;
 
 type Await<T> = T extends Promise<infer U> ? U : T;
 
@@ -141,7 +146,7 @@ type RequestContext<TContext> = WithRequired<
 
 export class ApolloGateway implements GraphQLService {
   public schema?: GraphQLSchema;
-  protected serviceMap: ServiceMap = Object.create(null);
+  protected serviceMap: DataSourceCache = Object.create(null);
   protected config: GatewayConfig;
   protected logger: Logger;
   protected queryPlanStore?: InMemoryLRUCache<QueryPlan>;
@@ -279,7 +284,7 @@ export class ApolloGateway implements GraphQLService {
     }
 
     if (
-      !('serviceDefinitions' in result) ||
+      !result.serviceDefinitions ||
       JSON.stringify(this.serviceDefinitions) ===
       JSON.stringify(result.serviceDefinitions)
     ) {
@@ -394,8 +399,11 @@ export class ApolloGateway implements GraphQLService {
     serviceDef: ServiceEndpointDefinition,
   ): GraphQLDataSource {
     // If the DataSource has already been created, early return
-    if (this.serviceMap[serviceDef.name])
-      return this.serviceMap[serviceDef.name];
+    if (
+      this.serviceMap[serviceDef.name] &&
+      serviceDef.url === this.serviceMap[serviceDef.name].url
+    )
+      return this.serviceMap[serviceDef.name].dataSource;
 
     if (!serviceDef.url && !isLocalConfig(this.config)) {
       throw new Error(
@@ -410,7 +418,7 @@ export class ApolloGateway implements GraphQLService {
         });
 
     // Cache the created DataSource
-    this.serviceMap[serviceDef.name] = dataSource;
+    this.serviceMap[serviceDef.name] = { url: serviceDef.url, dataSource };
 
     return dataSource;
   }
@@ -510,17 +518,25 @@ export class ApolloGateway implements GraphQLService {
       }
     }
 
+    const serviceMap: ServiceMap = Object.entries(this.serviceMap).reduce(
+      (serviceDataSources, [serviceName, { dataSource }]) => {
+        serviceDataSources[serviceName] = dataSource;
+        return serviceDataSources;
+      },
+      {} as ServiceMap,
+    );
+
     if (this.experimental_didResolveQueryPlan) {
       this.experimental_didResolveQueryPlan({
         queryPlan,
-        serviceMap: this.serviceMap,
+        serviceMap,
         operationContext,
       });
     }
 
     const response = await executeQueryPlan<TContext>(
       queryPlan,
-      this.serviceMap,
+      serviceMap,
       requestContext,
       operationContext,
     );

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -281,7 +281,7 @@ export class ApolloGateway implements GraphQLService {
     if (
       !('serviceDefinitions' in result) ||
       JSON.stringify(this.serviceDefinitions) ===
-        JSON.stringify(result.serviceDefinitions)
+      JSON.stringify(result.serviceDefinitions)
     ) {
       this.logger.debug('No change in service definitions since last check');
       return;

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -126,7 +126,7 @@ export type Experimental_DidUpdateCompositionCallback = (
 ) => void;
 
 /**
- * Note: It's possible for a schema to be the same (`isNewSchema: false`) when
+ * **Note:** It's possible for a schema to be the same (`isNewSchema: false`) when
  * `serviceDefinitions` have changed. For example, during type migration, the
  * composed schema may be identical but the `serviceDefinitions` would differ
  * since a type has moved from one service to another.

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -288,7 +288,7 @@ export class ApolloGateway implements GraphQLService {
     if (
       !result.serviceDefinitions ||
       JSON.stringify(this.serviceDefinitions) ===
-      JSON.stringify(result.serviceDefinitions)
+        JSON.stringify(result.serviceDefinitions)
     ) {
       this.logger.debug('No change in service definitions since last check');
       return;
@@ -408,7 +408,9 @@ export class ApolloGateway implements GraphQLService {
       return this.serviceMap[serviceDef.name].dataSource;
 
     if (!serviceDef.url && !isLocalConfig(this.config)) {
-      this.logger.error(`Service definition for service ${serviceDef.name} is missing a url`)
+      this.logger.error(
+        `Service definition for service ${serviceDef.name} is missing a url`,
+      );
     }
 
     const dataSource = this.config.buildService

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -126,8 +126,10 @@ export type Experimental_DidUpdateCompositionCallback = (
 ) => void;
 
 /**
- * Note: it's possible for a schema to be the same with serviceDefinitions that
- * have changed. For example, during type migration.
+ * Note: It's possible for a schema to be the same (`isNewSchema: false`) when
+ * `serviceDefinitions` have changed. For example, during type migration, the
+ * composed schema may be identical but the `serviceDefinitions` would differ
+ * since a type has moved from one service to another.
  */
 export type Experimental_UpdateServiceDefinitions = (
   config: GatewayConfig,

--- a/packages/apollo-gateway/src/loadServicesFromRemoteEndpoint.ts
+++ b/packages/apollo-gateway/src/loadServicesFromRemoteEndpoint.ts
@@ -78,8 +78,5 @@ export async function getServiceDefinitionsFromRemoteEndpoint({
     serviceDefinitions.filter(Boolean),
   )) as ServiceDefinition[];
 
-  // XXX TS can't seem to infer that isNewSchema could be true
-  return (isNewSchema as true | false)
-    ? { serviceDefinitions, isNewSchema: true }
-    : { isNewSchema: false };
+  return { serviceDefinitions, isNewSchema }
 }


### PR DESCRIPTION
This PR addresses a bug in the gateway that prevents it from constructing new `DataSource`s when composition updates and the url of an underlying service changes. Currently the creation of a `DataSource` is cached based on its `serviceName`, but really the caching should depend on both the `serviceName` and `url` of the `ServiceDefinition`.

The bug in question was introduced in #3388.

Note:
This is broken out from its original PR: #3409
In order to separate two unrelated changes and cleanup some unnecessary git madness that I introduced.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
