### PR TITLE
Fix Gateway / Playground Query Plan view

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-* _Nothing yet! Stay tuned!_
+* Fix Gateway / Playground Query Plan view [#3418](https://github.com/apollographql/apollo-server/pull/3418)
 
 # v.0.10.7
 

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -539,11 +539,17 @@ export class ApolloGateway implements GraphQLService {
       this.logger.debug(serializedQueryPlan);
     }
 
-    if (shouldShowQueryPlan && serializedQueryPlan) {
+    if (shouldShowQueryPlan) {
       // TODO: expose the query plan in a more flexible JSON format in the future
       // and rename this to `queryPlan`. Playground should cutover to use the new
       // option once we've built a way to print that representation.
-      response.extensions = { __queryPlanExperimental: serializedQueryPlan };
+
+      // In the case that `serializedQueryPlan` is null (on introspection), we
+      // still want to respond to Playground with something truthy since it depends
+      // on this to decide that query plans are supported by this gateway.
+      response.extensions = {
+        __queryPlanExperimental: serializedQueryPlan || true,
+      };
     }
     return response;
   };


### PR DESCRIPTION
This commit revisits recent changes from PR #3376 which broke
Playground's ability to detect support for the Query Plan view.

Playground's internals decide that QP is supported based on the
response from the first introspection query. The previously mentioned
PR broke this by not providing any `response.extensions.__queryPlanExperimental`
at all. This makes sense for `debug` mode, but Playground still needs
some form of hint to know that it's supported and continue sending
the `Apollo-Query-Plan-Experimental` header.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
