### PR TITLE
formatResponse: Fix typings and provide full request context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
+- `apollo-server-core`: Provide accurate type for `formatResponse` rather than generic `Function` type. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO)
+- `apollo-server-core`: Pass complete request context to `formatResponse`, rather than just `context`. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO)
+
 ### v2.9.7
 
 > [See complete versioning details.](https://github.com/apollographql/apollo-server/commit/5d94e986f04457ec17114791ee6db3ece4213dd8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- `apollo-server-core`: Provide accurate type for `formatResponse` rather than generic `Function` type. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO)
-- `apollo-server-core`: Pass complete request context to `formatResponse`, rather than just `context`. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO)
+- `apollo-server-core`: Provide accurate type for `formatResponse` rather than generic `Function` type. [PR #3431](https://github.com/apollographql/apollo-server/pull/3431)
+- `apollo-server-core`: Pass complete request context to `formatResponse`, rather than just `context`. [PR #3431](https://github.com/apollographql/apollo-server/pull/3431)
 
 ### v2.9.7
 

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -12,7 +12,12 @@ import { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
 import { DataSource } from 'apollo-datasource';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import { GraphQLParseOptions } from 'graphql-tools';
-import { GraphQLExecutor, ValueOrPromise } from 'apollo-server-types';
+import {
+  GraphQLExecutor,
+  ValueOrPromise,
+  GraphQLResponse,
+  GraphQLRequestContext,
+} from 'apollo-server-types';
 
 /*
  * GraphQLServerOptions
@@ -40,7 +45,10 @@ export interface GraphQLServerOptions<
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;
   executor?: GraphQLExecutor;
-  formatResponse?: Function;
+  formatResponse?: (
+    response: GraphQLResponse | null,
+    requestContext: GraphQLRequestContext<TContext>,
+  ) => GraphQLResponse
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   debug?: boolean;
   tracing?: boolean;

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -87,7 +87,10 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   cacheControl?: CacheControlExtensionOptions;
 
   formatError?: (error: GraphQLError) => GraphQLFormattedError;
-  formatResponse?: Function;
+  formatResponse?: (
+    response: GraphQLResponse | null,
+    requestContext: GraphQLRequestContext<TContext>,
+  ) => GraphQLResponse;
 
   plugins?: ApolloServerPlugin[];
   documentStore?: InMemoryLRUCache<DocumentNode>;

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -388,9 +388,7 @@ export async function processGraphQLRequest<TContext>(
     if (config.formatResponse) {
       const formattedResponse: GraphQLResponse | null = config.formatResponse(
         response,
-        {
-          context: requestContext.context,
-        },
+        requestContext,
       );
       if (formattedResponse != null) {
         response = formattedResponse;


### PR DESCRIPTION
Previously, the `formatResponse` was only typed as a `Function`.  However, since it's expected that the function return a `GraphQLResponse` (the same thing that it receives, that typing seems a bit too generic.  This changes the typing to more accurately reflect the way it should be used, and also provides it the complete `requestContext` rather than just the cherry-picked `context` property.