### PR TITLE
Begin supporting executable directives in federation

### DIFF
--- a/docs/source/federation/errors.md
+++ b/docs/source/federation/errors.md
@@ -37,7 +37,7 @@ Apollo Federation implements a strict composition model. When building a gateway
 ### Custom directives
 
 - `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives may only be [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
-- `EXECUTABLE_DIRECTIVES_EVERYWHERE`: Custom directives must be implemented across all services. It's acceptable to implement a directive as a no-op within a particular service, but it must still be defined.
+- `EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES`: Custom directives must be implemented across all services. It's acceptable to implement a directive as a no-op within a particular service, but it must still be defined.
 - `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives must be implemented identically from one service to the next. This means that arguments and their respective types, as well as the directives locations, must all be identical within every service.
 
 ### Enums and Scalars

--- a/docs/source/federation/errors.md
+++ b/docs/source/federation/errors.md
@@ -36,7 +36,7 @@ Apollo Federation implements a strict composition model. When building a gateway
 
 ### Custom directives
 
-- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives may only be [ExecutableDirective]s(https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
+- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives may only be [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
 - `EXECUTABLE_DIRECTIVES_EVERYWHERE`: Custom directives must be implemented across all services. It's acceptable to implement a directive as a no-op within a particular service, but it must still be defined.
 - `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives must be implemented identically from one service to the next. This means that arguments and their respective types, as well as the directives locations, must all be identical within every service.
 

--- a/docs/source/federation/errors.md
+++ b/docs/source/federation/errors.md
@@ -36,7 +36,7 @@ Apollo Federation implements a strict composition model. When building a gateway
 
 ### Custom directives
 
-- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives can only be [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
+- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives can only be [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations that a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
 - `EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES`: Custom directives must be implemented across all services. It's acceptable to implement a directive as a no-op within a particular service, but it must still be defined.
 - `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives must be implemented identically across all services. This means that arguments and their respective types, as well as the directive's locations, must all be identical within every service.
 

--- a/docs/source/federation/errors.md
+++ b/docs/source/federation/errors.md
@@ -32,19 +32,19 @@ Apollo Federation implements a strict composition model. When building a gateway
 
 - `REQUIRES_FIELDS_MISSING_EXTERNAL`: For every field in a `@requires` selection, there must be a matching `@external` field in the service.
 - `REQUIRES_FIELDS_MISSING_ON_BASE`: The fields arg in `@requires` can only reference fields on the base type.
-- `REQUIRES_USED_ON_BASE`: The requires directive may not be used on fields defined on a base type.
+- `REQUIRES_USED_ON_BASE`: The requires directive can not be used on fields defined on a base type.
 
 ### Custom directives
 
-- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives may only be [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
+- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives can only be [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
 - `EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES`: Custom directives must be implemented across all services. It's acceptable to implement a directive as a no-op within a particular service, but it must still be defined.
-- `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives must be implemented identically from one service to the next. This means that arguments and their respective types, as well as the directives locations, must all be identical within every service.
+- `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives must be implemented identically across all services. This means that arguments and their respective types, as well as the directive's locations, must all be identical within every service.
 
 ### Enums and Scalars
 
 - `DUPLICATE_ENUM_DEFINITION`: An Enum was defined multiple times in a single service. Remove one of the definitions.
 - `DUPLICATE_SCALAR_DEFINITION`: A Scalar was defined multiple times in a single service. Remove one of the definitions.
-- `DUPLICATE_ENUM_VALUE`: A service has multiple definitions of the same Enum `value`. This duplicate value may be in the definition itself or enum extensions.
+- `DUPLICATE_ENUM_VALUE`: A service has multiple definitions of the same Enum `value`. This duplicate value can be in the definition itself or enum extensions.
 - `ENUM_MISMATCH`: An Enum does not have identical values across all services. Even if a service does not use all enum values, they still must be provided if another service uses them. This error will list services with matching definitions like `[serviceA, serviceB], [serviceC]` where `serviceA` and `serviceB` have matching enum definitions, and `serviceC` does not match the other definitions.
 - `ENUM_MISMATCH_TYPE`: Enums must not use the name of a type in another service. For example, if a service defines an enum of `Category`, all definitions of `Category` in other services must also be enums.
 

--- a/docs/source/federation/errors.md
+++ b/docs/source/federation/errors.md
@@ -34,6 +34,12 @@ Apollo Federation implements a strict composition model. When building a gateway
 - `REQUIRES_FIELDS_MISSING_ON_BASE`: The fields arg in `@requires` can only reference fields on the base type.
 - `REQUIRES_USED_ON_BASE`: The requires directive may not be used on fields defined on a base type.
 
+### Custom directives
+
+- `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives may only be [ExecutableDirective]s(https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). The locations which a directive implements must be a subset of: `QUERY`, `MUTATION`, `SUBSCRIPTION`, `FIELD`, `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD`, and `INLINE_FRAGMENT`.
+- `EXECUTABLE_DIRECTIVES_EVERYWHERE`: Custom directives must be implemented across all services. It's acceptable to implement a directive as a no-op within a particular service, but it must still be defined.
+- `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives must be implemented identically from one service to the next. This means that arguments and their respective types, as well as the directives locations, must all be identical within every service.
+
 ### Enums and Scalars
 
 - `DUPLICATE_ENUM_DEFINITION`: An Enum was defined multiple times in a single service. Remove one of the definitions.

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -361,12 +361,12 @@ To learn more about `buildService` and `RemoteGraphQLDataSource`, see the [API d
 
 ## Implementing custom directives
 
-The gateway currently provides limited support for custom, service-level directives. In order to use this feature, there are a few requirements that must be met in order to compose a valid graph.
+The gateway currently provides limited support for custom, service-level directives. To use this feature, there are a few requirements that must be met in order to compose a valid graph.
 
-* Directives may only implement executable locations. Executable directive locations are documented in the [spec](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation).
+* Directives can only implement executable locations. Executable directive locations are documented in the [spec](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation).
 > The following locations are considered valid to the gateway: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT\_DEFINITION, FRAGMENT\_SPREAD, INLINE\_FRAGMENT
 * Directives must be implemented by *every* service that's part of the graph. It's acceptable for a service to do nothing with a particular directive, but a directive definition must exist within every service's schema.
-* Directive definitions must be identical from one service to another. A directive definition is identical if its name, arguments and their types, and locations are all the same.
+* Directive definitions must be identical across all services. A directive definition is identical if its name, arguments and their types, and locations are all the same.
 
 > Note: `ApolloServer` does not currently support executable directives.
 

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -359,6 +359,17 @@ server.listen().then(({ url }) => {
 
 To learn more about `buildService` and `RemoteGraphQLDataSource`, see the [API docs](/api/apollo-gateway/).
 
+## Implementing custom directives
+
+The gateway currently provides limited support for custom, service-level directives. In order to use this feature, there are a few requirements that must be met in order to compose a valid graph.
+
+* Directives may only implement executable locations. Executable directive locations are documented in the [spec](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation).
+> The following locations are considered valid to the gateway: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT
+* Directives must be implemented by *every* service that's part of the graph. It's acceptable for a service to do nothing with a particular directive, but a directive definition must exist within every service's schema.
+* Directive definitions must be identical from one service to another. A directive definition is identical if its name, arguments and their types, and locations are all the same.
+
+> Note: `ApolloServer` does not currently support executable directives.
+
 ## Managing a federated graph
 
 With Apollo Federation, teams are able to move quickly as they build out their GraphQL services. However, distributed systems introduce complexities which require special tooling and coordination across teams to safely rollout changes. The [Apollo Graph Manager](https://engine.apollographql.com) provides solutions to problems like schema change validation, graph update coordination, and metrics collection.  For more information on the value of Graph Manager, read our [article on managed federation](https://www.apollographql.com/docs/graph-manager/federation/).

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -364,7 +364,7 @@ To learn more about `buildService` and `RemoteGraphQLDataSource`, see the [API d
 The gateway currently provides limited support for custom, service-level directives. In order to use this feature, there are a few requirements that must be met in order to compose a valid graph.
 
 * Directives may only implement executable locations. Executable directive locations are documented in the [spec](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation).
-> The following locations are considered valid to the gateway: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT
+> The following locations are considered valid to the gateway: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT\_DEFINITION, FRAGMENT\_SPREAD, INLINE\_FRAGMENT
 * Directives must be implemented by *every* service that's part of the graph. It's acceptable for a service to do nothing with a particular directive, but a directive definition must exist within every service's schema.
 * Directive definitions must be identical from one service to another. A directive definition is identical if its name, arguments and their types, and locations are all the same.
 

--- a/docs/source/federation/implementing.md
+++ b/docs/source/federation/implementing.md
@@ -361,14 +361,14 @@ To learn more about `buildService` and `RemoteGraphQLDataSource`, see the [API d
 
 ## Implementing custom directives
 
-The gateway currently provides limited support for custom, service-level directives. To use this feature, there are a few requirements that must be met in order to compose a valid graph.
+> Note: Apollo Server does not currently support executable directives, however they are supported by the gateway.
+
+The gateway currently provides limited support for custom, service-level directives. To use this feature, there are a few requirements that must be met in order to compose a valid graph:
 
 * Directives can only implement executable locations. Executable directive locations are documented in the [spec](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation).
 > The following locations are considered valid to the gateway: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT\_DEFINITION, FRAGMENT\_SPREAD, INLINE\_FRAGMENT
 * Directives must be implemented by *every* service that's part of the graph. It's acceptable for a service to do nothing with a particular directive, but a directive definition must exist within every service's schema.
 * Directive definitions must be identical across all services. A directive definition is identical if its name, arguments and their types, and locations are all the same.
-
-> Note: `ApolloServer` does not currently support executable directives.
 
 ## Managing a federated graph
 

--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
+* Begin supporting executable directives in federation [#3464](https://github.com/apollographql/apollo-server/pull/3464)
+
 ### v0.10.3
 
 > [See complete versioning details.](https://github.com/apollographql/apollo-server/commit/3cdde1b7a71ace6411fbacf82a1a61bf737444a6)

--- a/packages/apollo-federation/src/composition/__tests__/compose.test.ts
+++ b/packages/apollo-federation/src/composition/__tests__/compose.test.ts
@@ -1,4 +1,8 @@
-import { GraphQLObjectType, isSpecifiedDirective } from 'graphql';
+import {
+  GraphQLObjectType,
+  isSpecifiedDirective,
+  GraphQLDirective,
+} from 'graphql';
 import gql from 'graphql-tag';
 import { composeServices } from '../compose';
 import {
@@ -1310,6 +1314,47 @@ describe('composeServices', () => {
           }
         `);
       });
+    });
+  });
+  describe('executable directives', () => {
+    it('keeps executable directives in the schema', () => {
+      const serviceA = {
+        typeDefs: gql`
+          directive @defer on  FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        `,
+        name: 'serviceA',
+      };
+
+      const { schema, errors } = composeServices([serviceA]);
+
+      expect(errors).toHaveLength(0);
+
+      const defer = schema.getDirective('defer') as GraphQLDirective;
+      expect(defer).toMatchInlineSnapshot(`"@defer"`);
+    });
+    it('keeps executable directives in the schema', () => {
+      const serviceA = {
+        typeDefs: gql`
+          directive @defer on  FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        `,
+        name: 'serviceA',
+      };
+      const serviceB = {
+        typeDefs: gql`
+          directive @stream on  FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+        `,
+        name: 'serviceB',
+      };
+
+      const { schema, errors } = composeServices([serviceA, serviceB]);
+
+      expect(errors).toHaveLength(0);
+
+      const defer = schema.getDirective('defer') as GraphQLDirective;
+      expect(defer).toMatchInlineSnapshot(`"@defer"`);
+
+      const stream = schema.getDirective('stream') as GraphQLDirective;
+      expect(stream).toMatchInlineSnapshot(`"@stream"`);
     });
   });
 });

--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -52,15 +52,16 @@ const EmptyMutationDefinition = {
   serviceName: null,
 };
 
-// Map of all definitions to eventually be passed to extendSchema
-interface DefinitionsMap {
+// Map of all type definitions to eventually be passed to extendSchema
+interface TypeDefinitionsMap {
   [name: string]: TypeDefinitionNode[];
 }
-// Map of all extensions to eventually be passed to extendSchema
-interface ExtensionsMap {
+// Map of all type extensions to eventually be passed to extendSchema
+interface TypeExtensionsMap {
   [name: string]: TypeExtensionNode[];
 }
 
+// Map of all directive definitions to eventually be passed to extendSchema
 interface DirectiveDefinitionsMap {
   [name: string]: { [serviceName: string]: DirectiveDefinitionNode };
 }
@@ -114,11 +115,11 @@ type ValueTypes = Set<string>;
 /**
  * Loop over each service and process its typeDefs (`definitions`)
  * - build up typeToServiceMap
- * - push individual definitions onto either definitionsMap or extensionsMap
+ * - push individual definitions onto either typeDefinitionsMap or typeExtensionsMap
  */
 export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
-  const definitionsMap: DefinitionsMap = Object.create(null);
-  const extensionsMap: ExtensionsMap = Object.create(null);
+  const typeDefinitionsMap: TypeDefinitionsMap = Object.create(null);
+  const typeExtensionsMap: TypeExtensionsMap = Object.create(null);
   const directiveDefinitionsMap: DirectiveDefinitionsMap = Object.create(null);
   const typeToServiceMap: TypeToServiceMap = Object.create(null);
   const externalFields: ExternalFieldDefinition[] = [];
@@ -183,11 +184,13 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
          * take precedence). If the types are determined to be identical, add the type name
          * to the valueTypes Set.
          *
-         * If not, create the definitions array and add it to the definitionsMap.
+         * If not, create the definitions array and add it to the typeDefinitionsMap.
          */
-        if (definitionsMap[typeName]) {
+        if (typeDefinitionsMap[typeName]) {
           const isValueType = typeNodesAreEquivalent(
-            definitionsMap[typeName][definitionsMap[typeName].length - 1],
+            typeDefinitionsMap[typeName][
+              typeDefinitionsMap[typeName].length - 1
+            ],
             definition,
           );
 
@@ -195,9 +198,9 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
             valueTypes.add(typeName);
           }
 
-          definitionsMap[typeName].push({ ...definition, serviceName });
+          typeDefinitionsMap[typeName].push({ ...definition, serviceName });
         } else {
-          definitionsMap[typeName] = [{ ...definition, serviceName }];
+          typeDefinitionsMap[typeName] = [{ ...definition, serviceName }];
         }
       } else if (isTypeExtensionNode(definition)) {
         const typeName = definition.name.value;
@@ -255,12 +258,12 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
         /**
          * If an extension for this type already exists in the extensions map, push this extension to the
          * array (since a type can be extended by multiple services). If not, create the extensions array
-         * and add it to the extensionsMap.
+         * and add it to the typeExtensionsMap.
          */
-        if (extensionsMap[typeName]) {
-          extensionsMap[typeName].push({ ...definition, serviceName });
+        if (typeExtensionsMap[typeName]) {
+          typeExtensionsMap[typeName].push({ ...definition, serviceName });
         } else {
-          extensionsMap[typeName] = [{ ...definition, serviceName }];
+          typeExtensionsMap[typeName] = [{ ...definition, serviceName }];
         }
       } else if (definition.kind === Kind.DIRECTIVE_DEFINITION) {
         const directiveName = definition.name.value;
@@ -284,14 +287,15 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
   // extendSchema will complain about this. We can't add an empty
   // GraphQLObjectType to the schema constructor, so we add an empty definition
   // here. We only add mutation if there is a mutation extension though.
-  if (!definitionsMap.Query) definitionsMap.Query = [EmptyQueryDefinition];
-  if (extensionsMap.Mutation && !definitionsMap.Mutation)
-    definitionsMap.Mutation = [EmptyMutationDefinition];
+  if (!typeDefinitionsMap.Query)
+    typeDefinitionsMap.Query = [EmptyQueryDefinition];
+  if (typeExtensionsMap.Mutation && !typeDefinitionsMap.Mutation)
+    typeDefinitionsMap.Mutation = [EmptyMutationDefinition];
 
   return {
     typeToServiceMap,
-    definitionsMap,
-    extensionsMap,
+    typeDefinitionsMap,
+    typeExtensionsMap,
     directiveDefinitionsMap,
     externalFields,
     keyDirectivesMap,
@@ -300,12 +304,12 @@ export function buildMapsFromServiceList(serviceList: ServiceDefinition[]) {
 }
 
 export function buildSchemaFromDefinitionsAndExtensions({
-  definitionsMap,
-  extensionsMap,
+  typeDefinitionsMap,
+  typeExtensionsMap,
   directiveDefinitionsMap,
 }: {
-  definitionsMap: DefinitionsMap;
-  extensionsMap: ExtensionsMap;
+  typeDefinitionsMap: TypeDefinitionsMap;
+  typeExtensionsMap: TypeExtensionsMap;
   directiveDefinitionsMap: DirectiveDefinitionsMap;
 }) {
   let errors: GraphQLError[] | undefined = undefined;
@@ -319,7 +323,7 @@ export function buildSchemaFromDefinitionsAndExtensions({
   const definitionsDocument: DocumentNode = {
     kind: Kind.DOCUMENT,
     definitions: [
-      ...Object.values(definitionsMap).flat(),
+      ...Object.values(typeDefinitionsMap).flat(),
       ...Object.values(directiveDefinitionsMap).map(
         definitions => Object.values(definitions)[0],
       ),
@@ -332,7 +336,7 @@ export function buildSchemaFromDefinitionsAndExtensions({
   // Extend the schema with the extension definitions (as an AST node)
   const extensionsDocument: DocumentNode = {
     kind: Kind.DOCUMENT,
-    definitions: Object.values(extensionsMap).flat(),
+    definitions: Object.values(typeExtensionsMap).flat(),
   };
 
   errors.push(...validateSDL(extensionsDocument, schema, compositionRules));
@@ -490,8 +494,8 @@ export function addFederationMetadataToSchemaNodes({
 export function composeServices(services: ServiceDefinition[]) {
   const {
     typeToServiceMap,
-    definitionsMap,
-    extensionsMap,
+    typeDefinitionsMap,
+    typeExtensionsMap,
     directiveDefinitionsMap,
     externalFields,
     keyDirectivesMap,
@@ -499,8 +503,8 @@ export function composeServices(services: ServiceDefinition[]) {
   } = buildMapsFromServiceList(services);
 
   let { schema, errors } = buildSchemaFromDefinitionsAndExtensions({
-    definitionsMap,
-    extensionsMap,
+    typeDefinitionsMap,
+    typeExtensionsMap,
     directiveDefinitionsMap,
   });
 

--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -29,7 +29,7 @@ import {
   parseSelections,
   mapFieldNamesToServiceName,
   stripExternalFieldsFromTypeDefs,
-  typeNodesAreEquivalent
+  typeNodesAreEquivalent,
 } from './utils';
 import {
   ServiceDefinition,
@@ -39,8 +39,8 @@ import {
 import { validateSDL } from 'graphql/validation/validate';
 import { compositionRules } from './rules';
 
-function isFederationDirective (directive: GraphQLDirective): boolean {
-  return federationDirectives.some(({ name }) => name === directive.name)
+function isFederationDirective(directive: GraphQLDirective): boolean {
+  return federationDirectives.some(({ name }) => name === directive.name);
 }
 
 const EmptyQueryDefinition = {
@@ -58,7 +58,7 @@ const EmptyMutationDefinition = {
 
 // Map of all definitions to eventually be passed to extendSchema
 interface DefinitionsMap {
-  [name: string]: TypeDefinitionNode[] | DirectiveDefinitionNode[];
+  [name: string]: (TypeDefinitionNode | DirectiveDefinitionNode)[];
 }
 // Map of all extensions to eventually be passed to extendSchema
 interface ExtensionsMap {

--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -320,9 +320,9 @@ export function buildSchemaFromDefinitionsAndExtensions({
     kind: Kind.DOCUMENT,
     definitions: [
       ...Object.values(definitionsMap).flat(),
-      ...Object.values(directiveDefinitionsMap)
-        .map(Object.values)
-        .flat(),
+      ...Object.values(directiveDefinitionsMap).map(
+        definitions => Object.values(definitions)[0],
+      ),
     ],
   };
 

--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -482,11 +482,7 @@ export function addFederationMetadataToSchemaNodes({
     if (!directive) continue;
 
     directive.federation = {
-      ...directive.federation,
-      directiveDefinitions: {
-        ...(directive.federation && directive.federation.directiveDefinitions),
-        ...directiveDefinitionsMap[directiveName],
-      },
+      directiveDefinitions: directiveDefinitionsMap[directiveName],
     };
   }
 }

--- a/packages/apollo-federation/src/composition/compose.ts
+++ b/packages/apollo-federation/src/composition/compose.ts
@@ -480,6 +480,7 @@ export function addFederationMetadataToSchemaNodes({
     if (!directive) continue;
 
     directive.federation = {
+      ...directive.federation,
       directiveDefinitions: directiveDefinitionsMap[directiveName],
     };
   }

--- a/packages/apollo-federation/src/composition/composeAndValidate.ts
+++ b/packages/apollo-federation/src/composition/composeAndValidate.ts
@@ -23,7 +23,12 @@ export function composeAndValidate(serviceList: ServiceDefinition[]) {
   errors.push(...compositionResult.errors);
 
   // validate the composed schema based on service information
-  errors.push(...validateComposedSchema(compositionResult.schema));
+  errors.push(
+    ...validateComposedSchema({
+      schema: compositionResult.schema,
+      serviceList,
+    }),
+  );
 
   // TODO remove the warnings array once no longer used by clients
   return { schema: compositionResult.schema, warnings: [], errors };

--- a/packages/apollo-federation/src/composition/types.ts
+++ b/packages/apollo-federation/src/composition/types.ts
@@ -124,4 +124,8 @@ declare module 'graphql/language/ast' {
   interface InputObjectTypeExtensionNode {
     serviceName?: string | null;
   }
+
+  interface DirectiveDefinitionNode {
+    serviceName?: string | null;
+  }
 }

--- a/packages/apollo-federation/src/composition/types.ts
+++ b/packages/apollo-federation/src/composition/types.ts
@@ -1,4 +1,9 @@
-import { SelectionNode, DocumentNode, FieldDefinitionNode } from 'graphql';
+import {
+  SelectionNode,
+  DocumentNode,
+  FieldDefinitionNode,
+  DirectiveDefinitionNode,
+} from 'graphql';
 
 export type ServiceName = string | null;
 
@@ -77,6 +82,16 @@ declare module 'graphql/type/definition' {
   }
 }
 
+declare module 'graphql/type/directives' {
+  interface GraphQLDirective {
+    federation?: {
+      directiveDefinitions: {
+        [serviceName: string]: DirectiveDefinitionNode;
+      };
+    };
+  }
+}
+
 declare module 'graphql/language/ast' {
   interface UnionTypeDefinitionNode {
     serviceName?: string | null;
@@ -122,10 +137,6 @@ declare module 'graphql/language/ast' {
   }
 
   interface InputObjectTypeExtensionNode {
-    serviceName?: string | null;
-  }
-
-  interface DirectiveDefinitionNode {
     serviceName?: string | null;
   }
 }

--- a/packages/apollo-federation/src/composition/utils.ts
+++ b/packages/apollo-federation/src/composition/utils.ts
@@ -33,6 +33,7 @@ import {
 } from 'graphql';
 import Maybe from 'graphql/tsutils/Maybe';
 import { ExternalFieldDefinition } from './types';
+import federationDirectives from '../directives';
 
 export function isStringValueNode(node: any): node is StringValueNode {
   return node.kind === Kind.STRING;
@@ -449,3 +450,24 @@ export const defKindToExtKind: { [kind: string]: string } = {
   [Kind.ENUM_TYPE_DEFINITION]: Kind.ENUM_TYPE_EXTENSION,
   [Kind.INPUT_OBJECT_TYPE_DEFINITION]: Kind.INPUT_OBJECT_TYPE_EXTENSION,
 };
+
+export const executableDirectiveLocations = [
+  'QUERY',
+  'MUTATION',
+  'SUBSCRIPTION',
+  'FIELD',
+  'FRAGMENT_DEFINITION',
+  'FRAGMENT_SPREAD',
+  'INLINE_FRAGMENT',
+  'VARIABLE_DEFINITION',
+];
+
+export function isExecutableDirective(directive: GraphQLDirective): boolean {
+  return directive.locations.every(location =>
+    executableDirectiveLocations.includes(location),
+  );
+}
+
+export function isFederationDirective(directive: GraphQLDirective): boolean {
+  return federationDirectives.some(({ name }) => name === directive.name);
+}

--- a/packages/apollo-federation/src/composition/utils.ts
+++ b/packages/apollo-federation/src/composition/utils.ts
@@ -28,6 +28,8 @@ import {
   BREAK,
   print,
   ASTNode,
+  DirectiveDefinitionNode,
+  GraphQLDirective,
 } from 'graphql';
 import Maybe from 'graphql/tsutils/Maybe';
 import { ExternalFieldDefinition } from './types';
@@ -341,12 +343,12 @@ export function isTypeNodeAnEntity(
  * - kind: An array of length 0 or 2. If their kinds are different, they will be added to the array.
  *     (['InputObjectTypeDefinition', 'InterfaceTypeDefinition'])
  *
- * @param firstNode TypeDefinitionNode | TypeExtensionNode
- * @param secondNode TypeDefinitionNode | TypeExtensionNode
+ * @param firstNode TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode
+ * @param secondNode TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode
  */
 export function diffTypeNodes(
-  firstNode: TypeDefinitionNode | TypeExtensionNode,
-  secondNode: TypeDefinitionNode | TypeExtensionNode,
+  firstNode: TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode,
+  secondNode: TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode,
 ) {
   const fieldsDiff: {
     [fieldName: string]: string[];
@@ -416,12 +418,12 @@ export function diffTypeNodes(
 /**
  * A common implementation of diffTypeNodes to ensure two type nodes are equivalent
  *
- * @param firstNode TypeDefinitionNode | TypeExtensionNode
- * @param secondNode TypeDefinitionNode | TypeExtensionNode
+ * @param firstNode TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode
+ * @param secondNode TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode
  */
 export function typeNodesAreEquivalent(
-  firstNode: TypeDefinitionNode | TypeExtensionNode,
-  secondNode: TypeDefinitionNode | TypeExtensionNode,
+  firstNode: TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode,
+  secondNode: TypeDefinitionNode | TypeExtensionNode | DirectiveDefinitionNode,
 ) {
   const { name, kind, fields, unionTypes } = diffTypeNodes(
     firstNode,

--- a/packages/apollo-federation/src/composition/validate/index.ts
+++ b/packages/apollo-federation/src/composition/validate/index.ts
@@ -38,19 +38,21 @@ export const validateServicesBeforeComposition = (
   return warningsOrErrors;
 };
 
-const postCompositionValidators = [
-  validateSchema,
-  ...Object.values(postCompositionRules),
-];
+const postCompositionValidators = Object.values(postCompositionRules);
 
-export const validateComposedSchema = (
-  schema: GraphQLSchema,
-): GraphQLError[] => {
+export const validateComposedSchema = ({
+  schema,
+  serviceList,
+}: {
+  schema: GraphQLSchema;
+  serviceList: ServiceDefinition[];
+}): GraphQLError[] => {
   const warningsOrErrors: GraphQLError[] = [];
 
   // https://github.com/graphql/graphql-js/blob/4b55f10f16cc77302613e8ad67440259c68633df/src/type/validate.js#L56
+  warningsOrErrors.push(...validateSchema(schema));
   for (const validator of postCompositionValidators) {
-    warningsOrErrors.push(...validator(schema));
+    warningsOrErrors.push(...validator({ schema, serviceList }));
   }
 
   return warningsOrErrors;

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesEverywhere.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesEverywhere.test.ts
@@ -1,0 +1,68 @@
+import gql from 'graphql-tag';
+import { composeServices } from '../../../compose';
+import { executableDirectivesEverywhere } from '../';
+import { graphqlErrorSerializer } from '../../../../snapshotSerializers';
+
+expect.addSnapshotSerializer(graphqlErrorSerializer);
+
+describe('executableDirectivesEverywhere', () => {
+  it('throws no errors when custom, executable directives are defined in every service', () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceB',
+    };
+
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesEverywhere({ schema, serviceList });
+    expect(errors).toHaveLength(0);
+  });
+
+  it("throws errors when custom, executable directives aren't defined in every service", () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        extend type Query {
+          thing: String
+        }
+      `,
+      name: 'serviceB',
+    };
+
+    const serviceC = {
+      typeDefs: gql`
+        extend type Query {
+          otherThing: String
+        }
+      `,
+      name: 'serviceC',
+    };
+
+    const serviceList = [serviceA, serviceB, serviceC];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesEverywhere({ schema, serviceList });
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_EVERYWHERE",
+          "message": "[@stream] -> Custom directives must be implemented in every service. The following services do not implement the @stream directive: serviceB, serviceC.",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesIdentical.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesIdentical.test.ts
@@ -1,0 +1,67 @@
+import gql from 'graphql-tag';
+import { composeServices } from '../../../compose';
+import { executableDirectivesIdentical } from '../';
+import { graphqlErrorSerializer } from '../../../../snapshotSerializers';
+
+expect.addSnapshotSerializer(graphqlErrorSerializer);
+
+describe('executableDirectivesIdentical', () => {
+  it('throws no errors when custom, executable directives are defined identically every service', () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceB',
+    };
+
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesIdentical({ schema, serviceList });
+    expect(errors).toHaveLength(0);
+  });
+
+  it("throws errors when custom, executable directives aren't defined in every service", () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        directive @stream on FIELD | QUERY
+      `,
+      name: 'serviceB',
+    };
+
+    const serviceC = {
+      typeDefs: gql`
+        directive @stream on INLINE_FRAGMENT
+      `,
+      name: 'serviceC',
+    };
+
+    const serviceList = [serviceA, serviceB, serviceC];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesIdentical({ schema, serviceList });
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_IDENTICAL",
+          "message": "[@stream] -> custom directives must be defined identically across all services. See below for a list of current implementations:
+      	serviceA: directive @stream on FIELD
+      	serviceB: directive @stream on FIELD | QUERY
+      	serviceC: directive @stream on INLINE_FRAGMENT",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesIdentical.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesIdentical.test.ts
@@ -10,6 +10,7 @@ describe('executableDirectivesIdentical', () => {
     const serviceA = {
       typeDefs: gql`
         directive @stream on FIELD
+        directive @instrument(tag: String!) on FIELD
       `,
       name: 'serviceA',
     };
@@ -17,6 +18,7 @@ describe('executableDirectivesIdentical', () => {
     const serviceB = {
       typeDefs: gql`
         directive @stream on FIELD
+        directive @instrument(tag: String!) on FIELD
       `,
       name: 'serviceB',
     };
@@ -27,7 +29,7 @@ describe('executableDirectivesIdentical', () => {
     expect(errors).toHaveLength(0);
   });
 
-  it("throws errors when custom, executable directives aren't defined in every service", () => {
+  it("throws errors when custom, executable directives aren't defined with the same locations in every service", () => {
     const serviceA = {
       typeDefs: gql`
         directive @stream on FIELD
@@ -60,6 +62,36 @@ describe('executableDirectivesIdentical', () => {
       	serviceA: directive @stream on FIELD
       	serviceB: directive @stream on FIELD | QUERY
       	serviceC: directive @stream on INLINE_FRAGMENT",
+        },
+      ]
+    `);
+  });
+
+  it("throws errors when custom, executable directives aren't defined with the same arguments in every service", () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @instrument(tag: String!) on FIELD
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        directive @instrument(tag: Boolean) on FIELD
+      `,
+      name: 'serviceB',
+    };
+
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesIdentical({ schema, serviceList });
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_IDENTICAL",
+          "message": "[@instrument] -> custom directives must be defined identically across all services. See below for a list of current implementations:
+      	serviceA: directive @instrument(tag: String!) on FIELD
+      	serviceB: directive @instrument(tag: Boolean) on FIELD",
         },
       ]
     `);

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesInAllServices.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesInAllServices.test.ts
@@ -1,11 +1,11 @@
 import gql from 'graphql-tag';
 import { composeServices } from '../../../compose';
-import { executableDirectivesEverywhere } from '../';
+import { executableDirectivesInAllServices } from '../';
 import { graphqlErrorSerializer } from '../../../../snapshotSerializers';
 
 expect.addSnapshotSerializer(graphqlErrorSerializer);
 
-describe('executableDirectivesEverywhere', () => {
+describe('executableDirectivesInAllServices', () => {
   it('throws no errors when custom, executable directives are defined in every service', () => {
     const serviceA = {
       typeDefs: gql`
@@ -23,7 +23,7 @@ describe('executableDirectivesEverywhere', () => {
 
     const serviceList = [serviceA, serviceB];
     const { schema } = composeServices(serviceList);
-    const errors = executableDirectivesEverywhere({ schema, serviceList });
+    const errors = executableDirectivesInAllServices({ schema, serviceList });
     expect(errors).toHaveLength(0);
   });
 
@@ -55,11 +55,11 @@ describe('executableDirectivesEverywhere', () => {
 
     const serviceList = [serviceA, serviceB, serviceC];
     const { schema } = composeServices(serviceList);
-    const errors = executableDirectivesEverywhere({ schema, serviceList });
+    const errors = executableDirectivesInAllServices({ schema, serviceList });
     expect(errors).toMatchInlineSnapshot(`
       Array [
         Object {
-          "code": "EXECUTABLE_DIRECTIVES_EVERYWHERE",
+          "code": "EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES",
           "message": "[@stream] -> Custom directives must be implemented in every service. The following services do not implement the @stream directive: serviceB, serviceC.",
         },
       ]

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesOnly.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/executableDirectivesOnly.test.ts
@@ -1,0 +1,125 @@
+import gql from 'graphql-tag';
+import { composeServices } from '../../../compose';
+import { executableDirectivesOnly } from '../';
+import { graphqlErrorSerializer } from '../../../../snapshotSerializers';
+
+expect.addSnapshotSerializer(graphqlErrorSerializer);
+
+describe('executableDirectivesOnly', () => {
+  it('throws no errors when custom, executable directives are defined', () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @query on QUERY
+        directive @mutation on MUTATION
+        directive @subscription on SUBSCRIPTION
+        directive @field on FIELD
+        directive @fragmentDefinition on FRAGMENT_DEFINITION
+        directive @fragmentSpread on FRAGMENT_SPREAD
+        directive @inlineFragment on INLINE_FRAGMENT
+        directive @variableDefinition on VARIABLE_DEFINITION
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceList = [serviceA];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesOnly({ schema, serviceList });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('throws errors when custom, type system directives are defined', () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @schema on SCHEMA
+        directive @scalar on SCALAR
+        directive @object on OBJECT
+        directive @fieldDefinition on FIELD_DEFINITION
+        directive @argumentDefinition on ARGUMENT_DEFINITION
+        directive @interface on INTERFACE
+        directive @union on UNION
+        directive @enum on ENUM
+        directive @enumValue on ENUM_VALUE
+        directive @inputObject on INPUT_OBJECT
+        directive @inputFieldDefinition on INPUT_FIELD_DEFINITION
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceList = [serviceA];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesOnly({ schema, serviceList });
+    expect(errors).toHaveLength(11);
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @schema -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @scalar -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @object -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @fieldDefinition -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @argumentDefinition -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @interface -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @union -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @enum -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @enumValue -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @inputObject -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+        Object {
+          "code": "EXECUTABLE_DIRECTIVES_ONLY",
+          "message": "[serviceA] @inputFieldDefinition -> is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD, INLINE_FRAGMENT, VARIABLE_DEFINITION",
+        },
+      ]
+    `);
+  });
+
+  it('handles multiple services', () => {
+    const serviceA = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        directive @stream on FIELD
+      `,
+      name: 'serviceB',
+    };
+
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const errors = executableDirectivesOnly({ schema, serviceList });
+    expect(errors).toHaveLength(0);
+
+    const stream = schema.getDirective('stream');
+    expect(stream).toMatchInlineSnapshot(`"@stream"`);
+  });
+});

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalMissingOnBase.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalMissingOnBase.test.ts
@@ -39,8 +39,9 @@ describe('externalMissingOnBase', () => {
       name: 'serviceC',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB, serviceC]);
-    const warnings = validateExternalMissingOnBase(schema);
+    const serviceList = [serviceA, serviceB, serviceC];
+    const { schema } = composeServices([serviceA, serviceB, serviceC]);
+    const warnings = validateExternalMissingOnBase({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -76,8 +77,9 @@ describe('externalMissingOnBase', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalMissingOnBase(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalMissingOnBase({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalTypeMismatch.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalTypeMismatch.test.ts
@@ -27,8 +27,9 @@ describe('validateExternalDirectivesOnSchema', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalTypeMismatch(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalTypeMismatch({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -60,8 +61,9 @@ describe('validateExternalDirectivesOnSchema', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalTypeMismatch(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalTypeMismatch({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalUnused.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalUnused.test.ts
@@ -29,8 +29,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -61,8 +62,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -86,8 +88,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -112,8 +115,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -141,8 +145,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -187,8 +192,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -256,8 +262,9 @@ describe('externalUnused', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -290,8 +297,9 @@ describe('externalUnused', () => {
       name: 'serviceC',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB, serviceC]);
-    const warnings = validateExternalUnused(schema);
+    const serviceList = [serviceA, serviceB, serviceC];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 });

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/keyFieldsMissingOnBase.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/keyFieldsMissingOnBase.test.ts
@@ -35,10 +35,11 @@ describe('keyFieldsMissingOnBase', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateKeyFieldsMissingOnBase(schema);
+    const warnings = validateKeyFieldsMissingOnBase({ schema, serviceList });
     expect(warnings).toHaveLength(0);
   });
 
@@ -64,10 +65,11 @@ describe('keyFieldsMissingOnBase', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateKeyFieldsMissingOnBase(schema);
+    const warnings = validateKeyFieldsMissingOnBase({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -101,10 +103,11 @@ describe('keyFieldsMissingOnBase', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateKeyFieldsMissingOnBase(schema);
+    const warnings = validateKeyFieldsMissingOnBase({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot();
   });
 });

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/keyFieldsSelectInvalidType.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/keyFieldsSelectInvalidType.test.ts
@@ -35,10 +35,14 @@ describe('keyFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateKeyFieldsSelectInvalidType(schema);
+    const warnings = validateKeyFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toHaveLength(0);
   });
 
@@ -67,10 +71,14 @@ describe('keyFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateKeyFieldsSelectInvalidType(schema);
+    const warnings = validateKeyFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -104,10 +112,14 @@ describe('keyFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateKeyFieldsSelectInvalidType(schema);
+    const warnings = validateKeyFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/providesFieldsMissingExternals.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/providesFieldsMissingExternals.test.ts
@@ -50,9 +50,13 @@ describe('providesFieldsMissingExternal', () => {
       name: 'serviceC',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB, serviceC]);
+    const serviceList = [serviceA, serviceB, serviceC];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toEqual([]);
-    const warnings = validateProdivesFieldsMissingExternal(schema);
+    const warnings = validateProdivesFieldsMissingExternal({
+      schema,
+      serviceList,
+    });
     expect(warnings).toEqual([]);
   });
 
@@ -83,9 +87,13 @@ describe('providesFieldsMissingExternal', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toEqual([]);
-    const warnings = validateProdivesFieldsMissingExternal(schema);
+    const warnings = validateProdivesFieldsMissingExternal({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/providesFieldsSelectInvalidType.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/providesFieldsSelectInvalidType.test.ts
@@ -33,10 +33,14 @@ describe('providesFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateprovidesFieldsSelectInvalidType(schema);
+    const warnings = validateprovidesFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toHaveLength(0);
   });
 
@@ -74,10 +78,14 @@ describe('providesFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateprovidesFieldsSelectInvalidType(schema);
+    const warnings = validateprovidesFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -122,10 +130,14 @@ describe('providesFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateprovidesFieldsSelectInvalidType(schema);
+    const warnings = validateprovidesFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -182,10 +194,14 @@ describe('providesFieldsSelectInvalidType', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
+    const serviceList = [serviceA, serviceB];
+    const { schema, errors } = composeServices(serviceList);
     expect(errors).toHaveLength(0);
 
-    const warnings = validateprovidesFieldsSelectInvalidType(schema);
+    const warnings = validateprovidesFieldsSelectInvalidType({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/providesNotOnEntity.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/providesNotOnEntity.test.ts
@@ -27,8 +27,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -56,8 +57,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`Array []`);
   });
 
@@ -85,8 +87,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
 
@@ -117,8 +120,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -156,8 +160,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -197,8 +202,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -238,8 +244,9 @@ describe('providesNotOnEntity', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateProvidesNotOnEntity(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateProvidesNotOnEntity({ schema, serviceList });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/requiresFieldsMissingExternals.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/requiresFieldsMissingExternals.test.ts
@@ -28,8 +28,12 @@ describe('requiresFieldsMissingExternal', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateRequiresFieldsMissingExternal(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateRequiresFieldsMissingExternal({
+      schema,
+      serviceList,
+    });
     expect(warnings).toEqual([]);
   });
 
@@ -54,8 +58,12 @@ describe('requiresFieldsMissingExternal', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateRequiresFieldsMissingExternal(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateRequiresFieldsMissingExternal({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/requiresFieldsMissingOnBase.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/requiresFieldsMissingOnBase.test.ts
@@ -26,8 +26,12 @@ describe('requiresFieldsMissingOnBase', () => {
       name: 'serviceB',
     };
 
-    const { schema, errors } = composeServices([serviceA, serviceB]);
-    const warnings = validateRequiresFieldsMissingOnBase(schema);
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateRequiresFieldsMissingOnBase({
+      schema,
+      serviceList,
+    });
     expect(warnings).toEqual([]);
   });
 
@@ -57,8 +61,12 @@ describe('requiresFieldsMissingOnBase', () => {
       `,
       name: 'serviceC',
     };
-    const { schema, errors } = composeServices([serviceA, serviceB, serviceC]);
-    const warnings = validateRequiresFieldsMissingOnBase(schema);
+    const serviceList = [serviceA, serviceB, serviceC];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateRequiresFieldsMissingOnBase({
+      schema,
+      serviceList,
+    });
     expect(warnings).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesEverywhere.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesEverywhere.ts
@@ -1,0 +1,56 @@
+import 'apollo-server-env';
+import { GraphQLError, isSpecifiedDirective } from 'graphql';
+import {
+  errorWithCode,
+  isFederationDirective,
+  logDirective,
+} from '../../utils';
+import { PostCompositionValidator } from '.';
+
+/**
+ * All custom directives must be implemented in every service. This validator
+ * is not responsible for ensuring the directives are an ExecutableDirective.
+ */
+export const executableDirectivesEverywhere: PostCompositionValidator = ({
+  schema,
+  serviceList
+}) => {
+  const errors: GraphQLError[] = [];
+
+  const customDirectives = schema
+    .getDirectives()
+    .filter(x => !isFederationDirective(x) && !isSpecifiedDirective(x));
+
+  customDirectives.forEach(directive => {
+    if (!directive.federation) return;
+
+    const allServiceNames = serviceList.map(({ name }) => name);
+    const serviceNamesWithDirective = Object.keys(
+      directive.federation.directiveDefinitions,
+    );
+
+    const serviceNamesWithoutDirective = allServiceNames.reduce(
+      (without, serviceName) => {
+        if (!serviceNamesWithDirective.includes(serviceName)) {
+          without.push(serviceName);
+        }
+        return without;
+      },
+      [] as string[],
+    );
+
+    if (serviceNamesWithoutDirective.length > 0) {
+      errors.push(
+        errorWithCode(
+          'EXECUTABLE_DIRECTIVES_EVERYWHERE',
+          logDirective(directive.name) +
+            `Custom directives must be implemented in every service. The following services do not implement the @${
+              directive.name
+            } directive: ${serviceNamesWithoutDirective.join(', ')}.`,
+        ),
+      );
+    }
+  });
+
+  return errors;
+}

--- a/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesIdentical.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesIdentical.ts
@@ -1,0 +1,57 @@
+import 'apollo-server-env';
+import { GraphQLError, isSpecifiedDirective, print } from 'graphql';
+import {
+  errorWithCode,
+  isFederationDirective,
+  logDirective,
+  typeNodesAreEquivalent,
+} from '../../utils';
+import { PostCompositionValidator } from '.';
+
+/**
+ * A custom directive must be defined identically across all services. This means
+ * they must have the same name and same locations. Locations are the "on" part of
+ * a directive, for example:
+ *    directive @stream on FIELD | QUERY
+ */
+export const executableDirectivesIdentical: PostCompositionValidator = ({
+  schema,
+}) => {
+  const errors: GraphQLError[] = [];
+
+  const customDirectives = schema
+    .getDirectives()
+    .filter(x => !isFederationDirective(x) && !isSpecifiedDirective(x));
+
+  customDirectives.forEach(directive => {
+    if (!directive.federation) return;
+
+    const definitions = Object.entries(
+      directive.federation.directiveDefinitions,
+    );
+
+    // Side-by-side compare all definitions of a single directive, if there's a
+    // discrepancy in any of those diffs, we should provide an error.
+    const shouldError = definitions.some(([, definition], index) => {
+      // Skip the non-comparison step
+      if (index === 0) return;
+      const [, previousDefinition] = definitions[index - 1];
+      return !typeNodesAreEquivalent(definition, previousDefinition);
+    });
+
+    if (shouldError) {
+      errors.push(
+        errorWithCode(
+          'EXECUTABLE_DIRECTIVES_IDENTICAL',
+          logDirective(directive.name) +
+            `custom directives must be defined identically across all services. See below for a list of current implementations:\n${definitions
+              .map(([serviceName, definition]) => {
+                return `\t${serviceName}: ${print(definition)}`;
+              })
+              .join('\n')}`,
+        ),
+      );
+    }
+  });
+  return errors;
+};

--- a/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesInAllServices.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesInAllServices.ts
@@ -4,6 +4,7 @@ import {
   errorWithCode,
   isFederationDirective,
   logDirective,
+  isExecutableDirective,
 } from '../../utils';
 import { PostCompositionValidator } from '.';
 
@@ -11,17 +12,22 @@ import { PostCompositionValidator } from '.';
  * All custom directives must be implemented in every service. This validator
  * is not responsible for ensuring the directives are an ExecutableDirective.
  */
-export const executableDirectivesEverywhere: PostCompositionValidator = ({
+export const executableDirectivesInAllServices: PostCompositionValidator = ({
   schema,
-  serviceList
+  serviceList,
 }) => {
   const errors: GraphQLError[] = [];
 
-  const customDirectives = schema
+  const customExecutableDirectives = schema
     .getDirectives()
-    .filter(x => !isFederationDirective(x) && !isSpecifiedDirective(x));
+    .filter(
+      x =>
+        !isFederationDirective(x) &&
+        !isSpecifiedDirective(x) &&
+        isExecutableDirective(x),
+    );
 
-  customDirectives.forEach(directive => {
+  customExecutableDirectives.forEach(directive => {
     if (!directive.federation) return;
 
     const allServiceNames = serviceList.map(({ name }) => name);
@@ -42,7 +48,7 @@ export const executableDirectivesEverywhere: PostCompositionValidator = ({
     if (serviceNamesWithoutDirective.length > 0) {
       errors.push(
         errorWithCode(
-          'EXECUTABLE_DIRECTIVES_EVERYWHERE',
+          'EXECUTABLE_DIRECTIVES_IN_ALL_SERVICES',
           logDirective(directive.name) +
             `Custom directives must be implemented in every service. The following services do not implement the @${
               directive.name
@@ -53,4 +59,4 @@ export const executableDirectivesEverywhere: PostCompositionValidator = ({
   });
 
   return errors;
-}
+};

--- a/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesOnly.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/executableDirectivesOnly.ts
@@ -1,0 +1,51 @@
+import 'apollo-server-env';
+import { GraphQLError, isSpecifiedDirective } from 'graphql';
+import {
+  logServiceAndType,
+  errorWithCode,
+  isExecutableDirective,
+  isFederationDirective,
+  executableDirectiveLocations,
+} from '../../utils';
+import { PostCompositionValidator } from '.';
+
+/**
+ * For custom directives, they must be an ExecutableDirective. ExecutableDirectives
+ * consist of directives with strictly a subset of the following locations:
+ * QUERY, MUTATION, SUBSCRIPTION, FIELD, FRAGMENT_DEFINITION, FRAGMENT_SPREAD,
+ * INLINE_FRAGMENT, VARIABLE_DEFINITION
+ */
+export const executableDirectivesOnly: PostCompositionValidator = ({
+  schema,
+}) => {
+  const errors: GraphQLError[] = [];
+
+  // We only need to validate against user-provided, TypeSystemDirectives (non-executable directives)
+  const customTypeSystemDirectives = schema
+    .getDirectives()
+    .filter(
+      x =>
+        !isFederationDirective(x) &&
+        !isSpecifiedDirective(x) &&
+        !isExecutableDirective(x),
+    );
+
+  customTypeSystemDirectives.forEach(directive => {
+    if (!directive.federation) return;
+
+    Object.keys(directive.federation.directiveDefinitions).forEach(
+      serviceName => {
+        errors.push(
+          errorWithCode(
+            'EXECUTABLE_DIRECTIVES_ONLY',
+            logServiceAndType(serviceName, '@' + directive.name) +
+              `is a type system directive, but only executable directives are permitted. Executable directives exist for the following locations: ${executableDirectiveLocations.join(
+                ', ',
+              )}`,
+          ),
+        );
+      },
+    );
+  });
+  return errors;
+};

--- a/packages/apollo-federation/src/composition/validate/postComposition/externalMissingOnBase.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/externalMissingOnBase.ts
@@ -1,11 +1,12 @@
 import 'apollo-server-env';
-import { GraphQLSchema, isObjectType, GraphQLError } from 'graphql';
+import { isObjectType, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  * All fields marked with @external must exist on the base type
  */
-export const externalMissingOnBase = (schema: GraphQLSchema) => {
+export const externalMissingOnBase: PostCompositionValidator = ({ schema }) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/externalTypeMismatch.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/externalTypeMismatch.ts
@@ -1,17 +1,12 @@
-import {
-  GraphQLSchema,
-  isObjectType,
-  typeFromAST,
-  isEqualType,
-  GraphQLError,
-} from 'graphql';
+import { isObjectType, typeFromAST, isEqualType, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  * All fields marked with @external must match the type definition of the base service.
  * Additional warning if the type of the @external field doesn't exist at all on the schema
  */
-export const externalTypeMismatch = (schema: GraphQLSchema) => {
+export const externalTypeMismatch: PostCompositionValidator = ({ schema }) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/externalUnused.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/externalUnused.ts
@@ -1,5 +1,4 @@
-import { GraphQLSchema, isObjectType, GraphQLError, Kind } from 'graphql';
-
+import { isObjectType, GraphQLError, Kind } from 'graphql';
 import {
   findDirectivesOnTypeOrField,
   logServiceAndType,
@@ -10,12 +9,13 @@ import {
   isStringValueNode,
   selectionIncludesField,
 } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  *  for every @external field, there should be a @requires, @key, or @provides
  *  directive that uses it
  */
-export const externalUnused = (schema: GraphQLSchema) => {
+export const externalUnused: PostCompositionValidator = ({ schema }) => {
   const errors: GraphQLError[] = [];
   const types = schema.getTypeMap();
   for (const [parentTypeName, parentType] of Object.entries(types)) {

--- a/packages/apollo-federation/src/composition/validate/postComposition/index.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/index.ts
@@ -10,3 +10,4 @@ export {
   providesFieldsSelectInvalidType,
 } from './providesFieldsSelectInvalidType';
 export { providesNotOnEntity } from './providesNotOnEntity';
+export { executableDirectivesOnly } from './executableDirectivesOnly';

--- a/packages/apollo-federation/src/composition/validate/postComposition/index.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/index.ts
@@ -1,3 +1,6 @@
+import { GraphQLSchema, GraphQLError } from 'graphql';
+import { ServiceDefinition } from '../../types';
+
 export { externalUnused } from './externalUnused';
 export { externalMissingOnBase } from './externalMissingOnBase';
 export { externalTypeMismatch } from './externalTypeMismatch';
@@ -11,3 +14,15 @@ export {
 } from './providesFieldsSelectInvalidType';
 export { providesNotOnEntity } from './providesNotOnEntity';
 export { executableDirectivesOnly } from './executableDirectivesOnly';
+export {
+  executableDirectivesEverywhere,
+} from './executableDirectivesEverywhere';
+export { executableDirectivesIdentical } from './executableDirectivesIdentical';
+
+export type PostCompositionValidator = ({
+  schema,
+  serviceList,
+}: {
+  schema: GraphQLSchema;
+  serviceList: ServiceDefinition[];
+}) => GraphQLError[];

--- a/packages/apollo-federation/src/composition/validate/postComposition/index.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/index.ts
@@ -15,8 +15,8 @@ export {
 export { providesNotOnEntity } from './providesNotOnEntity';
 export { executableDirectivesOnly } from './executableDirectivesOnly';
 export {
-  executableDirectivesEverywhere,
-} from './executableDirectivesEverywhere';
+  executableDirectivesInAllServices,
+} from './executableDirectivesInAllServices';
 export { executableDirectivesIdentical } from './executableDirectivesIdentical';
 
 export type PostCompositionValidator = ({

--- a/packages/apollo-federation/src/composition/validate/postComposition/keyFieldsMissingOnBase.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/keyFieldsMissingOnBase.ts
@@ -1,11 +1,13 @@
-import { GraphQLSchema, isObjectType, FieldNode, GraphQLError } from 'graphql';
-
+import { isObjectType, FieldNode, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  * - The fields argument can not select fields that were overwritten by another service
  */
-export const keyFieldsMissingOnBase = (schema: GraphQLSchema) => {
+export const keyFieldsMissingOnBase: PostCompositionValidator = ({
+  schema,
+}) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/keyFieldsSelectInvalidType.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/keyFieldsSelectInvalidType.ts
@@ -1,5 +1,4 @@
 import {
-  GraphQLSchema,
   isObjectType,
   FieldNode,
   isInterfaceType,
@@ -8,15 +7,17 @@ import {
   isUnionType,
   GraphQLError,
 } from 'graphql';
-
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  * - The fields argument can not have root fields that result in a list
  * - The fields argument can not have root fields that result in an interface
  * - The fields argument can not have root fields that result in a union type
  */
-export const keyFieldsSelectInvalidType = (schema: GraphQLSchema) => {
+export const keyFieldsSelectInvalidType: PostCompositionValidator = ({
+  schema,
+}) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/providesFieldsMissingExternal.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/providesFieldsMissingExternal.ts
@@ -1,11 +1,13 @@
-import { GraphQLSchema, isObjectType, FieldNode, GraphQLError } from 'graphql';
-
+import { isObjectType, FieldNode, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  *  for every field in a @provides, there should be a matching @external
  */
-export const providesFieldsMissingExternal = (schema: GraphQLSchema) => {
+export const providesFieldsMissingExternal: PostCompositionValidator = ({
+  schema,
+}) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/providesFieldsSelectInvalidType.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/providesFieldsSelectInvalidType.ts
@@ -1,5 +1,4 @@
 import {
-  GraphQLSchema,
   GraphQLError,
   isObjectType,
   FieldNode,
@@ -9,15 +8,17 @@ import {
   getNullableType,
   isUnionType,
 } from 'graphql';
-
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  * - The fields argument can not have root fields that result in a list
  * - The fields argument can not have root fields that result in an interface
  * - The fields argument can not have root fields that result in a union type
  */
-export const providesFieldsSelectInvalidType = (schema: GraphQLSchema) => {
+export const providesFieldsSelectInvalidType: PostCompositionValidator = ({
+  schema,
+}) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/providesNotOnEntity.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/providesNotOnEntity.ts
@@ -1,17 +1,16 @@
 import {
-  GraphQLSchema,
   isObjectType,
   GraphQLError,
   isListType,
   isNonNullType,
 } from 'graphql';
-
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  *  Provides directive can only be added to return types that are entities
  */
-export const providesNotOnEntity = (schema: GraphQLSchema) => {
+export const providesNotOnEntity: PostCompositionValidator = ({ schema }) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/requiresFieldsMissingExternal.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/requiresFieldsMissingExternal.ts
@@ -1,11 +1,13 @@
-import { GraphQLSchema, isObjectType, FieldNode, GraphQLError } from 'graphql';
-
+import { isObjectType, FieldNode, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  *  for every @requires, there should be a matching @external
  */
-export const requiresFieldsMissingExternal = (schema: GraphQLSchema) => {
+export const requiresFieldsMissingExternal: PostCompositionValidator = ({
+  schema,
+}) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/postComposition/requiresFieldsMissingOnBase.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/requiresFieldsMissingOnBase.ts
@@ -1,11 +1,13 @@
-import { GraphQLSchema, isObjectType, FieldNode, GraphQLError } from 'graphql';
-
+import { isObjectType, FieldNode, GraphQLError } from 'graphql';
 import { logServiceAndType, errorWithCode } from '../../utils';
+import { PostCompositionValidator } from '.';
 
 /**
  * The fields arg in @requires can only reference fields on the base type
  */
-export const requiresFieldsMissingOnBase = (schema: GraphQLSchema) => {
+export const requiresFieldsMissingOnBase: PostCompositionValidator = ({
+  schema,
+}) => {
   const errors: GraphQLError[] = [];
 
   const types = schema.getTypeMap();

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/matchingEnums.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/matchingEnums.test.ts
@@ -28,10 +28,10 @@ expect.addSnapshotSerializer(selectionSetSerializer);
 const createDefinitionsDocumentForServices = (
   serviceList: ServiceDefinition[],
 ): DocumentNode => {
-  const { definitionsMap } = buildMapsFromServiceList(serviceList);
+  const { typeDefinitionsMap } = buildMapsFromServiceList(serviceList);
   return {
     kind: Kind.DOCUMENT,
-    definitions: Object.values(definitionsMap).flat(),
+    definitions: Object.values(typeDefinitionsMap).flat(),
   };
 };
 

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/matchingUnions.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/matchingUnions.test.ts
@@ -21,17 +21,17 @@ expect.addSnapshotSerializer(typeSerializer);
 function createDocumentsForServices(
   serviceList: ServiceDefinition[],
 ): DocumentNode[] {
-  const { definitionsMap, extensionsMap } = buildMapsFromServiceList(
+  const { typeDefinitionsMap, typeExtensionsMap } = buildMapsFromServiceList(
     serviceList,
   );
   return [
     {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(definitionsMap).flat(),
+      definitions: Object.values(typeDefinitionsMap).flat(),
     },
     {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(extensionsMap).flat(),
+      definitions: Object.values(typeExtensionsMap).flat(),
     },
   ];
 }

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/possibleTypeExtensions.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/possibleTypeExtensions.test.ts
@@ -27,17 +27,17 @@ const createDefinitionsDocumentForServices = (
   definitions: DocumentNode;
   extensions: DocumentNode;
 } => {
-  const { definitionsMap, extensionsMap } = buildMapsFromServiceList(
+  const { typeDefinitionsMap, typeExtensionsMap } = buildMapsFromServiceList(
     serviceList,
   );
   return {
     definitions: {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(definitionsMap).flat(),
+      definitions: Object.values(typeDefinitionsMap).flat(),
     },
     extensions: {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(extensionsMap).flat(),
+      definitions: Object.values(typeExtensionsMap).flat(),
     },
   };
 };

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/uniqueFieldDefinitionNames.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/uniqueFieldDefinitionNames.test.ts
@@ -19,17 +19,17 @@ expect.addSnapshotSerializer(typeSerializer);
 function createDocumentsForServices(
   serviceList: ServiceDefinition[],
 ): DocumentNode[] {
-  const { definitionsMap, extensionsMap } = buildMapsFromServiceList(
+  const { typeDefinitionsMap, typeExtensionsMap } = buildMapsFromServiceList(
     serviceList,
   );
   return [
     {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(definitionsMap).flat(),
+      definitions: Object.values(typeDefinitionsMap).flat(),
     },
     {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(extensionsMap).flat(),
+      definitions: Object.values(typeExtensionsMap).flat(),
     },
   ];
 }

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/uniqueTypeNamesWithFields.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/uniqueTypeNamesWithFields.test.ts
@@ -21,17 +21,17 @@ expect.addSnapshotSerializer(typeSerializer);
 function createDocumentsForServices(
   serviceList: ServiceDefinition[],
 ): DocumentNode[] {
-  const { definitionsMap, extensionsMap } = buildMapsFromServiceList(
+  const { typeDefinitionsMap, typeExtensionsMap } = buildMapsFromServiceList(
     serviceList,
   );
   return [
     {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(definitionsMap).flat(),
+      definitions: Object.values(typeDefinitionsMap).flat(),
     },
     {
       kind: Kind.DOCUMENT,
-      definitions: Object.values(extensionsMap).flat(),
+      definitions: Object.values(typeExtensionsMap).flat(),
     },
   ];
 }

--- a/packages/apollo-federation/src/service/__tests__/buildFederatedSchema.test.ts
+++ b/packages/apollo-federation/src/service/__tests__/buildFederatedSchema.test.ts
@@ -476,6 +476,30 @@ extend type User @key(fields: "email") {
 }
 `);
     });
+    it('keeps custom directives', async () => {
+      const query = `query GetServiceDetails {
+        _service {
+          sdl
+        }
+      }`;
+
+      const schema = buildFederatedSchema(gql`
+        directive @custom on FIELD
+
+        extend type User @key(fields: "email") {
+          email: String @external
+        }
+      `);
+
+      const { data, errors } = await graphql(schema, query);
+      expect(errors).toBeUndefined();
+      expect(data._service.sdl).toEqual(`directive @custom on FIELD
+
+extend type User @key(fields: "email") {
+  email: String @external
+}
+`);
+    });
   });
 });
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/accounts.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/accounts.ts
@@ -3,6 +3,8 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'accounts';
 export const typeDefs = gql`
+  directive @stream on FIELD
+
   extend type Query {
     user(id: ID!): User
     me: User

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/accounts.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/accounts.ts
@@ -4,6 +4,7 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 export const name = 'accounts';
 export const typeDefs = gql`
   directive @stream on FIELD
+  directive @transform(from: String!) on FIELD
 
   extend type Query {
     user(id: ID!): User

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
@@ -3,6 +3,8 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'books';
 export const typeDefs = gql`
+  directive @stream on FIELD
+
   extend type Query {
     book(isbn: String!): Book
     books: [Book]

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/books.ts
@@ -4,6 +4,7 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 export const name = 'books';
 export const typeDefs = gql`
   directive @stream on FIELD
+  directive @transform(from: String!) on FIELD
 
   extend type Query {
     book(isbn: String!): Book

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/inventory.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/inventory.ts
@@ -3,6 +3,8 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'inventory';
 export const typeDefs = gql`
+  directive @stream on FIELD
+
   extend interface Product {
     inStock: Boolean
   }

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/inventory.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/inventory.ts
@@ -4,6 +4,7 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 export const name = 'inventory';
 export const typeDefs = gql`
   directive @stream on FIELD
+  directive @transform(from: String!) on FIELD
 
   extend interface Product {
     inStock: Boolean

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
@@ -3,6 +3,8 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 
 export const name = 'product';
 export const typeDefs = gql`
+  directive @stream on FIELD
+
   extend type Query {
     product(upc: String!): Product
     topProducts(first: Int = 5): [Product]

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/product.ts
@@ -4,6 +4,7 @@ import { GraphQLResolverMap } from 'apollo-graphql';
 export const name = 'product';
 export const typeDefs = gql`
   directive @stream on FIELD
+  directive @transform(from: String!) on FIELD
 
   extend type Query {
     product(upc: String!): Product

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
@@ -3,6 +3,8 @@ import gql from 'graphql-tag';
 
 export const name = 'reviews';
 export const typeDefs = gql`
+  directive @stream on FIELD
+
   extend type Query {
     topReviews(first: Int = 5): [Review]
   }

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 export const name = 'reviews';
 export const typeDefs = gql`
   directive @stream on FIELD
+  directive @transform(from: String!) on FIELD
 
   extend type Query {
     topReviews(first: Int = 5): [Review]

--- a/packages/apollo-gateway/src/__tests__/integration/custom-directives.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/custom-directives.test.ts
@@ -13,7 +13,7 @@ expect.addSnapshotSerializer(astSerializer);
 expect.addSnapshotSerializer(queryPlanSerializer);
 
 describe('custom executable directives', () => {
-  it('passes directives along in requests to underlying services', async () => {
+  it('successfully passes directives along in requests to an underlying service', async () => {
     const query = gql`
       query GetReviewers {
         topReviews {
@@ -22,7 +22,7 @@ describe('custom executable directives', () => {
       }
     `;
 
-    const { data, errors, queryPlan } = await execute(
+    const { errors, queryPlan } = await execute(
       [accounts, books, inventory, product, reviews],
       {
         query,
@@ -32,16 +32,72 @@ describe('custom executable directives', () => {
     expect(errors).toBeUndefined();
     expect(queryPlan).toCallService('reviews');
     expect(queryPlan).toMatchInlineSnapshot(`
-      QueryPlan {
-        Fetch(service: "reviews") {
-          {
-            topReviews {
-              body @stream
+        QueryPlan {
+          Fetch(service: "reviews") {
+            {
+              topReviews {
+                body @stream
+              }
             }
+          },
+        }
+      `);
+  });
+
+  it('successfully passes directives and their variables along in requests to underlying services', async () => {
+    const query = gql`
+      query GetReviewers {
+        topReviews {
+          body @stream
+          author @transform(from: "JSON") {
+            name @stream
           }
-        },
+        }
       }
-    `);
+    `;
+
+    const { errors, queryPlan } = await execute(
+      [accounts, books, inventory, product, reviews],
+      {
+        query,
+      },
+    );
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toCallService('reviews');
+    expect(queryPlan).toCallService('accounts');
+    expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "reviews") {
+              {
+                topReviews {
+                  body @stream
+                  author @transform(from: "JSON") {
+                    __typename
+                    id
+                  }
+                }
+              }
+            },
+            Flatten(path: "topReviews.@.author") {
+              Fetch(service: "accounts") {
+                {
+                  ... on User {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on User {
+                    name @stream
+                  }
+                }
+              },
+            },
+          },
+        }
+      `);
   });
 
   it("returns validation errors when directives aren't present across all services", async () => {
@@ -66,6 +122,8 @@ describe('custom executable directives', () => {
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
 "[@stream] -> Custom directives must be implemented in every service. The following services do not implement the @stream directive: invalidService.
+
+[@transform] -> Custom directives must be implemented in every service. The following services do not implement the @transform directive: invalidService.
 
 [@invalid] -> Custom directives must be implemented in every service. The following services do not implement the @invalid directive: accounts, books, inventory, product, reviews."
 `);
@@ -92,7 +150,9 @@ describe('custom executable directives', () => {
         query,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-"[@stream] -> custom directives must be defined identically across all services. See below for a list of current implementations:
+"[@transform] -> Custom directives must be implemented in every service. The following services do not implement the @transform directive: invalid.
+
+[@stream] -> custom directives must be defined identically across all services. See below for a list of current implementations:
 	accounts: directive @stream on FIELD
 	books: directive @stream on FIELD
 	inventory: directive @stream on FIELD

--- a/packages/apollo-gateway/src/__tests__/integration/custom-directives.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/custom-directives.test.ts
@@ -1,0 +1,104 @@
+import gql from 'graphql-tag';
+import { execute } from '../execution-utils';
+
+import * as accounts from '../__fixtures__/schemas/accounts';
+import * as books from '../__fixtures__/schemas/books';
+import * as inventory from '../__fixtures__/schemas/inventory';
+import * as product from '../__fixtures__/schemas/product';
+import * as reviews from '../__fixtures__/schemas/reviews';
+
+import { astSerializer, queryPlanSerializer } from '../../snapshotSerializers';
+
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(queryPlanSerializer);
+
+describe('custom executable directives', () => {
+  it('passes directives along in requests to underlying services', async () => {
+    const query = gql`
+      query GetReviewers {
+        topReviews {
+          body @stream
+        }
+      }
+    `;
+
+    const { data, errors, queryPlan } = await execute(
+      [accounts, books, inventory, product, reviews],
+      {
+        query,
+      },
+    );
+
+    expect(errors).toBeUndefined();
+    expect(queryPlan).toCallService('reviews');
+    expect(queryPlan).toMatchInlineSnapshot(`
+      QueryPlan {
+        Fetch(service: "reviews") {
+          {
+            topReviews {
+              body @stream
+            }
+          }
+        },
+      }
+    `);
+  });
+
+  it("returns validation errors when directives aren't present across all services", async () => {
+    const invalidService = {
+      name: 'invalidService',
+      typeDefs: gql`
+        directive @invalid on QUERY
+      `,
+    };
+
+    const query = gql`
+      query GetReviewers {
+        topReviews {
+          body @stream
+        }
+      }
+    `;
+
+    expect(
+      execute([accounts, books, inventory, product, reviews, invalidService], {
+        query,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+"[@stream] -> Custom directives must be implemented in every service. The following services do not implement the @stream directive: invalidService.
+
+[@invalid] -> Custom directives must be implemented in every service. The following services do not implement the @invalid directive: accounts, books, inventory, product, reviews."
+`);
+  });
+
+  it("returns validation errors when directives aren't identical across all services", async () => {
+    const invalidService = {
+      name: 'invalid',
+      typeDefs: gql`
+        directive @stream on QUERY
+      `,
+    };
+
+    const query = gql`
+      query GetReviewers {
+        topReviews {
+          body @stream
+        }
+      }
+    `;
+
+    expect(
+      execute([accounts, books, inventory, product, reviews, invalidService], {
+        query,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+"[@stream] -> custom directives must be defined identically across all services. See below for a list of current implementations:
+	accounts: directive @stream on FIELD
+	books: directive @stream on FIELD
+	inventory: directive @stream on FIELD
+	product: directive @stream on FIELD
+	reviews: directive @stream on FIELD
+	invalid: directive @stream on QUERY"
+`);
+  });
+});


### PR DESCRIPTION
The purpose of this PR is to introduce support for [`ExecutableDirective`s](https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation). This doesn't require any changes from the gateway, only in how we perform composition and validation.

* Composition now adds _all_ custom directives to the final schema
> Note: since we're dealing with n implementations of the same directive, composition arbitrarily chooses the first one it sees. This should be fine based on our new validations.
* Additional validations:
  * `EXECUTABLE_DIRECTIVES_ONLY`: Custom directives *must* be executable only. Directives that use a`TypeSystemDirectiveLocation` are disallowed and will trigger validation errors
  * `EXECUTABLE_DIRECTIVES_EVERYWHERE`: Custom directives *must* be implemented within every service, even if it's just a no-op. The directive must exist in the SDL query for every service `{ _service { sdl } }`
  * `EXECUTABLE_DIRECTIVES_IDENTICAL`: Custom directives *must* be identical across all services. This means that the `locations` of the directive must be exactly the same from one service to the next.

Preserved commentary from @jbaxley:
>It removes extra filtering we currently do to allow any directives that were part of the service definitions to be maintained in the final schema. The final implementation is a model where if an executable directive is present, __all__ services must both contain and exactly match the ones found in other services. This is because executable directives can't be limited to __specific__ types/fields, but must be usable on any location they are defined. Long term we may be able to move support for common executable directives to the gateway but custom ones will always require them to be present in all services (even as a no-op)
