### PR TITLE
[BE-615] AER: use a static identifier for GraphQL validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-core`: Fix typo in error message for unparsable/invalid schemas provided via `overrideReportedSchema`. [PR #4581](https://github.com/apollographql/apollo-server/pull/4581)
+- `apollo-server-core`: Do not send  operation documents that cannot be executed to Apollo Studio. Instead, a constant identifier will be sent; it will be for parse failure, validation failure, operation name not found. `sendUnexecutableOperationDocuments` added to send the operation document as part of a trace so the unexecutable operation document can be viewed in on a trace in Apollo Studio.
 
 ## v2.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 ## vNEXT
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
+- `apollo-server-core`: Do not send  operation documents that cannot be executed to Apollo Studio. Instead, information about these operations will be combined into one "operation" for parse failures, one for validation failures, and one for unknown operation names.
 
 ## v2.18.1
 
@@ -20,7 +21,6 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-server-core`: Improve a usage reporting error which occurs when you use Apollo Server in an unsupported way. [PR #4588](https://github.com/apollographql/apollo-server/pull/4588)
 
 - `apollo-server-core`: Fix typo in error message for unparsable/invalid schemas provided via `overrideReportedSchema`. [PR #4581](https://github.com/apollographql/apollo-server/pull/4581)
-- `apollo-server-core`: Do not send  operation documents that cannot be executed to Apollo Studio. Instead, a constant identifier will be sent; it will be for parse failure, validation failure, operation name not found. `sendUnexecutableOperationDocuments` added to send the operation document as part of a trace so the unexecutable operation document can be viewed in on a trace in Apollo Studio.
 
 ## v2.18.0
 

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -167,6 +167,20 @@ If you are using the `overrideReportedSchema` option to the [schema reporting pl
 </tr>
 
 <tr>
+<td>
+
+###### `sendOperationWhenUnexecutable`
+
+`Boolean`
+</td>
+<td>
+
+Statistics about operations that your server cannot execute are not reported under each document separately to Apollo Studio, but are grouped together as "parse failure", "validation failure", or "unknown operation name". By default, the usage reporting plugin does not include the full operation document in reported traces, because it is challenging to strip potential private information (like string constants) from invalid operations. If you'd like the usage reporting plugin to send the full operation document and operation name so you can view it in Apollo Studio's trace view, set this to true.
+
+</td>
+</tr>
+
+<tr>
 <td colspan="2">
 
 **Configure the mechanics of communicating with Apollo's servers**
@@ -320,20 +334,6 @@ If set, prints all reports as JSON when they are sent. (Note that this feature i
 <td>
 
 Specify the function for creating a signature for a query. This option is not recommended, as Apollo's servers make assumptions about how the signature relates to the operation you executed.
-</td>
-</tr>
-
-<tr>
-<td>
-
-###### `sendOperationDocumentsOnUnexecutableOperation`
-
-`Boolean`
-</td>
-<td>
-
-Statistics about operations that your server cannot execute are not reported under each document separately to Apollo Studio, but are grouped together as "parse failure", "validation failure", or "unknown operation name". By default, the usage reporting plugin does not include the full operation document in reported traces, because it is challenging to strip potential private information (like string constants) from invalid operations. If you'd like the usage reporting plugin to send the full operation document and operation name so you can view it in Apollo Studio's trace view, set this to true.
-
 </td>
 </tr>
 

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -323,5 +323,18 @@ Specify the function for creating a signature for a query. This option is not re
 </td>
 </tr>
 
+<tr>
+<td>
+
+###### `sendOperationDocumentsOnUnexecutableOperation`
+
+`Boolean`
+</td>
+<td>
+
+Whether to include the entire document in the trace if the operation was a GraphQL parse or validation error (i.e. failed the GraphQL parse or validation phases). This will be included as a separate field on the trace and the operation name and signature will always be reported with a cosntant identifier. Whether the operation was a parse failure or a validation failure will be embedded within the stats report key itself.
+</td>
+</tr>
+
 </tbody>
 </table>

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -169,7 +169,7 @@ If you are using the `overrideReportedSchema` option to the [schema reporting pl
 <tr>
 <td>
 
-###### `sendOperationWhenUnexecutable`
+###### `sendUnexecutableOperationDocuments`
 
 `Boolean`
 </td>

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -332,7 +332,8 @@ Specify the function for creating a signature for a query. This option is not re
 </td>
 <td>
 
-Whether to include the entire document in the trace if the operation was a GraphQL parse or validation error (i.e. failed the GraphQL parse or validation phases). This will be included as a separate field on the trace and the operation name and signature will always be reported with a cosntant identifier. Whether the operation was a parse failure or a validation failure will be embedded within the stats report key itself.
+Statistics about operations that your server cannot execute are not reported under each document separately to Apollo Studio, but are grouped together as "parse failure", "validation failure", or "unknown operation name". By default, the usage reporting plugin does not include the full operation document in reported traces, because it is challenging to strip potential private information (like string constants) from invalid operations. If you'd like the usage reporting plugin to send the full operation document and operation name so you can view it in Apollo Studio's trace view, set this to true.
+
 </td>
 </tr>
 

--- a/packages/apollo-cache-control/src/__tests__/cacheControlPlugin.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlPlugin.test.ts
@@ -30,7 +30,8 @@ describe('plugin', () => {
       return pluginTestHarness({
         pluginInstance,
         overallCachePolicy,
-        graphqlRequest: { query: 'does not matter' },
+        // This query needs to pass graphql validation
+        graphqlRequest: { query: 'query { hello }' },
         executor: () => {
           const response: GraphQLResponse = {
             http: {

--- a/packages/apollo-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-reporting-protobuf/src/reports.proto
@@ -196,6 +196,12 @@ message Trace {
 	// instead.
 	string signature = 19;
 
+	// Optional: when GraphQL parsing or validation against the GraphQL schema fails, these fields
+	// can include reference to the operation being sent for users to dig into the set of operations
+	// that are failing validation.
+	string unexecutedOperationBody = 27;
+	string unexecutedOperationName = 28;
+
 	Details details = 6;
 
 	// Note: engineproxy always sets client_name, client_version, and client_address to "none".

--- a/packages/apollo-server-core/src/plugin/traceTreeBuilder.ts
+++ b/packages/apollo-server-core/src/plugin/traceTreeBuilder.ts
@@ -17,7 +17,7 @@ export class TraceTreeBuilder {
   private nodes = new Map<string, Trace.Node>([
     [responsePathAsString(), this.rootNode],
   ]);
-  private rewriteError?: (err: GraphQLError) => GraphQLError | null;
+  private readonly rewriteError?: (err: GraphQLError) => GraphQLError | null;
 
   public constructor(options: {
     logger?: Logger;

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
@@ -126,7 +126,7 @@ describe('end-to-end', () => {
     ).toBeTruthy();
   });
 
-  it('fails parse for invalid gql', async () => {
+  it('fails parse for non-parseable gql', async () => {
     const { report } = await runTest({ query: 'random text' });
     expect(Object.keys(report!.tracesPerQuery)).toHaveLength(1);
     expect(Object.keys(report!.tracesPerQuery)[0]).toBe(

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
@@ -130,7 +130,7 @@ describe('end-to-end', () => {
     const { report } = await runTest({ query: 'random text' });
     expect(Object.keys(report!.tracesPerQuery)).toHaveLength(1);
     expect(Object.keys(report!.tracesPerQuery)[0]).toBe(
-      '# GraphQLParseFailure\n',
+      '## GraphQLParseFailure\n',
     );
     const traces = Object.values(report!.tracesPerQuery)[0].trace;
     expect(traces).toHaveLength(1);
@@ -140,7 +140,7 @@ describe('end-to-end', () => {
     const { report } = await runTest({ query: 'query q { nonExistentField }' });
     expect(Object.keys(report!.tracesPerQuery)).toHaveLength(1);
     expect(Object.keys(report!.tracesPerQuery)[0]).toBe(
-      '# GraphQLValidationFailure\n',
+      '## GraphQLValidationFailure\n',
     );
     const traces = Object.values(report!.tracesPerQuery)[0].trace;
     expect(traces).toHaveLength(1);
@@ -150,7 +150,7 @@ describe('end-to-end', () => {
     const { report } = await runTest({ query: 'query notQ { aString }' });
     expect(Object.keys(report!.tracesPerQuery)).toHaveLength(1);
     expect(Object.keys(report!.tracesPerQuery)[0]).toBe(
-      '# GraphQLUnknownOperationName\n',
+      '## GraphQLUnknownOperationName\n',
     );
     const traces = Object.values(report!.tracesPerQuery)[0].trace;
     expect(traces).toHaveLength(1);

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
@@ -150,7 +150,7 @@ describe('end-to-end', () => {
     expect(traces).toHaveLength(1);
   });
 
-  it('is unknown for missing operation', async () => {
+  it('unknown operation error if not specified', async () => {
     const { report } = await runTest({ query: 'query notQ { aString }' });
     expect(Object.keys(report!.tracesPerQuery)).toHaveLength(1);
     expect(Object.keys(report!.tracesPerQuery)[0]).toBe(
@@ -160,7 +160,7 @@ describe('end-to-end', () => {
     expect(traces).toHaveLength(1);
   });
 
-  it('is unknown for missing operation', async () => {
+  it('handles anonymous operation', async () => {
     const { report } = await runTest({
       query: 'query { aString }',
       operationName: null,

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
@@ -166,7 +166,7 @@ describe('end-to-end', () => {
       operationName: null,
     });
     expect(Object.keys(report!.tracesPerQuery)).toHaveLength(1);
-    expect(Object.keys(report!.tracesPerQuery)[0]).toBe('# -\n{aString}');
+    expect(Object.keys(report!.tracesPerQuery)[0]).toMatch(/^# -\n/);
     const traces = Object.values(report!.tracesPerQuery)[0].trace;
     expect(traces).toHaveLength(1);
   });

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/signatureCache.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/signatureCache.test.ts
@@ -5,7 +5,7 @@ describe('signature cache key', () => {
     expect(signatureCacheKey('abc123', '')).toEqual('abc123');
   });
 
-  it('generates without the operationName', () => {
+  it('generates with the operationName', () => {
     expect(signatureCacheKey('abc123', 'myOperation')).toEqual(
       'abc123:myOperation',
     );

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -87,7 +87,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * },
    * ```
    *
-   */
+send   */
   includeRequest?: (
     request:
       | GraphQLRequestContextDidResolveOperation<TContext>
@@ -109,6 +109,16 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * ID that the other plugin reports.
    */
   overrideReportedSchema?: string;
+  // FIXME Add to the API reference docs
+  /**
+   * Whether to include the entire document in the trace if the operation
+   * was a GraphQL parse or validation error (i.e. failed the GraphQL parse or
+   * validation phases). This will be included as a separate field on the trace
+   * and the operation name and signature will always be reported with a cosntant
+   * identifier. Whether the operation was a parse failure or a validation
+   * failure will be embedded within the stats report key itself
+   */
+  sendOperationDocumentsOnUnexecutableOperation?: boolean;
   //#endregion
 
   //#region Configure the mechanics of communicating with Apollo's servers.

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -117,7 +117,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * identifier. Whether the operation was a parse failure or a validation
    * failure will be embedded within the stats report key itself.
    */
-  sendOperationWhenUnexecutable?: boolean;
+  sendUnexecutableOperationDocuments?: boolean;
   //#endregion
 
   //#region Configure the mechanics of communicating with Apollo's servers.

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -87,7 +87,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * },
    * ```
    *
-send   */
+   */
   includeRequest?: (
     request:
       | GraphQLRequestContextDidResolveOperation<TContext>
@@ -109,7 +109,6 @@ send   */
    * ID that the other plugin reports.
    */
   overrideReportedSchema?: string;
-  // FIXME Add to the API reference docs
   /**
    * Whether to include the entire document in the trace if the operation
    * was a GraphQL parse or validation error (i.e. failed the GraphQL parse or

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -116,7 +116,7 @@ send   */
    * validation phases). This will be included as a separate field on the trace
    * and the operation name and signature will always be reported with a cosntant
    * identifier. Whether the operation was a parse failure or a validation
-   * failure will be embedded within the stats report key itself
+   * failure will be embedded within the stats report key itself.
    */
   sendOperationDocumentsOnUnexecutableOperation?: boolean;
   //#endregion

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -117,7 +117,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * identifier. Whether the operation was a parse failure or a validation
    * failure will be embedded within the stats report key itself.
    */
-  sendOperationDocumentsOnUnexecutableOperation?: boolean;
+  sendOperationWhenUnexecutable?: boolean;
   //#endregion
 
   //#region Configure the mechanics of communicating with Apollo's servers.

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -468,7 +468,7 @@ export function ApolloServerPluginUsageReporting<TContext>(
 
             let statsReportKey: string;
             if (!requestContext.document) {
-              statsReportKey = `# GraphQLParseFailure\n`;
+              statsReportKey = `## GraphQLParseFailure\n`;
               if (
                 options.sendOperationDocumentsOnUnexecutableOperation &&
                 requestContext.source
@@ -478,7 +478,7 @@ export function ApolloServerPluginUsageReporting<TContext>(
                 treeBuilder.trace.unexecutedOperationName = operationName;
               }
             } else if (graphqlValidationFailure) {
-              statsReportKey = `# GraphQLValidationFailure\n`;
+              statsReportKey = `## GraphQLValidationFailure\n`;
               if (
                 options.sendOperationDocumentsOnUnexecutableOperation &&
                 requestContext.source
@@ -488,7 +488,7 @@ export function ApolloServerPluginUsageReporting<TContext>(
                 treeBuilder.trace.unexecutedOperationName = operationName;
               }
             } else if (graphqlUnknownOperationName) {
-              statsReportKey = `# GraphQLUnknownOperationName\n`;
+              statsReportKey = `## GraphQLUnknownOperationName\n`;
               if (
                 options.sendOperationDocumentsOnUnexecutableOperation &&
                 requestContext.source

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -477,7 +477,7 @@ export function ApolloServerPluginUsageReporting<TContext>(
 
             if (statsReportKey) {
               if (
-                options.sendOperationWhenUnexecutable
+                options.sendUnexecutableOperationDocuments
               ) {
                 treeBuilder.trace.unexecutedOperationBody =
                   requestContext.source;

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -477,7 +477,7 @@ export function ApolloServerPluginUsageReporting<TContext>(
 
             if (statsReportKey) {
               if (
-                options.sendOperationDocumentsOnUnexecutableOperation
+                options.sendOperationWhenUnexecutable
               ) {
                 treeBuilder.trace.unexecutedOperationBody =
                   requestContext.source;

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -466,32 +466,18 @@ export function ApolloServerPluginUsageReporting<TContext>(
             const reportData = getReportData(executableSchemaId);
             const { report } = reportData;
 
-            let statsReportKey: string;
+            let statsReportKey: string | undefined = undefined;
             if (!requestContext.document) {
               statsReportKey = `## GraphQLParseFailure\n`;
-              if (
-                options.sendOperationDocumentsOnUnexecutableOperation &&
-                requestContext.source
-              ) {
-                treeBuilder.trace.unexecutedOperationBody =
-                  requestContext.source;
-                treeBuilder.trace.unexecutedOperationName = operationName;
-              }
             } else if (graphqlValidationFailure) {
               statsReportKey = `## GraphQLValidationFailure\n`;
-              if (
-                options.sendOperationDocumentsOnUnexecutableOperation &&
-                requestContext.source
-              ) {
-                treeBuilder.trace.unexecutedOperationBody =
-                  requestContext.source;
-                treeBuilder.trace.unexecutedOperationName = operationName;
-              }
             } else if (graphqlUnknownOperationName) {
               statsReportKey = `## GraphQLUnknownOperationName\n`;
+            }
+
+            if (statsReportKey) {
               if (
-                options.sendOperationDocumentsOnUnexecutableOperation &&
-                requestContext.source
+                options.sendOperationDocumentsOnUnexecutableOperation
               ) {
                 treeBuilder.trace.unexecutedOperationBody =
                   requestContext.source;

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -323,6 +323,8 @@ export function ApolloServerPluginUsageReporting<TContext>(
         });
         treeBuilder.startTiming();
         metrics.startHrTime = treeBuilder.startHrTime;
+        let graphqlValidationFailure = false;
+        let graphqlUnknownOperationName = false;
 
         if (http) {
           treeBuilder.trace.http = new Trace.HTTP({
@@ -464,15 +466,49 @@ export function ApolloServerPluginUsageReporting<TContext>(
             const reportData = getReportData(executableSchemaId);
             const { report } = reportData;
 
+            let statsReportKey: string;
+            if (!requestContext.document) {
+              statsReportKey = `# GraphQLParseFailure\n`;
+              if (
+                options.sendOperationDocumentsOnUnexecutableOperation &&
+                requestContext.source
+              ) {
+                treeBuilder.trace.unexecutedOperationBody =
+                  requestContext.source;
+                treeBuilder.trace.unexecutedOperationName = operationName;
+              }
+            } else if (graphqlValidationFailure) {
+              statsReportKey = `# GraphQLValidationFailure\n`;
+              if (
+                options.sendOperationDocumentsOnUnexecutableOperation &&
+                requestContext.source
+              ) {
+                treeBuilder.trace.unexecutedOperationBody =
+                  requestContext.source;
+                treeBuilder.trace.unexecutedOperationName = operationName;
+              }
+            } else if (graphqlUnknownOperationName) {
+              statsReportKey = `# GraphQLUnknownOperationName\n`;
+              if (
+                options.sendOperationDocumentsOnUnexecutableOperation &&
+                requestContext.source
+              ) {
+                treeBuilder.trace.unexecutedOperationBody =
+                  requestContext.source;
+                treeBuilder.trace.unexecutedOperationName = operationName;
+              }
+            } else {
+              const signature = getTraceSignature();
+              statsReportKey = `# ${operationName || '-'}\n${signature}`;
+            }
+
             const protobufError = Trace.verify(treeBuilder.trace);
             if (protobufError) {
               throw new Error(`Error encoding trace: ${protobufError}`);
             }
+
             const encodedTrace = Trace.encode(treeBuilder.trace).finish();
 
-            const signature = getTraceSignature();
-
-            const statsReportKey = `# ${operationName || '-'}\n${signature}`;
             if (!report.tracesPerQuery.hasOwnProperty(statsReportKey)) {
               report.tracesPerQuery[statsReportKey] = new TracesAndStats();
               (report.tracesPerQuery[statsReportKey] as any).encodedTraces = [];
@@ -482,6 +518,7 @@ export function ApolloServerPluginUsageReporting<TContext>(
             (report.tracesPerQuery[statsReportKey] as any).encodedTraces.push(
               encodedTrace,
             );
+
             reportData.size +=
               encodedTrace.length + Buffer.byteLength(statsReportKey);
 
@@ -496,9 +533,10 @@ export function ApolloServerPluginUsageReporting<TContext>(
           }
 
           function getTraceSignature(): string {
-            if (!requestContext.document && !requestContext.source) {
-              // This shouldn't happen: one of those options must be passed to runQuery.
-              throw new Error('No document or source?');
+            if (!requestContext.document) {
+              // This shouldn't happen: no document means parse failure, which
+              // uses its own special statsReportKey.
+              throw new Error('No document?');
             }
 
             const cacheKey = signatureCacheKey(
@@ -512,17 +550,6 @@ export function ApolloServerPluginUsageReporting<TContext>(
 
             if (cachedSignature) {
               return cachedSignature;
-            }
-
-            if (!requestContext.document) {
-              // We didn't get an AST, possibly because of a parse failure. Let's just
-              // use the full query string.
-              //
-              // XXX This does mean that even if you use a calculateSignature which
-              //     hides literals, you might end up sending literals for queries
-              //     that fail parsing or validation. Provide some way to mask them
-              //     anyway?
-              return requestContext.source as string;
             }
 
             const generatedSignature = (
@@ -584,7 +611,18 @@ export function ApolloServerPluginUsageReporting<TContext>(
               treeBuilder.trace.clientName = clientName || '';
             }
           },
+          validationDidStart() {
+            return (validationErrors?: ReadonlyArray<Error>) => {
+              graphqlValidationFailure = validationErrors
+                ? validationErrors.length !== 0
+                : false;
+            };
+          },
           async didResolveOperation(requestContext) {
+            // If operation is undefined then `getOperationAST` returned null
+            // and an unknown operation was specified.
+            graphqlUnknownOperationName =
+              requestContext.operation === undefined;
             await shouldIncludeRequest(requestContext);
 
             if (metrics.captureTraces === false) {

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -7,6 +7,10 @@ import {
   GraphQLRequestContextWillSendResponse,
   GraphQLRequestContext,
   Logger,
+  GraphQLRequestContextDidEncounterErrors,
+  GraphQLRequestContextDidResolveSource,
+  GraphQLRequestContextParsingDidStart,
+  GraphQLRequestContextValidationDidStart,
 } from 'apollo-server-types';
 import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql/type';
 import { CacheHint } from 'apollo-cache-control';
@@ -21,7 +25,8 @@ import {
 } from 'apollo-server-plugin-base';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { Dispatcher } from './dispatcher';
-import { generateSchemaHash } from "./schemaHash";
+import { generateSchemaHash } from './schemaHash';
+import { getOperationAST, parse, validate as graphqlValidate } from 'graphql';
 
 // This test harness guarantees the presence of `query`.
 type IPluginTestHarnessGraphqlRequest = WithRequired<GraphQLRequest, 'query'>;
@@ -118,7 +123,9 @@ export default async function pluginTestHarness<TContext>({
     }
   }
 
-  const requestContext: GraphQLRequestContext<TContext> = {
+  type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+  const requestContext: Mutable<GraphQLRequestContext<TContext>> = {
     logger: logger || console,
     schema,
     schemaHash: generateSchemaHash(schema),
@@ -128,6 +135,10 @@ export default async function pluginTestHarness<TContext>({
     cache: new InMemoryLRUCache(),
     context,
   };
+
+  if (requestContext.source === undefined) {
+    throw new Error("No source provided for test");
+  }
 
   requestContext.overallCachePolicy = overallCachePolicy;
 
@@ -141,8 +152,75 @@ export default async function pluginTestHarness<TContext>({
 
   const executionListeners: GraphQLRequestExecutionListener<TContext>[] = [];
 
-  // This logic is duplicated in the request pipeline right now.
+  // Let the plugins know that we now have a STRING of what we hope will
+  // parse and validate into a document we can execute on.  Unless we have
+  // retrieved this from our APQ cache, there's no guarantee that it is
+  // syntactically correct, so this string should not be trusted as a valid
+  // document until after it's parsed and validated.
   await dispatcher.invokeHookAsync(
+    'didResolveSource',
+    requestContext as GraphQLRequestContextDidResolveSource<TContext>,
+  );
+
+  if (!requestContext.document) {
+    await dispatcher.invokeDidStartHook(
+      'parsingDidStart',
+      requestContext as GraphQLRequestContextParsingDidStart<TContext>,
+    );
+
+    try {
+      requestContext.document = parse(requestContext.source, undefined);
+    } catch (syntaxError) {
+      const errorOrErrors = syntaxError
+      requestContext.errors = Array.isArray(errorOrErrors)
+        ? errorOrErrors
+        : [errorOrErrors];
+      await dispatcher.invokeHookAsync(
+        'didEncounterErrors',
+        requestContext as GraphQLRequestContextDidEncounterErrors<TContext>,
+      );
+
+      return requestContext as GraphQLRequestContextWillSendResponse<TContext>;
+    }
+
+    const validationDidEnd = await dispatcher.invokeDidStartHook(
+      'validationDidStart',
+      requestContext as GraphQLRequestContextValidationDidStart<TContext>,
+    );
+
+    /**
+     * We are validating only with the default rules.
+     */
+    const validationErrors = graphqlValidate(requestContext.schema, requestContext.document);
+
+    if (validationErrors.length !== 0) {
+      requestContext.errors = validationErrors;
+      validationDidEnd(validationErrors);
+      await dispatcher.invokeHookAsync(
+        'didEncounterErrors',
+        requestContext as GraphQLRequestContextDidEncounterErrors<TContext>,
+      );
+      return requestContext as GraphQLRequestContextWillSendResponse<TContext>;
+    } else {
+      validationDidEnd();
+    }
+  }
+
+  const operation = getOperationAST(
+    requestContext.document,
+    requestContext.request.operationName,
+  );
+
+  requestContext.operation = operation || undefined;
+  // We'll set `operationName` to `null` for anonymous operations.  Note that
+  // apollo-engine-reporting relies on the fact that the requestContext passed
+  // to requestDidStart is mutated to add this field before requestDidEnd is
+  // called
+  requestContext.operationName =
+    (operation && operation.name && operation.name.value) || null;
+
+  // This logic is duplicated in the request pipeline right now.
+  dispatcher.invokeHookAsync(
     'didResolveOperation',
     requestContext as GraphQLRequestContextExecutionDidStart<TContext>,
   );

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -220,7 +220,7 @@ export default async function pluginTestHarness<TContext>({
     (operation && operation.name && operation.name.value) || null;
 
   // This logic is duplicated in the request pipeline right now.
-  dispatcher.invokeHookAsync(
+  await dispatcher.invokeHookAsync(
     'didResolveOperation',
     requestContext as GraphQLRequestContextExecutionDidStart<TContext>,
   );

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -219,7 +219,6 @@ export default async function pluginTestHarness<TContext>({
   requestContext.operationName =
     (operation && operation.name && operation.name.value) || null;
 
-  // This logic is duplicated in the request pipeline right now.
   await dispatcher.invokeHookAsync(
     'didResolveOperation',
     requestContext as GraphQLRequestContextExecutionDidStart<TContext>,

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1154,7 +1154,8 @@ export function testApolloServer<AS extends ApolloServerBase>(
             await setupApolloServerAndFetchPair();
 
             await apolloFetch({
-              query: `notQ {justAField}`,
+              query: `query notQ {justAField}`,
+              operationName: 'q'
             });
 
             const reports = await reportIngress.promiseOfReports;

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -1150,6 +1150,46 @@ export function testApolloServer<AS extends ApolloServerBase>(
             );
           });
 
+          it('sets the trace key to unknown operation for missing operation', async () => {
+            await setupApolloServerAndFetchPair();
+
+            await apolloFetch({
+              query: `notQ {justAField}`,
+            });
+
+            const reports = await reportIngress.promiseOfReports;
+            expect(reports.length).toBe(1);
+
+            expect(Object.keys(reports[0].tracesPerQuery)[0]).toBe('## GraphQLUnknownOperationName\n',);
+          });
+
+          it('sets the trace key to parse failure when non-parseable gql', async () => {
+            await setupApolloServerAndFetchPair();
+
+            await apolloFetch({
+              query: `{nonExistentField`,
+            });
+
+            const reports = await reportIngress.promiseOfReports;
+            expect(reports.length).toBe(1);
+
+            expect(Object.keys(reports[0].tracesPerQuery)[0]).toBe('## GraphQLParseFailure\n',);
+          });
+
+          it('sets the trace key to validation failure when invalid operation', async () => {
+            await setupApolloServerAndFetchPair();
+
+            await apolloFetch({
+              query: `{nonExistentField}`,
+            });
+
+            const reports = await reportIngress.promiseOfReports;
+            expect(reports.length).toBe(1);
+
+            expect(Object.keys(reports[0].tracesPerQuery)[0]).toBe('## GraphQLValidationFailure\n',);
+          });
+
+
           it('sets the trace key to "-" when operationName is undefined', async () => {
             await setupApolloServerAndFetchPair();
 


### PR DESCRIPTION
This PR changes the apollo usage reporting library to use static identifiers for operation documents that are not able to be executed. 

When users of this module receive many un-executable operation documents, such as a non parse-able operation documents, invalid operation documents, or invalid operation names, every operation document is sent to Apollo Studio. This results in a cardinality explosion within Graph Manager. After a few thousand of these invalid operation names / documents are reported, the UI for the customer is borderline unusable due to the cardinality explosion & schema validation reaches a capacity of operations as well.

In general, we want to avoid storing & exposing personal information in Studio, and in current reporting agents, this is also problematic for operations that fail to execute. Because we currently report these operations with a signature matching the entire operation body, this is an easy trap for users to accidentally send user information through our system, when argument literals exist in the document.

The static identifiers are:
- `## GraphQLParseFailure` for documents that don't parse as valid graphql
- `## GraphQLValidationFailure` for documents that aren't valid given the schema running on the server
- `## GraphQLUnknownOperationName` for operation documents which don't have an operation name in the document

Additionally, it allows users to optionally include the body of the operations that fail validation with `sendUnexecutableOperationDocuments`. This will send the operation body as part of the trace so they can be viewed alongside the trace.