### PR TITLE
Remove TS types from subscriptions.md

### DIFF
--- a/docs/source/data/subscriptions.md
+++ b/docs/source/data/subscriptions.md
@@ -53,12 +53,12 @@ const resolvers = {
     },
   },
   Query: {
-    posts(root: any, args: any, context: any) {
+    posts(root, args, context) {
       return postController.posts();
     },
   },
   Mutation: {
-    addPost(root: any, args: any, context: any) {
+    addPost(root, args, context) {
       pubsub.publish(POST_ADDED, { postAdded: args });
       return postController.addPost(args);
     },


### PR DESCRIPTION
Looking through the `Fetching data` section, this was the only bit that added types. Removing them avoids confusion and adds consistency across the docs.