### PR TITLE
Correction to mocking a schema using introspection

### DIFF
--- a/docs/source/testing/mocking.md
+++ b/docs/source/testing/mocking.md
@@ -198,7 +198,7 @@ const { buildClientSchema } = require('graphql');
 const introspectionResult = require('schema.json');
 const { ApolloServer } = require('apollo-server');
 
-const schema = buildClientSchema(introspectionResult);
+const schema = buildClientSchema(introspectionResult.data);
 
 const server = new ApolloServer({
   schema,


### PR DESCRIPTION
When reading from schema.json we must pass the .data property of the introspection result to buildClientSchema.

https://github.com/graphql/graphql-js/issues/1970#issuecomment-500874598