### PR TITLE
Don't parse empty `extensions` or `variables` as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
+- `apollo-server-core`: Don't try parsing `variables` and `extensions` as JSON if they are defined but empty strings. [PR #3501](https://github.com/apollographql/apollo-server/pull/3501)
+
 ### v2.9.8
 
 > [See complete versioning details.](https://github.com/apollographql/apollo-server/commit/3cdde1b7a71ace6411fbacf82a1a61bf737444a6)

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -366,7 +366,7 @@ function parseGraphQLRequest(
   let queryString: string | undefined = requestParams.query;
   let extensions = requestParams.extensions;
 
-  if (extensions && extensions !== '' && typeof extensions === 'string') {
+  if (extensions && typeof extensions === 'string' && extensions !== '') {
     // For GET requests, we have to JSON-parse extensions. (For POST
     // requests they get parsed as part of parsing the larger body they're
     // inside.)
@@ -397,7 +397,7 @@ function parseGraphQLRequest(
   const operationName = requestParams.operationName;
 
   let variables = requestParams.variables;
-  if (variables && variables !== '' && typeof variables === 'string') {
+  if (variables && typeof variables === 'string' && variables !== '') {
     try {
       // XXX Really we should only do this for GET requests, but for
       // compatibility reasons we'll keep doing this at least for now for

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -366,7 +366,7 @@ function parseGraphQLRequest(
   let queryString: string | undefined = requestParams.query;
   let extensions = requestParams.extensions;
 
-  if (extensions && typeof extensions === 'string' && extensions !== '') {
+  if (typeof extensions === 'string' && extensions !== '') {
     // For GET requests, we have to JSON-parse extensions. (For POST
     // requests they get parsed as part of parsing the larger body they're
     // inside.)
@@ -397,7 +397,7 @@ function parseGraphQLRequest(
   const operationName = requestParams.operationName;
 
   let variables = requestParams.variables;
-  if (variables && typeof variables === 'string' && variables !== '') {
+  if (typeof variables === 'string' && variables !== '') {
     try {
       // XXX Really we should only do this for GET requests, but for
       // compatibility reasons we'll keep doing this at least for now for

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -397,7 +397,7 @@ function parseGraphQLRequest(
   const operationName = requestParams.operationName;
 
   let variables = requestParams.variables;
-  if (typeof variables === 'string') {
+  if (variables && variables !== '' && typeof variables === 'string') {
     try {
       // XXX Really we should only do this for GET requests, but for
       // compatibility reasons we'll keep doing this at least for now for

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -366,7 +366,7 @@ function parseGraphQLRequest(
   let queryString: string | undefined = requestParams.query;
   let extensions = requestParams.extensions;
 
-  if (typeof extensions === 'string') {
+  if (extensions && extensions !== '' && typeof extensions === 'string') {
     // For GET requests, we have to JSON-parse extensions. (For POST
     // requests they get parsed as part of parsing the larger body they're
     // inside.)


### PR DESCRIPTION
If variables is an empty string than JSON.parse(variables) will throw an error.
So anyone sending a request with variables = '' will get an unnecessary error.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
