### PR TITLE
Gateway over-merging fields of unioned types 

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
+ * Gateway over-merging fields of unioned types [#3581](https://github.com/apollographql/apollo-server/pull/3581)
+
 # v0.11.0
 
 > [See complete versioning details.](https://github.com/apollographql/apollo-server/commit/93002737d53dd9a50b473ab9cef14849b3e539aa)

--- a/packages/apollo-gateway/src/__tests__/integration/unions.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/unions.test.ts
@@ -1,0 +1,100 @@
+import gql from 'graphql-tag';
+import { astSerializer, queryPlanSerializer } from '../../snapshotSerializers';
+import { execute } from '../execution-utils';
+
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(queryPlanSerializer);
+
+it('handles multiple union type conditions', async () => {
+  const query = gql`
+    query {
+      union {
+        ...Foo
+        ...Bar
+      }
+    }
+
+    fragment Foo on Foo {
+      nested {
+        thing
+      }
+    }
+
+    fragment Bar on Bar {
+      nested {
+        stuff
+      }
+    }
+  `;
+
+  const { data, queryPlan, errors } = await execute(
+    [
+      {
+        name: 'unionService',
+        typeDefs: gql`
+          extend type Query {
+            union: MyUnion
+          }
+
+          union MyUnion = Foo | Bar
+
+          type Foo {
+            nested: Thing
+          }
+
+          type Thing {
+            thing: String
+          }
+
+          type Bar {
+            nested: Stuff
+          }
+
+          type Stuff {
+            stuff: String
+          }
+        `,
+        resolvers: {
+          Query: {},
+        },
+      },
+    ],
+    { query },
+  );
+
+  expect(data).toMatchInlineSnapshot(`
+    Object {
+      "union": null,
+    }
+  `);
+  expect(queryPlan).toMatchInlineSnapshot(`
+    QueryPlan {
+      Fetch(service: "unionService") {
+        {
+          union {
+            __typename
+            ... on Foo {
+              nested {
+                thing
+                stuff
+              }
+            }
+            ... on Bar {
+              nested {
+                thing
+                stuff
+              }
+            }
+          }
+        }
+      },
+    }
+  `);
+
+  expect(errors).toMatchInlineSnapshot(`
+    Array [
+      [GraphQLError: Cannot query field "stuff" on type "Thing".],
+      [GraphQLError: Cannot query field "thing" on type "Stuff".],
+    ]
+  `);
+});

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -31,7 +31,7 @@ import {
   Field,
   FieldSet,
   groupByParentType,
-  groupByResponseName,
+  groupByParentTypeAndResponseName,
   matchesField,
   selectionSetFromFieldSet,
   Scope,
@@ -373,7 +373,7 @@ function splitFields(
   fields: FieldSet,
   groupForField: (field: Field<GraphQLObjectType>) => FetchGroup,
 ) {
-  for (const fieldsForResponseName of groupByResponseName(fields).values()) {
+  for (const fieldsForResponseName of groupByParentTypeAndResponseName(fields).values()) {
     for (const [parentType, fieldsForParentType] of groupByParentType(
       fieldsForResponseName,
     )) {


### PR DESCRIPTION
This PR adds some granularity to how fields are keyed when we group them within a selection set. Previously, the field name was considered sufficient for merging selections (and it almost always is!). However, in the case that the `parentType` of these same-named fields is _different_, we most certainly should not group selections as it will result in invalid query plans.

The new test illustrates this edge case via two `union`ed types that share a same top-level field name. The gateway was incorrectly grouping these separate fields into the same `selectionSet` under the `media` field. By keying on `parentType:responseName` instead, the gateway will know better than to group two distinct `media` fields of different types.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
