### PR TITLE
Reduce interface expansion for types contained to a single service

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
 * Fix onSchemaChange callbacks for unmanaged configs [#3605](https://github.com/apollographql/apollo-server/pull/3605)
+* Reduce interface expansion for types contained to a single service [#3582](https://github.com/apollographql/apollo-server/pull/3582)
 
 # v0.11.4
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
@@ -52,7 +52,17 @@ export const typeDefs = gql`
     relatedReviews: [Review!]! @requires(fields: "similarBooks { isbn }")
   }
 
-  extend type Car @key(fields: "id") {
+  extend interface Vehicle {
+    retailPrice: String
+  }
+
+  extend type Car implements Vehicle @key(fields: "id") {
+    id: String! @external
+    price: String @external
+    retailPrice: String @requires(fields: "price")
+  }
+
+  extend type Van implements Vehicle @key(fields: "id") {
     id: String! @external
     price: String @external
     retailPrice: String @requires(fields: "price")
@@ -215,6 +225,11 @@ export const resolvers: GraphQLResolverMap<any> = {
   Car: {
     retailPrice(car) {
       return car.price;
+    },
+  },
+  Van: {
+    retailPrice(van) {
+      return van.price;
     },
   },
   MetadataOrError: {


### PR DESCRIPTION
## Purpose
The purpose of this PR is to take a first step towards minimizing query plans and their requests to downstream services. Currently, querying fields that return an abstract type result in large query plans because the planner expands these fields into an inline fragment on every implementing type.

## Optimization
This work targets an optimization concerning the over-expansion of abstract types. Previously, any query that asked for a field on an interface would be expanded to a selection of type conditions for all possible types. This would result in overly large operations sent to downstream services. If every field of an interface and its implementors belong to a single service, we can optimize the query plan by not expanding all possible types when building queries for fields that return an interface type.