### PR TITLE
Clarify `didEncounterErrors` documentation

### DIFF
--- a/docs/source/integrations/plugins.md
+++ b/docs/source/integrations/plugins.md
@@ -297,8 +297,8 @@ executionDidStart?(
 
 ### `didEncounterErrors`
 
-The `didEncounterErrors` event fires whenever Apollo Server encounters an error while
-executing a GraphQL operation.
+The `didEncounterErrors` event fires when Apollo Server encounters errors while
+parsing, validating, or executing a GraphQL operation.
 
 ```typescript
 didEncounterErrors?(


### PR DESCRIPTION
The `didEncounterErrors` event fires only once during the lifecycle of a request and fires regardless of whether the error(s) happened during parsing, validation, or execution. Here's a small edit to the docs to make that a little more clear