### PR TITLE
federation: Include originalError in downstreamServiceError

### DIFF
--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -14,6 +14,7 @@ import {
   TypeNameMetaFieldDef,
   VariableDefinitionNode,
   GraphQLFieldResolver,
+  GraphQLFormattedError,
 } from 'graphql';
 import { Trace, google } from 'apollo-engine-reporting-protobuf';
 import { GraphQLDataSource } from './datasources/types';
@@ -330,6 +331,7 @@ async function executeFetch<TContext>(
           variables,
           error.extensions,
           error.path,
+          error,
         ),
       );
       context.errors.push(...errors);
@@ -454,6 +456,7 @@ function downstreamServiceError(
   variables?: Record<string, any>,
   extensions?: Record<string, any>,
   path?: ReadonlyArray<string | number> | undefined,
+  originalError?: GraphQLFormattedError | undefined,
 ) {
   if (!message) {
     message = `Error while fetching subquery from service "${serviceName}"`;
@@ -473,7 +476,7 @@ function downstreamServiceError(
     undefined,
     undefined,
     path,
-    undefined,
+    originalError as Error,
     extensions,
   );
 }


### PR DESCRIPTION
original https://github.com/apollographql/apollo-server/pull/3211
sans `yarn.lock`

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
