### PR TITLE
Allow infinite TTL (time-to-live) on KeyValueCache's set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-server-core`: Upgrade TS to 3.7.3 [#3618](https://github.com/apollographql/apollo-server/pull/3618)
 - `apollo-server-cloud-functions`: Transmit CORS headers on `OPTIONS` request. [PR #3557](https://github.com/apollographql/apollo-server/pull/3557)
 - `apollo-server-caching`: De-compose options interface for `KeyValueCache.prototype.set` to accommodate better TSDoc annotations for its properties (e.g. to specify that `ttl` is defined in _seconds_). [PR #3619](https://github.com/apollographql/apollo-server/pull/3619)
+- `apollo-server-core`, `apollo-server-caching`: Introduce a `ttl` property, specified in seconds, on the options for automated persisted queries (APQ) which applies specific TTL settings to the cache `set`s during APQ registration.  Previously, all APQ cache records were set to 300 seconds.  Additionally, this adds support (to the underlying `apollo-server-caching` mechanisms) for a time-to-live (TTL) value of `null` which, when supported by the cache implementation, skips the assignment of a TTL value altogether.  This allows the cache's controller to determine when eviction happens (e.g. cache forever, and purge least recently used when the cache is full), which may be desireable for network cache stores (e.g. Memcached, Redis). [PR #3623](https://github.com/apollographql/apollo-server/pull/3623)
 
 ### v2.9.14
 

--- a/packages/apollo-server-cache-memcached/src/index.ts
+++ b/packages/apollo-server-cache-memcached/src/index.ts
@@ -29,7 +29,13 @@ export class MemcachedCache implements TestableKeyValueCache {
     options?: KeyValueCacheSetOptions,
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
-    await this.client.set(key, value, ttl);
+    if (typeof ttl === 'number') {
+      await this.client.set(key, value, ttl);
+    } else {
+      // In Memcached, zero indicates no specific expiration time.  Of course,
+      // it may be purged from the cache for other reasons as deemed necessary.
+      await this.client.set(key, value, 0);
+    }
   }
 
   async get(key: string): Promise<string | undefined> {

--- a/packages/apollo-server-cache-memcached/src/index.ts
+++ b/packages/apollo-server-cache-memcached/src/index.ts
@@ -1,11 +1,14 @@
-import { TestableKeyValueCache } from 'apollo-server-caching';
+import {
+  TestableKeyValueCache,
+  KeyValueCacheSetOptions,
+} from 'apollo-server-caching';
 import Memcached from 'memcached';
 import { promisify } from 'util';
 
 export class MemcachedCache implements TestableKeyValueCache {
   // FIXME: Replace any with proper promisified type
   readonly client: any;
-  readonly defaultSetOptions = {
+  readonly defaultSetOptions: KeyValueCacheSetOptions = {
     ttl: 300,
   };
 
@@ -23,7 +26,7 @@ export class MemcachedCache implements TestableKeyValueCache {
   async set(
     key: string,
     value: string,
-    options?: { ttl?: number },
+    options?: KeyValueCacheSetOptions,
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
     await this.client.set(key, value, ttl);

--- a/packages/apollo-server-cache-redis/src/RedisCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisCache.ts
@@ -1,10 +1,13 @@
-import { TestableKeyValueCache } from 'apollo-server-caching';
+import {
+  TestableKeyValueCache,
+  KeyValueCacheSetOptions,
+} from 'apollo-server-caching';
 import Redis, { RedisOptions } from 'ioredis';
 import DataLoader from 'dataloader';
 
 export class RedisCache implements TestableKeyValueCache<string> {
   readonly client: any;
-  readonly defaultSetOptions = {
+  readonly defaultSetOptions: KeyValueCacheSetOptions = {
     ttl: 300,
   };
 
@@ -22,7 +25,7 @@ export class RedisCache implements TestableKeyValueCache<string> {
   async set(
     key: string,
     value: string,
-    options?: { ttl?: number },
+    options?: KeyValueCacheSetOptions,
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
     await this.client.set(key, value, 'EX', ttl);

--- a/packages/apollo-server-cache-redis/src/RedisCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisCache.ts
@@ -28,7 +28,13 @@ export class RedisCache implements TestableKeyValueCache<string> {
     options?: KeyValueCacheSetOptions,
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
-    await this.client.set(key, value, 'EX', ttl);
+    if (typeof ttl === 'number') {
+      await this.client.set(key, value, 'EX', ttl);
+    } else {
+      // We'll leave out the EXpiration when no value is specified.  Of course,
+      // it may be purged from the cache for other reasons as deemed necessary.
+      await this.client.set(key, value);
+    }
   }
 
   async get(key: string): Promise<string | undefined> {

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -30,7 +30,13 @@ export class RedisClusterCache implements KeyValueCache {
     options?: KeyValueCacheSetOptions,
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
-    await this.client.set(key, data, 'EX', ttl);
+    if (typeof ttl === 'number') {
+      await this.client.set(key, data, 'EX', ttl);
+    } else {
+      // We'll leave out the EXpiration when no value is specified.  Of course,
+      // it may be purged from the cache for other reasons as deemed necessary.
+      await this.client.set(key, data);
+    }
   }
 
   async get(key: string): Promise<string | undefined> {

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -1,4 +1,4 @@
-import { KeyValueCache } from 'apollo-server-caching';
+import { KeyValueCache, KeyValueCacheSetOptions } from 'apollo-server-caching';
 import Redis, {
   ClusterOptions,
   ClusterNode,
@@ -8,7 +8,7 @@ import DataLoader from 'dataloader';
 
 export class RedisClusterCache implements KeyValueCache {
   readonly client: any;
-  readonly defaultSetOptions = {
+  readonly defaultSetOptions: KeyValueCacheSetOptions = {
     ttl: 300,
   };
 
@@ -27,7 +27,7 @@ export class RedisClusterCache implements KeyValueCache {
   async set(
     key: string,
     data: string,
-    options?: { ttl?: number },
+    options?: KeyValueCacheSetOptions,
   ): Promise<void> {
     const { ttl } = Object.assign({}, this.defaultSetOptions, options);
     await this.client.set(key, data, 'EX', ttl);

--- a/packages/apollo-server-cache-redis/src/__mocks__/ioredis.ts
+++ b/packages/apollo-server-cache-redis/src/__mocks__/ioredis.ts
@@ -22,9 +22,11 @@ const setKey = (key, value, type, ttl) => {
     value,
     ttl,
   };
-  setTimeout(() => {
-    delete keyValue[key];
-  }, ttl * 1000);
+  if (ttl) {
+    setTimeout(() => {
+      delete keyValue[key];
+    }, ttl * 1000);
+  }
   return Promise.resolve(true);
 };
 

--- a/packages/apollo-server-caching/src/KeyValueCache.ts
+++ b/packages/apollo-server-caching/src/KeyValueCache.ts
@@ -4,7 +4,7 @@ export interface KeyValueCacheSetOptions {
    * Specified in **seconds**, the time-to-live (TTL) value limits the lifespan
    * of the data being stored in the cache.
    */
-  ttl?: number
+  ttl?: number | null
 };
 
 export interface KeyValueCache<V = string> {

--- a/packages/apollo-server-caching/src/KeyValueCache.ts
+++ b/packages/apollo-server-caching/src/KeyValueCache.ts
@@ -1,5 +1,5 @@
 /** Options for {@link KeyValueCache.set} */
-interface KeyValueCacheSetOptions {
+export interface KeyValueCacheSetOptions {
   /**
    * Specified in **seconds**, the time-to-live (TTL) value limits the lifespan
    * of the data being stored in the cache.

--- a/packages/apollo-server-caching/src/PrefixingKeyValueCache.ts
+++ b/packages/apollo-server-caching/src/PrefixingKeyValueCache.ts
@@ -1,4 +1,4 @@
-import { KeyValueCache } from './KeyValueCache';
+import { KeyValueCache, KeyValueCacheSetOptions } from './KeyValueCache';
 
 // PrefixingKeyValueCache wraps another cache and adds a prefix to all keys used
 // by all operations.  This allows multiple features to share the same
@@ -16,7 +16,7 @@ export class PrefixingKeyValueCache<V = string> implements KeyValueCache<V> {
   get(key: string) {
     return this.wrapped.get(this.prefix + key);
   }
-  set(key: string, value: V, options?: { ttl?: number }) {
+  set(key: string, value: V, options?: KeyValueCacheSetOptions) {
     return this.wrapped.set(this.prefix + key, value, options);
   }
   delete(key: string) {

--- a/packages/apollo-server-caching/src/__tests__/testsuite.ts
+++ b/packages/apollo-server-caching/src/__tests__/testsuite.ts
@@ -54,6 +54,17 @@ export function testKeyValueCache_Expiration(
       expect(await keyValueCache.get('short')).toBeUndefined();
       expect(await keyValueCache.get('long')).toBeUndefined();
     });
+
+    it('does not expire when ttl is null', async () => {
+      await keyValueCache.set('forever', 'yours', { ttl: null });
+      expect(await keyValueCache.get('forever')).toBe('yours');
+      advanceTimeBy(1500);
+      jest.advanceTimersByTime(1500);
+      expect(await keyValueCache.get('forever')).toBe('yours');
+      advanceTimeBy(4000);
+      jest.advanceTimersByTime(4000);
+      expect(await keyValueCache.get('forever')).toBe('yours');
+    });
   });
 }
 

--- a/packages/apollo-server-caching/src/index.ts
+++ b/packages/apollo-server-caching/src/index.ts
@@ -1,3 +1,7 @@
-export { KeyValueCache, TestableKeyValueCache } from './KeyValueCache';
+export {
+  KeyValueCache,
+  TestableKeyValueCache,
+  KeyValueCacheSetOptions,
+} from './KeyValueCache';
 export { InMemoryLRUCache } from './InMemoryLRUCache';
 export { PrefixingKeyValueCache } from './PrefixingKeyValueCache';

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -243,13 +243,14 @@ export class ApolloServerBase {
     }
 
     if (requestOptions.persistedQueries !== false) {
+      const {
+        cache: apqCache = requestOptions.cache!,
+        ...apqOtherOptions
+      } = requestOptions.persistedQueries || Object.create(null);
+
       requestOptions.persistedQueries = {
-        cache: new PrefixingKeyValueCache(
-          (requestOptions.persistedQueries &&
-            requestOptions.persistedQueries.cache) ||
-            requestOptions.cache!,
-          APQ_CACHE_PREFIX,
-        ),
+        cache: new PrefixingKeyValueCache(apqCache, APQ_CACHE_PREFIX),
+        ...apqOtherOptions,
       };
     } else {
       // the user does not want to use persisted queries, so we remove the field

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -69,6 +69,14 @@ export type DataSources<TContext> = {
 
 export interface PersistedQueryOptions {
   cache: KeyValueCache;
+  /**
+   * Specified in **seconds**, this time-to-live (TTL) value limits the lifespan
+   * of how long the persisted query should be cached.  To specify a desired
+   * lifespan of "infinite", set this to `null`, in which case the eviction will
+   * be determined by the cache's eviction policy, but the record will never
+   * simply expire.
+   */
+  ttlSeconds?: number | null;
 }
 
 export default GraphQLServerOptions;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -76,7 +76,7 @@ export interface PersistedQueryOptions {
    * be determined by the cache's eviction policy, but the record will never
    * simply expire.
    */
-  ttlSeconds?: number | null;
+  ttl?: number | null;
 }
 
 export default GraphQLServerOptions;

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -335,9 +335,9 @@ export async function processGraphQLRequest<TContext>(
           queryHash,
           query,
           config.persistedQueries &&
-            typeof config.persistedQueries.ttlSeconds !== 'undefined'
+            typeof config.persistedQueries.ttl !== 'undefined'
             ? {
-                ttl: config.persistedQueries.ttlSeconds,
+                ttl: config.persistedQueries.ttl,
               }
             : Object.create(null),
         ),

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -330,9 +330,18 @@ export async function processGraphQLRequest<TContext>(
     // an error) and not actually write, we'll write to the cache if it was
     // determined earlier in the request pipeline that we should do so.
     if (metrics.persistedQueryRegister && persistedQueryCache) {
-      Promise.resolve(persistedQueryCache.set(queryHash, query)).catch(
-        console.warn,
-      );
+      Promise.resolve(
+        persistedQueryCache.set(
+          queryHash,
+          query,
+          config.persistedQueries &&
+            typeof config.persistedQueries.ttlSeconds !== 'undefined'
+            ? {
+                ttl: config.persistedQueries.ttlSeconds,
+              }
+            : Object.create(null),
+        ),
+      ).catch(console.warn);
     }
 
     let response: GraphQLResponse | null = await dispatcher.invokeHooksUntilNonNull(

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -1226,16 +1226,20 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
         Parameters<GraphQLRequestListener['didEncounterErrors']>
       >;
 
-      beforeEach(async () => {
+      function createMockCache() {
         const map = new Map<string, string>();
-        const cache = {
-          set: async (key, val) => {
+        return {
+          set: jest.fn(async (key, val) => {
             await map.set(key, val);
-          },
-          get: async key => map.get(key),
-          delete: async key => map.delete(key),
+          }),
+          get: jest.fn(async key => map.get(key)),
+          delete: jest.fn(async key => map.delete(key)),
         };
+      }
+
+      beforeEach(async () => {
         didEncounterErrors = jest.fn();
+        const cache = createMockCache();
         app = await createApp({
           graphqlOptions: {
             schema,

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -1264,7 +1264,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
             schema,
             persistedQueries: {
               cache: cache,
-              ttlSeconds: 900,
+              ttl: 900,
             },
           },
         });


### PR DESCRIPTION
Previously, while it was possible to set very high TTL values on individual `set`s, it was not possible to say "Do not assign a TTL value.".  This adds that possibility.

Furthermore, this allows the persisted query cache configuration (and its options `PersistedQueryOptions`) in Apollo Server to specify a setting and, when specified, to pass that option into the `set` used in `ApolloServer`.

Of course, that still necessitates passing a default that's isolated to Apollo Server itself, rather than a default that's able to be specified when constructing the cache. 
 There's another approach to solving this problem which might be worth (still? in partial replacement of?) allowing, but I couldn't convince myself of the approach.

The alternate pattern would allow the instantiation of the cache itself to override its previously hard-coded `defaultSetOptions` ([for example](https://github.com/apollographql/apollo-server/blob/d025580fa64840f8ee3cbcf7ee80a6061b09aa01/packages/apollo-server-cache-memcached/src/index.ts#L11-L13)), but I found that approach unfortunately complicated by varying constructor signatures on those classes which implement `KeyValueCache`.

In particular, they didn't seem to share a common pattern which had a home for such options that didn't necessitate the new option object becoming the second or third argument on those constructors.  For example:

#### `RedisClusterCache`'s

https://github.com/apollographql/apollo-server/blob/d025580fa64840f8ee3cbcf7ee80a6061b09aa01/packages/apollo-server-cache-redis/src/RedisClusterCache.ts#L17-L18

#### `RedisCache`'s

https://github.com/apollographql/apollo-server/blob/d025580fa64840f8ee3cbcf7ee80a6061b09aa01/packages/apollo-server-cache-redis/src/RedisCache.ts#L16

#### `MemcachedCache`'s

https://github.com/apollographql/apollo-server/blob/d025580fa64840f8ee3cbcf7ee80a6061b09aa01/packages/apollo-server-cache-memcached/src/index.ts#L15

Please review commit-by-commit messages for further details.