### PR TITLE
Respect is base64 encoded

### DIFF
--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -42,7 +42,7 @@ export function graphqlLambda(
 
     if (event.isBase64Encoded && event.body) {
       const bodyBuffer = new Buffer(event.body, 'base64');
-      event.body = bodyBuffer.toString('ascii');
+      event.body = bodyBuffer.toString('utf8');
     }
 
     const contentType = event.headers["content-type"] || event.headers["Content-Type"];

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -40,6 +40,11 @@ export function graphqlLambda(
       });
     }
 
+    if (event.isBase64Encoded && event.body) {
+      const bodyBuffer = new Buffer(event.body, 'base64');
+      event.body = bodyBuffer.toString('ascii');
+    }
+
     const contentType = event.headers["content-type"] || event.headers["Content-Type"];
     let query: Record<string, any> | Record<string, any>[];
 


### PR DESCRIPTION
[AWS Lambdas](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format) have the option for the body being sent to the Function to be encoded in Base64.  I'm trying to use this feature with Zeit's `now dev` and they are, indeed, Base64 encoding the body.  Funnily enough, this is not the case when you run your lambda function within their production environment.  Because of AWS having this flag, I thought it was appropriate to make a PR here rather than have Zeit change their practices.
