### PR TITLE
Fix regression caused by #3614 when using APQ with Graph Manager reporting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-server-core`: Upgrade TS to 3.7.3 [#3618](https://github.com/apollographql/apollo-server/pull/3618)
 - `apollo-server-cloud-functions`: Transmit CORS headers on `OPTIONS` request. [PR #3557](https://github.com/apollographql/apollo-server/pull/3557)
 - `apollo-server-caching`: De-compose options interface for `KeyValueCache.prototype.set` to accommodate better TSDoc annotations for its properties (e.g. to specify that `ttl` is defined in _seconds_). [PR #3619](https://github.com/apollographql/apollo-server/pull/3619)
+- `apollo-engine-reporting`: Fix regression introduced by [#3614](https://github.com/apollographql/apollo-server/pull/3614) which caused `PersistedQueryNotFoundError`, `PersistedQueryNotSupportedError` and `InvalidGraphQLRequestError` errors to be triggered before the `requestDidStart` handler triggered `treeBuilder`'s `startTiming` method. This fix preserves the existing behavior by special-casing these specific errors.  [PR #3638](https://github.com/apollographql/apollo-server/pull/3638) [Issue #3627](https://github.com/apollographql/apollo-server/issues/3627)
 
 ### v2.9.14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4057,6 +4057,7 @@
         "apollo-graphql": "^0.3.4",
         "apollo-server-caching": "file:packages/apollo-server-caching",
         "apollo-server-env": "file:packages/apollo-server-env",
+        "apollo-server-errors": "file:packages/apollo-server-errors",
         "apollo-server-types": "file:packages/apollo-server-types",
         "async-retry": "^1.2.1",
         "graphql-extensions": "file:packages/graphql-extensions"

--- a/packages/apollo-engine-reporting/package.json
+++ b/packages/apollo-engine-reporting/package.json
@@ -15,6 +15,7 @@
     "apollo-graphql": "^0.3.4",
     "apollo-server-caching": "file:../apollo-server-caching",
     "apollo-server-env": "file:../apollo-server-env",
+    "apollo-server-errors": "file:../apollo-server-errors",
     "apollo-server-types": "file:../apollo-server-types",
     "async-retry": "^1.2.1",
     "graphql-extensions": "file:../graphql-extensions"

--- a/packages/apollo-engine-reporting/src/treeBuilder.ts
+++ b/packages/apollo-engine-reporting/src/treeBuilder.ts
@@ -5,7 +5,11 @@ import {
   responsePathAsArray,
 } from 'graphql';
 import { Trace, google } from 'apollo-engine-reporting-protobuf';
-import { PersistedQueryNotFoundError } from 'apollo-server-errors';
+import {
+  PersistedQueryNotFoundError,
+  PersistedQueryNotSupportedError,
+} from 'apollo-server-errors';
+import { InvalidGraphQLRequestError } from "apollo-server-types";
 
 function internalError(message: string) {
   return new Error(`[internal apollo-server error] ${message}`);
@@ -78,7 +82,9 @@ export class EngineReportingTreeBuilder {
 
   public didEncounterErrors(errors: GraphQLError[]) {
     errors.forEach(err => {
-      if (err instanceof PersistedQueryNotFoundError) {
+      if (err instanceof PersistedQueryNotFoundError ||
+        err instanceof PersistedQueryNotSupportedError ||
+        err instanceof InvalidGraphQLRequestError) {
         return;
       }
 

--- a/packages/apollo-engine-reporting/src/treeBuilder.ts
+++ b/packages/apollo-engine-reporting/src/treeBuilder.ts
@@ -5,6 +5,7 @@ import {
   responsePathAsArray,
 } from 'graphql';
 import { Trace, google } from 'apollo-engine-reporting-protobuf';
+import { PersistedQueryNotFoundError } from 'apollo-server-errors';
 
 function internalError(message: string) {
   return new Error(`[internal apollo-server error] ${message}`);
@@ -77,6 +78,10 @@ export class EngineReportingTreeBuilder {
 
   public didEncounterErrors(errors: GraphQLError[]) {
     errors.forEach(err => {
+      if (err instanceof PersistedQueryNotFoundError) {
+        return;
+      }
+
       // This is an error from a federated service. We will already be reporting
       // it in the nested Trace in the query plan.
       //

--- a/packages/apollo-engine-reporting/tsconfig.json
+++ b/packages/apollo-engine-reporting/tsconfig.json
@@ -8,6 +8,7 @@
   "exclude": ["**/__tests__", "**/__mocks__"],
   "references": [
     { "path": "../graphql-extensions" },
+    { "path": "../apollo-server-errors" },
     { "path": "../apollo-server-types" },
   ]
 }


### PR DESCRIPTION
The fix in #3614 changed behavior which was not surfacing errors to the extensions and request pipeline plugins when those errors occurred during APQ negotiation.

However, it failed to consider - nor were there any tests - which ensured that the `apollo-engine-reporting`'s mechanism didn't receive an error earlier in the request pipeline than previously allowed.

This applies a fix which special-cases the APQ error in this case, and avoids reporting it to Apollo Graph Manager (which is the same behavior as before).

Fixes: https://github.com/apollographql/apollo-server/issues/3627