### PR TITLE
Error handling from liftoff

### DIFF
--- a/v3/package.json
+++ b/v3/package.json
@@ -55,11 +55,12 @@
     "@types/node": "^12.7.8",
     "codecov": "3.5.0",
     "graphql": "14.5.4",
-    "jest": "24.9.0",
+    "jest": "^24.9.0",
     "jest-junit": "7.0.0",
     "jest-matcher-utils": "24.9.0",
+    "prettier": "^1.19.1",
     "ts-jest": "24.0.2",
-    "typescript": "3.6.2"
+    "typescript": "^3.7.2"
   },
   "peerDependencies": {
     "graphql": "^14.5.0"

--- a/v3/src/errors/__snapshots__/guard.test.ts.snap
+++ b/v3/src/errors/__snapshots__/guard.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`guard performs comparisons 1`] = `"Assertion failed: hello === world"`;

--- a/v3/src/errors/__snapshots__/guard.test.ts.snap
+++ b/v3/src/errors/__snapshots__/guard.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`guard performs comparisons 1`] = `"Assertion failed: hello === world"`;

--- a/v3/src/errors/fail.test.ts
+++ b/v3/src/errors/fail.test.ts
@@ -55,7 +55,7 @@ describe("fail", () => {
     it("creates errors, taking the constructor params", () => {
       const fail = E_TOO_FAST(100, "a-client");
       expect(fail).toMatchInlineSnapshot(`
-        Failure {
+        FailureElement {
           "messages": Array [],
           "mode": [Function],
           "params": Array [

--- a/v3/src/errors/fail.test.ts
+++ b/v3/src/errors/fail.test.ts
@@ -1,0 +1,87 @@
+import { fail } from "./fail";
+
+describe("fail", () => {
+  describe("basically", () => {
+    const E_EXAMPLE = fail("EXAMPLE");
+
+    it("creates errors", () => {
+      expect(E_EXAMPLE().create()).toBeInstanceOf(Error);
+    });
+
+    it("has a static code and creates errors with that code", () => {
+      expect(E_EXAMPLE.code).toBe('EXAMPLE');
+      expect(E_EXAMPLE().create().code).toBe("EXAMPLE");
+    });
+
+    it("has the error code as its message", () => {
+      expect(E_EXAMPLE().create().message).toMatchInlineSnapshot(`undefined`);
+    });
+
+    it("returns a Failure when called, which captures constructor params", () => {
+      expect(E_EXAMPLE()).toMatchInlineSnapshot(`
+        Failure {
+          "messages": Array [],
+          "mode": [Function],
+          "params": Array [],
+        }
+      `);
+    });
+  });
+
+  describe("accepts messages", () => {
+    const E_EXAMPLE = fail("EXAMPLE");
+    it("as template strings", () => {
+      const E_EXAMPLE_TEMPLATE = E_EXAMPLE.message`Something went wrong`;
+      expect(E_EXAMPLE_TEMPLATE().create()).toMatchInlineSnapshot(`
+        Failure {
+          "messages": Array [
+            Array [
+              Array [
+                "Something went wrong",
+              ],
+            ],
+          ],
+          "mode": [Function],
+          "params": Array [],
+        }
+      `);
+    });
+
+    it("as plain strings", () => {
+      const E_EXAMPLE_STRING = E_EXAMPLE.message("A plain string");
+      expect(E_EXAMPLE_STRING().create()).toMatchInlineSnapshot(`
+        Failure {
+          "messages": Array [
+            Array [
+              "A plain string",
+            ],
+          ],
+          "mode": [Function],
+          "params": Array [],
+        }
+      `);
+    });
+
+    it("as formatters, adjusting its required arguments", () => {
+      const E_EXAMPLE_FORMAT = E_EXAMPLE.message(
+        (p: { cause: string }) => `What went wrong? ${p.cause}`
+      );
+      expect(E_EXAMPLE_FORMAT({ cause: "something" }).create())
+        .toMatchInlineSnapshot(`
+        Failure {
+          "messages": Array [
+            Array [
+              [Function],
+            ],
+          ],
+          "mode": [Function],
+          "params": Array [
+            Object {
+              "cause": "something",
+            },
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/v3/src/errors/fail.ts
+++ b/v3/src/errors/fail.ts
@@ -1,0 +1,133 @@
+import { Class, Instance, isTemplateInvocation } from '../utilities/types'
+
+export function fail
+  (code: string): FailureMode<[]>
+export function fail<P extends any[], M extends FailureMode<P, any>>
+  (code: string, mode: M): M
+export function fail<E extends Class<Error>>
+  (code: string, Base: E): FailureMode<ConstructorParameters<E>, Instance<E>>
+export function fail<E extends ErrorWithStaticCode>
+  (Base: E): FailureMode<ConstructorParameters<E>, Instance<E>>
+
+export function fail<E extends ErrorWithStaticCode>(
+  codeOrBase: E | string,
+  ...rest: any[]
+): any {
+  let code: string
+  let Base: Class<Error>
+  if (typeof codeOrBase === 'string') {
+    code = codeOrBase
+    Base = rest[1] || Error
+  } else {
+    Base = rest[0]
+    code = codeOrBase.code
+  }
+
+  return failureMode(Base, code)
+}
+
+
+export type Message<P extends any[]> = [string] | [(...params: P) => string] | [TemplateStringsArray, ...any[]]
+
+export type Fail<P extends any[], Base extends Error> = Base & {
+  readonly code: string
+  readonly params: P
+}
+
+export interface FailureMode<P extends any[] = [object?], Base extends Error = Error> {
+  (...params: P): Failure<P, Base>
+  readonly code: string
+  class: Class<Fail<P, Base>> & (new (fromFailure: Failure<P, Base>) => Fail<P, Base>)
+  message: <MoreProps=undefined>(...msg: Message<[MoreProps]>) =>
+    P extends []
+      ? MoreProps extends object
+        ? FailureMode<[MoreProps], Base>
+        : FailureMode<P, Base>
+      :
+    P extends [infer Props]
+      ? MoreProps extends object
+        ? FailureMode<[Props & MoreProps], Base>
+        : FailureMode<P, Base>
+      :
+      FailureMode<P, Base>
+}
+
+export interface Failure<P extends any[], Base extends Error> {
+  create(): Fail<P, Base>
+  readonly messages: Message<P>[]
+}
+
+export class Failure<P extends any[], Base extends Error> {
+  constructor(
+    public readonly mode: FailureMode<P, Base>,
+    public readonly params: P,
+    public readonly messages: Message<P>[] = []) {}
+
+  create(): Fail<P, Base> {
+    return new this.mode.class(this)
+  }
+}
+
+export interface ErrorWithStaticCode extends Class<Error> {
+  readonly code: string
+}
+
+function formatMsg<P extends any[]>(message: Message<P>, params: P) {
+  if (!message.length) return null
+  const [format] = message
+  console.log('format:', format)
+  if (typeof format === 'function') {
+    console.log(format, params)
+    return format(...params)
+  }
+  if (isTemplateInvocation(message)) return String.raw(...message)
+  if (typeof format === 'string') return format
+  return null
+}
+
+const FAILURE_CODE = Symbol('Failure code')
+
+function failureMode<B extends Class<Error>>(Base: B, code: string, ...messages: Message<ConstructorParameters<B>>[]): FailureMode<ConstructorParameters<B>, Instance<B>> {
+  const FailureClass = ((Base as any)[FAILURE_CODE] === code) ? Base :
+    class FailureClass extends Base {
+      static readonly [FAILURE_CODE] = code
+      static readonly code = code
+      public readonly failure: Failure<ConstructorParameters<B>, Instance<B>>
+
+      constructor(...args: any[]) {
+        const [failure] = args as [Failure<ConstructorParameters<B>, Instance<B>>]
+        super(...failure.params)
+        this.failure = failure
+      }
+
+      get message() {
+        if (!super.message && !this.failure.messages.length) return code
+        return [
+          super.message,
+          ...this.failure.messages.map(m => formatMsg(m, this.failure.params))
+        ].filter(Boolean).join('\n\n')
+      }
+    }
+
+  function FailureMode(...args: ConstructorParameters<B>) {
+    return new Failure(FailureMode as any, args, messages)
+  }
+
+  Object.defineProperties(FailureClass, {
+    name: { value: code },
+  })
+
+  Object.defineProperties(FailureMode, {
+    code: {value: code},
+    message: {
+      value(...message: Message<ConstructorParameters<B>>) {
+        return failureMode(FailureClass, code, ...messages, message)
+      }
+    }
+  })
+
+  FailureMode.prototype = Object.create(FailureClass.prototype)
+  FailureMode.prototype.constructor = FailureMode
+
+  return FailureMode as any
+}

--- a/v3/src/errors/fail.ts
+++ b/v3/src/errors/fail.ts
@@ -56,20 +56,7 @@ export interface Failure<P extends any[]=any[], Base extends Error=Error> {
   create(): Fail<P, Base>
   readonly messages: Message<P>[]
   readonly message: string
-  msg: (
-    <MoreProps>(...msg: Message<[MoreProps]>) =>
-    P extends []
-      ? MoreProps extends object
-        ? Failure<[MoreProps], Base>
-        : Failure<P, Base>
-      :
-    P extends [infer Props]
-      ? MoreProps extends object
-        ? Failure<[Props & MoreProps], Base>
-        : Failure<P, Base>
-      :
-      Failure<P, Base>
-  ) & ((...msg: Message<P>) => Failure<P, Base>)
+  msg(...msg: Message<P>): Failure<P, Base>
 }
 
 export class FailureElement<P extends any[], Base extends Error> implements Failure<P, Base> {

--- a/v3/src/errors/fail.ts
+++ b/v3/src/errors/fail.ts
@@ -115,7 +115,7 @@ function formatMsg<P extends any[]>(message: Message<P>, params: P) {
 const FAILURE_MODE = Symbol('Failure mode')
 
 function failureMode<B extends Class<Error>>(Base: B, code: string, messages: Message<ConstructorParameters<B>>[] = []): FailureMode<ConstructorParameters<B>, Instance<B>> {
-  const FailureClass = ((Base as any)[FAILURE_MODE]?.code === code) ? Base :
+  const FailureClass = ((Base as any)[FAILURE_MODE]?.code === code) ? (Base as any)[FAILURE_MODE].class :
     class FailureClass extends Base {
       static readonly [FAILURE_MODE] = FailureMode
       static readonly code = code
@@ -126,7 +126,9 @@ function failureMode<B extends Class<Error>>(Base: B, code: string, messages: Me
         super(...args[0].params)
         this.failure = args[0]
         Object.defineProperty(this, 'message', {
-          value: this.failure.message
+          value: this.failure.message,
+          configurable: false,
+          writable: false,
         })
       }
     }
@@ -150,9 +152,6 @@ function failureMode<B extends Class<Error>>(Base: B, code: string, messages: Me
     [FAILURE_MODE]: { value: FailureMode },
     class: { value: FailureClass }
   })
-
-  FailureMode.prototype = Object.create(FailureClass.prototype)
-  FailureMode.prototype.constructor = FailureMode
 
   return FailureMode as any
 }

--- a/v3/src/errors/guard.test.ts
+++ b/v3/src/errors/guard.test.ts
@@ -1,4 +1,4 @@
-import { guard, Comparison } from "./guard";
+import { guard, Comparison, check } from "./guard";
 import { fail } from "./fail";
 
 describe("guard", () => {
@@ -30,48 +30,72 @@ describe("guard", () => {
     }).not.toThrow();
   });
 
-  const comparisons: Comparison[] = ['<', '>', '==', '===', '!=', '!==', '<=', '>=']
-  const obj = {}
+  it("optionally takes a failure to throw if the guard fails", () => {
+    const E_CLIENT_INVALID = fail("CLIENT_INVALID").msg(
+      (props: { client: string | undefined }) =>
+        `Client ${props.client} invalid`
+    );
+    expect(() => {
+      guard(null, E_CLIENT_INVALID({ client: undefined }));
+    }).toThrowErrorMatchingInlineSnapshot(`
+"Client undefined invalid
 
-  it.each([...function*() {
-    const obj = {}
-    const examples = new Map<any, any>()
-    examples.set(0, [-1, 1, 0, 100, -Infinity, Infinity])
-    examples.set('hello', ['hello', '', obj])
-    examples.set(obj, [{}, obj, 'a string'])
-    for (const lhs of examples.keys()) {
-      for (const rhs of examples.get(lhs)) {
-        for (const op of comparisons) {
-          yield [lhs, op, rhs]
+Assertion failed"
+`);
+  });
+});
+
+describe("check", () => {
+  const comparisons: Comparison[] = [
+    "<",
+    ">",
+    "==",
+    "===",
+    "!=",
+    "!==",
+    "<=",
+    ">="
+  ];
+
+  it.each([
+    ...(function*() {
+      const obj = {};
+      const examples = new Map<any, any>();
+      examples.set(0, [-1, 1, 0, 100, -Infinity, Infinity]);
+      examples.set("hello", ["hello", "", obj]);
+      examples.set(obj, [{}, obj, "a string"]);
+      for (const lhs of examples.keys()) {
+        for (const rhs of examples.get(lhs)) {
+          for (const op of comparisons) {
+            yield [lhs, op, rhs];
+          }
         }
       }
-    }
-  }()])("compares %s %s %s", ((lhs, op, rhs) => {
-    const func = `((l, r) => l ${op} r)`
+    })()
+  ])("compares %s %s %s", (lhs, op, rhs) => {
+    const compare = eval(`((lhs, rhs) => lhs ${op} rhs)`);
     const run = expect(() => {
-      guard(lhs, op, rhs)
-    })
-    if (eval(func)(lhs, rhs)) {
-      run.not.toThrow()
+      check(lhs, op as Comparison, rhs);
+    });
+    if (compare(lhs, rhs)) {
+      run.not.toThrow();
     } else {
-      run.toThrowError(`Assertion failed: ${lhs} ${op} ${rhs}`)
+      run.toThrowError(`Assertion failed: ${lhs} ${op} ${rhs}`);
     }
-  }));
+  });
 
-  it('compares objects', () => {
-    guard(obj, '==', obj)
-  })
-
-  const E_TOO_FAST = fail("TOO_FAST").msg(
-    (props: { maxRate: number, rate: number, client: string }) =>
-      `Client ${props.client} exceeded ${props.maxRate} with rate=${props.rate}`
-  );
-  it("optionally, takes a failure to guard with", () => {
+  it("optionally, takes a failure to throw if the check fails", () => {
     const maxRate = 1000;
     const rate = 9999;
     const client = "a-client";
+
+    const E_TOO_FAST = fail("TOO_FAST").msg(
+      (props: { maxRate: number; rate: number; client: string }) =>
+        `Client ${props.client} exceeded ${props.maxRate} with rate=${props.rate}`
+    );
+
     expect(() => {
-      guard(rate, "<=", maxRate, E_TOO_FAST({ maxRate, rate, client }));
+      check(rate, "<=", maxRate, E_TOO_FAST({ maxRate, rate, client }));
     }).toThrowErrorMatchingInlineSnapshot(`
 "Client a-client exceeded 1000 with rate=9999
 

--- a/v3/src/errors/guard.test.ts
+++ b/v3/src/errors/guard.test.ts
@@ -95,66 +95,76 @@ describe("check", () => {
     );
 
     expect(() => {
-      check(rate, "<=", maxRate, E_TOO_FAST({ maxRate, rate, client }));
+      check(
+        rate,
+        "<=",
+        maxRate,
+        E_TOO_FAST({ maxRate, rate, client }),
+        "Coming in hot"
+      );
     }).toThrowErrorMatchingInlineSnapshot(`
 "Client a-client exceeded 1000 with rate=9999
+
+Coming in hot
 
 Check failed: 9999 <= 1000"
 `);
   });
 
-  describe('.exists checks for non-nullishness', () => {
+  describe(".exists checks for non-nullishness", () => {
     it.each([
-      [0, 'pass'],
-      ['', 'pass'],
-      [NaN, 'pass'],
-      [null, 'fail'],
-      [undefined, 'fail'],
-    ] as any)('%s will %s', (val, expectation) => {
+      [0, "pass"],
+      ["", "pass"],
+      [NaN, "pass"],
+      [null, "fail"],
+      [undefined, "fail"]
+    ] as any)("%s will %s", (val, expectation) => {
       const run = expect(() => {
-        check.exists(val)
-      })
-      if (expectation === 'pass') {
-        run.not.toThrow()
+        check.exists(val);
+      });
+      if (expectation === "pass") {
+        run.not.toThrow();
       } else {
-        run.toThrowError(`Check failed: ${val} exists`)
+        run.toThrowError(`Check failed: ${val} exists`);
       }
-    })
-  })
+    });
+  });
 
-  describe('type guards', () => {
-    it.each([...function *() {
-      const examples = [
-        [0,              'number'],
-        [NaN,            'number'],
-        [Infinity,       'number'],
-        ['',             'string'],
-        [undefined,      'undefined'],
-        [{},             'object'],
-        [[],             'object'],
-        [() => {},       'function'],
-        [false,          'boolean'],
-        [Symbol.iterator,'symbol']
-      ]
-      const types = new Set(examples.map(x => x[1]))
-      let i = examples.length; while (i --> 0) {
-        const [val, type] = examples[i]
-        yield [type, val, 'pass']
-        for (const other of types) {
-          if (other === type) continue
-          yield [other, val, 'fail']
+  describe("type guards", () => {
+    it.each([
+      ...(function*() {
+        const examples = [
+          [0, "number"],
+          [NaN, "number"],
+          [Infinity, "number"],
+          ["", "string"],
+          [undefined, "undefined"],
+          [{}, "object"],
+          [[], "object"],
+          [() => {}, "function"],
+          [false, "boolean"],
+          [Symbol.iterator, "symbol"]
+        ];
+        const types = new Set(examples.map(x => x[1]));
+        let i = examples.length;
+        while (i-- > 0) {
+          const [val, type] = examples[i];
+          yield [type, val, "pass"];
+          for (const other of types) {
+            if (other === type) continue;
+            yield [other, val, "fail"];
+          }
         }
-      }
-
-    }()] as any)('.%s(%s) should %s', (type: string, val: any, expectation) => {
+      })()
+    ] as any)(".%s(%s) should %s", (type: string, val: any, expectation) => {
       const run = expect(() => {
-        (check as any)[type](val)
-      })
-      if (expectation === 'pass') {
-        run.not.toThrow()
+        (check as any)[type](val);
+      });
+      if (expectation === "pass") {
+        run.not.toThrow();
       } else {
-        run.toThrowError(`Check failed: ${String(val)} is ${type}`)
+        run.toThrowError(`Check failed: ${String(val)} is ${type}`);
       }
-    })
-  })
+    });
+  });
 });

--- a/v3/src/errors/guard.test.ts
+++ b/v3/src/errors/guard.test.ts
@@ -1,0 +1,79 @@
+import { guard, Comparison } from "./guard";
+import { fail } from "./fail";
+
+describe("guard", () => {
+  it("asserts conditions", () => {
+    const a = "hello";
+    expect(() => {
+      guard(a !== a);
+    }).toThrowErrorMatchingInlineSnapshot(`"Assertion failed"`);
+  });
+
+  it("passes when condition ok", () => {
+    const a = "hello";
+    expect(() => {
+      guard(a === a);
+    }).not.toThrow();
+  });
+
+  it(".instance asserts instanceof", () => {
+    expect(() => {
+      guard.instance(2, String);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Assertion failed: 2 instanceof String"`
+    );
+  });
+
+  it(".instance passes when ok", () => {
+    expect(() => {
+      guard.instance(new String("hello"), String);
+    }).not.toThrow();
+  });
+
+  const comparisons: Comparison[] = ['<', '>', '==', '===', '!=', '!==', '<=', '>=']
+  const obj = {}
+
+  it.each `
+  lhs        | rhs
+  ${0}       | ${[-1, 1, 0, 100, -Infinity, Infinity]}
+  ${'hello'} | ${['hello', '', obj]}
+  ${obj}     | ${[{}, obj, 'a string']}
+  `
+  ("compares $lhs to $rhs", (({ lhs, rhs }) => {
+    for (const op of comparisons) {
+      for (const r of rhs) {
+        const func = `((l, r) => l ${op} r)`
+        const run = expect(() => {
+          guard(lhs, op, r)
+        })
+        console.log(lhs, op, r, eval(func)(lhs, r))
+        if (eval(func)(lhs, r)) {
+          run.not.toThrow()
+        } else {
+          run.toThrowError(`Assertion failed: ${lhs} ${op} ${r}`)
+        }
+      }
+    }
+  }));
+
+  it('compares objects', () => {
+    guard(obj, '==', obj)
+  })
+
+  const E_TOO_FAST = fail("TOO_FAST").msg(
+    (props: { maxRate: number, rate: number, client: string }) =>
+      `Client ${props.client} exceeded ${props.maxRate} with rate=${props.rate}`
+  );
+  it("optionally, takes a failure to guard with", () => {
+    const maxRate = 1000;
+    const rate = 9999;
+    const client = "a-client";
+    expect(() => {
+      guard(rate, "<=", maxRate, E_TOO_FAST({ maxRate, rate, client }));
+    }).toThrowErrorMatchingInlineSnapshot(`
+"Client a-client exceeded 1000 with rate=9999
+
+Assertion failed: 9999 <= 1000"
+`);
+  });
+});

--- a/v3/src/errors/guard.test.ts
+++ b/v3/src/errors/guard.test.ts
@@ -121,4 +121,40 @@ Check failed: 9999 <= 1000"
       }
     })
   })
+
+  describe('type guards', () => {
+    it.each([...function *() {
+      const examples = [
+        [0,              'number'],
+        [NaN,            'number'],
+        [Infinity,       'number'],
+        ['',             'string'],
+        [undefined,      'undefined'],
+        [{},             'object'],
+        [[],             'object'],
+        [() => {},       'function'],
+        [false,          'boolean'],
+        [Symbol.iterator,'symbol']
+      ]
+      const types = new Set(examples.map(x => x[1]))
+      let i = examples.length; while (i --> 0) {
+        const [val, type] = examples[i]
+        yield [type, val, 'pass']
+        for (const other of types) {
+          if (other === type) continue
+          yield [other, val, 'fail']
+        }
+      }
+
+    }()] as any)('.%s(%s) should %s', (type: string, val: any, expectation) => {
+      const run = expect(() => {
+        (check as any)[type](val)
+      })
+      if (expectation === 'pass') {
+        run.not.toThrow()
+      } else {
+        run.toThrowError(`Check failed: ${String(val)} is ${type}`)
+      }
+    })
+  })
 });

--- a/v3/src/errors/guard.test.ts
+++ b/v3/src/errors/guard.test.ts
@@ -6,27 +6,13 @@ describe("guard", () => {
     const a = "hello";
     expect(() => {
       guard(a !== a);
-    }).toThrowErrorMatchingInlineSnapshot(`"Assertion failed"`);
+    }).toThrowErrorMatchingInlineSnapshot(`"Guard failed"`);
   });
 
   it("passes when condition ok", () => {
     const a = "hello";
     expect(() => {
       guard(a === a);
-    }).not.toThrow();
-  });
-
-  it(".instance asserts instanceof", () => {
-    expect(() => {
-      guard.instance(2, String);
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"Assertion failed: 2 instanceof String"`
-    );
-  });
-
-  it(".instance passes when ok", () => {
-    expect(() => {
-      guard.instance(new String("hello"), String);
     }).not.toThrow();
   });
 
@@ -40,7 +26,7 @@ describe("guard", () => {
     }).toThrowErrorMatchingInlineSnapshot(`
 "Client undefined invalid
 
-Assertion failed"
+Guard failed"
 `);
   });
 });
@@ -80,8 +66,22 @@ describe("check", () => {
     if (compare(lhs, rhs)) {
       run.not.toThrow();
     } else {
-      run.toThrowError(`Assertion failed: ${lhs} ${op} ${rhs}`);
+      run.toThrowError(`Check failed: ${lhs} ${op} ${rhs}`);
     }
+  });
+
+  it(".instance asserts instanceof", () => {
+    expect(() => {
+      check.instance(2, String);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Check failed: 2 instanceof String"`
+    );
+  });
+
+  it(".instance passes when ok", () => {
+    expect(() => {
+      check.instance(new String("hello"), String);
+    }).not.toThrow();
   });
 
   it("optionally, takes a failure to throw if the check fails", () => {
@@ -99,7 +99,26 @@ describe("check", () => {
     }).toThrowErrorMatchingInlineSnapshot(`
 "Client a-client exceeded 1000 with rate=9999
 
-Assertion failed: 9999 <= 1000"
+Check failed: 9999 <= 1000"
 `);
   });
+
+  describe('.exists checks for non-nullishness', () => {
+    it.each([
+      [0, 'pass'],
+      ['', 'pass'],
+      [NaN, 'pass'],
+      [null, 'fail'],
+      [undefined, 'fail'],
+    ] as any)('%s will %s', (val, expectation) => {
+      const run = expect(() => {
+        check.exists(val)
+      })
+      if (expectation === 'pass') {
+        run.not.toThrow()
+      } else {
+        run.toThrowError(`Check failed: ${val} exists`)
+      }
+    })
+  })
 });

--- a/v3/src/errors/guard.test.ts
+++ b/v3/src/errors/guard.test.ts
@@ -33,26 +33,28 @@ describe("guard", () => {
   const comparisons: Comparison[] = ['<', '>', '==', '===', '!=', '!==', '<=', '>=']
   const obj = {}
 
-  it.each `
-  lhs        | rhs
-  ${0}       | ${[-1, 1, 0, 100, -Infinity, Infinity]}
-  ${'hello'} | ${['hello', '', obj]}
-  ${obj}     | ${[{}, obj, 'a string']}
-  `
-  ("compares $lhs to $rhs", (({ lhs, rhs }) => {
-    for (const op of comparisons) {
-      for (const r of rhs) {
-        const func = `((l, r) => l ${op} r)`
-        const run = expect(() => {
-          guard(lhs, op, r)
-        })
-        console.log(lhs, op, r, eval(func)(lhs, r))
-        if (eval(func)(lhs, r)) {
-          run.not.toThrow()
-        } else {
-          run.toThrowError(`Assertion failed: ${lhs} ${op} ${r}`)
+  it.each([...function*() {
+    const obj = {}
+    const examples = new Map<any, any>()
+    examples.set(0, [-1, 1, 0, 100, -Infinity, Infinity])
+    examples.set('hello', ['hello', '', obj])
+    examples.set(obj, [{}, obj, 'a string'])
+    for (const lhs of examples.keys()) {
+      for (const rhs of examples.get(lhs)) {
+        for (const op of comparisons) {
+          yield [lhs, op, rhs]
         }
       }
+    }
+  }()])("compares %s %s %s", ((lhs, op, rhs) => {
+    const func = `((l, r) => l ${op} r)`
+    const run = expect(() => {
+      guard(lhs, op, rhs)
+    })
+    if (eval(func)(lhs, rhs)) {
+      run.not.toThrow()
+    } else {
+      run.toThrowError(`Assertion failed: ${lhs} ${op} ${rhs}`)
     }
   }));
 

--- a/v3/src/errors/guard.ts
+++ b/v3/src/errors/guard.ts
@@ -22,7 +22,9 @@ function use(failure: FailureMode | Failure<any>) {
 export function guard(condition: any, op?: Comparison, rhs?: any, failure: FailureMode | Failure<any> = E_GUARD): asserts condition {
   if (op && op in COMPARE) {
     const lhs = condition
+    console.log('compairong', lhs, op, rhs, COMPARE[op], COMPARE[op](lhs, rhs))
     if (!COMPARE[op](lhs, rhs)) {
+      console.log('throwing', lhs, op, rhs, COMPARE[op], COMPARE[op](lhs, rhs))
       throw use(failure).msg `Assertion failed: ${lhs} ${op} ${rhs}`.create()
     }
   }

--- a/v3/src/errors/guard.ts
+++ b/v3/src/errors/guard.ts
@@ -19,18 +19,15 @@ function use(failure: FailureMode | Failure<any>) {
   return 'create' in failure ? failure : failure()
 }
 
-export function guard(condition: any, op?: Comparison, rhs?: any, failure: FailureMode | Failure<any> = E_GUARD): asserts condition {
-  if (op && op in COMPARE) {
-    const lhs = condition
-    console.log('compairong', lhs, op, rhs, COMPARE[op], COMPARE[op](lhs, rhs))
-    if (!COMPARE[op](lhs, rhs)) {
-      console.log('throwing', lhs, op, rhs, COMPARE[op], COMPARE[op](lhs, rhs))
-      throw use(failure).msg `Assertion failed: ${lhs} ${op} ${rhs}`.create()
-    }
-  }
+export function guard(condition: any, failure: FailureMode | Failure<any> = E_GUARD): asserts condition {
   if (!condition) {
     throw use(failure).msg `Assertion failed`.create()
   }
+}
+
+export function check(lhs: any, op: Comparison, rhs: any, failure: FailureMode | Failure<any> = E_GUARD): boolean {
+  if (op in COMPARE && COMPARE[op](lhs, rhs)) return true
+  throw use(failure).msg `Assertion failed: ${lhs} ${op} ${rhs}`.create()
 }
 
 guard.instance = <R>(lhs: any, cls: Class<R>, failure: FailureMode | Failure<any> = E_GUARD): asserts lhs is R => {
@@ -38,3 +35,5 @@ guard.instance = <R>(lhs: any, cls: Class<R>, failure: FailureMode | Failure<any
     throw use(failure).msg `Assertion failed: ${lhs} instanceof ${cls.name}`.create()
   }
 }
+
+guard.check = check

--- a/v3/src/errors/guard.ts
+++ b/v3/src/errors/guard.ts
@@ -1,5 +1,5 @@
 import { fail, FailureMode, Failure } from "./fail";
-import { Class } from "../utilities/types";
+import { Class, AnyFunc } from "../utilities/types";
 
 const E_GUARD = fail('GUARD')
 const E_CHECK = fail('CHECK')
@@ -42,6 +42,55 @@ check.instance = <R>(lhs: any, cls: Class<R>, failure: ToThrow = E_CHECK): asser
 check.exists = (o: any, failure: ToThrow = E_CHECK): o is Exclude<any, null | undefined> => {
   if (o == null) {
     throw use(failure).msg `Check failed: ${o} exists`.create()
+  }
+  return true
+}
+
+check.string = (o: any, failure: ToThrow = E_CHECK): o is string => {
+  if (typeof o !== "string") {
+    throw use(failure).msg `Check failed: ${String(o)} is string`.create()
+  }
+  return true
+}
+
+check.number = (o: any, failure: ToThrow = E_CHECK): o is number => {
+  if (typeof o !== "number") {
+    throw use(failure).msg `Check failed: ${String(o)} is number`.create()
+  }
+  return true
+}
+
+check.boolean = (o: any, failure: ToThrow = E_CHECK): o is boolean => {
+  if (typeof o !== "boolean") {
+    throw use(failure).msg `Check failed: ${String(o)} is boolean`.create()
+  }
+  return true
+}
+
+check.symbol = (o: any, failure: ToThrow = E_CHECK): o is symbol => {
+  if (typeof o !== "symbol") {
+    throw use(failure).msg `Check failed: ${String(o)} is symbol`.create()
+  }
+  return true
+}
+
+check.undefined = (o: any, failure: ToThrow = E_CHECK): o is undefined => {
+  if (typeof o !== "undefined") {
+    throw use(failure).msg `Check failed: ${String(o)} is undefined`.create()
+  }
+  return true
+}
+
+check.object = (o: any, failure: ToThrow = E_CHECK): o is object => {
+  if (!o || typeof o !== "object") {
+    throw use(failure).msg `Check failed: ${String(o)} is object`.create()
+  }
+  return true
+}
+
+check.function = (o: any, failure: ToThrow = E_CHECK): o is AnyFunc => {
+  if (typeof o !== "function") {
+    throw use(failure).msg `Check failed: ${String(o)} is function`.create()
   }
   return true
 }

--- a/v3/src/errors/guard.ts
+++ b/v3/src/errors/guard.ts
@@ -18,79 +18,82 @@ const COMPARE = {
 
 export type ToThrow = FailureMode<any, any> | Failure<any, any>
 
-function panic(toThrow: ToThrow, ...messages: Message<any>[]): never {
+function panic(toThrow: ToThrow, ...messages: (Message<any> | [])[]): never {
   let failure = 'create' in toThrow ? toThrow : toThrow()
-  for (const m of messages) failure = failure.msg(...m)
+  for (const m of messages) {
+    if (Array.isArray(m) && m.length)
+      failure = failure.msg(...(m as any))
+  }
   throw failure.create()
 }
 
-export function guard(condition: any, failure: ToThrow = E_GUARD, ...message: Message<any>): asserts condition {
+export function guard(condition: any, failure: ToThrow = E_GUARD, ...message: Message<any> | []): asserts condition {
   if (!condition) {
     panic(failure, message, ['Guard failed'])
   }
 }
 
-export function check(lhs: any, op: Comparison, rhs: any, failure: ToThrow = E_CHECK, ...message: Message<any>): boolean {
+export function check(lhs: any, op: Comparison, rhs: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): boolean {
   if (op in COMPARE && COMPARE[op](lhs, rhs)) return true
   panic(failure, message, [`Check failed: ${lhs} ${op} ${rhs}`])
 }
 
-check.instance = <R>(lhs: any, cls: Class<R>, failure: ToThrow = E_CHECK, ...message: Message<any>): asserts lhs is R => {
+check.instance = <R>(lhs: any, cls: Class<R>, failure: ToThrow = E_CHECK, ...message: Message<any> | []): asserts lhs is R => {
   if (!(lhs instanceof cls)) {
     panic(failure, message, [`Check failed: ${lhs} instanceof ${cls.name}`])
   }
 }
 
-check.exists = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is Exclude<any, null | undefined> => {
+check.exists = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is Exclude<any, null | undefined> => {
   if (o == null) {
     panic(failure, message, [`Check failed: ${o} exists`])
   }
   return true
 }
 
-check.string = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is string => {
+check.string = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is string => {
   if (typeof o !== "string") {
     panic(failure, message, [`Check failed: ${String(o)} is string`])
   }
   return true
 }
 
-check.number = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is number => {
+check.number = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is number => {
   if (typeof o !== "number") {
     panic(failure, message, [`Check failed: ${String(o)} is number`])
   }
   return true
 }
 
-check.boolean = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is boolean => {
+check.boolean = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is boolean => {
   if (typeof o !== "boolean") {
     panic(failure, message, [`Check failed: ${String(o)} is boolean`])
   }
   return true
 }
 
-check.symbol = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is symbol => {
+check.symbol = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is symbol => {
   if (typeof o !== "symbol") {
     panic(failure, message, [`Check failed: ${String(o)} is symbol`])
   }
   return true
 }
 
-check.undefined = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is undefined => {
+check.undefined = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is undefined => {
   if (typeof o !== "undefined") {
     panic(failure, message, [`Check failed: ${String(o)} is undefined`])
   }
   return true
 }
 
-check.object = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is object => {
+check.object = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is object => {
   if (!o || typeof o !== "object") {
     panic(failure, message, [`Check failed: ${String(o)} is object`])
   }
   return true
 }
 
-check.function = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any>): o is AnyFunc => {
+check.function = (o: any, failure: ToThrow = E_CHECK, ...message: Message<any> | []): o is AnyFunc => {
   if (typeof o !== "function") {
     panic(failure, message, [`Check failed: ${String(o)} is function`])
   }

--- a/v3/src/errors/guard.ts
+++ b/v3/src/errors/guard.ts
@@ -1,0 +1,38 @@
+import { fail, FailureMode, Failure } from "./fail";
+import { Class } from "../utilities/types";
+
+const E_GUARD = fail('GUARD')
+
+export type Comparison = '<' | '>' | '==' | '===' | '!=' | '!==' | '<=' | '>='
+const COMPARE = {
+  '<': (lhs: any, rhs: any) => lhs < rhs,
+  '>': (lhs: any, rhs: any) => lhs > rhs,
+  '==': (lhs: any, rhs: any) => lhs == rhs,
+  '===': (lhs: any, rhs: any) => lhs === rhs,
+  '!=': (lhs: any, rhs: any) => lhs != rhs,
+  '!==': (lhs: any, rhs: any) => lhs !== rhs,
+  '<=': (lhs: any, rhs: any) => lhs <= rhs,
+  '>=': (lhs: any, rhs: any) => lhs >= rhs,
+}
+
+function use(failure: FailureMode | Failure<any>) {
+  return 'create' in failure ? failure : failure()
+}
+
+export function guard(condition: any, op?: Comparison, rhs?: any, failure: FailureMode | Failure<any> = E_GUARD): asserts condition {
+  if (op && op in COMPARE) {
+    const lhs = condition
+    if (!COMPARE[op](lhs, rhs)) {
+      throw use(failure).msg `Assertion failed: ${lhs} ${op} ${rhs}`.create()
+    }
+  }
+  if (!condition) {
+    throw use(failure).msg `Assertion failed`.create()
+  }
+}
+
+guard.instance = <R>(lhs: any, cls: Class<R>, failure: FailureMode | Failure<any> = E_GUARD): asserts lhs is R => {
+  if (!(lhs instanceof cls)) {
+    throw use(failure).msg `Assertion failed: ${lhs} instanceof ${cls.name}`.create()
+  }
+}

--- a/v3/src/errors/guard.ts
+++ b/v3/src/errors/guard.ts
@@ -2,6 +2,7 @@ import { fail, FailureMode, Failure } from "./fail";
 import { Class } from "../utilities/types";
 
 const E_GUARD = fail('GUARD')
+const E_CHECK = fail('CHECK')
 
 export type Comparison = '<' | '>' | '==' | '===' | '!=' | '!==' | '<=' | '>='
 const COMPARE = {
@@ -15,25 +16,32 @@ const COMPARE = {
   '>=': (lhs: any, rhs: any) => lhs >= rhs,
 }
 
-function use(failure: FailureMode | Failure<any>) {
-  return 'create' in failure ? failure : failure()
+export type ToThrow = FailureMode | Failure<any>
+
+function use(toThrow: ToThrow) {
+  return 'create' in toThrow ? toThrow : toThrow()
 }
 
-export function guard(condition: any, failure: FailureMode | Failure<any> = E_GUARD): asserts condition {
+export function guard(condition: any, failure: ToThrow = E_GUARD): asserts condition {
   if (!condition) {
-    throw use(failure).msg `Assertion failed`.create()
+    throw use(failure).msg `Guard failed`.create()
   }
 }
 
-export function check(lhs: any, op: Comparison, rhs: any, failure: FailureMode | Failure<any> = E_GUARD): boolean {
+export function check(lhs: any, op: Comparison, rhs: any, failure: ToThrow = E_CHECK): boolean {
   if (op in COMPARE && COMPARE[op](lhs, rhs)) return true
-  throw use(failure).msg `Assertion failed: ${lhs} ${op} ${rhs}`.create()
+  throw use(failure).msg `Check failed: ${lhs} ${op} ${rhs}`.create()
 }
 
-guard.instance = <R>(lhs: any, cls: Class<R>, failure: FailureMode | Failure<any> = E_GUARD): asserts lhs is R => {
+check.instance = <R>(lhs: any, cls: Class<R>, failure: ToThrow = E_CHECK): asserts lhs is R => {
   if (!(lhs instanceof cls)) {
-    throw use(failure).msg `Assertion failed: ${lhs} instanceof ${cls.name}`.create()
+    throw use(failure).msg `Check failed: ${lhs} instanceof ${cls.name}`.create()
   }
 }
 
-guard.check = check
+check.exists = (o: any, failure: ToThrow = E_CHECK): o is Exclude<any, null | undefined> => {
+  if (o == null) {
+    throw use(failure).msg `Check failed: ${o} exists`.create()
+  }
+  return true
+}

--- a/v3/src/utilities/types.ts
+++ b/v3/src/utilities/types.ts
@@ -1,0 +1,31 @@
+export type AnyFunc = (...args: any[]) => any
+
+export type ValueType = string | number | bigint | boolean | symbol | null | undefined
+export const isValueType = (o: any): o is ValueType => !isReferenceType(o)
+
+export type ReferenceType = object | AnyFunc
+export const isReferenceType = (o: any): o is ReferenceType => {
+  if (o === null) return false
+  const type = typeof o
+  return (type === 'object' || type === 'function')
+}
+
+export const isTemplateStringsArray = (o: any): o is TemplateStringsArray =>
+  Array.isArray(o) && (o as any).raw
+
+export const isTemplateInvocation = (o: any): o is Parameters<typeof String['raw']> =>
+  Array.isArray(o) && isTemplateStringsArray(o[0])
+
+export interface Constructor<T> {
+  new(...args: any[]): T
+}
+
+export interface EmptyConstructor<T> {
+  new(): T
+}
+
+export interface Class<T> extends Constructor<T> {
+  prototype: T
+}
+
+export type Instance<C extends Class<any>> = C extends Class<infer I> ? I : never

--- a/v3/tsconfig.json
+++ b/v3/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
     "lib": ["es2017", "esnext.asynciterable"],
     "baseUrl": ".",
     "rootDir": "./src",


### PR DESCRIPTION
I've gone ahead and extracted the error handling from Liftoff for more general use. An example:

```ts
// A simple error type
const E_INVALID_QUERY = fail('INVALID_QUERY').msg `Query is invalid`

// An error with more properties.
const E_TOO_MANY = fail('TOO_MANY').msg(
  // We infer the required parameters of `E_TOO_MANY` from the type of these
  // formatter functions.
  (props: { current: number, max: number }) =>
    `Number of requests (${props.current}) is greater than maximum (${props.max}).`
)


// Using them:
function handleQuery(client: string, query?: string) {
  check.exists(query, E_INVALID_QUERY)
  check(count + 1, '<' max,
    // We have to call `E_TOO_MANY` with `current` and `max`, or ts will complain.
    E_TOO_MANY({ current: count, max }).msg(`while connecting ${client}`))
  // ...
}
```

## Define error codes with `fail`

You define failure modes with `fail`:

```typescript
// You can create an error with just a code:
const E_AGAIN = fail('AGAIN')

// You can extend an existing error class:
const E_PARSE_FAILED = fail('GRAPHQL_PARSE_FAILED', SyntaxError)

// You can omit the error code if and only if you are extending an existing class which has it statically available as `.code`:
const E_GRAPHQL_VALIDATION_FAILED = fail(ValidationError)
```

`fail` returns a `FailureMode`, a function with `code`, `msg`, and `class` properties, holding the error code, providing the ability to attach messages, and giving us access to the underlying class.

## Failures

When we call `E_AGAIN` or any of the other failure modes, we don't get an error. Instead, we get a `Failure` structure—a plain object holding an error class, messages, and constructor parameters:

```typescript
export interface Failure<P extends any[]=any[], Base extends Error=Error> {
  create(): Base
  params: P
  readonly messages: Message<P>[]
  readonly message: string
  msg(...Message<P>): Failure<P, Base>
}
```

Why? Well, creating errors is expensive, and we usually won't throw, so we'd usually like to avoid it. At the same time, we'd like to be able to have our assertion functions (`guard` and `check`) throw a custom error. The `Failure` structure captures everything we need to construct an error, so our assertion functions can throw it if they fail.

We could use `Error.cause` to the same effect, but in practice, that usually involves `try`/`catch` in various layers of callers, making the code far more of a bummer to write.

## Checks and guards

Most of the time, we'll want to use a `check` function to verify some precondition and throw if it's not met.

For instance:

```typescript
check(count, '<', max) // throws if count >= max
check.string(q) // throws if q is not a string
check.instance(query, GraphQLAst) // throws if !(query instanceof GraphQLAst)
```

`check` functions optionally take a `Failure` or `FailureMode` to fail with:

```typescript
check.string(q, E_INVALID_QUERY)
check.instance(query, GraphQLAst, E_INVALID_QUERY)
```

`check` functions are broken out like this to help us format errors nicely. For example, if that `check.string` fails (say we called it with a Buffer), we'll get a message like this:

```
[INVALID_QUERY] Error: Query is invalid

Check failed: Buffer is string
```

`check(lhs, '<' | '>' | '<=' |..., rhs)` provides a similarly informative error message (`Check failed: lhs < rhs`), in addition to any other messages already attached to the failure.

For cases where you really just want to assert some condition, use `guard`:

```typescript
guard(!safelist || safelist.has(query), E_INVALID_QUERY,
  `${query} not found in active safelist`)
```

Yes, it would be nice if these could be the same function, but the typings were too complex for me to work out—I'm not even totally sure they're possible with assertion functions, which `guard` is and some (but not all!) of the `check` variants are.