### PR TITLE
Change version options to strings

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -11,9 +11,9 @@ module.exports = {
         subtitle: 'Apollo Server',
         description: 'A guide to using Apollo Server',
         githubRepo: 'apollographql/apollo-server',
-        defaultVersion: 2,
+        defaultVersion: '2',
         versions: {
-          1: 'version-1',
+          '1': 'version-1',
         },
         sidebarCategories: {
           null: [


### PR DESCRIPTION
This branch changes the version config options for the docs to strings rather than ints.