### PR TITLE
Add tests to 'Reduce interface expansion for types contained to a single service'

### DIFF
--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/reviews.ts
@@ -52,7 +52,17 @@ export const typeDefs = gql`
     relatedReviews: [Review!]! @requires(fields: "similarBooks { isbn }")
   }
 
-  extend type Car @key(fields: "id") {
+  extend interface Vehicle {
+    retailPrice: String
+  }
+
+  extend type Car implements Vehicle @key(fields: "id") {
+    id: String! @external
+    price: String @external
+    retailPrice: String @requires(fields: "price")
+  }
+
+  extend type Van implements Vehicle @key(fields: "id") {
     id: String! @external
     price: String @external
     retailPrice: String @requires(fields: "price")
@@ -215,6 +225,11 @@ export const resolvers: GraphQLResolverMap<any> = {
   Car: {
     retailPrice(car) {
       return car.price;
+    },
+  },
+  Van: {
+    retailPrice(van) {
+      return van.price;
     },
   },
   MetadataOrError: {

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -508,7 +508,7 @@ describe('executeQueryPlan', () => {
     `);
   });
 
-  it(`can execute queries that whose fields are union types`, async () => {
+  it(`can execute queries whose fields are union types`, async () => {
     const query = gql`
       query {
         user(id: "1") {

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -15,6 +15,10 @@ import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
 import { executeQueryPlan } from '../executeQueryPlan';
 import { LocalGraphQLDataSource } from '../datasources/LocalGraphQLDataSource';
 
+import { astSerializer, queryPlanSerializer } from '../snapshotSerializers';
+expect.addSnapshotSerializer(astSerializer);
+expect.addSnapshotSerializer(queryPlanSerializer);
+
 function buildLocalService(modules: GraphQLSchemaModule[]) {
   const schema = buildFederatedSchema(modules);
   return new LocalGraphQLDataSource(schema);
@@ -432,6 +436,119 @@ describe('executeQueryPlan', () => {
 
     expect(response.data).toHaveProperty('__schema');
     expect(response.errors).toBeUndefined();
+  });
+
+  it(`can execute queries on interface types`, async () => {
+    const query = gql`
+      query {
+        vehicle(id: "1") {
+          description
+          price
+          retailPrice
+        }
+      }
+    `;
+
+    const operationContext = buildOperationContext(schema, query);
+    const queryPlan = buildQueryPlan(operationContext);
+
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
+
+    expect(response.data).toMatchInlineSnapshot(`
+      Object {
+        "vehicle": Object {
+          "description": "Humble Toyota",
+          "price": "9990",
+          "retailPrice": "9990",
+        },
+      }
+    `);
+  });
+
+  it(`can execute queries whose fields are interface types`, async () => {
+    const query = gql`
+      query {
+        user(id: "1") {
+          name
+          vehicle {
+            description
+            price
+            retailPrice
+          }
+        }
+      }
+    `;
+
+    const operationContext = buildOperationContext(schema, query);
+    const queryPlan = buildQueryPlan(operationContext);
+
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
+
+    expect(response.data).toMatchInlineSnapshot(`
+      Object {
+        "user": Object {
+          "name": "Ada Lovelace",
+          "vehicle": Object {
+            "description": "Humble Toyota",
+            "price": "9990",
+            "retailPrice": "9990",
+          },
+        },
+      }
+    `);
+  });
+
+  it(`can execute queries that whose fields are union types`, async () => {
+    const query = gql`
+      query {
+        user(id: "1") {
+          name
+          thing {
+            ... on Vehicle {
+              description
+              price
+              retailPrice
+            }
+            ... on Ikea {
+              asile
+            }
+          }
+        }
+      }
+    `;
+
+    const operationContext = buildOperationContext(schema, query);
+    const queryPlan = buildQueryPlan(operationContext);
+
+    const response = await executeQueryPlan(
+      queryPlan,
+      serviceMap,
+      buildRequestContext(),
+      operationContext,
+    );
+
+    expect(response.data).toMatchInlineSnapshot(`
+      Object {
+        "user": Object {
+          "name": "Ada Lovelace",
+          "thing": Object {
+            "description": "Humble Toyota",
+            "price": "9990",
+            "retailPrice": "9990",
+          },
+        },
+      }
+    `);
   });
 
   it('can execute queries with falsey @requires (except undefined)', async () => {


### PR DESCRIPTION
Deps: #3582 

@trevor-scheer. I've simplified the cases where the previous code was misbehaving into three straightforward tests, which I'm merging into the [branch](https://github.com/apollographql/apollo-server/tree/jbaxleyiii/reduce-interface-expansion). Both pull requests are ready to go in my head.