### PR TITLE
Add sampleRate option to limit data volume

### DIFF
--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -185,6 +185,10 @@ export interface EngineReportingOptions<TContext> {
    * Creates the client information for operation traces.
    */
   generateClientInfo?: GenerateClientInfo<TContext>;
+  /**
+   * If non-zero, sample traces at the given rate, e.g. 0.5 = half of all traces
+   */
+  sampleRate?: number;
 }
 
 export interface AddTraceArgs {

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -156,14 +156,16 @@ export class EngineReportingExtension<TContext = any>
           o.requestContext.metrics.queryPlanTrace;
       }
 
-      this.addTrace({
-        operationName,
-        queryHash,
-        documentAST,
-        queryString: this.queryString || '',
-        trace: this.treeBuilder.trace,
-        schemaHash: this.schemaHash,
-      });
+      if (!this.options.sampleRate || this.options.sampleRate >= Math.random()) {
+        this.addTrace({
+          operationName,
+          queryHash,
+          documentAST,
+          queryString: this.queryString || '',
+          trace: this.treeBuilder.trace,
+          schemaHash: this.schemaHash,
+        });
+      }
     };
   }
 


### PR DESCRIPTION
Limit the addition of traces to engine reports by random sampling.

This is intended to support Glassdoor's use of Apollo server.