### PR TITLE
Remove '@types/graphql' since 'graphql' already includes TS typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3471,12 +3471,6 @@
         "@types/node": "*"
       }
     },
-    "@types/graphql": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz",
-      "integrity": "sha512-UoCovaxbJIxagCvVfalfK7YaNhmxj3BQFRQ2RHQKLiu+9wNXhJnlbspsLHt/YQM99IaLUUFJNzCwzc6W0ypMeQ==",
-      "dev": true
-    },
     "@types/graphql-upload": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@types/body-parser": "1.17.1",
     "@types/connect": "3.4.33",
     "@types/fast-json-stable-stringify": "2.0.0",
-    "@types/graphql": "14.2.3",
     "@types/hapi": "17.8.7",
     "@types/ioredis": "4.14.4",
     "@types/jest": "24.9.1",


### PR DESCRIPTION
`graphql` includes TS typings since `14.5.0` release.
@abernix Also without it you can't check TS definitions in `15.0.0`, in #3712