### PR TITLE
tests: Bring `tsconfig.json` for `@apollo/gateway`'s `datasources` directory.

### DIFF
--- a/packages/apollo-gateway/src/datasources/__tests__/tsconfig.json
+++ b/packages/apollo-gateway/src/datasources/__tests__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../tsconfig.test.base",
+  "include": ["**/*"],
+  "references": [
+    { "path": "../../../" },
+  ]
+}


### PR DESCRIPTION
Previously missing, and thus defaulting to the root `tsconfig.base.json` and
causing a lot of unhappy red-squigglies (on, e.g. `describe`, `it`, `test`) due to the lack of `jest` types being available!