### PR TITLE
docs: add `graphql-java-federation` to server implementation list

### DIFF
--- a/docs/source/federation/other-servers.md
+++ b/docs/source/federation/other-servers.md
@@ -9,6 +9,7 @@ The following is a list of known open source GraphQL server libraries that have 
 | ----------- | ------------- | -------------------------------------------------------------------------------- |
 | Go          | gqlgen        | [gqlgen](https://github.com/99designs/gqlgen/tree/master/plugin/federation)      |
 | Java        | graphql-java  | [federation-jvm](https://github.com/apollographql/federation-jvm)                |
+| Java        | graphql-java  | [graphql-java-federation](https://github.com/rkudryashov/graphql-java-federation)|
 | Kotlin      | graphql-java  | [graphql-kotlin](https://github.com/ExpediaGroup/graphql-kotlin)                 |
 | PHP         | graphql-php   | [php-graphql-federation](https://github.com/pascaldevink/php-graphql-federation) |
 | PHP         | wp-graphql    | [wp-graphql-federation](https://github.com/wp-graphql/wp-graphql-federation)     |


### PR DESCRIPTION
Hi,

This library is intended to be used with GraphQL Java services: https://github.com/rkudryashov/graphql-java-federation