### PR TITLE
Gateway(experimental): compress downstream requests via generated fragments

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Experimental feature: compress downstream requests via generated fragments [#3791](https://github.com/apollographql/apollo-server/pull/3791) This feature enables the gateway to generate fragments for queries to downstream services in order to minimize bytes over the wire and parse time. This can be enabled via the gateway config by setting `experimental_autoFragmentization: true`. It is currently disabled by default.
 
 ## v0.12.1
 

--- a/packages/apollo-gateway/src/QueryPlan.ts
+++ b/packages/apollo-gateway/src/QueryPlan.ts
@@ -21,7 +21,6 @@ export type OperationContext = {
   schema: GraphQLSchema;
   operation: OperationDefinitionNode;
   fragments: FragmentMap;
-  compressDownstreamRequests: boolean;
 };
 
 export type PlanNode = SequenceNode | ParallelNode | FetchNode | FlattenNode;

--- a/packages/apollo-gateway/src/QueryPlan.ts
+++ b/packages/apollo-gateway/src/QueryPlan.ts
@@ -21,6 +21,7 @@ export type OperationContext = {
   schema: GraphQLSchema;
   operation: OperationDefinitionNode;
   fragments: FragmentMap;
+  compressDownstreamRequests: boolean;
 };
 
 export type PlanNode = SequenceNode | ParallelNode | FetchNode | FlattenNode;
@@ -41,6 +42,7 @@ export interface FetchNode {
   selectionSet: SelectionSetNode;
   variableUsages?: { [name: string]: VariableDefinitionNode };
   requires?: SelectionSetNode;
+  internalFragments: Set<FragmentDefinitionNode>;
 }
 export interface FlattenNode {
   kind: 'Flatten';

--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -856,25 +856,25 @@ describe('buildQueryPlan', () => {
     const queryPlan = buildQueryPlan(buildOperationContext(schema, query));
 
     expect(queryPlan).toMatchInlineSnapshot(`
-    QueryPlan {
-      Fetch(service: "product") {
-        {
-          product(upc: "") {
-            __typename
-            ... on Book {
-              details {
-                country
+      QueryPlan {
+        Fetch(service: "product") {
+          {
+            product(upc: "") {
+              __typename
+              ... on Book {
+                details {
+                  country
+                }
               }
-            }
-            ... on Furniture {
-              details {
-                country
+              ... on Furniture {
+                details {
+                  country
+                }
               }
             }
           }
-        }
-      },
-    }
+        },
+      }
     `);
   });
 

--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -898,7 +898,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true }
+        { compressDownstreamRequests: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1014,7 +1014,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true }
+        { compressDownstreamRequests: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1044,7 +1044,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true }
+        { compressDownstreamRequests: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1060,6 +1060,129 @@ describe('buildQueryPlan', () => {
               body
               author
             }
+          },
+        }
+      `);
+    });
+
+    it(`should generate fragments correctly when aliases are used`, () => {
+      const query = gql`
+        query {
+          reviews: topReviews {
+            content: body
+            author
+            product {
+              name
+              cost: price
+              details {
+                origin: country
+              }
+            }
+          }
+        }
+      `;
+
+      const queryPlan = buildQueryPlan(
+        buildOperationContext(schema, query, undefined),
+        { compressDownstreamRequests: true },
+      );
+
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "reviews") {
+              {
+                reviews: topReviews {
+                  ...__QueryPlanFragment_1__
+                }
+              }
+              fragment __QueryPlanFragment_1__ on Review {
+                content: body
+                author
+                product {
+                  ...__QueryPlanFragment_0__
+                }
+              }
+              fragment __QueryPlanFragment_0__ on Product {
+                __typename
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on Furniture {
+                  __typename
+                  upc
+                }
+              }
+            },
+            Parallel {
+              Sequence {
+                Flatten(path: "reviews.@.product") {
+                  Fetch(service: "books") {
+                    {
+                      ... on Book {
+                        __typename
+                        isbn
+                      }
+                    } =>
+                    {
+                      ... on Book {
+                        __typename
+                        isbn
+                        title
+                        year
+                      }
+                    }
+                  },
+                },
+                Flatten(path: "reviews.@.product") {
+                  Fetch(service: "product") {
+                    {
+                      ... on Book {
+                        __typename
+                        isbn
+                        title
+                        year
+                      }
+                    } =>
+                    {
+                      ... on Book {
+                        name
+                      }
+                    }
+                  },
+                },
+              },
+              Flatten(path: "reviews.@.product") {
+                Fetch(service: "product") {
+                  {
+                    ... on Furniture {
+                      __typename
+                      upc
+                    }
+                    ... on Book {
+                      __typename
+                      isbn
+                    }
+                  } =>
+                  {
+                    ... on Furniture {
+                      name
+                      cost: price
+                      details {
+                        origin: country
+                      }
+                    }
+                    ... on Book {
+                      cost: price
+                      details {
+                        origin: country
+                      }
+                    }
+                  }
+                },
+              },
+            },
           },
         }
       `);

--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -877,4 +877,189 @@ describe('buildQueryPlan', () => {
     }
     `);
   });
+
+  describe(`experimental compression to downstream services`, () => {
+    it(`should generate fragments internally to downstream requests`, () => {
+      const query = gql`
+        query {
+          topReviews {
+            body
+            author
+            product {
+              name
+              price
+              details {
+                country
+              }
+            }
+          }
+        }
+      `;
+
+      const queryPlan = buildQueryPlan(
+        buildOperationContext(schema, query, undefined, true),
+      );
+
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Sequence {
+            Fetch(service: "reviews") {
+              {
+                topReviews {
+                  ...__QueryPlanFragment_1__
+                }
+              }
+              fragment __QueryPlanFragment_1__ on Review {
+                body
+                author
+                product {
+                  ...__QueryPlanFragment_0__
+                }
+              }
+              fragment __QueryPlanFragment_0__ on Product {
+                __typename
+                ... on Book {
+                  __typename
+                  isbn
+                }
+                ... on Furniture {
+                  __typename
+                  upc
+                }
+              }
+            },
+            Parallel {
+              Sequence {
+                Flatten(path: "topReviews.@.product") {
+                  Fetch(service: "books") {
+                    {
+                      ... on Book {
+                        __typename
+                        isbn
+                      }
+                    } =>
+                    {
+                      ... on Book {
+                        __typename
+                        isbn
+                        title
+                        year
+                      }
+                    }
+                  },
+                },
+                Flatten(path: "topReviews.@.product") {
+                  Fetch(service: "product") {
+                    {
+                      ... on Book {
+                        __typename
+                        isbn
+                        title
+                        year
+                      }
+                    } =>
+                    {
+                      ... on Book {
+                        name
+                      }
+                    }
+                  },
+                },
+              },
+              Flatten(path: "topReviews.@.product") {
+                Fetch(service: "product") {
+                  {
+                    ... on Furniture {
+                      __typename
+                      upc
+                    }
+                    ... on Book {
+                      __typename
+                      isbn
+                    }
+                  } =>
+                  {
+                    ... on Furniture {
+                      name
+                      price
+                      details {
+                        country
+                      }
+                    }
+                    ... on Book {
+                      price
+                      details {
+                        country
+                      }
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it(`shouldn't generate fragments for selection sets of length 2 or less`, () => {
+      const query = gql`
+        query {
+          topReviews {
+            body
+            author
+          }
+        }
+      `;
+
+      const queryPlan = buildQueryPlan(
+        buildOperationContext(schema, query, undefined, true),
+      );
+
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Fetch(service: "reviews") {
+            {
+              topReviews {
+                body
+                author
+              }
+            }
+          },
+        }
+      `);
+    });
+
+    it(`should generate fragments for selection sets of length 3 or greater`, () => {
+      const query = gql`
+        query {
+          topReviews {
+            id
+            body
+            author
+          }
+        }
+      `;
+
+      const queryPlan = buildQueryPlan(
+        buildOperationContext(schema, query, undefined, true),
+      );
+
+      expect(queryPlan).toMatchInlineSnapshot(`
+        QueryPlan {
+          Fetch(service: "reviews") {
+            {
+              topReviews {
+                ...__QueryPlanFragment_0__
+              }
+            }
+            fragment __QueryPlanFragment_0__ on Review {
+              id
+              body
+              author
+            }
+          },
+        }
+      `);
+    });
+  });
 });

--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -897,7 +897,8 @@ describe('buildQueryPlan', () => {
       `;
 
       const queryPlan = buildQueryPlan(
-        buildOperationContext(schema, query, undefined, true),
+        buildOperationContext(schema, query, undefined),
+        { compressDownstreamRequests: true }
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1012,7 +1013,8 @@ describe('buildQueryPlan', () => {
       `;
 
       const queryPlan = buildQueryPlan(
-        buildOperationContext(schema, query, undefined, true),
+        buildOperationContext(schema, query, undefined),
+        { compressDownstreamRequests: true }
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1041,7 +1043,8 @@ describe('buildQueryPlan', () => {
       `;
 
       const queryPlan = buildQueryPlan(
-        buildOperationContext(schema, query, undefined, true),
+        buildOperationContext(schema, query, undefined),
+        { compressDownstreamRequests: true }
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`

--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -898,7 +898,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true },
+        { autoFragmentization: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1014,7 +1014,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true },
+        { autoFragmentization: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1044,7 +1044,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true },
+        { autoFragmentization: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`
@@ -1084,7 +1084,7 @@ describe('buildQueryPlan', () => {
 
       const queryPlan = buildQueryPlan(
         buildOperationContext(schema, query, undefined),
-        { compressDownstreamRequests: true },
+        { autoFragmentization: true },
       );
 
       expect(queryPlan).toMatchInlineSnapshot(`

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -87,7 +87,7 @@ it('Extracts service definitions from remote storage', async () => {
     implementingServiceLocations: [
       {
         name: federatedServiceName,
-        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath}.json`,
+        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath}`,
       },
     ],
   });
@@ -169,7 +169,7 @@ it('Rollsback to a previous schema when triggered', async () => {
     implementingServiceLocations: [
       {
         name: federatedServiceName,
-        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath1}.json`,
+        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath1}`,
       },
     ],
   });
@@ -205,7 +205,7 @@ it('Rollsback to a previous schema when triggered', async () => {
     implementingServiceLocations: [
       {
         name: federatedServiceName,
-        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath2}.json`,
+        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath2}`,
       },
     ],
   });
@@ -241,7 +241,7 @@ it('Rollsback to a previous schema when triggered', async () => {
     implementingServiceLocations: [
       {
         name: federatedServiceName,
-        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath1}.json`,
+        path: `${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath1}`,
       },
     ],
   });
@@ -271,7 +271,7 @@ it('Rollsback to a previous schema when triggered', async () => {
   // don't have the _correct_ answer here, but it seems that pushing this process
   // to the back of the task queue is insufficient.
   jest.useRealTimers();
-  await new Promise(resolve => setTimeout(resolve, 10));
+  await new Promise(resolve => setTimeout(resolve, 100));
   jest.useFakeTimers();
 
   expect(onChange.mock.calls.length).toBe(1);
@@ -279,7 +279,7 @@ it('Rollsback to a previous schema when triggered', async () => {
   jest.advanceTimersByTime(10000);
 
   jest.useRealTimers();
-  await new Promise(resolve => setTimeout(resolve, 10));
+  await new Promise(resolve => setTimeout(resolve, 100));
   jest.useFakeTimers();
 
   expect(onChange.mock.calls.length).toBe(2);

--- a/packages/apollo-gateway/src/__tests__/integration/nockMocks.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/nockMocks.ts
@@ -43,7 +43,7 @@ export const mockGetImplementingServices = ({
   federatedServiceName: string;
 }) =>
   nock('https://storage.googleapis.com:443').get(
-    `/engine-partial-schema-prod/${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath}.json`,
+    `/engine-partial-schema-prod/${storageSecret}/current/v1/implementing-services/${federatedServiceName}/${implementingServicePath}`,
   );
 
 // get raw-partial-schema, using received composition-config

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -886,18 +886,20 @@ export class QueryPlanningContext {
       [name: string]: VariableDefinitionNode;
     } = Object.create(null);
 
-    const Variable: VisitFn<ASTNode, VariableNode> = node => {
-      usages[node.name.value] = this.variableDefinitions[node.name.value];
+    // Construct a document of the selection set and fragment definitions so we
+    // can visit them, adding all variable usages to the `usages` object.
+    const document: DocumentNode = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        { kind: Kind.OPERATION_DEFINITION, selectionSet, operation: 'query' },
+        ...Array.from(fragments),
+      ],
     };
 
-    visit(selectionSet, {
-      Variable,
-    });
-
-    fragments.forEach(fragment => {
-      visit(fragment, {
-        Variable,
-      });
+    visit(document, {
+      Variable: (node) => {
+        usages[node.name.value] = this.variableDefinitions[node.name.value];
+      },
     });
 
     return usages;

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -26,7 +26,6 @@ import {
   TypeNameMetaFieldDef,
   visit,
   VariableDefinitionNode,
-  print,
   VisitFn,
   ASTNode,
   VariableNode,
@@ -61,8 +60,15 @@ const typenameField = {
   },
 };
 
-export function buildQueryPlan(operationContext: OperationContext): QueryPlan {
-  const context = buildQueryPlanningContext(operationContext);
+interface BuildQueryPlanOptions {
+  compressDownstreamRequests: boolean;
+}
+
+export function buildQueryPlan(
+  operationContext: OperationContext,
+  options: BuildQueryPlanOptions = { compressDownstreamRequests: false },
+): QueryPlan {
+  const context = buildQueryPlanningContext(operationContext, options);
 
   if (context.operation.operation === 'subscription') {
     throw new GraphQLError(
@@ -769,7 +775,6 @@ export function buildOperationContext(
   schema: GraphQLSchema,
   document: DocumentNode,
   operationName?: string,
-  compressDownstreamRequests: boolean = false,
 ): OperationContext {
   let operation: OperationDefinitionNode | undefined;
   const fragments: {
@@ -804,16 +809,19 @@ export function buildOperationContext(
     }
   }
 
-  return { schema, operation, fragments, compressDownstreamRequests };
+  return { schema, operation, fragments };
 }
 
-export function buildQueryPlanningContext({
-  operation,
-  schema,
-  fragments,
-  compressDownstreamRequests,
-}: OperationContext): QueryPlanningContext {
-  return new QueryPlanningContext(schema, operation, fragments, compressDownstreamRequests);
+export function buildQueryPlanningContext(
+  { operation, schema, fragments }: OperationContext,
+  options: BuildQueryPlanOptions,
+): QueryPlanningContext {
+  return new QueryPlanningContext(
+    schema,
+    operation,
+    fragments,
+    options.compressDownstreamRequests,
+  );
 }
 
 export class QueryPlanningContext {

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -26,9 +26,6 @@ import {
   TypeNameMetaFieldDef,
   visit,
   VariableDefinitionNode,
-  VisitFn,
-  ASTNode,
-  VariableNode,
 } from 'graphql';
 import {
   Field,

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -61,12 +61,12 @@ const typenameField = {
 };
 
 interface BuildQueryPlanOptions {
-  compressDownstreamRequests: boolean;
+  autoFragmentization: boolean;
 }
 
 export function buildQueryPlan(
   operationContext: OperationContext,
-  options: BuildQueryPlanOptions = { compressDownstreamRequests: false },
+  options: BuildQueryPlanOptions = { autoFragmentization: false },
 ): QueryPlan {
   const context = buildQueryPlanningContext(operationContext, options);
 
@@ -559,7 +559,7 @@ function completeField(
     let definition: FragmentDefinitionNode;
     let selectionSet = selectionSetFromFieldSet(subGroup.fields, returnType);
 
-    if (context.compressDownstreamRequests && subGroup.fields.length > 2) {
+    if (context.autoFragmentization && subGroup.fields.length > 2) {
       ({ definition, selectionSet } = getInternalFragment(
         selectionSet,
         returnType,
@@ -821,7 +821,7 @@ export function buildQueryPlanningContext(
     schema,
     operation,
     fragments,
-    options.compressDownstreamRequests,
+    options.autoFragmentization,
   );
 }
 
@@ -845,7 +845,7 @@ export class QueryPlanningContext {
     public readonly schema: GraphQLSchema,
     public readonly operation: OperationDefinitionNode,
     public readonly fragments: FragmentMap,
-    public readonly compressDownstreamRequests: boolean,
+    public readonly autoFragmentization: boolean,
   ) {
     this.variableDefinitions = Object.create(null);
     visit(operation, {

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -589,15 +589,15 @@ function getInternalFragment(
     const name = `__QueryPlanFragment_${context.internalFragmentCount++}__`;
 
     const definition: FragmentDefinitionNode = {
-      kind: 'FragmentDefinition',
+      kind: Kind.FRAGMENT_DEFINITION,
       name: {
-        kind: 'Name',
+        kind: Kind.NAME,
         value: name,
       },
       typeCondition: {
-        kind: 'NamedType',
+        kind: Kind.NAMED_TYPE,
         name: {
-          kind: 'Name',
+          kind: Kind.NAME,
           value: returnType.name,
         },
       },
@@ -605,12 +605,12 @@ function getInternalFragment(
     };
 
     const fragmentSelection: SelectionSetNode = {
-      kind: 'SelectionSet',
+      kind: Kind.SELECTION_SET,
       selections: [
         {
-          kind: 'FragmentSpread',
+          kind: Kind.FRAGMENT_SPREAD,
           name: {
-            kind: 'Name',
+            kind: Kind.NAME,
             value: name,
           },
         },

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -588,7 +588,7 @@ function getInternalFragment(
 ) {
   const expandedSelectionSet = selectionSetFromFieldSet(fields, returnType);
 
-  const key = print(expandedSelectionSet);
+  const key = JSON.stringify(expandedSelectionSet);
   if (!context.internalFragments[key]) {
     const name = `__QueryPlanFragment_${context.internalFragmentCount++}__`;
 

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -59,6 +59,7 @@ interface GatewayConfigBase {
   experimental_didUpdateComposition?: Experimental_DidUpdateCompositionCallback;
   experimental_pollInterval?: number;
   experimental_approximateQueryPlanStoreMiB?: number;
+  experimental_compressDownstreamRequests?: boolean;
 }
 
 interface RemoteGatewayConfig extends GatewayConfigBase {
@@ -493,6 +494,7 @@ export class ApolloGateway implements GraphQLService {
       this.schema!,
       document,
       request.operationName,
+      this.config.experimental_compressDownstreamRequests
     );
 
     // No need to build a query plan if we know the request is invalid beforehand

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -59,7 +59,7 @@ interface GatewayConfigBase {
   experimental_didUpdateComposition?: Experimental_DidUpdateCompositionCallback;
   experimental_pollInterval?: number;
   experimental_approximateQueryPlanStoreMiB?: number;
-  experimental_compressDownstreamRequests?: boolean;
+  experimental_autoFragmentization?: boolean;
 }
 
 interface RemoteGatewayConfig extends GatewayConfigBase {
@@ -514,8 +514,8 @@ export class ApolloGateway implements GraphQLService {
 
     if (!queryPlan) {
       queryPlan = buildQueryPlan(operationContext, {
-        compressDownstreamRequests: Boolean(
-          this.config.experimental_compressDownstreamRequests,
+        autoFragmentization: Boolean(
+          this.config.experimental_autoFragmentization,
         ),
       });
       if (this.queryPlanStore) {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -494,7 +494,6 @@ export class ApolloGateway implements GraphQLService {
       this.schema!,
       document,
       request.operationName,
-      this.config.experimental_compressDownstreamRequests
     );
 
     // No need to build a query plan if we know the request is invalid beforehand
@@ -514,7 +513,11 @@ export class ApolloGateway implements GraphQLService {
     }
 
     if (!queryPlan) {
-      queryPlan = buildQueryPlan(operationContext);
+      queryPlan = buildQueryPlan(operationContext, {
+        compressDownstreamRequests: Boolean(
+          this.config.experimental_compressDownstreamRequests,
+        ),
+      });
       if (this.queryPlanStore) {
         // The underlying cache store behind the `documentStore` returns a
         // `Promise` which is resolved (or rejected), eventually, based on the

--- a/packages/apollo-gateway/src/snapshotSerializers/queryPlanSerializer.ts
+++ b/packages/apollo-gateway/src/snapshotSerializers/queryPlanSerializer.ts
@@ -71,6 +71,23 @@ function printNode(
         ) +
         config.spacingOuter +
         indentation +
+        (node.internalFragments.size > 0
+          ? '  ' +
+            Array.from(node.internalFragments)
+              .map(fragment =>
+                printer(
+                  fragment,
+                  config,
+                  indentationNext,
+                  depth,
+                  refs,
+                  printer,
+                ),
+              )
+              .join(`\n${indentationNext}`) +
+            config.spacingOuter +
+            indentation
+          : '') +
         '}';
       break;
     case 'Flatten':


### PR DESCRIPTION
For large queries (esp. ones that leverage many nested fragments), queries to downstream services can blow up astronomically because the gateway expands everything during a downstream request. For example, we've seen a ~700 line query making heavy use of fragments become over 200k lines (formatted) due to this expansion.

This PR has the gateway build fragments on the fly for the selection sets that it encounters and reuses them whenever possible. This is an heavy-handed and simple implementation, but with tangible wins for large queries. More complex and correct solutions exist and are currently being discussed. If anyone feels so inclined to solve this interesting problem, please reach out to us - we'd be happy to discuss approach and entertain a contribution here.

This is currently being landed as an experimental feature that is disabled by default. To enable, simply add to your gateway config: `experimental_compressDownstreamRequests: true`

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
