### PR TITLE
Federation: Preserve @deprecated type-system directives

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- Don't strip the `@deprecated` type-system directive [#3792](https://github.com/apollographql/apollo-server/pull/3792) This PR resolves a breaking change introduced by [#3736](https://github.com/apollographql/apollo-server/pull/3736) in the `v0.12.0` release of `@apollo/federation`. As an oversight, we began stripping all type-system directives from SDL. This behavior didn't account for the special case that is the `@deprecated` directive. This change reinstates the previous behavior so the `@deprecated` directive remains in SDL.
+- Fix `v0.12.0` regression: Preserve the `@deprecated` type-system directive as a special case when removing type system directives during composition, resolving an unintentional breaking change introduced by [#3736](https://github.com/apollographql/apollo-server/pull/3736). [#3792](https://github.com/apollographql/apollo-server/pull/3792)
 
 ## v0.12.0
 

--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Don't strip the `@deprecated` type-system directive [#3792](https://github.com/apollographql/apollo-server/pull/3792) This PR resolves a breaking change introduced by [#3736](https://github.com/apollographql/apollo-server/pull/3736) in the `v0.12.0` release of `@apollo/federation`. As an oversight, we began stripping all type-system directives from SDL. This behavior didn't account for the special case that is the `@deprecated` directive. This change reinstates the previous behavior so the `@deprecated` directive remains in SDL.
 
 ## v0.12.0
 

--- a/packages/apollo-federation/src/composition/utils.ts
+++ b/packages/apollo-federation/src/composition/utils.ts
@@ -86,6 +86,9 @@ export function stripExternalFieldsFromTypeDefs(
 export function stripTypeSystemDirectivesFromTypeDefs(typeDefs: DocumentNode) {
   const typeDefsWithoutTypeSystemDirectives = visit(typeDefs, {
     Directive(node) {
+      // The `deprecated` directive is an exceptional case that we want to leave in
+      if (node.name.value === 'deprecated') return;
+
       const isFederationDirective = federationDirectives.some(
         ({ name }) => name === node.name.value,
       );


### PR DESCRIPTION
This commit resolves a breaking and unintentional change from #3736.

While type-system directives _should_ be removed, @deprecated is a
special case which can and should be left in.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
