### PR TITLE
tests: Use an ephemeral port, rather than port 4001/4002.

### DIFF
--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import http from 'http';
+import http, { Server } from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 
@@ -10,10 +10,9 @@ import { ApolloServer } from '../ApolloServer';
 import { createServerInfo } from 'apollo-server-integration-testsuite';
 import { gql } from '../index';
 
-const restPort = 4001;
-
 export class IdAPI extends RESTDataSource {
-  baseURL = `http://localhost:${restPort}/`;
+  // Set in subclass
+  // baseURL = `http://localhost:${restPort}/`;
 
   async getId(id: string) {
     return this.get(`id/${id}`);
@@ -63,11 +62,15 @@ restAPI.use('/str/:id', (req, res) => {
 });
 
 describe('apollo-server-express', () => {
-  let restServer;
+  let restServer: Server;
+  let restUrl: string;
 
   beforeAll(async () => {
-    await new Promise(resolve => {
-      restServer = restAPI.listen(restPort, resolve);
+    restUrl = await new Promise(resolve => {
+      restServer = restAPI.listen(0, () => {
+        const { port } = restServer.address();
+        resolve(`http://localhost:${port}`);
+      });
     });
   });
 
@@ -92,14 +95,16 @@ describe('apollo-server-express', () => {
       typeDefs,
       resolvers,
       dataSources: () => ({
-        id: new IdAPI(),
+        id: new class extends IdAPI {
+          baseURL = restUrl;
+        },
       }),
     });
     const app = express();
 
     server.applyMiddleware({ app });
     httpServer = await new Promise<http.Server>(resolve => {
-      const s = app.listen({ port: 0 }, () => resolve(s));
+      const s: Server = app.listen({ port: 0 }, () => resolve(s));
     });
     const { url: uri } = createServerInfo(server, httpServer);
 
@@ -122,14 +127,16 @@ describe('apollo-server-express', () => {
       typeDefs,
       resolvers,
       dataSources: () => ({
-        id: new IdAPI(),
+        id: new class extends IdAPI {
+          baseURL = restUrl;
+        },
       }),
     });
     const app = express();
 
     server.applyMiddleware({ app });
-    httpServer = await new Promise<http.Server>(resolve => {
-      const s = app.listen({ port: 0 }, () => resolve(s));
+    httpServer = await new Promise(resolve => {
+      const s: Server = app.listen({ port: 0 }, () => resolve(s));
     });
     const { url: uri } = createServerInfo(server, httpServer);
 


### PR DESCRIPTION
Similar to e7949d62c0f2a3f096573f1ee07f146d7aabd8af in #3622, this further eradicates explicit port usage in our tests -- which create confusion in local development when those ports are in-use by other applications -- by switching to ephemeral ports which are randomly selected by the operating system based on what is free.

In this particular case, I spent at least 60 minutes chasing down a test failure which could certainly have been related to a change in the implementation being tested, only to find out eventually that it was due to a server that I'd started in another terminal on Friday and forgot to shutdown!  It was even more perplexing since the application that I started (the federation demo application) uses ports 4001-4003, and these two tests use port 4001 and 4002 respectively.

It's worth noting that this does nothing to be IPv6-aware, even though the first solution that I pushed to CircleCI did, I think, attempt it:

https://circleci.com/workflow-run/e8a16b46-cf3a-4eed-90d9-bb00a6373d32

But for that matter, it's worth re-iterating that this is just in tests.