### PR TITLE
Switch to existing `fetch` type, rather than that of `make-fetch-happen`.

### DIFF
--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -40,8 +40,9 @@ import { GraphQLDataSource } from './datasources/types';
 import { RemoteGraphQLDataSource } from './datasources/RemoteGraphQLDataSource';
 import { HeadersInit } from 'node-fetch';
 import { getVariableValues } from 'graphql/execution/values';
-import fetcher, { Fetcher } from 'make-fetch-happen';
+import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
+import { fetch } from 'apollo-server-env';
 
 export type ServiceEndpointDefinition = Pick<ServiceDefinition, 'name' | 'url'>;
 
@@ -61,7 +62,7 @@ interface GatewayConfigBase {
   experimental_pollInterval?: number;
   experimental_approximateQueryPlanStoreMiB?: number;
   experimental_autoFragmentization?: boolean;
-  fetcher?: Fetcher;
+  fetcher?: typeof fetch;
 }
 
 interface RemoteGatewayConfig extends GatewayConfigBase {
@@ -164,7 +165,7 @@ export class ApolloGateway implements GraphQLService {
   private compositionMetadata?: CompositionMetadata;
   private serviceSdlCache = new Map<string, string>();
 
-  private fetcher: Fetcher = fetcher.defaults({
+  private fetcher: typeof fetch = fetcher.defaults({
     cacheManager: new HttpRequestCache(),
     // All headers should be lower-cased here, as `make-fetch-happen`
     // treats differently cased headers as unique (unlike the `Headers` object).


### PR DESCRIPTION
Follows-up https://github.com/apollographql/apollo-server/pull/3783.

These types are compatible, but this change is necessary to account for the fact that, while we have provided types for `make-fetch-happen` which matter during development of Apollo Server, we don't include those types in the distribution.  We could do that, of course, but as I'll note in a minute, we want something more generic anyhow.

The omission of the types in the published package (currently, before this commit) results in typing errors for consumers of `@apollo/gateway` since the `import` statement for the `Fetcher` type from `make-fetch-happen` is still emitted (see attached [Screenshot]).

Switching to the type that `apollo-serve-env` already provides via its `fetch` implementation (literally, `typeof fetch`) should be a no-op change and actually provide the more generic compatibility we want for those who want to bring-their-own-fetch.  This should be the same as any type provided by other Fetch-compatible packages as well, including `isomorphic-fetch`, etc.

[Screenshot]: https://cc.jro.cc/E0uqEXrX