### PR TITLE
Fail to compose when a service's federated SDL cannot be retrieved.

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## 0.14.0 (pre-release; `@next` tag)
 
-- During composition, the unavailability of a downstream service in unmanaged federation mode will no longer result in a partially composed schema which merely lacks the types provided by the downed service.  This prevents unexpected validation errors for clients querying a graph which lacks types which were merely unavailable during the initial composition but were intended to be part of the graph. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO)
+- During composition, the unavailability of a downstream service in unmanaged federation mode will no longer result in a partially composed schema which merely lacks the types provided by the downed service.  This prevents unexpected validation errors for clients querying a graph which lacks types which were merely unavailable during the initial composition but were intended to be part of the graph. [PR #3867](https://github.com/apollographql/apollo-server/pull/3867)
 
 ## 0.13.2
 

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Provide a more helpful error message when encountering expected errors. [PR #3811](https://github.com/apollographql/apollo-server/pull/3811)
 - General improvements and clarity to error messages and logging. [PR #3811](https://github.com/apollographql/apollo-server/pull/3811)
 
+## 0.14.0 (pre-release; `@next` tag)
+
+- During composition, the unavailability of a downstream service in unmanaged federation mode will no longer result in a partially composed schema which merely lacks the types provided by the downed service.  This prevents unexpected validation errors for clients querying a graph which lacks types which were merely unavailable during the initial composition but were intended to be part of the graph. [PR #TODO](https://github.com/apollographql/apollo-server/pull/TODO)
+
 ## 0.13.2
 
 - __BREAKING__: The behavior and signature of `RemoteGraphQLDataSource`'s `didReceiveResponse` method has been changed.  No changes are necessary _unless_ your implementation has overridden the default behavior of this method by either extending the class and overriding the method or by providing `didReceiveResponse` as a parameter to the `RemoteGraphQLDataSource`'s constructor options.  Implementations which have provided their own `didReceiveResponse` using either of these methods should view the PR linked here for details on what has changed.  [PR #3743](https://github.com/apollographql/apollo-server/pull/3743)

--- a/packages/apollo-gateway/src/__tests__/loadServicesFromRemoteEndpoint.test.ts
+++ b/packages/apollo-gateway/src/__tests__/loadServicesFromRemoteEndpoint.test.ts
@@ -1,0 +1,35 @@
+import { getServiceDefinitionsFromRemoteEndpoint } from '../loadServicesFromRemoteEndpoint';
+import { mockLocalhostSDLQuery } from './integration/nockMocks';
+import { RemoteGraphQLDataSource } from '../datasources';
+import nock = require('nock');
+
+describe('getServiceDefinitionsFromRemoteEndpoint', () => {
+  it('errors when no URL was specified', async () => {
+    const serviceSdlCache = new Map<string, string>();
+    const dataSource = new RemoteGraphQLDataSource({ url: '' });
+    const serviceList = [{ name: 'test', dataSource }];
+    await expect(
+      getServiceDefinitionsFromRemoteEndpoint({
+        serviceList,
+        serviceSdlCache,
+      }),
+    ).rejects.toThrowError(
+      "Tried to load schema for 'test' but no 'url' was specified.",
+    );
+  });
+
+  it('throws when the downstream service returns errors', async () => {
+    const serviceSdlCache = new Map<string, string>();
+    const host = 'http://host-which-better-not-resolve';
+    const url = host + '/graphql';
+
+    const dataSource = new RemoteGraphQLDataSource({ url });
+    const serviceList = [{ name: 'test', url, dataSource }];
+    await expect(
+      getServiceDefinitionsFromRemoteEndpoint({
+        serviceList,
+        serviceSdlCache,
+      }),
+    ).rejects.toThrowError(/^Couldn't load service definitions for "test" at http:\/\/host-which-better-not-resolve\/graphql: request to http:\/\/host-which-better-not-resolve\/graphql failed, reason: getaddrinfo ENOTFOUND/);
+  });
+});

--- a/packages/apollo-gateway/src/loadServicesFromRemoteEndpoint.ts
+++ b/packages/apollo-gateway/src/loadServicesFromRemoteEndpoint.ts
@@ -26,58 +26,51 @@ export async function getServiceDefinitionsFromRemoteEndpoint({
 
   let isNewSchema = false;
   // for each service, fetch its introspection schema
-  const serviceDefinitions: ServiceDefinition[] = (await Promise.all(
-    serviceList.map(({ name, url, dataSource }) => {
-      if (!url) {
-        throw new Error(
-          `Tried to load schema for '${name}' but no 'url' was specified.`);
-      }
+  const promiseOfServiceList = serviceList.map(({ name, url, dataSource }) => {
+    if (!url) {
+      throw new Error(
+        `Tried to load schema for '${name}' but no 'url' was specified.`);
+    }
 
-      const request: GraphQLRequest = {
-        query: 'query GetServiceDefinition { _service { sdl } }',
-        http: {
-          url,
-          method: 'POST',
-          headers: new Headers(headers),
-        },
-      };
+    const request: GraphQLRequest = {
+      query: 'query GetServiceDefinition { _service { sdl } }',
+      http: {
+        url,
+        method: 'POST',
+        headers: new Headers(headers),
+      },
+    };
 
-      return dataSource
-        .process({ request, context: {} })
-        .then(({ data, errors }) => {
-          if (data && !errors) {
-            const typeDefs = data._service.sdl as string;
-            const previousDefinition = serviceSdlCache.get(name);
-            // this lets us know if any downstream service has changed
-            // and we need to recalculate the schema
-            if (previousDefinition !== typeDefs) {
-              isNewSchema = true;
-            }
-            serviceSdlCache.set(name, typeDefs);
-            return {
-              name,
-              url,
-              typeDefs: parse(typeDefs),
-            };
+    return dataSource
+      .process({ request, context: {} })
+      .then(({ data, errors }): ServiceDefinition => {
+        if (data && !errors) {
+          const typeDefs = data._service.sdl as string;
+          const previousDefinition = serviceSdlCache.get(name);
+          // this lets us know if any downstream service has changed
+          // and we need to recalculate the schema
+          if (previousDefinition !== typeDefs) {
+            isNewSchema = true;
           }
+          serviceSdlCache.set(name, typeDefs);
+          return {
+            name,
+            url,
+            typeDefs: parse(typeDefs),
+          };
+        }
 
-          // XXX handle local errors better for local development
-          if (errors) {
-            errors.forEach(console.error);
-          }
+        throw new Error(errors?.map(e => e.message).join("\n"));
+      })
+      .catch(err => {
+        const errorMessage =
+          `Couldn't load service definitions for "${name}" at ${url}` +
+          (err && err.message ? ": " + err.message || err : "");
 
-          return false;
-        })
-        .catch(error => {
-          console.warn(
-            `Encountered error when loading ${name} at ${url}: ${error.message}`,
-          );
-          return false;
-        });
-    }),
-  ).then(serviceDefinitions =>
-    serviceDefinitions.filter(Boolean),
-  )) as ServiceDefinition[];
+        throw new Error(errorMessage);
+      });
+  });
 
+  const serviceDefinitions = await Promise.all(promiseOfServiceList);
   return { serviceDefinitions, isNewSchema }
 }


### PR DESCRIPTION
Previously, when attempting to compose a schema from a downstream service in
unmanaged mode, the unavailability of a service would not cause composition
to fail.

Given a condition when the remaining downstream services are still
composable (e.g. they do not depend on the unavailable service and it does
not depend on them), this could still render a valid, but unintentionally
partial schema.

While a partial schema is in many ways fine, it will cause any client's
queries against that now-missing part of the graph to suddenly become
queries which will no longer validate, despite the fact that they may have
previously been designed to fail gracefully during degradation of the service.

Rather than simply logging errors with `console.error` in those conditions,
we will now `throw` the errors.  Thanks to changes in the upstream invokers'
error handling (e.g.https://github.com/apollographql/apollo-server/pull/3811),
this `throw`-ing will now prevent unintentionally serving an incomplete graph.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
