### PR TITLE
gateway: Warn when both local and remote configurations are present.

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Several previously unhandled Promise rejection errors stemming from, e.g. connectivity, failures when communicating with Apollo Graph Manager within asynchronous code are now handled. [PR #3811](https://github.com/apollographql/apollo-server/pull/3811)
 - Provide a more helpful error message when encountering expected errors. [PR #3811](https://github.com/apollographql/apollo-server/pull/3811)
 - General improvements and clarity to error messages and logging. [PR #3811](https://github.com/apollographql/apollo-server/pull/3811)
+- Warn of a possible misconfiguration when local service configuration is provided (via `serviceList` or `localServiceList`) and a remote Apollo Graph Manager configuration is subsequently found as well. [PR #3868](https://github.com/apollographql/apollo-server/pull/3868)
 
 ## 0.13.2
 

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -11,7 +11,10 @@ import {
   graphId,
   mockImplementingServices,
   mockRawPartialSchema,
+  mockCompositionConfigLink,
 } from './nockMocks';
+
+import loadServicesFromStorage = require("../../loadServicesFromStorage");
 
 // This is a nice DX hack for GraphQL code highlighting and formatting within the file.
 // Anything wrapped within the gql tag within this file is just a string, not an AST.
@@ -92,6 +95,59 @@ it('Extracts service definitions from remote storage', async () => {
 
   await gateway.load({ engine: { apiKeyHash, graphId } });
   expect(gateway.schema!.getType('User')!.description).toBe('This is my User');
+});
+
+it.each([
+  ['warned', 'present'],
+  ['not warned', 'absent'],
+])('conflicting configurations are %s about when %s', async (_word, mode) => {
+  const isConflict = mode === 'present';
+  const spyConsoleWarn = jest.spyOn(console, 'warn');
+  let blockerResolve: () => void;
+  const blocker = new Promise(resolve => (blockerResolve = resolve));
+  const original = loadServicesFromStorage.getServiceDefinitionsFromStorage;
+  const spyGetServiceDefinitionsFromStorage = jest
+    .spyOn(loadServicesFromStorage, 'getServiceDefinitionsFromStorage')
+    .mockImplementationOnce(async (...args) => {
+      try {
+        return await original(...args);
+      } catch (e) {
+        throw e;
+      } finally {
+        setImmediate(blockerResolve);
+      }
+    });
+
+  mockStorageSecretSuccess();
+  if (isConflict) {
+    mockCompositionConfigLinkSuccess();
+    mockCompositionConfigsSuccess([service.implementingServicePath]);
+    mockImplementingServicesSuccess(service);
+    mockRawPartialSchemaSuccess(service);
+  } else {
+    mockCompositionConfigLink().reply(403);
+  }
+
+  mockLocalhostSDLQuery({ url: service.federatedServiceURL }).reply(200, {
+    data: { _service: { sdl: service.federatedServiceSchema } },
+  });
+
+  const gateway = new ApolloGateway({
+    serviceList: [
+      { name: 'accounts', url: `${service.federatedServiceURL}/graphql` },
+    ],
+  });
+
+  await gateway.load({ engine: { apiKeyHash, graphId } });
+  await blocker; // Wait for the definitions to be "fetched".
+
+  (isConflict
+    ? expect(spyConsoleWarn)
+    : expect(spyConsoleWarn).not
+  ).toHaveBeenCalledWith(expect.stringMatching(
+    /A local gateway service list is overriding an Apollo Graph Manager managed configuration/));
+  spyGetServiceDefinitionsFromStorage.mockRestore();
+  spyConsoleWarn.mockRestore();
 });
 
 it('Rollsback to a previous schema when triggered', async () => {

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -475,15 +475,13 @@ export class ApolloGateway implements GraphQLService {
   protected async loadServiceDefinitions(
     config: GatewayConfig,
   ): ReturnType<Experimental_UpdateServiceDefinitions> {
-    const getRemoteConfig = (engineConfig: GraphQLServiceEngineConfig) => {
-      return getServiceDefinitionsFromStorage({
-        graphId: engineConfig.graphId,
-        apiKeyHash: engineConfig.apiKeyHash,
-        graphVariant: engineConfig.graphVariant,
-        federationVersion:
-          (config as ManagedGatewayConfig).federationVersion || 1,
-        fetcher: this.fetcher,
-      });
+    const storageOptions = {
+      graphId: this.engineConfig.graphId,
+      apiKeyHash: this.engineConfig.apiKeyHash,
+      graphVariant: this.engineConfig.graphVariant,
+      federationVersion:
+        (config as ManagedGatewayConfig).federationVersion || 1,
+      fetcher: this.fetcher,
     };
 
     if (isLocalConfig(config) || isRemoteConfig(config)) {
@@ -493,7 +491,7 @@ export class ApolloGateway implements GraphQLService {
         // This error helps avoid common misconfiguration.
         // We don't await this because a local configuration should assume
         // remote is unavailable for one reason or another.
-        getRemoteConfig(this.engineConfig).then(() => {
+        getServiceDefinitionsFromStorage(storageOptions).then(() => {
           this.logger.warn(
             "A local gateway service list is overriding an Apollo Graph " +
             "Manager managed configuration.  To use the managed " +
@@ -528,7 +526,7 @@ export class ApolloGateway implements GraphQLService {
       );
     }
 
-    return getRemoteConfig(this.engineConfig);
+    return getServiceDefinitionsFromStorage(storageOptions);
   }
 
   // XXX Nothing guarantees that the only errors thrown or returned in

--- a/packages/apollo-gateway/src/index.ts
+++ b/packages/apollo-gateway/src/index.ts
@@ -152,6 +152,15 @@ type RequestContext<TContext> = WithRequired<
   'document' | 'queryHash'
 >;
 
+// Local state to track whether particular UX-improving warning messages have
+// already been emitted.  This is particularly useful to prevent recurring
+// warnings of the same type in, e.g. repeating timers, which don't provide
+// additional value when they are repeated over and over during the life-time
+// of a server.
+type WarnedStates = {
+  remoteWithLocalConfig?: boolean;
+};
+
 export class ApolloGateway implements GraphQLService {
   public schema?: GraphQLSchema;
   protected serviceMap: DataSourceCache = Object.create(null);
@@ -164,6 +173,7 @@ export class ApolloGateway implements GraphQLService {
   private serviceDefinitions: ServiceDefinition[] = [];
   private compositionMetadata?: CompositionMetadata;
   private serviceSdlCache = new Map<string, string>();
+  private warnedStates: WarnedStates = Object.create(null);
 
   private fetcher: typeof fetch = fetcher.defaults({
     cacheManager: new HttpRequestCache(),
@@ -465,6 +475,34 @@ export class ApolloGateway implements GraphQLService {
   protected async loadServiceDefinitions(
     config: GatewayConfig,
   ): ReturnType<Experimental_UpdateServiceDefinitions> {
+    const getRemoteConfig = (engineConfig: GraphQLServiceEngineConfig) => {
+      return getServiceDefinitionsFromStorage({
+        graphId: engineConfig.graphId,
+        apiKeyHash: engineConfig.apiKeyHash,
+        graphVariant: engineConfig.graphVariant,
+        federationVersion:
+          (config as ManagedGatewayConfig).federationVersion || 1,
+        fetcher: this.fetcher,
+      });
+    };
+
+    if (isLocalConfig(config) || isRemoteConfig(config)) {
+      if (this.engineConfig && !this.warnedStates.remoteWithLocalConfig) {
+        // Only display this warning once per start-up.
+        this.warnedStates.remoteWithLocalConfig = true;
+        // This error helps avoid common misconfiguration.
+        // We don't await this because a local configuration should assume
+        // remote is unavailable for one reason or another.
+        getRemoteConfig(this.engineConfig).then(() => {
+          this.logger.warn(
+            "A local gateway service list is overriding an Apollo Graph " +
+            "Manager managed configuration.  To use the managed " +
+            "configuration, do not specifiy a service list locally.",
+          );
+        }).catch(() => {}); // Don't mind errors if managed config is missing.
+      }
+    }
+
     if (isLocalConfig(config)) {
       return { isNewSchema: false };
     }
@@ -490,13 +528,7 @@ export class ApolloGateway implements GraphQLService {
       );
     }
 
-    return getServiceDefinitionsFromStorage({
-      graphId: this.engineConfig.graphId,
-      apiKeyHash: this.engineConfig.apiKeyHash,
-      graphVariant: this.engineConfig.graphVariant,
-      federationVersion: config.federationVersion || 1,
-      fetcher: this.fetcher
-    });
+    return getRemoteConfig(this.engineConfig);
   }
 
   // XXX Nothing guarantees that the only errors thrown or returned in


### PR DESCRIPTION
To help address the configuration when a local configuration is provided and
one is also available in the cloud, warn the user of the dual-configuration
to avoid what is a common unintended mode of operation.