### PR TITLE
fixes subscriptions install bug

### DIFF
--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -156,6 +156,10 @@ export class ApolloServer extends ApolloServerBase {
             },
           ];
 
+          if (this.subscriptionServerOptions) {
+            await this.installSubscriptionHandlers(instance.server);
+          }
+
           if (typeof processFileUploads === 'function' && this.uploadsConfig) {
             instance.addContentTypeParser(
               'multipart',


### PR DESCRIPTION
Webhooks don't work in `apollo-server-fastify` because the subscription handlers don't get installed. Found the [installation call in the generic apollo-server](https://github.com/apollographql/apollo-server/blob/30b3066668d35fbff5f95eb36218bb26a2a9aead/packages/apollo-server/src/index.ts#L117) and ported it to the fastify version.