### PR TITLE
[Apollo-Engine-Reporting] Update reports.proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-lambda`: Support file uploads on AWS Lambda [Issue #1419](https://github.com/apollographql/apollo-server/issues/1419) [Issue #1703](https://github.com/apollographql/apollo-server/issues/1703) [PR #3926](https://github.com/apollographql/apollo-server/pull/3926)
+- **breaking** `apollo-engine-reporting-protobuf`: Drop legacy fields that were never used by `apollo-engine-reporting`. Added new fields `StatsContext` to allow `apollo-server` to send summary stats instead of full traces, and renamed `FullTracesReport` to `Report` and `Traces` to `TracesAndStats` since reports now can include stats as well as traces.
 
 ### v2.12.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4367,23 +4367,23 @@
       }
     },
     "apollo-link-http": {
-      "version": "1.5.16",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.16.tgz",
-      "integrity": "sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==",
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.17.tgz",
+      "integrity": "sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.13",
-        "apollo-link-http-common": "^0.2.15",
+        "apollo-link": "^1.2.14",
+        "apollo-link-http-common": "^0.2.16",
         "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz",
-      "integrity": "sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz",
+      "integrity": "sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.13",
+        "apollo-link": "^1.2.14",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@types/ws": "6.0.4",
     "apollo-fetch": "0.7.0",
     "apollo-link": "1.2.14",
-    "apollo-link-http": "1.5.16",
+    "apollo-link-http": "1.5.17",
     "apollo-link-persisted-queries": "0.2.2",
     "azure-functions-ts-essentials": "1.3.2",
     "body-parser": "1.19.0",

--- a/packages/apollo-engine-reporting-protobuf/src/index.js
+++ b/packages/apollo-engine-reporting-protobuf/src/index.js
@@ -15,8 +15,8 @@ protobufJS.configure();
 // a casually noticeable effect on p50 times. This also makes it easier for us
 // to implement maxUncompressedReportSize as we know the encoded size of traces
 // as we go.
-const originalTracesEncode = protobuf.Traces.encode;
-protobuf.Traces.encode = function(message, originalWriter) {
+const originalTracesEncode = protobuf.TracesAndStats.encode;
+protobuf.TracesAndStats.encode = function(message, originalWriter) {
   const writer = originalTracesEncode(message, originalWriter);
   const encodedTraces = message.encodedTraces;
   if (encodedTraces != null && encodedTraces.length) {

--- a/packages/apollo-engine-reporting-protobuf/src/index.js
+++ b/packages/apollo-engine-reporting-protobuf/src/index.js
@@ -15,9 +15,9 @@ protobufJS.configure();
 // a casually noticeable effect on p50 times. This also makes it easier for us
 // to implement maxUncompressedReportSize as we know the encoded size of traces
 // as we go.
-const originalTracesEncode = protobuf.TracesAndStats.encode;
+const originalTracesAndStatsEncode = protobuf.TracesAndStats.encode;
 protobuf.TracesAndStats.encode = function(message, originalWriter) {
-  const writer = originalTracesEncode(message, originalWriter);
+  const writer = originalTracesAndStatsEncode(message, originalWriter);
   const encodedTraces = message.encodedTraces;
   if (encodedTraces != null && encodedTraces.length) {
     for (let i = 0; i < encodedTraces.length; ++i) {

--- a/packages/apollo-engine-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/src/reports.proto
@@ -131,7 +131,9 @@ message Trace {
 			// XXX When we want to include more details about the sub-operation that was
 			// executed against this service, we should include that here in each fetch node.
 			// This might include an operation signature, requires directive, reference resolutions, etc.
-			string serviceName = 1;
+			string service_name = 1;
+
+			bool trace_parsing_failed = 2;
 
 			// This Trace only contains start_time, end_time, duration_ns, and root;
 			// all timings were calculated **on the federated service**, and clock skew

--- a/packages/apollo-engine-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/src/reports.proto
@@ -24,15 +24,9 @@ message Trace {
 		map<string, string> variables_json = 4;
 		// Deprecated. Engineproxy did not encode variable values as JSON, so you
 		// couldn't tell numbers from numeric strings. Send variables_json instead.
-		map<string, bytes> variables = 1;
-		// Optional: this is the original full query before the signature algorithm
-		// is applied.  Engineproxy always sent this in all traces, which meant that
-		// literal-masking done by the signature algorithm didn't fully hide
-		// sensitive data from Engine servers. apollo-engine-reporting does not
-		// include this by default.  (The Engine frontend does not currently show
-		// this field.)
-		string raw_query = 2;
-		// Don't include this in traces inside a FullTracesReport; the operation
+		map<string, bytes> deprecated_variables = 1;
+		// This is deprecated and only used for legacy applications
+		// don't include this in traces inside a FullTracesReport; the operation
 		// name for these traces comes from the key of the traces_per_query map.
 		string operation_name = 3;
 	}
@@ -139,8 +133,6 @@ message Trace {
 			// This might include an operation signature, requires directive, reference resolutions, etc.
 			string serviceName = 1;
 
-			bool traceParsingFailed = 2;
-
 			// This Trace only contains start_time, end_time, duration_ns, and root;
 			// all timings were calculated **on the federated service**, and clock skew
 			// will be handled by the ingress server.
@@ -240,9 +232,6 @@ message Trace {
 
 	// --------------------------------------------------------------
 	// Fields below this line are only set by the old Go engineproxy.
-	google.protobuf.Timestamp origin_reported_start_time = 15;
-	google.protobuf.Timestamp origin_reported_end_time = 16;
-	uint64 origin_reported_duration_ns = 17;
 
 	// Older agents (eg the Go engineproxy) relied to some degree on the Engine
 	// backend to run their own semi-compatible implementation of a specific
@@ -251,7 +240,6 @@ message Trace {
 	// from engineproxy, but we've now simplified the backend to no longer do this.
 	// Deprecated and ignored in FullTracesReports.
 	string legacy_signature_needs_resigning = 5;
-
 
 	// removed: Node parse = 12; Node validate = 13;
 	//          Id128 server_id = 1; Id128 client_id = 2;
@@ -266,7 +254,6 @@ message Trace {
 // agent_version, etc.) is sent by the Apollo Engine Reporting agent, but we do not currently save that
 // information to any of our persistent storage.
 message ReportHeader {
-	string service = 3;
 	// eg "host-01.example.com"
 	string hostname = 5;
 
@@ -282,39 +269,14 @@ message ReportHeader {
 	string schema_tag = 10;
 	// The hex representation of the sha512 of the introspection response
 	string schema_hash = 11;
+
+	reserved 3; // removed string service = 3;
 }
 
 message PathErrorStats {
 	map<string, PathErrorStats> children = 1;
 	uint64 errors_count = 4;
 	uint64 requests_with_errors_count = 5;
-}
-
-message ClientNameStats {
-	// Duration histogram for non-cache-hit queries.
-	// (See docs/histograms.md for the histogram format.)
-	repeated int64 latency_count = 1;
-	reserved 2; // removed: repeated uint64 error_count = 2;
-	// These per-version fields were used to understand what versions contributed to this sample
-	// when we were implementing the aggregation of this information ourselves using BigTable.
-	// However, since the per-version stats don't separate out latency, it makes more sense to
-	// have stats reported with contextual information so we can have the specific breakdown we're
-	// looking for. These fields are somewhat misleading as we never actually do any per-version
-	// awareness with anything reporting in the legacy "per_client_name" stats, and instead use
-	// "query_stats_with_context" to have more contextual information.
-	map<string, uint64> requests_count_per_version = 3; // required
-	map<string, uint64> cache_hits_per_version = 4;
-	map<string, uint64> persisted_query_hits_per_version = 10;
-	map<string, uint64> persisted_query_misses_per_version = 11;
-	map<string, uint64> registered_operation_count_per_version = 12;
-	map<string, uint64> forbidden_operation_count_per_version = 13;
-	repeated int64 cache_latency_count = 5; // Duration histogram; see docs/histograms.md
-	PathErrorStats root_error_stats = 6;
-	uint64 requests_with_errors_count = 7;
-	// TTL histograms for cache misses for the public cache.
-	repeated int64 public_cache_ttl_count = 8;
-	// TTL histograms for cache misses for the private cache.
-	repeated int64 private_cache_ttl_count = 9;
 }
 
 message QueryLatencyStats {
@@ -349,39 +311,18 @@ message ContextualizedTypeStats {
 }
 
 message FieldStat {
-	string name = 2; // deprecated; only set when stored in TypeStat.field
 	string return_type = 3; // required; eg "String!" for User.email:String!
 	uint64 errors_count = 4;
 	uint64 count = 5;
 	uint64 requests_with_errors_count = 6;
 	repeated int64 latency_count = 8; // Duration histogram; see docs/histograms.md
+	reserved 1, 2, 7;
 }
 
 message TypeStat {
-	string name = 1; // deprecated; only set when stored in QueryStats.per_type
-	repeated FieldStat field = 2;  // deprecated; use per_field_stat instead
 	// Key is (eg) "email" for User.email:String!
 	map<string, FieldStat> per_field_stat = 3;
-}
-
-message QueryStats {
-	// Either per_client_name (for back-compat) or query_stats_with_context must be specified. If both are
-	// specified, then query_stats_with_context will be used and per_client_name will be ignored. Although
-	// the fields in ClientNameStats mention things "per-version," the information in the "per-version"
-	// fields will only ever be over the default version, the empty String: "", if arrived at via the
-	// FullTracesAggregator.
-	map<string, ClientNameStats> per_client_name = 1; // deprecated; use stats_with_context instead
-	repeated ContextualizedQueryLatencyStats query_stats_with_context = 4;
-	repeated TypeStat per_type = 2; // deprecated; use type_stats_with_context instead
-	// Key is the parent type, e.g. "User" for User.email:String!
-	map<string, TypeStat> per_type_stat = 3; // deprecated; use type_stats_with_context instead
-	repeated ContextualizedTypeStats type_stats_with_context = 5;
-}
-
-// Top-level message type for the server-side traces endpoint
-message TracesReport {
-	ReportHeader header = 1; // required
-	repeated Trace trace = 2; // required
+	reserved 1, 2;
 }
 
 message Field {
@@ -392,68 +333,6 @@ message Field {
 message Type {
 	string name = 1; // required; eg "User" for User.email:String!
 	repeated Field field = 2;
-}
-
-message MemStats {
-	uint64 total_bytes = 1; // MemStats.Sys
-	uint64 stack_bytes = 2; // MemStats.StackSys
-	uint64 heap_bytes = 3; // MemStats.HeapSys
-	uint64 heap_released_bytes = 13; // MemStats.HeapReleased
-	uint64 gc_overhead_bytes = 4; // MemStats.GCSys
-
-	uint64 stack_used_bytes = 5; // MemStats.StackInuse
-	uint64 heap_allocated_bytes = 6; // MemStats.HeapAlloc
-	uint64 heap_allocated_objects = 7; // MemStats.HeapObjects
-
-	uint64 heap_allocated_bytes_delta = 8; // MemStats.TotalAlloc delta
-	uint64 heap_allocated_objects_delta = 9; // MemStats.Mallocs delta
-	uint64 heap_freed_objects_delta = 10; // MemStats.Frees delta
-
-	uint64 gc_stw_ns_delta = 11; // MemStats.PauseTotalNs delta
-	uint64 gc_count_delta = 12; // MemStats.NumGC delta
-}
-
-message TimeStats {
-	uint64 uptime_ns = 1;
-	uint64 real_ns_delta = 2;
-	uint64 user_ns_delta = 3;
-	uint64 sys_ns_delta = 4;
-}
-
-// Top-level message type for the server-side stats endpoint
-message StatsReport {
-	ReportHeader header = 1; // required
-
-	// These fields are about properties of the engineproxy and are not generated
-	// from FullTracesReports.
-	MemStats mem_stats = 2;
-	TimeStats time_stats = 3;
-
-	// Beginning of the period over which stats are collected.
-	google.protobuf.Timestamp start_time = 8;
-	// End of the period of which stats are collected.
-	google.protobuf.Timestamp end_time = 9;
-	// Only used to interpret mem_stats and time_stats; not generated from
-	// FullTracesReports.
-	uint64 realtime_duration = 10;
-
-
-	// Maps from query descriptor to QueryStats. Required unless
-	// legacy_per_query_missing_operation_name is set. The keys are strings of the
-	// form `# operationName\nsignature` (literal hash and space), with
-	// operationName - if there is no operation name.
-	map<string, QueryStats> per_query = 14;
-
-	// Older agents (Go engineproxy) didn't explicitly include the operation name
-	// in the key of this map, and the server had to parse it out (after a
-	// re-signing operation which is no longer performed). The key here is just the query
-	// signature. Deprecated.
-	map<string, QueryStats> legacy_per_query_implicit_operation_name = 12;
-
-	// Deprecated: it was useful in Optics where we had access to the whole schema
-	// but has not been ever used in Engine.  apollo-engine-reporting will not
-	// send it.
-	repeated Type type = 13;
 }
 
 // This is the top-level message used by the new traces ingress. This
@@ -477,12 +356,15 @@ message FullTracesReport {
 	map<string, Traces> traces_per_query = 5;
 }
 
-// Just a sequence of traces with the same statsReportKey.
-message Traces {
-	repeated Trace trace = 1;
+message ContextualizedStats {
+	StatsContext context = 1;
+	QueryLatencyStats query_latency_stats = 2;
+	// Key is type name.
+	map<string, TypeStat> per_type_stat = 3;
 }
 
-message TraceV1 {
-	ReportHeader header = 1;
-	Trace trace = 2;
+// A sequence of traces and stats. An individual trace should either be counted as a stat or trace
+message Traces {
+	repeated Trace trace = 1;
+	repeated ContextualizedStats stats_with_context = 2;
 }

--- a/packages/apollo-engine-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-engine-reporting-protobuf/src/reports.proto
@@ -341,10 +341,11 @@ message Type {
 // is designed for the apollo-engine-reporting TypeScript agent and will
 // eventually be documented as a public ingress API. This message consists
 // solely of traces; the equivalent of the StatsReport is automatically
-// generated server-side from this message.  Agents should send traces
-// for all requests in this report.  Generally, buffering up until a large
+// generated server-side from this message. Agent should either send a trace or include it in the stats
+// for every request in this report. Generally, buffering up until a large
 // size has been reached (say, 4MB) or 5-10 seconds has passed is appropriate.
-message FullTracesReport {
+// This message used to be know as FullTracesReport, but got renamed since it isn't just for traces anymore
+message Report {
 	ReportHeader header = 1;
 
 	// key is statsReportKey (# operationName\nsignature) Note that the nested
@@ -355,7 +356,13 @@ message FullTracesReport {
 	// legacy_per_query_implicit_operation_name, and we don't require them to have
 	// details.raw_query (which would consume a lot of space and has privacy/data
 	// access issues, and isn't currently exposed by our app anyway).
-	map<string, Traces> traces_per_query = 5;
+	map<string, TracesAndStats> traces_per_query = 5;
+
+	// This is the time that the requests in this trace are considered to have taken place
+	// If this field is not present the max of the end_time of each trace will be used instead.
+	// If there are no traces and no end_time present the report will not be able to be processed.
+	// Note: This will override the end_time from traces.
+	google.protobuf.Timestamp end_time = 2; // required if no traces in this message
 }
 
 message ContextualizedStats {
@@ -366,7 +373,7 @@ message ContextualizedStats {
 }
 
 // A sequence of traces and stats. An individual trace should either be counted as a stat or trace
-message Traces {
+message TracesAndStats {
 	repeated Trace trace = 1;
 	repeated ContextualizedStats stats_with_context = 2;
 }

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -16,7 +16,7 @@ import { defaultEngineReportingSignature } from 'apollo-graphql';
 import {
   Report,
   TracesAndStats
-} from "apollo-engine-reporting-protobuf/dist/protobuf";
+} from "apollo-engine-reporting-protobuf";
 
 export interface ClientInfo {
   clientName?: string;

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -4,6 +4,8 @@ import { DocumentNode, GraphQLError } from 'graphql';
 import {
   ReportHeader,
   Trace,
+  Report,
+  TracesAndStats
 } from 'apollo-engine-reporting-protobuf';
 
 import { fetch, RequestAgent, Response } from 'apollo-server-env';
@@ -13,10 +15,6 @@ import { EngineReportingExtension } from './extension';
 import { GraphQLRequestContext, Logger } from 'apollo-server-types';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { defaultEngineReportingSignature } from 'apollo-graphql';
-import {
-  Report,
-  TracesAndStats
-} from "apollo-engine-reporting-protobuf";
 
 export interface ClientInfo {
   clientName?: string;

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -2,9 +2,7 @@ import os from 'os';
 import { gzip } from 'zlib';
 import { DocumentNode, GraphQLError } from 'graphql';
 import {
-  FullTracesReport,
   ReportHeader,
-  Traces,
   Trace,
 } from 'apollo-engine-reporting-protobuf';
 
@@ -15,6 +13,10 @@ import { EngineReportingExtension } from './extension';
 import { GraphQLRequestContext, Logger } from 'apollo-server-types';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { defaultEngineReportingSignature } from 'apollo-graphql';
+import {
+  Report,
+  TracesAndStats
+} from "apollo-engine-reporting-protobuf/dist/protobuf";
 
 export interface ClientInfo {
   clientName?: string;
@@ -222,12 +224,12 @@ export class EngineReportingAgent<TContext = any> {
   private options: EngineReportingOptions<TContext>;
   private logger: Logger = console;
   private apiKey: string;
-  private reports: { [schemaHash: string]: FullTracesReport } = Object.create(
+  private reports: { [schemaHash: string]: Report } = Object.create(
     null,
   );
   private reportSizes: { [schemaHash: string]: number } = Object.create(null);
   private reportTimer: any; // timer typing is weird and node-specific
-  private sendReportsImmediately?: boolean;
+  private readonly sendReportsImmediately?: boolean;
   private stopped: boolean = false;
   private reportHeaders: { [schemaHash: string]: ReportHeader } = Object.create(
     null,
@@ -330,7 +332,7 @@ export class EngineReportingAgent<TContext = any> {
 
     const statsReportKey = `# ${operationName || '-'}\n${signature}`;
     if (!report.tracesPerQuery.hasOwnProperty(statsReportKey)) {
-      report.tracesPerQuery[statsReportKey] = new Traces();
+      report.tracesPerQuery[statsReportKey] = new TracesAndStats();
       (report.tracesPerQuery[statsReportKey] as any).encodedTraces = [];
     }
     // See comment on our override of Traces.encode inside of
@@ -383,11 +385,11 @@ export class EngineReportingAgent<TContext = any> {
       );
     }
 
-    const protobufError = FullTracesReport.verify(report);
+    const protobufError = Report.verify(report);
     if (protobufError) {
       throw new Error(`Error encoding report: ${protobufError}`);
     }
-    const message = FullTracesReport.encode(report).finish();
+    const message = Report.encode(report).finish();
 
     const compressed = await new Promise<Buffer>((resolve, reject) => {
       // The protobuf library gives us a Uint8Array. Node 8's zlib lets us
@@ -557,7 +559,7 @@ export class EngineReportingAgent<TContext = any> {
   }
 
   private resetReport(schemaHash: string) {
-    this.reports[schemaHash] = new FullTracesReport({
+    this.reports[schemaHash] = new Report({
       header: this.reportHeaders[schemaHash],
     });
     this.reportSizes[schemaHash] = 0;

--- a/packages/apollo-gateway/src/__tests__/gateway/reporting.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/reporting.test.ts
@@ -5,7 +5,7 @@ import { GraphQLSchemaModule } from 'apollo-graphql';
 import gql from 'graphql-tag';
 import { buildFederatedSchema } from '@apollo/federation';
 import { ApolloServer } from 'apollo-server';
-import { FullTracesReport } from 'apollo-engine-reporting-protobuf';
+import { Reports } from 'apollo-engine-reporting-protobuf';
 import { execute, toPromise } from 'apollo-link';
 import { createHttpLink } from 'apollo-link-http';
 import fetch from 'node-fetch';
@@ -189,7 +189,7 @@ describe('reporting', () => {
     // nock returns binary bodies as hex strings
     const gzipReportBuffer = Buffer.from(reportBody, 'hex');
     const reportBuffer = gunzipSync(gzipReportBuffer);
-    const report = FullTracesReport.decode(reportBuffer);
+    const report = Reports.decode(reportBuffer);
 
     // Some handwritten tests to capture salient properties.
     const statsReportKey = '# -\n{me{name}topProducts{name}}';

--- a/packages/apollo-gateway/src/__tests__/gateway/reporting.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/reporting.test.ts
@@ -5,12 +5,12 @@ import { GraphQLSchemaModule } from 'apollo-graphql';
 import gql from 'graphql-tag';
 import { buildFederatedSchema } from '@apollo/federation';
 import { ApolloServer } from 'apollo-server';
-import { Reports } from 'apollo-engine-reporting-protobuf';
 import { execute, toPromise } from 'apollo-link';
 import { createHttpLink } from 'apollo-link-http';
 import fetch from 'node-fetch';
 import { ApolloGateway } from '../..';
 import { Plugin, Config, Refs } from 'pretty-format';
+import { Report } from 'apollo-engine-reporting-protobuf';
 
 // Normalize specific fields that change often (eg timestamps) to static values,
 // to make snapshot testing viable.  (If these helpers are more generally
@@ -189,7 +189,7 @@ describe('reporting', () => {
     // nock returns binary bodies as hex strings
     const gzipReportBuffer = Buffer.from(reportBody, 'hex');
     const reportBuffer = gunzipSync(gzipReportBuffer);
-    const report = Reports.decode(reportBuffer);
+    const report = Report.decode(reportBuffer);
 
     // Some handwritten tests to capture salient properties.
     const statsReportKey = '# -\n{me{name}topProducts{name}}';
@@ -219,6 +219,7 @@ describe('reporting', () => {
 
     expect(report).toMatchInlineSnapshot(`
       Object {
+        "endTime": null,
         "header": "<HEADER>",
         "tracesPerQuery": Object {
           "# -

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -4,7 +4,7 @@ import { URL } from 'url';
 import express = require('express');
 import bodyParser = require('body-parser');
 
-import { Reports, Trace } from 'apollo-engine-reporting-protobuf';
+import { Report, Trace } from 'apollo-engine-reporting-protobuf';
 
 import {
   GraphQLSchema,
@@ -795,12 +795,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
         class EngineMockServer {
           private app: express.Application;
           private server: http.Server;
-          private reports: Reports[] = [];
-          public readonly promiseOfReports: Promise<Reports[]>;
+          private reports: Report[] = [];
+          public readonly promiseOfReports: Promise<Report[]>;
 
           constructor() {
-            let reportResolver: (reports: Reports[]) => void;
-            this.promiseOfReports = new Promise<Reports[]>(resolve => {
+            let reportResolver: (reports: Report[]) => void;
+            this.promiseOfReports = new Promise<Report[]>(resolve => {
               reportResolver = resolve;
             });
 
@@ -818,7 +818,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             );
 
             this.app.use((req, res) => {
-              const report = Reports.decode(req.body);
+              const report = Report.decode(req.body);
               this.reports.push(report);
               res.end();
 

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -4,7 +4,7 @@ import { URL } from 'url';
 import express = require('express');
 import bodyParser = require('body-parser');
 
-import { FullTracesReport, Trace } from 'apollo-engine-reporting-protobuf';
+import { Reports, Trace } from 'apollo-engine-reporting-protobuf';
 
 import {
   GraphQLSchema,
@@ -795,12 +795,12 @@ export function testApolloServer<AS extends ApolloServerBase>(
         class EngineMockServer {
           private app: express.Application;
           private server: http.Server;
-          private reports: FullTracesReport[] = [];
-          public readonly promiseOfReports: Promise<FullTracesReport[]>;
+          private reports: Reports[] = [];
+          public readonly promiseOfReports: Promise<Reports[]>;
 
           constructor() {
-            let reportResolver: (reports: FullTracesReport[]) => void;
-            this.promiseOfReports = new Promise<FullTracesReport[]>(resolve => {
+            let reportResolver: (reports: Reports[]) => void;
+            this.promiseOfReports = new Promise<Reports[]>(resolve => {
               reportResolver = resolve;
             });
 
@@ -818,7 +818,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             );
 
             this.app.use((req, res) => {
-              const report = FullTracesReport.decode(req.body);
+              const report = Reports.decode(req.body);
               this.reports.push(report);
               res.end();
 


### PR DESCRIPTION
Drop fields that have been deprecated and are no longer used by AER. Also create new fields for Unified Reporting. The fields that have been dropped where never used by apollo-server, and only used by old reporting agents such as the `engine-proxy`.

Also rename fields to make them more generic, and add fields that will be used for stats aggregation.