### PR TITLE
Handle external types that do not exist gracefully

### DIFF
--- a/packages/apollo-federation-integration-testsuite/src/fixtures/product.ts
+++ b/packages/apollo-federation-integration-testsuite/src/fixtures/product.ts
@@ -9,6 +9,7 @@ export const typeDefs = gql`
 
   extend type Query {
     product(upc: String!): Product
+    products(upcs: [String!]!): [Product]
     vehicle(id: String!): Vehicle
     topProducts(first: Int = 5): [Product]
     topCars(first: Int = 5): [Car]
@@ -151,7 +152,8 @@ const products = [
   { __typename: 'Book', isbn: '0201633612', price: 49 },
   { __typename: 'Book', isbn: '1234567890', price: 59 },
   { __typename: 'Book', isbn: '404404404', price: 0 },
-  { __typename: 'Book', isbn: '0987654321', price: 29 },
+  { __typename: 'Book', isbn: '0987654321', price: 29, upc: '0987654321' },
+  { __typename: 'Book', isbn: '9999999999', price: 31, upc: '9999999999' },
 ];
 
 const vehicles = [
@@ -231,6 +233,10 @@ export const resolvers: GraphQLResolverMap<any> = {
   Query: {
     product(_, args) {
       return products.find(product => product.upc === args.upc);
+    },
+    products(_, args) {
+      const upcs: Array<string> = args.upcs
+      return upcs.map(upc => products.find(product => product.upc === upc));
     },
     vehicle(_, args) {
       return vehicles.find(vehicles => vehicles.id === args.id);

--- a/packages/apollo-federation/src/service/__tests__/printComposedSdl.test.ts
+++ b/packages/apollo-federation/src/service/__tests__/printComposedSdl.test.ts
@@ -186,6 +186,7 @@ describe('printComposedSdl', () => {
         library(id: ID!): Library @resolve(graph: \\"books\\")
         body: Body! @resolve(graph: \\"documents\\")
         product(upc: String!): Product @resolve(graph: \\"product\\")
+        products(upcs: [String!]!): [Product] @resolve(graph: \\"product\\")
         vehicle(id: String!): Vehicle @resolve(graph: \\"product\\")
         topProducts(first: Int = 5): [Product] @resolve(graph: \\"product\\")
         topCars(first: Int = 5): [Car] @resolve(graph: \\"product\\")

--- a/packages/apollo-federation/src/service/__tests__/printFederatedSchema.test.ts
+++ b/packages/apollo-federation/src/service/__tests__/printFederatedSchema.test.ts
@@ -136,6 +136,7 @@ describe('printFederatedSchema', () => {
         library(id: ID!): Library
         body: Body!
         product(upc: String!): Product
+        products(upcs: [String!]!): [Product]
         vehicle(id: String!): Vehicle
         topProducts(first: Int = 5): [Product]
         topCars(first: Int = 5): [Car]

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __FIX__: Continue resolving when an `@external` reference cannot be resolved. [#3914](https://github.com/apollographql/apollo-server/pull/3914)
 
 ## v0.19.0
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-server/issues/3859

Currently, the gateway fails when an entity referenced by an external type does not exist. Thus even entities that exist and could be processed further are not considered. 

I added a book product to the test data set with `upc = 9999999999` which is not know by the product service but not by the book service. 

When the resolvable and the non-resolvable book are queried, the response is the following:
```
[Object: null prototype] {
      products: [
        [Object: null prototype] {
          upc: '9999999999',
          name: null,
          price: '31'
        },
        [Object: null prototype] {
          upc: '0987654321',
          name: null,
          price: '29'
        }
      ]
    }
```

Notice how the name is not resolved also for `0987654321` which would be possible to resolve. Also If I query these two books in a different order, the result becomes different. The gateway would resolve everything until it processes the book unknown to the book service. Every following product would fail to resolve further.


With this PR such errors are collected but do not interrupt processing entities further that could be resolved. So the result for the query above is:
```
[Object: null prototype] {
      products: [
        [Object: null prototype] {
          upc: '9999999999',
          name: 'undefined (undefined)',
          price: '31'
        },
        [Object: null prototype] {
          upc: '0987654321',
          name: 'No Books Like This Book! (2019)',
          price: '29'
        }
      ]
    }
```