### PR TITLE
docs: Fix typo on implementing services

### DIFF
--- a/docs/source/federation/implementing-services.mdx
+++ b/docs/source/federation/implementing-services.mdx
@@ -221,7 +221,7 @@ Also make sure to read about the [gateway's support for custom directives](./gat
 
 ## Securing implementing services
 
-Because of the power and flexibility of Apollo Federation's `_entities` field, your implementing services should **not** be directly accessible by clients. Instead, only your [gateway](./gateway/) should have access to your implementing serivces. Clients then communicate with the gateway:
+Because of the power and flexibility of Apollo Federation's `_entities` field, your implementing services should **not** be directly accessible by clients. Instead, only your [gateway](./gateway/) should have access to your implementing services. Clients then communicate with the gateway:
 
 <FederationArchitecture />
 


### PR DESCRIPTION
Simply fixing a typo on the docs.