### PR TITLE
chore(federation,gateway): use SPDX'd `license` attr. in `package.json`.

### DIFF
--- a/packages/apollo-federation/package.json
+++ b/packages/apollo-federation/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "keywords": [],
   "author": "Apollo <opensource@apollographql.com>",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "engines": {
     "node": ">=8"
   },

--- a/packages/apollo-gateway/package.json
+++ b/packages/apollo-gateway/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "node": ">=8"
   },
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Using standard identifiers helps downstream folks correctly identify the license your project (and npm packages) are under.