### PR TITLE
Fixed a little type `FIELD_DEFINITON` to  `FIELD_DEFINITION`

### DIFF
--- a/docs/source/federation/federation-spec.md
+++ b/docs/source/federation/federation-spec.md
@@ -276,7 +276,7 @@ When fetching `Review.product` from the Reviews service, it is possible to reque
 ### `@requires`
 
 ```graphql
-directive @requires(fields: _FieldSet!) on FIELD_DEFINITON
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 ```
 
 The `@requires` directive is used to annotate the required input fieldset from a base type for a resolver. It is used to develop a query plan where the required fields may not be needed by the client, but the service may need additional information from other services. For example:


### PR DESCRIPTION
This pr just fixes a type in a directive example:

```graphql
directive @requires(fields: _FieldSet!) on FIELD_DEFINITON
```

The directive location is missing an `i`.