### PR TITLE
fix: Engine config load issue

### DIFF
--- a/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/lifecycle-hooks.test.ts
@@ -2,7 +2,6 @@ import {
   ApolloGateway,
   GatewayConfig,
   Experimental_UpdateServiceDefinitions,
-  Experimental_DidUpdateCompositionCallback,
 } from '../../index';
 import * as accounts from '../__fixtures__/schemas/accounts';
 import * as books from '../__fixtures__/schemas/books';
@@ -69,8 +68,6 @@ describe('lifecycle hooks', () => {
   });
 
   it('calls experimental_didUpdateComposition on schema update', async () => {
-    jest.useFakeTimers();
-
     const compositionMetadata = {
       formatVersion: 1,
       id: 'abc',
@@ -111,26 +108,33 @@ describe('lifecycle hooks', () => {
       };
     });
 
-    const didUpdate: Experimental_DidUpdateCompositionCallback = () => {};
-    const mockDidUpdate = jest.fn(didUpdate);
+    const mockDidUpdate = jest.fn();
 
     const gateway = new ApolloGateway({
       experimental_updateServiceDefinitions: mockUpdate,
       experimental_didUpdateComposition: mockDidUpdate,
-      experimental_pollInterval: 10,
+      experimental_pollInterval: 100,
     });
 
-    await gateway.load();
+    let resolve1: Function;
+    let resolve2: Function;
+    const schemaChangeBlocker1 = new Promise(res => (resolve1 = res));
+    const schemaChangeBlocker2 = new Promise(res => (resolve2 = res));
 
+    gateway.onSchemaChange(
+      jest
+        .fn()
+        .mockImplementationOnce(() => resolve1())
+        .mockImplementationOnce(() => resolve2()),
+    );
+
+    gateway.load();
+
+    await schemaChangeBlocker1;
     expect(mockUpdate).toBeCalledTimes(1);
     expect(mockDidUpdate).toBeCalledTimes(1);
 
-    gateway.onSchemaChange(() => {});
-
-    jest.runOnlyPendingTimers();
-    // XXX This allows the ApolloGateway.updateComposition() Promise to resolve
-    // after the poll ticks, and is necessary for allowing mockDidUpdate to see the expected calls.
-    await Promise.resolve();
+    await schemaChangeBlocker2;
 
     expect(mockUpdate).toBeCalledTimes(2);
     expect(mockDidUpdate).toBeCalledTimes(2);
@@ -179,8 +183,6 @@ describe('lifecycle hooks', () => {
   });
 
   it('registers schema change callbacks when experimental_pollInterval is set for unmanaged configs', async () => {
-    jest.useFakeTimers();
-
     const experimental_updateServiceDefinitions: Experimental_UpdateServiceDefinitions = jest.fn(
       async (_config: GatewayConfig) => {
         return { serviceDefinitions, isNewSchema: true };
@@ -190,18 +192,18 @@ describe('lifecycle hooks', () => {
     const gateway = new ApolloGateway({
       serviceList: [{ name: 'book', url: 'http://localhost:32542' }],
       experimental_updateServiceDefinitions,
-      experimental_pollInterval: 10,
+      experimental_pollInterval: 100,
     });
 
-    const schemaChangeCallback = jest.fn();
+    let resolve: Function;
+    const schemaChangeBlocker = new Promise(res => (resolve = res));
+    const schemaChangeCallback = jest.fn(() => resolve());
 
     gateway.onSchemaChange(schemaChangeCallback);
+    gateway.load();
 
-    jest.runOnlyPendingTimers();
-    await Promise.resolve();
+    await schemaChangeBlocker;
 
     expect(schemaChangeCallback).toBeCalledTimes(1);
-
-    jest.useRealTimers();
   });
 });

--- a/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/networkRequests.test.ts
@@ -402,15 +402,16 @@ describe('Downstream service health checks', () => {
       // @ts-ignore for testing purposes, a short pollInterval is ideal so we'll override here
       gateway.experimental_pollInterval = 100;
 
-      // load the gateway as usual
-      await gateway.load({ engine: { apiKeyHash, graphId } });
-      expect(gateway.schema!.getType('User')!.description).toBe('This is my User');
-
       // @ts-ignore for testing purposes, we'll call the original `updateComposition`
-      // function from our mock
+      // function from our mock. The first call should mimic original behavior,
+      // but the second call needs to handle the PromiseRejection. Typically for tests
+      // like these we would leverage the `gateway.onSchemaChange` callback to drive
+      // the test, but in this case, that callback isn't triggered when the update
+      // fails (as expected) so we get creative with the second mock as seen below.
       const original = gateway.updateComposition;
       const mockUpdateComposition = jest
         .fn(original)
+        .mockImplementationOnce(original)
         .mockImplementationOnce(async opts => {
           // mock the first poll and handle the error which would otherwise be caught
           // and logged from within the `pollServices` class method
@@ -427,14 +428,16 @@ describe('Downstream service health checks', () => {
       // function on the gateway with our mock
       gateway.updateComposition = mockUpdateComposition;
 
-      // This kicks off polling within the gateway
-      gateway.onSchemaChange(() => {});
+      // load the gateway as usual
+      await gateway.load({ engine: { apiKeyHash, graphId } });
+
+      expect(gateway.schema!.getType('User')!.description).toBe('This is my User');
 
       await schemaChangeBlocker;
 
       // At this point, the mock update should have been called but the schema
       // should not have updated to the new one.
-      expect(mockUpdateComposition.mock.calls.length).toBe(1);
+      expect(mockUpdateComposition.mock.calls.length).toBe(2);
       expect(gateway.schema!.getType('User')!.description).toBe('This is my User');
     });
   });


### PR DESCRIPTION
This PR separates the coupling of 2 unrelated concepts within the gateway:
* polling for schema changes
* registering schema change listeners

This coupling has been questionable for some time, but has become problematic with changes from the latest release branch `release-2.12.0`. Disentangling them is finally necessary.

Previously, polling would begin once a schema change listener was registered. This operated independently of the initial `gateway.load` call. This means that if you registered a listener before "loading" the gateway, polling would kickoff before the gateway had initialized.

After these changes, load and polling are coupled while schema change listener registration is completely independent of either. This allows a user/consumer to register listeners with no unexpected side effect, and then "load" the gateway and initiate polling when desirable.

Fixes #3976
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
