### PR TITLE
fix: report APQ hit/registration when `sendHeaders` is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- `apollo-engine-reporting`: Fix inadvertant conditional formatting which prevented automated persisted query (APQ) hits and misses from being reported to Apollo Graph Manager. [PR #3986](https://github.com/apollographql/apollo-server/pull/3986)
 
 ### v2.12.0
 

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -101,13 +101,13 @@ export class EngineReportingExtension<TContext = any>
         o.request.headers,
         this.options.sendHeaders,
       );
+    }
 
-      if (o.requestContext.metrics.persistedQueryHit) {
-        this.treeBuilder.trace.persistedQueryHit = true;
-      }
-      if (o.requestContext.metrics.persistedQueryRegister) {
-        this.treeBuilder.trace.persistedQueryRegister = true;
-      }
+    if (o.requestContext.metrics.persistedQueryHit) {
+      this.treeBuilder.trace.persistedQueryHit = true;
+    }
+    if (o.requestContext.metrics.persistedQueryRegister) {
+      this.treeBuilder.trace.persistedQueryRegister = true;
     }
 
     if (o.variables) {


### PR DESCRIPTION
This APQ flag reporting was almost surely a mistake from the past, causing this APQ boolean to not be properly set when the request was, in fact, an APQ request, unless `sendHeaders` was enabled - which it is _not_ by default after the change that released it.

Ref: https://github.com/apollographql/apollo-server/pull/2931/files#diff-24ae042112f9dcc18543ac851c4d8f7cR97-R102

### TODO

- [x] `CHANGELOG.md`