### PR TITLE
chore: Convert `schemaHash` from `string` to a faux-paque type.

### DIFF
--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -12,7 +12,7 @@ import { fetch, RequestAgent, Response } from 'apollo-server-env';
 import retry from 'async-retry';
 
 import { EngineReportingExtension } from './extension';
-import { GraphQLRequestContext, Logger } from 'apollo-server-types';
+import { GraphQLRequestContext, Logger, SchemaHash } from 'apollo-server-types';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { defaultEngineReportingSignature } from 'apollo-graphql';
 
@@ -202,7 +202,7 @@ export interface AddTraceArgs {
   trace: Trace;
   operationName: string;
   queryHash: string;
-  schemaHash: string;
+  schemaHash: SchemaHash;
   queryString?: string;
   documentAST?: DocumentNode;
 }
@@ -278,7 +278,7 @@ export class EngineReportingAgent<TContext = any> {
     handleLegacyOptions(this.options);
   }
 
-  public newExtension(schemaHash: string): EngineReportingExtension<TContext> {
+  public newExtension(schemaHash: SchemaHash): EngineReportingExtension<TContext> {
     return new EngineReportingExtension<TContext>(
       this.options,
       this.addTrace.bind(this),

--- a/packages/apollo-engine-reporting/src/extension.ts
+++ b/packages/apollo-engine-reporting/src/extension.ts
@@ -1,4 +1,9 @@
-import { GraphQLRequestContext, WithRequired, Logger } from 'apollo-server-types';
+import {
+  GraphQLRequestContext,
+  WithRequired,
+  Logger,
+  SchemaHash,
+} from 'apollo-server-types';
 import { Request, Headers } from 'apollo-server-env';
 import {
   GraphQLResolveInfo,
@@ -42,7 +47,7 @@ export class EngineReportingExtension<TContext = any>
   public constructor(
     options: EngineReportingOptions<TContext>,
     addTrace: (args: AddTraceArgs) => Promise<void>,
-    private schemaHash: string,
+    private schemaHash: SchemaHash,
   ) {
     this.options = {
       ...options,

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -69,7 +69,7 @@ import {
 
 import { Headers } from 'apollo-server-env';
 import { buildServiceDefinition } from '@apollographql/apollo-tools';
-import { Logger } from "apollo-server-types";
+import { Logger, SchemaHash } from "apollo-server-types";
 
 const NoIntrospection = (context: ValidationContext) => ({
   Field(node: FieldDefinitionNode) {
@@ -134,7 +134,7 @@ type SchemaDerivedData = {
   // on the same operation to be executed immediately.
   documentStore?: InMemoryLRUCache<DocumentNode>;
   schema: GraphQLSchema;
-  schemaHash: string;
+  schemaHash: SchemaHash;
   extensions: Array<() => GraphQLExtension>;
 };
 

--- a/packages/apollo-server-core/src/utils/schemaHash.ts
+++ b/packages/apollo-server-core/src/utils/schemaHash.ts
@@ -4,8 +4,9 @@ import { getIntrospectionQuery, IntrospectionSchema } from 'graphql/utilities';
 import stableStringify from 'fast-json-stable-stringify';
 import { GraphQLSchema } from 'graphql/type';
 import createSHA from './createSHA';
+import { SchemaHash } from "apollo-server-types";
 
-export function generateSchemaHash(schema: GraphQLSchema): string {
+export function generateSchemaHash(schema: GraphQLSchema): SchemaHash {
   const introspectionQuery = getIntrospectionQuery();
   const documentAST = parse(introspectionQuery);
   const result = execute(schema, documentAST) as ExecutionResult;
@@ -40,5 +41,5 @@ export function generateSchemaHash(schema: GraphQLSchema): string {
 
   return createSHA('sha512')
     .update(stringifiedSchema)
-    .digest('hex');
+    .digest('hex') as SchemaHash;
 }

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -18,10 +18,23 @@ export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
+ // By default, TypeScript uses structural typing (as opposed to nominal typing)
+ // Put another way, if it looks like the type and walks like that type, then
+ // TypeScript lets it be a type.
+ //
+ // That's often okay, but it leaves a lot to be desired since a `string` of one
+ // type can just be passed in as `string` for that type and TypeScript won't
+ // complain.  Flow offers opaque types which solve this, but TypeScript doesn't
+ // offer this (yet?).  This Faux-paque type can be used to gain nominal-esque
+ // typing, which is incredibly beneficial during re-factors!
+ type Fauxpaque<K, T> = K & { __fauxpaque: T };
+
+ export type SchemaHash = Fauxpaque<string, 'SchemaHash'>;
+
 export interface GraphQLServiceContext {
   logger: Logger;
   schema: GraphQLSchema;
-  schemaHash: string;
+  schemaHash: SchemaHash;
   engine: {
     serviceID?: string;
     apiKeyHash?: string;


### PR DESCRIPTION
By default, TypeScript uses structural typing (as opposed to nominal typing) Put another way, if it looks like the type and walks like that type, then TypeScript lets it be a type.

That's often okay, but it leaves a lot to be desired since a `string` of one type can just be passed in as `string` for that type and TypeScript won't complain.  Flow offers opaque types which solve this, but TypeScript doesn't offer this (yet?).  This Faux-paque type can be used to gain nominal-esque typing, which is incredibly beneficial during re-factors!

For the `schemaHash`, in particular, this is very much a string representation that serves a very particular purpose.  Passing it incorrectly somewhere could be problematic, but we can avoid that (particularly as I embark on some re-factoring with it momentarily), by typing it as a more-opaque type prior to refactoring.  Such passing around of strings can be common, for example, in positional parameters of functions: like a function that receives five strings, but a parameter ends up being misaligned with its destination.  With structural typing, it's completely possible to miss that, but `SchemaHash` will _always_ be a `SchemaHash` with this fauxpaque-typing.

Happy to not land this, but I think it provides some value.  Input appreciated!