### PR TITLE
Update Documentation Metric for federation to use ENGINE_SCHEMA_TAG env 

### DIFF
--- a/docs/source/federation/metrics.md
+++ b/docs/source/federation/metrics.md
@@ -20,7 +20,7 @@ Ensure that all dependencies on `apollo-server` are at version `2.7.0` or higher
 
 These options will cause the Apollo gateway to collect tracing information from the underlying federated services and pass them on, along with the query plan, to the Apollo metrics ingress. Currently, only Apollo Server supports detailed metrics insights as an implementing service, but we would love to work with you to implement the protocol in other languages!
 
-> NOTE: By default, metrics will be reported to the `current` variant. To change the variant for reporting, set the `ENGINE_GRAPH_VARIANT` environment variable.
+> NOTE: By default, metrics will be reported to the `current` variant. To change the variant for reporting, set the `ENGINE_SCHEMA_TAG` environment variable.
 
 ## How tracing data is exposed from a federated service
 


### PR DESCRIPTION
I'm currently running two services federated and a gateway. Using `ENGINE_GRAPH_VARIANT` wasn't working for me, to log the metric the Graph Manager.  I look up the source code, and it uses ENGINE_SCHEMA_TAG.

For reference here are the
A search for ENGINE_GRAPH_VARIANT
https://github.com/apollographql/apollo-server/search?q=ENGINE_GRAPH_VARIANT&unscoped_q=ENGINE_GRAPH_VARIANT

and ENGINE_SCHEMA_TAG
https://github.com/apollographql/apollo-server/search?q=ENGINE_SCHEMA_TAG&unscoped_q=ENGINE_SCHEMA_TAG
