### PR TITLE
Fix error in sample code

### DIFF
--- a/docs/source/data/resolvers.mdx
+++ b/docs/source/data/resolvers.mdx
@@ -262,7 +262,7 @@ const typeDefs = gql`
   # A book has a title and author
   type Book {
     title: String!
-    author: [Author!]
+    author: Author!
   }
 
   # An author has a name


### PR DESCRIPTION
This change fixes the error `"Expected Iterable, but did not find one for field \"Book.author\"."`

