### PR TITLE
Collapse nested required fields

### DIFF
--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -931,7 +931,9 @@ describe('buildQueryPlan', () => {
         query {
           topReviews {
             body
-            author
+            author {
+              username
+            }
             product {
               name
               price
@@ -959,7 +961,9 @@ describe('buildQueryPlan', () => {
               }
               fragment __QueryPlanFragment_1__ on Review {
                 body
-                author
+                author {
+                  username
+                }
                 product {
                   ...__QueryPlanFragment_0__
                 }
@@ -1084,7 +1088,9 @@ describe('buildQueryPlan', () => {
           topReviews {
             id
             body
-            author
+            author {
+              username
+            }
           }
         }
       `;
@@ -1105,7 +1111,9 @@ describe('buildQueryPlan', () => {
             fragment __QueryPlanFragment_0__ on Review {
               id
               body
-              author
+              author {
+                username
+              }
             }
           },
         }
@@ -1117,7 +1125,9 @@ describe('buildQueryPlan', () => {
         query {
           reviews: topReviews {
             content: body
-            author
+            author {
+              username
+            }
             product {
               name
               cost: price
@@ -1145,7 +1155,9 @@ describe('buildQueryPlan', () => {
               }
               fragment __QueryPlanFragment_1__ on Review {
                 content: body
-                author
+                author {
+                  username
+                }
                 product {
                   ...__QueryPlanFragment_0__
                 }

--- a/packages/apollo-gateway/src/__tests__/integration/complex-key.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/complex-key.test.ts
@@ -168,7 +168,6 @@ it('works fetches data correctly with complex / nested @key fields', async () =>
                 organization {
                   id
                   __typename
-                  id
                 }
               }
             }

--- a/packages/apollo-gateway/src/__tests__/integration/requires.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/requires.test.ts
@@ -5,6 +5,7 @@ import * as books from '../__fixtures__/schemas/books';
 import * as inventory from '../__fixtures__/schemas/inventory';
 import * as product from '../__fixtures__/schemas/product';
 import * as reviews from '../__fixtures__/schemas/reviews';
+import { serializeQueryPlan } from '../..';
 
 it('supports passing additional fields defined by a requires', async () => {
   const query = gql`
@@ -46,4 +47,140 @@ it('supports passing additional fields defined by a requires', async () => {
   expect(queryPlan).toCallService('reviews');
   expect(queryPlan).toCallService('product');
   expect(queryPlan).toCallService('books');
+});
+
+it('collapses nested requires', async () => {
+  const serviceA = {
+    name: 'a',
+    typeDefs: gql`
+      type Query {
+        user: User
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        preferences: Preferences
+      }
+
+      type Preferences {
+        favorites: Things
+      }
+
+      type Things {
+        color: String
+        animal: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        user() {
+          return {
+            id: '1',
+            preferences: { favorites: { color: 'limegreen', animal: 'platypus' } },
+          };
+        },
+      },
+    },
+  };
+
+  const serviceB = {
+    name: 'b',
+    typeDefs: gql`
+      extend type User @key(fields: "id") {
+        id: ID! @external
+        preferences: Preferences @external
+        favoriteColor: String
+          @requires(fields: "preferences { favorites { color } }")
+        favoriteAnimal: String
+          @requires(fields: "preferences { favorites { animal } }")
+      }
+
+      extend type Preferences {
+        favorites: Things @external
+      }
+
+      extend type Things {
+        color: String @external
+        animal: String @external
+      }
+    `,
+    resolvers: {
+      User: {
+        favoriteColor(user: any) {
+          return user.preferences.favorites.color;
+        },
+        favoriteAnimal(user: any) {
+          return user.preferences.favorites.animal;
+        },
+      },
+    },
+  };
+
+  const query = gql`
+    query UserFavorites {
+      user {
+        favoriteColor
+        favoriteAnimal
+      }
+    }
+  `;
+
+  const { data, errors, queryPlan } = await execute([serviceA, serviceB], {
+    query,
+  });
+
+  expect(errors).toEqual(undefined);
+
+  expect(serializeQueryPlan(queryPlan)).toMatchInlineSnapshot(`
+    "QueryPlan {
+      Sequence {
+        Fetch(service: \\"a\\") {
+          {
+            user {
+              __typename
+              id
+              preferences {
+                favorites {
+                  color
+                  animal
+                }
+              }
+            }
+          }
+        },
+        Flatten(path: \\"user\\") {
+          Fetch(service: \\"b\\") {
+            {
+              ... on User {
+                __typename
+                id
+                preferences {
+                  favorites {
+                    color
+                    animal
+                  }
+                }
+              }
+            } =>
+            {
+              ... on User {
+                favoriteColor
+                favoriteAnimal
+              }
+            }
+          },
+        },
+      },
+    }"
+  `);
+
+  expect(data).toEqual({
+    user: {
+      favoriteAnimal: 'platypus',
+      favoriteColor: 'limegreen',
+    },
+  });
+
+  expect(queryPlan).toCallService('a');
+  expect(queryPlan).toCallService('b');
 });

--- a/packages/apollo-gateway/src/buildQueryPlan.ts
+++ b/packages/apollo-gateway/src/buildQueryPlan.ts
@@ -117,10 +117,10 @@ function executionNodeForGroup(
   }: FetchGroup,
   parentType?: GraphQLCompositeType,
 ): PlanNode {
-  const selectionSet = selectionSetFromFieldSet(fields, parentType);
+  const selectionSet = selectionSetFromFieldSet(fields, context, parentType);
   const requires =
     requiredFields.length > 0
-      ? selectionSetFromFieldSet(requiredFields)
+      ? selectionSetFromFieldSet(requiredFields, context)
       : undefined;
   const variableUsages = context.getVariableUsages(
     selectionSet,
@@ -685,7 +685,7 @@ function completeField(
     parentGroup.otherDependentGroups.push(...subGroup.dependentGroups);
 
     let definition: FragmentDefinitionNode;
-    let selectionSet = selectionSetFromFieldSet(subGroup.fields, returnType);
+    let selectionSet = selectionSetFromFieldSet(subGroup.fields, context, returnType);
 
     if (context.autoFragmentization && subGroup.fields.length > 2) {
       ({ definition, selectionSet } = getInternalFragment(
@@ -1166,6 +1166,13 @@ export class QueryPlanningContext {
     }
 
     return providedFields;
+  }
+
+  getSubFields(
+    parentType: GraphQLCompositeType,
+    field: Field,
+  ): FieldSet {
+    return collectSubfields(this, parentType, [field]);
   }
 }
 


### PR DESCRIPTION
If two `@requires` directives reference the same nested relationship:

```graphql
one: Int @requires(fields: "foo { bar { baz } }")
two: Int @requires(fields: "foo { bar { quux } }")
```
The query plan ends up with two `bar` fields:
```graphql
foo {
  bar {
    baz
  }
  bar {
    quux
  }
}
```
This ends up with "last-one-wins" semantics, meaning that `foo.bar.baz` is dropped and the value sent to the dependent service is null.