### PR TITLE
Move @types dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5485,6 +5485,15 @@
         }
       }
     },
+    "@types/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5517,6 +5517,15 @@
       "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==",
       "dev": true
     },
+    "@types/fs-capacitor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
+      "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -5526,6 +5535,18 @@
         "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/graphql-upload": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
+      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/fs-capacitor": "*",
+        "@types/koa": "*",
+        "graphql": "^14.5.3"
       }
     },
     "@types/hapi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       "version": "file:packages/apollo-gateway",
       "requires": {
         "@apollo/federation": "file:packages/apollo-federation",
-        "@types/node-fetch": "2.5.4",
         "apollo-engine-reporting-protobuf": "file:packages/apollo-engine-reporting-protobuf",
         "apollo-env": "^0.6.1",
         "apollo-graphql": "^0.4.0",
@@ -5342,6 +5341,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       },
@@ -5349,7 +5349,8 @@
         "@types/node": {
           "version": "11.11.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
+          "dev": true
         }
       }
     },
@@ -5365,7 +5366,8 @@
     "@types/aws-lambda": {
       "version": "8.10.50",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.50.tgz",
-      "integrity": "sha512-RDzmQ5mO1f0BViKiuOudENZmoCACEa461nTRVtxhsAiEqGCgwdhCYN0aFgk42X5+ELAiqJKbv2mK0LkopYRYQg=="
+      "integrity": "sha512-RDzmQ5mO1f0BViKiuOudENZmoCACEa461nTRVtxhsAiEqGCgwdhCYN0aFgk42X5+ELAiqJKbv2mK0LkopYRYQg==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.7",
@@ -5467,6 +5469,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.1.tgz",
       "integrity": "sha512-ku6IvbucEyuC6i4zAVK/KnuzWNXdbFd1HkXlNLg/zhWDGTtQT5VhumiPruB/BHW34PWVFwyfwGftDQHfWNxu3Q==",
+      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -5477,16 +5480,9 @@
         "@types/node": {
           "version": "11.11.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
+          "dev": true
         }
-      }
-    },
-    "@types/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
-      "requires": {
-        "@types/express": "*"
       }
     },
     "@types/events": {
@@ -5499,6 +5495,7 @@
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
       "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -5520,14 +5517,6 @@
       "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==",
       "dev": true
     },
-    "@types/fs-capacitor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz",
-      "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -5537,17 +5526,6 @@
         "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
-      }
-    },
-    "@types/graphql-upload": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
-      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
-      "requires": {
-        "@types/express": "*",
-        "@types/fs-capacitor": "*",
-        "@types/koa": "*",
-        "graphql": "^14.5.3"
       }
     },
     "@types/hapi": {
@@ -5569,7 +5547,8 @@
     "@types/http-assert": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.4.0.tgz",
-      "integrity": "sha512-TZDqvFW4nQwL9DVSNJIJu4lPLttKgzRF58COa7Vs42Ki/MrhIqUbeIw0MWn4kGLiZLXB7oCBibm7nkSjPkzfKQ=="
+      "integrity": "sha512-TZDqvFW4nQwL9DVSNJIJu4lPLttKgzRF58COa7Vs42Ki/MrhIqUbeIw0MWn4kGLiZLXB7oCBibm7nkSjPkzfKQ==",
+      "dev": true
     },
     "@types/ioredis": {
       "version": "4.14.9",
@@ -5742,12 +5721,14 @@
     "@types/keygrip": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
-      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg="
+      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg=",
+      "dev": true
     },
     "@types/koa": {
       "version": "2.0.48",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.48.tgz",
       "integrity": "sha512-CiIUYhHlOFJhSCTmsFoFkV2t9ij1JwW26nt0W9XZoWTvmAw6zTE0+k3IAoGICtjzIfhZpZcO323NHmI1LGmdDw==",
+      "dev": true,
       "requires": {
         "@types/accepts": "*",
         "@types/cookies": "*",
@@ -5760,22 +5741,16 @@
         "@types/node": {
           "version": "11.11.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
+          "dev": true
         }
-      }
-    },
-    "@types/koa-bodyparser": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
-      "integrity": "sha512-aB/vwwq4G9FAtKzqZ2p8UHTscXxZvICFKVjuckqxCtkX1Ro7F5KHkTCUqTRZFBgDoEkmeca+bFLI1bIsdPPZTA==",
-      "requires": {
-        "@types/koa": "*"
       }
     },
     "@types/koa-compose": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.3.tgz",
       "integrity": "sha512-kXvR0DPyZ3gaFxZs4WycA8lpzlPGtFmwdbgce+NWd+TG3PycPO3o5FkePH60HoBPd8BBaSiw3vhtgM42O2kQcg==",
+      "dev": true,
       "requires": {
         "@types/koa": "*"
       }
@@ -5785,14 +5760,6 @@
       "resolved": "https://registry.npmjs.org/@types/koa-router/-/koa-router-7.4.0.tgz",
       "integrity": "sha512-CkNyhGOCJ6rpBEG0rlSQhwHsHNwMzGLE49tV3jE5f0TvMzy/SmoCAIlHWdOLs8Mro+BqtKFH6e/lDaibWkydag==",
       "dev": true,
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/koa__cors": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-2.2.3.tgz",
-      "integrity": "sha512-RfG2EuSc+nv/E+xbDSLW8KCoeri/3AkqwVPuENfF/DctllRoXhooboO//Sw7yFtkLvj7nG7O1H3JcZmoTQz8nQ==",
       "requires": {
         "@types/koa": "*"
       }
@@ -6033,6 +6000,7 @@
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
       "integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -6410,8 +6378,6 @@
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
-        "@types/graphql-upload": "^8.0.0",
-        "@types/ws": "^7.0.0",
         "apollo-cache-control": "file:packages/apollo-cache-control",
         "apollo-datasource": "file:packages/apollo-datasource",
         "apollo-engine-reporting": "file:packages/apollo-engine-reporting",
@@ -6453,10 +6419,6 @@
       "version": "file:packages/apollo-server-express",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
-        "@types/accepts": "^1.3.5",
-        "@types/body-parser": "1.19.0",
-        "@types/cors": "^2.8.4",
-        "@types/express": "4.17.4",
         "accepts": "^1.3.5",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-types": "file:packages/apollo-server-types",
@@ -6543,12 +6505,6 @@
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@koa/cors": "^2.2.1",
-        "@types/accepts": "^1.3.5",
-        "@types/cors": "^2.8.4",
-        "@types/koa": "^2.0.46",
-        "@types/koa-bodyparser": "^4.2.1",
-        "@types/koa-compose": "^3.2.2",
-        "@types/koa__cors": "^2.2.1",
         "accepts": "^1.3.5",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-types": "file:packages/apollo-server-types",
@@ -6565,7 +6521,6 @@
       "version": "file:packages/apollo-server-lambda",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
-        "@types/aws-lambda": "^8.10.31",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-env": "file:packages/apollo-server-env",
         "apollo-server-types": "file:packages/apollo-server-types",
@@ -10405,6 +10360,7 @@
       "version": "14.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
       "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
+      "dev": true,
       "requires": {
         "iterall": "^1.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/bunyan": "1.8.6",
     "@types/connect": "3.4.33",
     "@types/fast-json-stable-stringify": "2.0.0",
+    "@types/graphql-upload": "^8.0.3",
     "@types/hapi": "17.8.7",
     "@types/ioredis": "4.14.9",
     "@types/jest": "25.2.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/body-parser": "1.19.0",
     "@types/bunyan": "1.8.6",
     "@types/connect": "3.4.33",
+    "@types/cors": "^2.8.4",
     "@types/fast-json-stable-stringify": "2.0.0",
     "@types/graphql-upload": "^8.0.3",
     "@types/hapi": "17.8.7",

--- a/packages/apollo-gateway/package.json
+++ b/packages/apollo-gateway/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@apollo/federation": "file:../apollo-federation",
-    "@types/node-fetch": "2.5.4",
     "apollo-engine-reporting-protobuf": "file:../apollo-engine-reporting-protobuf",
     "apollo-env": "^0.6.1",
     "apollo-graphql": "^0.4.0",
@@ -33,6 +32,9 @@
     "loglevel": "^1.6.1",
     "make-fetch-happen": "^8.0.0",
     "pretty-format": "^25.0.0"
+  },
+  "devDependencies": {
+    "@types/node-fetch": "2.5.4"
   },
   "peerDependencies": {
     "graphql": "^14.2.1 || ^15.0.0"

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -26,8 +26,6 @@
   "dependencies": {
     "@apollographql/apollo-tools": "^0.4.3",
     "@apollographql/graphql-playground-html": "1.6.24",
-    "@types/graphql-upload": "^8.0.0",
-    "@types/ws": "^7.0.0",
     "apollo-cache-control": "file:../apollo-cache-control",
     "apollo-datasource": "file:../apollo-datasource",
     "apollo-engine-reporting": "file:../apollo-engine-reporting",
@@ -46,6 +44,10 @@
     "sha.js": "^2.4.11",
     "subscriptions-transport-ws": "^0.9.11",
     "ws": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/graphql-upload": "^8.0.0",
+    "@types/ws": "^7.0.0"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -27,10 +27,6 @@
   },
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.24",
-    "@types/accepts": "^1.3.5",
-    "@types/body-parser": "1.19.0",
-    "@types/cors": "^2.8.4",
-    "@types/express": "4.17.4",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
@@ -44,6 +40,10 @@
     "type-is": "^1.6.16"
   },
   "devDependencies": {
+    "@types/accepts": "^1.3.5",
+    "@types/body-parser": "1.19.0",
+    "@types/cors": "^2.8.4",
+    "@types/express": "4.17.4",
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -27,12 +27,6 @@
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.24",
     "@koa/cors": "^2.2.1",
-    "@types/accepts": "^1.3.5",
-    "@types/cors": "^2.8.4",
-    "@types/koa": "^2.0.46",
-    "@types/koa-bodyparser": "^4.2.1",
-    "@types/koa-compose": "^3.2.2",
-    "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
@@ -45,6 +39,12 @@
     "type-is": "^1.6.16"
   },
   "devDependencies": {
+    "@types/accepts": "^1.3.5",
+    "@types/cors": "^2.8.4",
+    "@types/koa": "^2.0.46",
+    "@types/koa-bodyparser": "^4.2.1",
+    "@types/koa-compose": "^3.2.2",
+    "@types/koa__cors": "^2.2.1",
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -26,14 +26,14 @@
   },
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.24",
-    "@types/aws-lambda": "^8.10.31",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-env": "file:../apollo-server-env",
     "apollo-server-types": "file:../apollo-server-types",
     "graphql-tools": "^4.0.0"
   },
   "devDependencies": {
-    "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
+    "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
+    "@types/aws-lambda": "^8.10.31"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"


### PR DESCRIPTION
All `@types` dependencies should be dev dependencies unless they're re-exported, which doesn't seem to be the case afaict. This ensures that production bundles don't include these unnecessary packages. 

In a very simple AWS Lambda that only imports `apollo-server-lambda` and `graphql` I reduced the size of the zip bundle from 6.2 MB to 5.2 MB just by explicitly excluding `node_modules/@types/**` in the `serverless.yml` file, which would have happened automatically if these packages were marked as dev dependencies.

I opened issue #4020 about this.