### PR TITLE
feat(gateway): support alternate query plan cache implementations

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Cache stringified representations of downstream query bodies within the query plan to address performance implications incurred by repeatedly `print`ing the same`DocumentNode`s with the `graphql` printer.  This improvement is more pronounced on larger documents.  [PR #4018](https://github.com/apollographql/apollo-server/pull/4018)
 - Add inadvertently excluded `apollo-server-errors` runtime dependency. [#3927](https://github.com/apollographql/apollo-server/pull/3927)
+- Support alternate query plan cache implementations via config. [#4026](https://github.com/apollographql/apollo-server/pull/4026)
 
 ## 0.14.1
 

--- a/packages/apollo-gateway/src/__tests__/gateway/queryPlanCache.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/queryPlanCache.test.ts
@@ -2,10 +2,9 @@ import gql from 'graphql-tag';
 import { createTestClient } from 'apollo-server-testing';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 import { buildFederatedSchema } from '@apollo/federation';
-import { TestableKeyValueCache } from 'apollo-server-caching';
 
 import { LocalGraphQLDataSource } from '../../datasources/LocalGraphQLDataSource';
-import { ApolloGateway, QueryPlan } from '../../';
+import { ApolloGateway, QueryPlan, QueryPlanCache } from '../../';
 
 import * as accounts from '../__fixtures__/schemas/accounts';
 import * as books from '../__fixtures__/schemas/books';
@@ -115,7 +114,7 @@ it('supports alternative cache implementations via config', async () => {
   const get = jest.fn((key) => Promise.resolve(cache[key]));
   const set = jest.fn((key, value) => (cache[key] = value));
 
-  const mockCache: TestableKeyValueCache<QueryPlan> = {
+  const mockCache: QueryPlanCache = {
     get,
     set,
     async delete() {},

--- a/packages/apollo-gateway/src/__tests__/gateway/queryPlanCache.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/queryPlanCache.test.ts
@@ -2,9 +2,10 @@ import gql from 'graphql-tag';
 import { createTestClient } from 'apollo-server-testing';
 import { ApolloServerBase as ApolloServer } from 'apollo-server-core';
 import { buildFederatedSchema } from '@apollo/federation';
+import { TestableKeyValueCache } from 'apollo-server-caching';
 
 import { LocalGraphQLDataSource } from '../../datasources/LocalGraphQLDataSource';
-import { ApolloGateway } from '../../';
+import { ApolloGateway, QueryPlan } from '../../';
 
 import * as accounts from '../__fixtures__/schemas/accounts';
 import * as books from '../__fixtures__/schemas/books';
@@ -20,7 +21,7 @@ it('caches the query plan for a request', async () => {
 
   const gateway = new ApolloGateway({
     localServiceList: [accounts, books, inventory, product, reviews],
-    buildService: service => {
+    buildService: (service) => {
       return new LocalGraphQLDataSource(buildFederatedSchema([service]));
     },
   });
@@ -76,7 +77,7 @@ it('supports multiple operations and operationName', async () => {
 
   const gateway = new ApolloGateway({
     localServiceList: [accounts, books, inventory, product, reviews],
-    buildService: service => {
+    buildService: (service) => {
       return new LocalGraphQLDataSource(buildFederatedSchema([service]));
     },
   });
@@ -107,4 +108,68 @@ it('supports multiple operations and operationName', async () => {
       { body: 'Wish I had read this before.' },
     ],
   });
+});
+
+it('supports alternative cache implementations via config', async () => {
+  const cache: Record<string, QueryPlan> = {};
+  const get = jest.fn((key) => Promise.resolve(cache[key]));
+  const set = jest.fn((key, value) => (cache[key] = value));
+
+  const mockCache: TestableKeyValueCache<QueryPlan> = {
+    get,
+    set,
+    async delete() {},
+    async flush() {},
+  };
+
+  const planner = require('../../buildQueryPlan');
+  const originalPlanner = planner.buildQueryPlan;
+
+  planner.buildQueryPlan = jest.fn(originalPlanner);
+
+  const server = new ApolloServer({
+    gateway: new ApolloGateway({
+      localServiceList: [accounts, books, inventory, product, reviews],
+      buildService: (service) => {
+        return new LocalGraphQLDataSource(buildFederatedSchema([service]));
+      },
+      queryPlanStore: mockCache,
+    }),
+    subscriptions: false,
+  });
+
+  const upc = '1';
+  const call = createTestClient(server);
+
+  const query = gql`
+    query GetProduct($upc: String!) {
+      product(upc: $upc) {
+        name
+      }
+    }
+  `;
+
+  const result = await call.query({
+    query,
+    variables: { upc },
+  });
+
+  expect(result.data).toEqual({
+    product: {
+      name: 'Table',
+    },
+  });
+
+  const secondResult = await call.query({
+    query,
+    variables: { upc },
+  });
+
+  expect(result.data).toEqual(secondResult.data);
+  expect(planner.buildQueryPlan).toHaveBeenCalledTimes(1);
+
+  const expectedQueryPlanHash = 'e89c7a5f097af1a09d856ff0a7f6d7644967d13cb43b8f5eae6f9f3c9eada390'
+  expect(mockCache.get).toHaveBeenCalledWith(expectedQueryPlanHash);
+  expect(mockCache.get).toHaveBeenCalledTimes(2);
+  expect(await mockCache.get(expectedQueryPlanHash)).toBeTruthy();
 });

--- a/packages/apollo-server-caching/src/SerialMultiCache.ts
+++ b/packages/apollo-server-caching/src/SerialMultiCache.ts
@@ -1,0 +1,66 @@
+import {
+  TestableKeyValueCache,
+  KeyValueCacheSetOptions,
+} from './KeyValueCache';
+
+/**
+ * The SerialMultiCache class's purpose is to support a number of cache implementations
+ * with fallback behavior. The order of the provided `caches` argument is important - it
+ * determines the order in which the multicache will look, with the zero index being first
+ * and so on. A good application of this multicache might be, for example, an
+ * `InMemoryCache` followed by a `RedisCache`. Expected behavior of the multicache:
+ *   1. `get()` will look to the first cache, then second, etc. until it finds a result.
+ *       Upon a cache hit, all previous caches that missed will be populated with the
+ *       result.
+ *   2. `set()` will populate all caches with the provided value.
+ *   3. `delete()` will clear the entry from all caches.
+ *   4. `flush()` will call `flush()` on each cache if the function is implemented.
+ *   5. `close()` will call `close()` on each cache if the function is implemented.
+ */
+export class SerialMultiCache<T = string> implements TestableKeyValueCache<T> {
+  constructor(private caches: TestableKeyValueCache<T>[]) {}
+
+  async get(key: string) {
+    let foundIndex = 0;
+    let result: T | undefined;
+    for (const cache of this.caches) {
+      result = await cache.get(key);
+      // cache hit, we don't need to look any further in our array of caches
+      if (typeof result !== 'undefined') break;
+      foundIndex++;
+    }
+
+    // Populate the cache misses with the result
+    if (result) {
+      for (let i = 0; i < foundIndex; i++) {
+        this.caches[i].set(key, result);
+      }
+    }
+
+    return result;
+  }
+
+  async set(key: string, value: T, options?: KeyValueCacheSetOptions) {
+    for (const cache of this.caches) {
+      cache.set(key, value, options);
+    }
+  }
+
+  async delete(key: string) {
+    for (const cache of this.caches) {
+      cache.delete(key);
+    }
+  }
+
+  async flush() {
+    for (const cache of this.caches) {
+      cache.flush?.();
+    }
+  }
+
+  async close() {
+    for (const cache of this.caches) {
+      cache.close?.();
+    }
+  }
+}

--- a/packages/apollo-server-caching/src/__tests__/SerialMultiCache.test.ts
+++ b/packages/apollo-server-caching/src/__tests__/SerialMultiCache.test.ts
@@ -1,0 +1,89 @@
+import { SerialMultiCache } from '../SerialMultiCache';
+import { KeyValueCache } from '../KeyValueCache';
+
+function getMockCache(
+  cache: Record<string, number> = {},
+): KeyValueCache<number> {
+  const get = jest.fn(async (key: string) => cache[key]);
+  const set = jest.fn(async (key: string, value: number) => {
+    cache[key] = value;
+  });
+  const del = jest.fn(async (key: string) => delete cache[key]);
+
+  return { get, set, delete: del };
+}
+
+let multiCache: SerialMultiCache<number>;
+let tier0: KeyValueCache<number>;
+let tier1: KeyValueCache<number>;
+let tier2: KeyValueCache<number>;
+
+beforeEach(() => {
+  tier0 = getMockCache({ zero: 0 });
+  tier1 = getMockCache({ one: 1 });
+  tier2 = getMockCache({ two: 2 });
+
+  multiCache = new SerialMultiCache([tier0, tier1, tier2]);
+});
+
+describe('SerialMultiCache', () => {
+  describe('get', () => {
+    it("returns cached value on first cache hit, doesn't look further (hit tier0)", async () => {
+      const result = await multiCache.get('zero');
+
+      expect(result).toEqual(0);
+      expect(tier0.get).toHaveBeenCalled();
+      expect(tier1.get).not.toHaveBeenCalled();
+    });
+
+    it("returns cached value on first cache hit, doesn't look further (hit tier1)", async () => {
+      const result = await multiCache.get('one');
+
+      // expect a call up the chain until a hit
+      expect(tier0.get).toHaveBeenCalled();
+      expect(tier1.get).toHaveBeenCalled();
+      expect(tier2.get).not.toHaveBeenCalled();
+
+      expect(result).toEqual(1);
+
+      // expect lower tiers to have been populated with the result
+      expect(tier0.set).toHaveBeenCalledWith('one', 1);
+      expect(await tier0.get('one')).toEqual(1);
+    });
+
+    it('returns cached value from tier2 cache and populates tier0 and tier1', async () => {
+      const result = await multiCache.get('two');
+
+      // expect a call up the chain until a hit
+      expect(tier0.get).toHaveBeenCalled();
+      expect(tier1.get).toHaveBeenCalled();
+      expect(tier2.get).toHaveBeenCalled();
+
+      expect(result).toEqual(2);
+
+      // expect lower tiers to have been populated with the result
+      expect(tier0.set).toHaveBeenCalledWith('two', 2);
+      expect(tier1.set).toHaveBeenCalledWith('two', 2);
+      expect(await tier0.get('two')).toEqual(2);
+      expect(await tier1.get('two')).toEqual(2);
+    });
+  });
+
+  it('sets a cached value on all tiers', async () => {
+    multiCache.set('three', 3);
+
+    expect(await tier0.get('three')).toEqual(3);
+    expect(await tier1.get('three')).toEqual(3);
+    expect(await tier2.get('three')).toEqual(3);
+  });
+
+  it('deletes a cached value from all tiers', async () => {
+    // populate all caches with the 'two' entry
+    const result = await multiCache.get('two');
+    expect(result).toEqual(2);
+
+    multiCache.delete('two');
+
+    expect(await multiCache.get('two')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This commit allows the user to specify their own cache to be used by the gateway for query plan caching. One intended use case, for example, is a distributed cache to be shared among a number of gateways.

For distributed cache implementations, you may find these packages useful!
* [Redis](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-cache-redis)
* [Memcached](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-cache-memcached)

A user provided cache must implement the `QueryPlanCache` interface, which can be seen [here](https://github.com/apollographql/apollo-server/pull/4026/files#diff-7b5e66976a637efc823826a985fa8e65R163-R167) within the PR for reference.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
