### PR TITLE
Upgrade graphql-upload to support Node.js v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,11 @@ jobs:
     steps:
       - common_test_steps
 
+  NodeJS 14:
+    executor: { name: oss/node, tag: '14' }
+    steps:
+      - common_test_steps
+
 # XXX We used to use this filter to only run a "Docs" job on docs branches.
 #     Now we use it to disable all jobs. It's unclear if there's a simpler way
 #     to do this!
@@ -100,6 +105,8 @@ workflows:
           <<: *common_non_publish_filters
       - NodeJS 12:
           <<: *common_non_publish_filters
+      - NodeJS 14:
+          <<: *common_non_publish_filters
       - oss/lerna_tarballs:
           name: Package tarballs
           <<: *common_non_publish_filters
@@ -108,6 +115,7 @@ workflows:
             - NodeJS 8
             - NodeJS 10
             - NodeJS 12
+            - NodeJS 14
       - oss/dry_run:
           name: Dry-run
           <<: *common_publish_filters
@@ -116,6 +124,7 @@ workflows:
             - NodeJS 8
             - NodeJS 10
             - NodeJS 12
+            - NodeJS 14
       - oss/confirmation:
           name: Confirmation
           type: approval

--- a/package-lock.json
+++ b/package-lock.json
@@ -6425,13 +6425,52 @@
         "graphql-extensions": "file:packages/graphql-extensions",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
-        "graphql-upload": "^8.0.2",
+        "graphql-upload": "^11.0.0",
         "loglevel": "^1.6.7",
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "ws": "^6.0.0"
       },
       "dependencies": {
+        "fs-capacitor": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.1.0.tgz",
+          "integrity": "sha512-YsKGCLAB40P3OKeciIa7cKzt7WkY8QT9ETa2wVIG3fQDHW2h3xtRo0770lUIbPrjCr5Sa+zFhixNJ+2xNxaraQ=="
+        },
+        "graphql-upload": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-10.0.0.tgz",
+          "integrity": "sha512-8n11qujsqHWT48visvQbqLqAj8o6NCLJ35tGkI/RynhDs7E07TxlswVe4vPZaLiXJeemZA7xrxkMohwP//DOqA==",
+          "requires": {
+            "busboy": "^0.3.1",
+            "fs-capacitor": "^6.1.0",
+            "http-errors": "^1.7.3",
+            "isobject": "^4.0.0",
+            "object-path": "^0.11.4"
+          }
+        },
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
         "loglevel": {
           "version": "1.6.7",
           "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
@@ -9759,11 +9798,6 @@
         }
       }
     },
-    "fs-capacitor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
-      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
-    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -10440,17 +10474,6 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      }
-    },
-    "graphql-upload": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.7.tgz",
-      "integrity": "sha512-gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==",
-      "requires": {
-        "busboy": "^0.3.1",
-        "fs-capacitor": "^2.0.4",
-        "http-errors": "^1.7.2",
-        "object-path": "^0.11.4"
       }
     },
     "growly": {

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -41,7 +41,7 @@
     "graphql-extensions": "file:../graphql-extensions",
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^4.0.0",
-    "graphql-upload": "^8.0.2",
+    "graphql-upload": "^11.0.0",
     "loglevel": "^1.6.7",
     "sha.js": "^2.4.11",
     "subscriptions-transport-ws": "^0.9.11",

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -508,7 +508,9 @@ describe('apollo-server-express', () => {
               },
               Mutation: {
                 singleUpload: async (_, args) => {
-                  expect((await args.file).stream).toBeDefined();
+                  const stream = (await args.file).createReadStream();
+                  expect(stream).toBeDefined();
+                  stream.destroy();
                   return args.file;
                 },
               },

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -429,7 +429,9 @@ describe('apollo-server-fastify', () => {
               },
               Mutation: {
                 singleUpload: async (_, args) => {
-                  expect((await args.file).stream).toBeDefined();
+                  const stream = (await args.file).createReadStream();
+                  expect(stream).toBeDefined();
+                  stream.destroy();
                   return args.file;
                 },
               },

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -432,7 +432,9 @@ const port = 0;
               },
               Mutation: {
                 singleUpload: async (_, args) => {
-                  expect((await args.file).stream).toBeDefined();
+                  const stream = (await args.file).createReadStream();
+                  expect(stream).toBeDefined();
+                  stream.destroy();
                   return args.file;
                 },
               },

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -370,7 +370,9 @@ const resolvers = {
               },
               Mutation: {
                 singleUpload: async (_, args) => {
-                  expect((await args.file).stream).toBeDefined();
+                  const stream = (await args.file).createReadStream();
+                  expect(stream).toBeDefined();
+                  stream.destroy();
                   return args.file;
                 },
               },

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -175,7 +175,9 @@ describe('apollo-server-micro', function() {
               },
               Mutation: {
                 singleUpload: async (_, args) => {
-                  expect((await args.file).stream).toBeDefined();
+                  const stream = (await args.file).createReadStream();
+                  expect(stream).toBeDefined();
+                  stream.destroy();
                   return args.file;
                 },
               },


### PR DESCRIPTION
Hi there!
I've updated `graphql-upload` to v10 to support Node.js v14. The documentation(docs/source/data/file-uploads.md) has already been updated to call `createReadStream`, but test codes ware still accessing the stream property, so I've updated the test codes.

fix #3508 and fix #3579
