### PR TITLE
fix for #3961

### DIFF
--- a/packages/apollo-server-env/package.json
+++ b/packages/apollo-server-env/package.json
@@ -15,7 +15,7 @@
   "browser": "dist/index.browser.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "git clean -fdX -- dist",
     "compile": "tsc && cp src/*.d.ts dist",
     "prepare": "npm run clean && npm run compile"
   },


### PR DESCRIPTION
Here is a fix for an #3961 issue, instead of unix based `rm` we gonna use git build in clean functionality which is already used in a root package.json

check:

```bash
cd packages\apollo-server-env

git clean -ndX
# Would remove dist/
# Would remove node_modules/

git clean -ndX -- dist
# Would remove dist/

git clean -fdX -- dist
Removing dist/
```

where:

- `-n` - used to check what will be deleted
- `-f` - used to actually perform deletion
- `-- dist` - used to define place from where to start
