### PR TITLE
feat(core): refactored invokeDidStartHook to accept async resolvig hooks/events

### DIFF
--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -51,7 +51,7 @@ export interface GraphQLRequestListener<TContext = Record<string, any>> {
   ): ((err?: Error) => void) | void;
   validationDidStart?(
     requestContext: GraphQLRequestContextValidationDidStart<TContext>,
-  ): ((err?: ReadonlyArray<Error>) => void) | void;
+  ): ValueOrPromise<((err?: ReadonlyArray<Error>) => void) | void>;
   didResolveOperation?(
     requestContext: GraphQLRequestContextDidResolveOperation<TContext>,
   ): ValueOrPromise<void>;


### PR DESCRIPTION
This commit intends to extend `validationDidStart` event API to allow for asynchronous execution (and therefore `didEnd` resolving).

This is related to #4049

The main goal is to allow for more complex operation validation that might depend on external service consumption.