### PR TITLE
feat(core): refactored requestDidStart event to be possibly asynchronous

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -126,7 +126,7 @@ export async function processGraphQLRequest<TContext>(
   const extensionStack = initializeExtensionStack();
   (requestContext.context as any)._extensionStack = extensionStack;
 
-  const dispatcher = initializeRequestListenerDispatcher();
+  const dispatcher = await initializeRequestListenerDispatcher();
 
   await initializeDataSources();
 
@@ -568,14 +568,14 @@ export async function processGraphQLRequest<TContext>(
     });
   }
 
-  function initializeRequestListenerDispatcher(): Dispatcher<
-    GraphQLRequestListener
+  async function initializeRequestListenerDispatcher(): Promise<
+    Dispatcher<GraphQLRequestListener>
   > {
     const requestListeners: GraphQLRequestListener<TContext>[] = [];
     if (config.plugins) {
       for (const plugin of config.plugins) {
         if (!plugin.requestDidStart) continue;
-        const listener = plugin.requestDidStart(requestContext);
+        const listener = await plugin.requestDidStart(requestContext);
         if (listener) {
           requestListeners.push(listener);
         }

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -42,7 +42,7 @@ export interface ApolloServerPlugin<TContext extends Record<string, any> = Recor
   serverWillStart?(service: GraphQLServiceContext): ValueOrPromise<void>;
   requestDidStart?(
     requestContext: GraphQLRequestContext<TContext>,
-  ): GraphQLRequestListener<TContext> | void;
+  ): ValueOrPromise<GraphQLRequestListener<TContext> | void>;
 }
 
 export interface GraphQLRequestListener<TContext = Record<string, any>> {


### PR DESCRIPTION
This commit intends to extend requestDidStart event API to allow for asynchronous execution.

This is related to #4050

The main goal is to allow for more complex plugin setup based on external (possibly async) service consumptions.