### PR TITLE
fix(gateway): Correctly handle unions with nested conditions that have no `possibleTypes`

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __FIX__: Correctly handle unions with nested conditions that have no `possibleTypes` [#4071](https://github.com/apollographql/apollo-server/pull/4071)
 
 ## 0.15.0
 


### PR DESCRIPTION
## Problem

The nested `for` loops within `splitFields` that utilize `groupByResponseName` and `groupByParentType` make a false assumption that the incoming fields are all valid. In this case, an "invalid" field is one with no `possibleTypes`.

In its current state, the `splitFields` function can consume an invalid field, leaving other valid, similarly-grouped fields ignored (only one will be taken). If an invalid field is consumed, the others will be ignored and the invalid field will subsequently be dropped, meaning the valid field is never represented due to the existence of an invalid field.

## Solution

A field with no `possibleTypes` can be dropped / ignored from the query since the requested field exists within an impossible condition. Thus, we can skip the `collectFields` step altogether for fields which have no `possibleTypes`. The effect of skipping this step is that invalid fields are no longer represented within the `splitFields` function, thereby resolving the issue.

Fixes #3983

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
