### PR TITLE
feat(plugins): Intro. `didResolveSource` to indicate availability of "source".

### DIFF
--- a/docs/source/integrations/plugins.md
+++ b/docs/source/integrations/plugins.md
@@ -121,17 +121,18 @@ The following diagram illustrates the sequence of events that fire for each requ
 
 ```mermaid
 graph TB;
-  request(requestDidStart) --> parsing(parsingDidStart*);
+  request(requestDidStart) --> resolveSource(didResolveSource);
+  resolveSource --"Success"--> parsing(parsingDidStart*);
   parsing --"Success"--> validation(validationDidStart*);
-  validation --"Success"--> resolve(didResolveOperation);
-  resolve --"Success"--> response(responseForOperation);
+  validation --"Success"--> resolveOperation(didResolveOperation);
+  resolveOperation --"Success"--> response(responseForOperation);
   execution(executionDidStart*);
   errors(didEncounterErrors);
   response --"Response provided"--> send;
   response --"No response provided"--> execution;
   execution --"Success"--> send(willSendResponse);
 
-  execution & resolve & parsing & validation --"Failure"--> errors;
+  execution & resolveSource & resolveOperation & parsing & validation --"Failure"--> errors;
   errors --> send;
   class server,request secondary;
 ```

--- a/docs/source/integrations/plugins.md
+++ b/docs/source/integrations/plugins.md
@@ -313,6 +313,23 @@ should not return a value.
 
 > If you're using TypeScript to create your plugin, implement the [ `GraphQLRequestListener` interface](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-plugin-base/src/index.ts) from the `apollo-server-plugin-base` module to define functions for request lifecycle events.
 
+### `didResolveSource`
+
+The `didResolveSource` event is invoked after Apollo Server has determined the
+`String`-representation of the incoming operation that it will act upon.  In the
+event that this `String` was not directly passed in from the client, this
+may be retrieved from a cache store (e.g., Automated Persisted Queries).
+
+At this stage, there is not a guarantee that the operation is not malformed.
+
+```typescript
+didResolveSource?(
+  requestContext: WithRequired<
+    GraphQLRequestContext<TContext>, 'source' | 'logger'>,
+  >,
+): ValueOrPromise<void>;
+```
+
 ### `parsingDidStart`
 
 The `parsingDidStart` event fires whenever Apollo Server will parse a GraphQL

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -479,6 +479,30 @@ describe('runQuery', () => {
       });
     });
 
+    describe('didResolveSource', () => {
+      const didResolveSource = jest.fn();
+      it('called with the source', async () => {
+        await runQuery({
+          schema,
+          queryString: '{ testString }',
+          plugins: [
+            {
+              requestDidStart() {
+                return {
+                  didResolveSource,
+                };
+              },
+            },
+          ],
+          request: new MockReq(),
+        });
+
+        expect(didResolveSource).toHaveBeenCalled();
+        expect(didResolveSource.mock.calls[0][0])
+          .toHaveProperty('source', '{ testString }');
+      });
+    });
+
     describe('parsingDidStart', () => {
       const parsingDidStart = jest.fn();
       it('called when parsing will result in an error', async () => {
@@ -882,6 +906,9 @@ describe('runQuery', () => {
             return validationDidEnd;
           });
 
+        const didResolveSource: GraphQLRequestListener['didResolveSource'] =
+          jest.fn(() => { callOrder.push('didResolveSource') });
+
         const didResolveField: GraphQLRequestListenerDidResolveField =
           jest.fn(() => callOrder.push("didResolveField"));
 
@@ -928,6 +955,7 @@ describe('runQuery', () => {
                 return {
                   parsingDidStart,
                   validationDidStart,
+                  didResolveSource,
                   executionDidStart,
                 };
               },
@@ -944,6 +972,7 @@ describe('runQuery', () => {
         expect(willResolveField).toHaveBeenCalledTimes(1);
         expect(didResolveField).toHaveBeenCalledTimes(1);
         expect(callOrder).toStrictEqual([
+          "didResolveSource",
           "parsingDidStart",
           "parsingDidEnd",
           "validationDidStart",

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -479,6 +479,15 @@ describe('runQuery', () => {
       });
     });
 
+    /**
+     * This tests the simple invocation of the "didResolveSource" hook, but
+     * doesn't test one of the primary reasons why "source" isn't guaranteed
+     * sooner in the request life-cycle: when "source" is populated via an APQ
+     * cache HIT.
+     *
+     * That functionality is tested in `apollo-server-integration-testsuite`,
+     * within the "Persisted Queries" tests. (Search for "didResolveSource").
+     */
     describe('didResolveSource', () => {
       const didResolveSource = jest.fn();
       it('called with the source', async () => {

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -49,6 +49,7 @@ import {
 import {
   ApolloServerPlugin,
   GraphQLRequestListener,
+  GraphQLRequestContextDidResolveSource,
   GraphQLRequestContextExecutionDidStart,
   GraphQLRequestContextResponseForOperation,
   GraphQLRequestContextDidResolveOperation,
@@ -208,6 +209,16 @@ export async function processGraphQLRequest<TContext>(
 
   requestContext.queryHash = queryHash;
   requestContext.source = query;
+
+  // Let the plugins know that we now have a STRING of what we hope will
+  // parse and validate into a document we can execute on.  Unless we have
+  // retrieved this from our APQ cache, there's no guarantee that it is
+  // syntactically correct, so this string should not be trusted as a valid
+  // document until after it's parsed and validated.
+  await dispatcher.invokeHookAsync(
+    'didResolveSource',
+    requestContext as GraphQLRequestContextDidResolveSource<TContext>,
+  );
 
   const requestDidEnd = extensionStack.requestDidStart({
     request: request.http!,

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -8,6 +8,7 @@ import {
   GraphQLResponse,
   ValueOrPromise,
   WithRequired,
+  GraphQLRequestContextDidResolveSource,
   GraphQLRequestContextParsingDidStart,
   GraphQLRequestContextValidationDidStart,
   GraphQLRequestContextDidResolveOperation,
@@ -35,6 +36,7 @@ export {
   GraphQLResponse,
   ValueOrPromise,
   WithRequired,
+  GraphQLRequestContextDidResolveSource,
   GraphQLRequestContextParsingDidStart,
   GraphQLRequestContextValidationDidStart,
   GraphQLRequestContextDidResolveOperation,
@@ -63,6 +65,9 @@ export type GraphQLRequestListenerDidResolveField =
 export interface GraphQLRequestListener<
   TContext extends BaseContext = DefaultContext
 > extends AnyFunctionMap {
+  didResolveSource?(
+    requestContext: GraphQLRequestContextDidResolveSource<TContext>,
+  ): ValueOrPromise<void>;
   parsingDidStart?(
     requestContext: GraphQLRequestContextParsingDidStart<TContext>,
   ): GraphQLRequestListenerParsingDidEnd | void;

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -148,12 +148,14 @@ export type Logger = {
   error(message?: any): void;
 }
 
-export type GraphQLRequestContextParsingDidStart<TContext> =
+export type GraphQLRequestContextDidResolveSource<TContext> =
   WithRequired<GraphQLRequestContext<TContext>,
     | 'metrics'
     | 'source'
     | 'queryHash'
   >;
+export type GraphQLRequestContextParsingDidStart<TContext> =
+  GraphQLRequestContextDidResolveSource<TContext>;
 export type GraphQLRequestContextValidationDidStart<TContext> =
   GraphQLRequestContextParsingDidStart<TContext> &
   WithRequired<GraphQLRequestContext<TContext>,


### PR DESCRIPTION
This PR targets https://github.com/apollographql/apollo-server/pull/3988 but was prompted by a need identified during review in [this comment](https://github.com/apollographql/apollo-server/pull/3998/files#r414911049) by @glasser.

As noted, this is tangible clunkiness which could make the implementation of the `ensurePreflight` invocations unnecessary.  While I had imagined we might consider this later, after further consideration and validation from that review, I think it makes a lot of sense to bring it into the request pipeline.

Introducing it removes the need for the defensiveness which `ensurePreflight` (in the other PR) was attempting and was only necessary because the extensions API - which #3988 + #3998 aims to render unnecessary - guaranteed the presence of the "source" (the text of the incoming operation) prior to invoking its `requestDidStart` method (which was actually a bit after the request had started, in reality).

Hopefully this proves to be a useful life-cycle for other cases!