### PR TITLE
Change status code to 400 when POST body is missing

### DIFF
--- a/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
@@ -28,7 +28,7 @@ export function graphqlAzureFunction(
     if (request.method === 'POST' && !request.body) {
       callback(null, {
         body: 'POST body missing.',
-        status: 500,
+        status: 400,
       });
       return;
     }

--- a/packages/apollo-server-cloud-functions/src/googleCloudApollo.ts
+++ b/packages/apollo-server-cloud-functions/src/googleCloudApollo.ts
@@ -27,7 +27,7 @@ export function graphqlCloudFunction(
   const graphqlHandler: any = (req: Request, res: Response): void => {
     const hasPostBody = req.body && Object.keys(req.body).length > 0;
     if (req.method === 'POST' && !hasPostBody) {
-      res.status(500).send('POST body missing.');
+      res.status(400).send('POST body missing.');
       return;
     }
 
@@ -49,7 +49,7 @@ export function graphqlCloudFunction(
       },
       (error: HttpQueryError) => {
         if ('HttpQueryError' !== error.name) {
-          res.status(500).send(error);
+          res.status(400).send(error);
           return;
         }
         res

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -208,7 +208,7 @@ export async function processHTTPRequest<TContext>(
     case 'POST':
       if (!httpRequest.query || Object.keys(httpRequest.query).length === 0) {
         throw new HttpQueryError(
-          500,
+          400,
           'POST body missing. Did you forget use body-parser middleware?',
         );
       }

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -241,7 +241,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           .post('/graphql')
           .send();
         return req.then(res => {
-          expect(res.status).toEqual(500);
+          expect(res.status).toEqual(400);
           expect(res.error.text).toMatch('POST body missing.');
         });
       });

--- a/packages/apollo-server-lambda/src/lambdaApollo.ts
+++ b/packages/apollo-server-lambda/src/lambdaApollo.ts
@@ -36,7 +36,7 @@ export function graphqlLambda(
     if (event.httpMethod === 'POST' && !event.body) {
       return callback(null, {
         body: 'POST body missing.',
-        statusCode: 500,
+        statusCode: 400,
       });
     }
 


### PR DESCRIPTION
Summary:

If a client sends a request with an empty POST body, `runHttpQuery`
currently throws a `HTTPQueryError` with a 500 response code. Since the
express integration [1] catches this error and doesn't log any details
before returning the error to the user, we lost a few hours trying to
track down the source of some 500 errors we were seeing in our logs.

This patch changes the response code here to be 400 Bad Request, which I
think better matches what is happening here - the client is sending a
badly formed request which the server should be rejecting. 

If we think it's too risky to potentially break folks who are depending
on this error code remaining the same, an alternative plan would be to
no longer have the server integrations swallow the error so that we
provide some way for folks to log the error happening here. I think that
might be a broader change, but open to exploring it if maintainers
prefer! (Some previous discussion of that approach happened in #756)

Test Plan:
`npm test`

[1]
https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-express/src/expressApollo.ts#L54-L76

