### PR TITLE
[AS-252] gateway: normalize root operation types in reporting

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Export `defaultRootOperationNameLookup` and `normalizeTypeDefs`; needed by `@apollo/gateway` to normalize root operation types when reporting to Apollo Graph Manager. [#4071](https://github.com/apollographql/apollo-server/pull/4071)
 
 ## 0.15.0
 

--- a/packages/apollo-federation/src/composition/index.ts
+++ b/packages/apollo-federation/src/composition/index.ts
@@ -2,3 +2,4 @@ export * from './compose';
 export * from './composeAndValidate';
 export * from './types';
 export { compositionRules } from './rules';
+export { defaultRootOperationNameLookup, normalizeTypeDefs } from './normalize';

--- a/packages/apollo-federation/src/composition/normalize.ts
+++ b/packages/apollo-federation/src/composition/normalize.ts
@@ -15,18 +15,18 @@ export function normalizeTypeDefs(typeDefs: DocumentNode) {
   );
 }
 
+// Map of OperationTypeNode to its respective default root operation type name
+export const defaultRootOperationNameLookup: {
+  [node in OperationTypeNode]: DefaultRootOperationTypeName;
+} = {
+  query: 'Query',
+  mutation: 'Mutation',
+  subscription: 'Subscription',
+};
+
 export function defaultRootOperationTypes(
   typeDefs: DocumentNode,
 ): DocumentNode {
-  // Map of OperationTypeNode to its respective default root operation type name
-  const defaultRootOperationNameLookup: {
-    [node in OperationTypeNode]: DefaultRootOperationTypeName;
-  } = {
-    query: 'Query',
-    mutation: 'Mutation',
-    subscription: 'Subscription',
-  };
-
   // Array of default root operation names
   const defaultRootOperationNames = Object.values(
     defaultRootOperationNameLookup,

--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - __FIX__: Correctly handle unions with nested conditions that have no `possibleTypes` [#4071](https://github.com/apollographql/apollo-server/pull/4071)
+- __FIX__: Normalize root operation types when reporting to Apollo Graph Manager. Federation always uses the default names `Query`, `Mutation`, and `Subscription` for root operation types even if downstream services choose different names; now we properly normalize traces received from downstream services in the same way. [#4100](https://github.com/apollographql/apollo-server/pull/4100)
 
 ## 0.15.0
 

--- a/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/accounts.ts
+++ b/packages/apollo-gateway/src/__tests__/__fixtures__/schemas/accounts.ts
@@ -6,7 +6,12 @@ export const typeDefs = gql`
   directive @stream on FIELD
   directive @transform(from: String!) on FIELD
 
-  extend type Query {
+  schema {
+    query: RootQuery
+    mutation: Mutation
+  }
+
+  extend type RootQuery {
     user(id: ID!): User
     me: User
   }
@@ -36,7 +41,7 @@ export const typeDefs = gql`
     metadata: [UserMetadata]
   }
 
-  extend type Mutation {
+  type Mutation {
     login(username: String!, password: String!): User
   }
 
@@ -80,7 +85,7 @@ const libraryUsers: { [name: string]: string[] } = {
 };
 
 export const resolvers: GraphQLResolverMap<any> = {
-  Query: {
+  RootQuery: {
     user(_, args) {
       return { id: args.id };
     },

--- a/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/buildQueryPlan.test.ts
@@ -5,7 +5,7 @@ import {
   GraphQLSchemaValidationError,
 } from 'apollo-graphql';
 import gql from 'graphql-tag';
-import { composeServices, buildFederatedSchema } from '@apollo/federation';
+import { composeServices, buildFederatedSchema, normalizeTypeDefs } from '@apollo/federation';
 
 import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
 
@@ -45,7 +45,7 @@ describe('buildQueryPlan', () => {
     ({ schema, errors } = composeServices(
       Object.entries(serviceMap).map(([serviceName, service]) => ({
         name: serviceName,
-        typeDefs: service.sdl(),
+        typeDefs: normalizeTypeDefs(service.sdl()),
       })),
     ));
 

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -9,7 +9,7 @@ import {
 import gql from 'graphql-tag';
 import { GraphQLRequestContext } from 'apollo-server-types';
 import { AuthenticationError } from 'apollo-server-core';
-import { composeServices, buildFederatedSchema } from '@apollo/federation';
+import { composeServices, buildFederatedSchema, normalizeTypeDefs } from '@apollo/federation';
 
 import { buildQueryPlan, buildOperationContext } from '../buildQueryPlan';
 import { executeQueryPlan } from '../executeQueryPlan';
@@ -60,7 +60,7 @@ describe('executeQueryPlan', () => {
     ({ schema, errors } = composeServices(
       Object.entries(serviceMap).map(([serviceName, service]) => ({
         name: serviceName,
-        typeDefs: service.sdl(),
+        typeDefs: normalizeTypeDefs(service.sdl()),
       })),
     ));
 
@@ -104,7 +104,7 @@ describe('executeQueryPlan', () => {
 
     it(`should include an error when a root-level field errors out`, async () => {
       overrideResolversInService('accounts', {
-        Query: {
+        RootQuery: {
           me() {
             throw new AuthenticationError('Something went wrong');
           },
@@ -151,7 +151,7 @@ describe('executeQueryPlan', () => {
 
     it(`should still include other root-level results if one root-level field errors out`, async () => {
       overrideResolversInService('accounts', {
-        Query: {
+        RootQuery: {
           me() {
             throw new Error('Something went wrong');
           },

--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -12,6 +12,7 @@ import {
   GraphQLFieldResolver,
 } from 'graphql';
 import { Trace, google } from 'apollo-engine-reporting-protobuf';
+import { defaultRootOperationNameLookup } from '@apollo/federation';
 import { GraphQLDataSource } from './datasources/types';
 import {
   FetchNode,
@@ -360,6 +361,19 @@ async function executeFetch<TContext>(
             );
             traceParsingFailed = true;
           }
+        }
+        if (traceNode.trace) {
+          // Federation requires the root operations in the composed schema
+          // to have the default names (Query, Mutation, Subscription) even
+          // if the implementing services choose different names, so we override
+          // whatever the implementing service reported here.
+          const rootTypeName =
+            defaultRootOperationNameLookup[
+              context.operationContext.operation.operation
+            ];
+          traceNode.trace.root?.child?.forEach((child) => {
+            child.parentType = rootTypeName;
+          });
         }
         traceNode.traceParsingFailed = traceParsingFailed;
       }


### PR DESCRIPTION
The federation spec allows your backends to use any name for their root
types (not just the standard Query/Mutation/Subscription) but the composed
schema will always use the standard names.

Both Apollo-maintained implementations of federated trace
reporting (apollo-engine-reporting and federation-jvm) include the backend's
potentially nonstandard name in the federated traces sent to the gateway. Then
the gateway continues to use those names in the traces it sends to AGM.

For example, one of AGM's own implementing services uses QueryRoot, so traces
produced by the gateway in front of it have `QueryRoot` on the traces despite
that type not actually being part of the composed schema.

The effect is that field stats (on the schema explorer) for all root fields are
empty!

Because normalizing root operation names is part of the federation spec, it
makes sense to keep the implementing services simple and fix this just once in
the gateway.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
