### PR TITLE
Mention that formatError masks without debug: true

### DIFF
--- a/docs/source/data/errors.md
+++ b/docs/source/data/errors.md
@@ -120,7 +120,7 @@ new ApolloError(message, code, additionalProperties);
 
 ### For the client response
 
-The Apollo Server constructor accepts a `formatError` function that is run on each error passed back to the client. This can be used to mask errors as well as for logging.
+The Apollo Server constructor accepts a `formatError` function that is run on each error passed back to the client. This can be used to mask errors as well as for logging. Note that in production, you must `debug: true` when creating the server; otherwise, `formatError` will only send `INTERNAL_SERVER_ERROR`s.
 
 > Note that while this changes the error which is sent to the client, it
 > doesn't change the error that is sent to Apollo Graph Manager.  See the
@@ -133,6 +133,7 @@ This example demonstrates throwing a different error when the error's message st
 const server = new ApolloServer({
   typeDefs,
   resolvers,
+  debug: true,
   formatError: (err) => {
     // Don't give the specific errors to the client.
     if (err.message.startsWith("Database Error: ")) {


### PR DESCRIPTION
I was following the [error masking guide](https://www.apollographql.com/docs/apollo-server/data/errors/#masking-and-logging-errors) and trying to pass-through UNAUTHENTICATED errors to the client. Noticed that the client always received INTERNAL_SERVER_ERROR, even when formatError was simply `return error;`.

This was fixed by setting `debug: true`. This PR adds that explanation to the error masking guide.