### PR TITLE
docs+changelog: For #4084 and `graphVariant`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ The version headers in this history reflect the versions of Apollo Server itself
     - The federated tracing plugin's `ftv1` response on `extensions` (which is present on the response from an implementing service to the gateway) is now placed on the `extensions` _after_ the `formatResponse` hook.  Anyone leveraging the `extensions`.`ftv1` data from the `formatResponse` hook will find that it is no longer present at that phase.
 - `apollo-tracing`: This package's internal integration with Apollo Server has been switched from using the soon-to-be-deprecated`graphql-extensions` API to using [the request pipeline plugin API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).  Behavior should remain otherwise the same.  [PR #3991](https://github.com/apollographql/apollo-server/pull/3991)
 
+- `apollo-engine-reporting`: Added an experimental schema reporting feature to engine reporting. Previously the only way to get schemas into the schema registry in Apollo Graph Manager, was to use the cli and run `apollo schema:push`. _Apollo schema reporting protocol_, is a *new* specification for GraphQL servers to automatically report schemas to the Apollo Graph Manager schema registry.  [PR #4084](https://github.com/apollographql/apollo-server/pull/4084), [Preview docs](https://github.com/apollographql/apollo-schema-reporting-preview-docs)
+
+    - To enable schema reporting provide a Graph Manager API key (available from [Apollo Graph Manager](https://engine.apollographql.com/)) in the `APOLLO_KEY` environment variable *and* set the `experimental_schemaReporting` option to `true` in the Apollo Server constructor options, like so:
+    ```js
+    const server = new ApolloServer({
+      typeDefs,
+      resolvers,
+      engine: {
+        experimental_schemaReporting: true,
+        /* Other existing options can remain the same. */
+      },
+    });
+    ```
+  - When enabled, a schema reporter is initiated by the `apollo-engine-reporting` agent.  It will loop until the `ApolloServer` instance is stopped, periodically calling back to Apollo Graph Manager to send information.  The life-cycle of this reporter is managed by the agent.
+
 ### v2.13.0
 
 > [See complete versioning details.](https://github.com/apollographql/apollo-server/commit/e37384a49b2bf474eed0de3e9f4a1bebaeee64c7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,6 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- `apollo-engine-reporting`: The underlying integration of this plugin, which instruments and traces the graph's resolver performance and transmits these metrics to [Apollo Graph Manager](https://engine.apollographql.com/), has been changed from the (soon to be deprecated) `graphql-extensions` API to the new [request pipeline `plugins` API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/). [PR #3998](https://github.com/apollographql/apollo-server/pull/3998)
-
-  _This change should be purely an implementation detail for a majority of users_.  There are, however, some special considerations which are worth noting:
-
-    - The federated tracing plugin's `ftv1` response on `extensions` (which is present on the response from an implementing service to the gateway) is now placed on the `extensions` _after_ the `formatResponse` hook.  Anyone leveraging the `extensions`.`ftv1` data from the `formatResponse` hook will find that it is no longer present at that phase.
-- `apollo-tracing`: This package's internal integration with Apollo Server has been switched from using the soon-to-be-deprecated`graphql-extensions` API to using [the request pipeline plugin API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).  Behavior should remain otherwise the same.  [PR #3991](https://github.com/apollographql/apollo-server/pull/3991)
-
 - `apollo-engine-reporting`: Added an _experimental_ schema reporting option,
   `experimental_schemaReporting`, for Apollo Graph Manager users. **During this
   experiment, we'd appreciate testing and feedback from current and new
@@ -49,6 +42,13 @@ The version headers in this history reflect the versions of Apollo Server itself
   introduced it to Apollo Server and the [preview documentation](https://github.com/apollographql/apollo-schema-reporting-preview-docs).
 
   [PR #4084](https://github.com/apollographql/apollo-server/pull/4084)
+- `apollo-engine-reporting`: The underlying integration of this plugin, which instruments and traces the graph's resolver performance and transmits these metrics to [Apollo Graph Manager](https://engine.apollographql.com/), has been changed from the (soon to be deprecated) `graphql-extensions` API to the new [request pipeline `plugins` API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/). [PR #3998](https://github.com/apollographql/apollo-server/pull/3998)
+
+  _This change should be purely an implementation detail for a majority of users_.  There are, however, some special considerations which are worth noting:
+
+    - The federated tracing plugin's `ftv1` response on `extensions` (which is present on the response from an implementing service to the gateway) is now placed on the `extensions` _after_ the `formatResponse` hook.  Anyone leveraging the `extensions`.`ftv1` data from the `formatResponse` hook will find that it is no longer present at that phase.
+- `apollo-tracing`: This package's internal integration with Apollo Server has been switched from using the soon-to-be-deprecated`graphql-extensions` API to using [the request pipeline plugin API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).  Behavior should remain otherwise the same.  [PR #3991](https://github.com/apollographql/apollo-server/pull/3991)
+
 
 
 ### v2.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,20 +16,40 @@ The version headers in this history reflect the versions of Apollo Server itself
     - The federated tracing plugin's `ftv1` response on `extensions` (which is present on the response from an implementing service to the gateway) is now placed on the `extensions` _after_ the `formatResponse` hook.  Anyone leveraging the `extensions`.`ftv1` data from the `formatResponse` hook will find that it is no longer present at that phase.
 - `apollo-tracing`: This package's internal integration with Apollo Server has been switched from using the soon-to-be-deprecated`graphql-extensions` API to using [the request pipeline plugin API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).  Behavior should remain otherwise the same.  [PR #3991](https://github.com/apollographql/apollo-server/pull/3991)
 
-- `apollo-engine-reporting`: Added an experimental schema reporting feature to engine reporting. Previously the only way to get schemas into the schema registry in Apollo Graph Manager, was to use the cli and run `apollo schema:push`. _Apollo schema reporting protocol_, is a *new* specification for GraphQL servers to automatically report schemas to the Apollo Graph Manager schema registry.  [PR #4084](https://github.com/apollographql/apollo-server/pull/4084), [Preview docs](https://github.com/apollographql/apollo-schema-reporting-preview-docs)
+- `apollo-engine-reporting`: Added an _experimental_ schema reporting option,
+  `experimental_schemaReporting`, for Apollo Graph Manager users. **During this
+  experiment, we'd appreciate testing and feedback from current and new
+  users of the schema registry!**
 
-    - To enable schema reporting provide a Graph Manager API key (available from [Apollo Graph Manager](https://engine.apollographql.com/)) in the `APOLLO_KEY` environment variable *and* set the `experimental_schemaReporting` option to `true` in the Apollo Server constructor options, like so:
-    ```js
-    const server = new ApolloServer({
-      typeDefs,
-      resolvers,
-      engine: {
-        experimental_schemaReporting: true,
-        /* Other existing options can remain the same. */
-      },
-    });
-    ```
-  - When enabled, a schema reporter is initiated by the `apollo-engine-reporting` agent.  It will loop until the `ApolloServer` instance is stopped, periodically calling back to Apollo Graph Manager to send information.  The life-cycle of this reporter is managed by the agent.
+  Prior to the introduction of this feature, the only way to get schemas into
+  the schema registry in Apollo Graph Manager was to use the CLI and run
+  `apollo schema:push`. _Apollo schema reporting protocol_ is a *new*
+  specification for GraphQL servers to automatically report schemas to the
+  Apollo Graph Manager schema registry.
+
+  **To enable schema reporting,** provide a Graph Manager API key (available
+  free from [Apollo Graph Manager](https://engine.apollographql.com/)) in the
+  `APOLLO_KEY` environment variable *and* set the `experimental_schemaReporting`
+  option to `true` in the Apollo Server constructor options, like so:
+
+  ```js
+  const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    engine: {
+      experimental_schemaReporting: true,
+      /* Other existing options can remain the same. */
+    },
+  });
+  ```
+
+  > When enabled, a schema reporter is initiated by the `apollo-engine-reporting` agent.  It will loop until the `ApolloServer` instance is stopped, periodically calling back to Apollo Graph Manager to send information.  The life-cycle of this reporter is managed by the agent.
+
+  For more details on the implementation of this new protocol, see the PR which
+  introduced it to Apollo Server and the [preview documentation](https://github.com/apollographql/apollo-schema-reporting-preview-docs).
+
+  [PR #4084](https://github.com/apollographql/apollo-server/pull/4084)
+
 
 ### v2.13.0
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -474,11 +474,11 @@ addMockFunctionsToSchema({
 
    > Will be deprecated in 3.0. Use the option `graphVariant` instead.
 
-   A human-readable name to tag this variant of a schema (i.e. staging, EU). Setting this value will cause metrics to be segmented in the Apollo Platform's UI. Additionally schema validation with a schema tag will only check metrics associate with the same string.
+   A human-readable name to tag this variant of a schema (i.e. staging, EU). Setting this value will cause metrics to be segmented in the Apollo Platform's UI. Additionally schema validation with a schema tag will only check metrics associated with the same string.
 
 *  `graphVariant`: String
 
-   A human-readable name for the variant of a schema (i.e. staging, EU). Setting this value will cause metrics to be segmented in the Apollo Graph Manager UI. Additionally schema validation with a graph variant will only check metrics associate with the same string.
+   A human-readable name for the variant of a schema (i.e. staging, EU). Setting this value will cause metrics to be segmented in the Apollo Graph Manager UI. Additionally schema validation with a graph variant will only check metrics associated with the same string.
 
 *  `generateClientInfo`: (GraphQLRequestContext) => ClientInfo **AS 2.2**
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -404,7 +404,7 @@ addMockFunctionsToSchema({
 
     - `{ none: true }`: Don't send any variable values. **(DEFAULT)**
     - `{ all: true }`: Send all variable values.
-    - `{ transform: ({ variables, operationString}) => { ... } }`: A custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value.  For security reasons, if an error occurs within this function, all variable values will be replaced with `[PREDICATE_FUNCTION_ERROR]`. 
+    - `{ transform: ({ variables, operationString}) => { ... } }`: A custom function for modifying variable values. Keys added by the custom function will be removed, and keys removed will be added back with an empty value.  For security reasons, if an error occurs within this function, all variable values will be replaced with `[PREDICATE_FUNCTION_ERROR]`.
     - `{ exceptNames: [...] }`: A case-sensitive list of names of variables whose values should not be sent to Apollo servers.
     - `{ onlyNames: [...] }`: A case-sensitive list of names of variables whose values will be sent to Apollo servers.
 
@@ -472,7 +472,13 @@ addMockFunctionsToSchema({
 
 *  `schemaTag`: String
 
+   > Will be deprecated in 3.0. Use the option `graphVariant` instead.
+
    A human-readable name to tag this variant of a schema (i.e. staging, EU). Setting this value will cause metrics to be segmented in the Apollo Platform's UI. Additionally schema validation with a schema tag will only check metrics associate with the same string.
+
+*  `graphVariant`: String
+
+   A human-readable name for the variant of a schema (i.e. staging, EU). Setting this value will cause metrics to be segmented in the Apollo Graph Manager UI. Additionally schema validation with a graph variant will only check metrics associate with the same string.
 
 *  `generateClientInfo`: (GraphQLRequestContext) => ClientInfo **AS 2.2**
 


### PR DESCRIPTION
Update the change log for https://github.com/apollographql/apollo-server/pull/4084 and also add `graphVariants` to the `api/apollo_sever.md`.