### PR TITLE
gateway: Support custom `fetcher` for RemoteGraphQLDataSource.

### DIFF
--- a/packages/apollo-gateway/CHANGELOG.md
+++ b/packages/apollo-gateway/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- __NEW__: Provide the ability to pass a custom `fetcher` during `RemoteGraphQLDataSource` construction to be used when executing operations against downstream services.  Providing a custom `fetcher` may be necessary to accommodate more advanced needs, e.g., configuring custom TLS certificates for internal services.  [PR #4149](https://github.com/apollographql/apollo-server/pull/4149)
+
+  The `fetcher` specified should be a compliant implementor of the [Fetch API standard](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).  This addition compliments, though is still orthognonal to, similar behavior originally introduced in [#3783](https://github.com/apollographql/apollo-server/pull/3783), which allowed customization of the implementation used to fetch _gateway configuration and federated SDL from services_ in managed and unmanaged modes, but didn't affect the communication that takes place during _operation execution_.
+
+  For now, the default `fetcher` will remain the same ([`node-fetch`](https://npm.im/node-fetch)) implementation.  A future major-version bump will update it to be consistent with other feature-rich implementations of the Fetch API which are used elsewhere in the Apollo Server stack where we use [`make-fetch-happen`](https://npm.im/make-fetch-happen).  In all likelihood, `ApolloGateway` will pass its own `fetcher` to the `RemoteGraphQLDataSource` during service initialization.
 
 ## 0.16.0
 

--- a/packages/apollo-gateway/src/datasources/RemoteGraphQLDataSource.ts
+++ b/packages/apollo-gateway/src/datasources/RemoteGraphQLDataSource.ts
@@ -20,7 +20,7 @@ import { GraphQLDataSource } from './types';
 import createSHA from 'apollo-server-core/dist/utils/createSHA';
 
 export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Record<string, any>> implements GraphQLDataSource<TContext> {
-  private fetcher: typeof fetch = fetch;
+  fetcher: typeof fetch = fetch;
 
   constructor(
     config?: Partial<RemoteGraphQLDataSource<TContext>> &

--- a/packages/apollo-gateway/src/datasources/RemoteGraphQLDataSource.ts
+++ b/packages/apollo-gateway/src/datasources/RemoteGraphQLDataSource.ts
@@ -20,6 +20,8 @@ import { GraphQLDataSource } from './types';
 import createSHA from 'apollo-server-core/dist/utils/createSHA';
 
 export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Record<string, any>> implements GraphQLDataSource<TContext> {
+  private fetcher: typeof fetch = fetch;
+
   constructor(
     config?: Partial<RemoteGraphQLDataSource<TContext>> &
       object &
@@ -144,7 +146,8 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
     });
 
     try {
-      const httpResponse = await fetch(httpRequest);
+      // Use our local `fetcher` to allow for fetch injection
+      const httpResponse = await this.fetcher(httpRequest);
 
       if (!httpResponse.ok) {
         throw await this.errorFromResponse(httpResponse);

--- a/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -240,7 +240,7 @@ describe('constructing requests', () => {
 });
 
 describe('fetcher', () => {
-  it('RemoteGraphQLDataSource constructor allows for an injectable `fetcher`', async () => {
+  it('uses a custom provided `fetcher`', async () => {
     const injectedFetch = fetch.mockJSONResponseOnce({ data: { injected: true } });
     const DataSource = new RemoteGraphQLDataSource({
       url: 'https://api.example.com/foo',

--- a/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -9,6 +9,7 @@ import {
 import { RemoteGraphQLDataSource } from '../RemoteGraphQLDataSource';
 import { Headers } from 'apollo-server-env';
 import { GraphQLRequestContext } from 'apollo-server-types';
+import { Response } from '../../../../../../apollo-tooling/packages/apollo-env/lib';
 
 beforeEach(() => {
   fetch.mockReset();
@@ -236,6 +237,30 @@ describe('constructing requests', () => {
       });
     });
   });
+});
+
+describe('fetcher', () => {
+  it('RemoteGraphQLDataSource constructor allows for an injectable `fetcher` just like the gateway', async () => {
+    const injectedFetch = fetch.mockJSONResponseOnce({ data: { injected: true } });
+    const DataSource = new RemoteGraphQLDataSource({
+      url: 'https://api.example.com/foo',
+      // @ts-ignore The below works, the fetcher is a typeof fetch, which is correct, but the signature varies slightly below
+      fetcher: injectedFetch
+    });
+
+    const { data } = await DataSource.process({
+      request: {
+        query: '{ me { name } }',
+        variables: { id: '1' },
+      },
+      context: {},
+    });
+
+    expect(injectedFetch).toHaveBeenCalled();
+    expect(data).toEqual({injected: true});
+
+  });
+
 });
 
 describe('willSendRequest', () => {

--- a/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -244,8 +244,7 @@ describe('fetcher', () => {
     const injectedFetch = fetch.mockJSONResponseOnce({ data: { injected: true } });
     const DataSource = new RemoteGraphQLDataSource({
       url: 'https://api.example.com/foo',
-      // @ts-ignore The below works, the fetcher is a typeof fetch, which is correct, but the signature varies slightly below
-      fetcher: injectedFetch
+      fetcher: injectedFetch,
     });
 
     const { data } = await DataSource.process({

--- a/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
+++ b/packages/apollo-gateway/src/datasources/__tests__/RemoteGraphQLDataSource.test.ts
@@ -240,7 +240,7 @@ describe('constructing requests', () => {
 });
 
 describe('fetcher', () => {
-  it('RemoteGraphQLDataSource constructor allows for an injectable `fetcher` just like the gateway', async () => {
+  it('RemoteGraphQLDataSource constructor allows for an injectable `fetcher`', async () => {
     const injectedFetch = fetch.mockJSONResponseOnce({ data: { injected: true } });
     const DataSource = new RemoteGraphQLDataSource({
       url: 'https://api.example.com/foo',


### PR DESCRIPTION
add: Ability for the RemoteGraphQLDataSource to accept a fetcher implementation, the same as the Gateway (this is part 1 of 2, I think).  The second sane step would be to use the Gateway's `fetcher` when instantiating a RGDS.  That said, you can do that like so without that additional change:

```
const gateway = new ApolloGateway({
  ...
  buildService({ name, url }) {
    return new RemoteGraphQLDataSource({ url, fetcher: myFetcherImplementation });
  },
});
```

**Note**: I added a new suite and test for the fetcher for sanity, but I'm seeing snapshot failures unrelated to my work here.  Are these test failures expected right now?