### PR TITLE
Improve defaultMaxAge setting

### DIFF
--- a/docs/source/performance/caching.md
+++ b/docs/source/performance/caching.md
@@ -90,6 +90,39 @@ const server = new ApolloServer({
 }));
 ```
 
+If you elect not to have a defaultMaxAge of 0 set for all resolvers and types you must explicitly set it to `null`. For example:
+
+```javascript
+
+const typeDefs = `
+  type Foo {
+    id: ID!
+    name: String!
+  }
+
+  type User {
+    id: ID!
+    name: String!
+    status: String!
+    foo: Foo!
+  }
+
+  type Query {
+    user: User @cacheControl(maxAge: 0, scope: PRIVATE)
+    userFoo: User @cacheControl(maxAge: 100)
+  }
+`;
+
+const server = new ApolloServer({
+  // ...
+  cacheControl: {
+    defaultMaxAge: null,
+  },
+}));
+```
+
+This is useful if you have multiple queries of identical types like in the example shown, `query user` will have a maxAge of 0 while `query userFoo` will have a maxAge of `100`.
+
 ### The overall cache policy
 
 Apollo Server's cache API lets you declare fine-grained cache hints on specific resolvers. Apollo Server then combines these hints into an overall cache policy for the response. The `maxAge` of this policy is the minimum `maxAge` across all fields in your request. As [described above](#setting-a-default-maxage), the default `maxAge` of all root fields and non-scalar fields is 0, so the overall cache policy for a response will have `maxAge` 0 (ie, uncacheable) unless all root and non-scalar fields in the response have cache hints (or if `defaultMaxAge` is specified).

--- a/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
@@ -84,13 +84,13 @@ describe('CacheControlExtension', () => {
       expect(cachePolicy).toHaveProperty('maxAge', 10);
     });
 
-    it('returns maxAge of 0 if any cache hint has a maxAge of 0', () => {
+    it('returns undefined if any cache hint has a maxAge of 0', () => {
       cacheControlExtension.addHint(responsePath, { maxAge: 120 });
       cacheControlExtension.addHint(responseSubPath, { maxAge: 0 });
       cacheControlExtension.addHint(responseSubSubPath, { maxAge: 20 });
 
       const cachePolicy = cacheControlExtension.computeOverallCachePolicy();
-      expect(cachePolicy).toHaveProperty('maxAge', 0);
+      expect(cachePolicy).toBeUndefined();
     });
 
     it('returns PUBLIC scope by default', () => {

--- a/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlExtension.test.ts
@@ -84,13 +84,13 @@ describe('CacheControlExtension', () => {
       expect(cachePolicy).toHaveProperty('maxAge', 10);
     });
 
-    it('returns undefined if any cache hint has a maxAge of 0', () => {
+    it('returns maxAge of 0 if any cache hint has a maxAge of 0', () => {
       cacheControlExtension.addHint(responsePath, { maxAge: 120 });
       cacheControlExtension.addHint(responseSubPath, { maxAge: 0 });
       cacheControlExtension.addHint(responseSubSubPath, { maxAge: 20 });
 
       const cachePolicy = cacheControlExtension.computeOverallCachePolicy();
-      expect(cachePolicy).toBeUndefined();
+      expect(cachePolicy).toHaveProperty('maxAge', 0);
     });
 
     it('returns PUBLIC scope by default', () => {

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -201,7 +201,7 @@ export class CacheControlExtension<TContext = any>
 
     // If maxAge is 0, then we consider it uncacheable so it doesn't matter what
     // the scope was.
-    return lowestMaxAge
+    return lowestMaxAge >= 0
       ? {
           maxAge: lowestMaxAge,
           scope,

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -199,7 +199,9 @@ export class CacheControlExtension<TContext = any>
       }
     }
 
-    return lowestMaxAge || lowestMaxAge === 0
+    // If maxAge is 0, then we consider it uncacheable so it doesn't matter what
+    // the scope was.
+    return lowestMaxAge
       ? {
           maxAge: lowestMaxAge,
           scope,

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -199,9 +199,7 @@ export class CacheControlExtension<TContext = any>
       }
     }
 
-    // If maxAge is 0, then we consider it uncacheable so it doesn't matter what
-    // the scope was.
-    return lowestMaxAge >= 0
+    return lowestMaxAge || lowestMaxAge === 0
       ? {
           maxAge: lowestMaxAge,
           scope,

--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -100,14 +100,14 @@ export class CacheControlExtension<TContext = any>
     // while root non-object fields can get explicit hints from their definition
     // on the Query/Mutation object, if that doesn't exist then there's no
     // parent field that would assign the default maxAge, so we do it here.)
-    if (
-      (targetType instanceof GraphQLObjectType ||
-        targetType instanceof GraphQLInterfaceType ||
-        !info.path.prev) &&
-      hint.maxAge === undefined
-    ) {
-      hint.maxAge = this.defaultMaxAge;
-    }
+    // if (
+    //   (targetType instanceof GraphQLObjectType ||
+    //     targetType instanceof GraphQLInterfaceType ||
+    //     !info.path.prev) &&
+    //   hint.maxAge === undefined
+    // ) {
+    //   hint.maxAge = this.defaultMaxAge;
+    // }
 
     if (hint.maxAge !== undefined || hint.scope !== undefined) {
       this.addHint(info.path, hint);
@@ -199,9 +199,10 @@ export class CacheControlExtension<TContext = any>
 
     // If maxAge is 0, then we consider it uncacheable so it doesn't matter what
     // the scope was.
-    return lowestMaxAge
+    const maxAge = lowestMaxAge || this.defaultMaxAge;
+    return maxAge
       ? {
-          maxAge: lowestMaxAge,
+          maxAge,
           scope,
         }
       : undefined;


### PR DESCRIPTION
This addresses the following issue: https://github.com/apollographql/apollo-server/issues/3559 - where a defaultMaxAge is required and there is no option to not have the blanket defaultMaxAge functionality.

If you elect not to have a `defaultMaxAge` of 0 set for all resolvers and types you must explicitly set it to `null`. For example:

```javascript
const server = new ApolloServer({
  // ...
  cacheControl: {
    defaultMaxAge: null,
  },
}));

const typeDefs = `
  type Foo {
    id: ID!
    name: String!
  }

  type User {
    id: ID!
    name: String!
    status: String!
    foo: Foo!
  }

  type Query {
    user: User @cacheControl(maxAge: 0, scope: PRIVATE)
    userFoo: User @cacheControl(maxAge: 100)
  }
`;

// fooUserQuery
query fooUser {
  id
  name
  status
  foo {
    id
    name
  }
}

// userQuery
query user {
  id
  name
  foo {
    id
    name
  }
}
```

This is useful if you have multiple queries of identical types like in the example shown, `query user` will have a `maxAge` of `0` while `query userFoo` will have a `maxAge `of `100` which would not be possible under the current usage of `defaultMaxAge` because you can't set the child to have two different maxAges depending on parent. 