### PR TITLE
Custom execute and subscribe functions

### DIFF
--- a/packages/apollo-server-core/CHANGELOG.md
+++ b/packages/apollo-server-core/CHANGELOG.md
@@ -13,3 +13,4 @@
 * `apollo-server-core`: context creation can be async and errors are formatted to include error code [PR #1024](https://github.com/apollographql/apollo-server/pull/1024)
 * `apollo-server-core`: add `mocks` parameter to the base constructor(applies to all variants) [PR#1017](https://github.com/apollographql/apollo-server/pull/1017)
 * `apollo-server-core`: Remove printing of stack traces with `debug` option and include response in logging function[PR#1018](https://github.com/apollographql/apollo-server/pull/1018)
+* `apollo-server-core`: Custom `execute` and `subscribe` functions [PR #4167](https://github.com/apollographql/apollo-server/pull/4167)

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -627,8 +627,8 @@ export class ApolloServerBase {
     this.subscriptionServer = SubscriptionServer.create(
       {
         schema,
-        execute,
-        subscribe,
+        execute: this.config.executeFn || execute,
+        subscribe: this.config.subscribeFn || subscribe,
         onConnect: onConnect
           ? onConnect
           : (connectionParams: Object) => ({ ...connectionParams }),
@@ -837,6 +837,8 @@ export class ApolloServerBase {
       documentStore,
       extensions,
       context,
+      executeFn: this.config.executeFn,
+      subscribeFn: this.config.subscribeFn,
       // Allow overrides from options. Be explicit about a couple of them to
       // avoid a bad side effect of the otherwise useful noUnusedLocals option
       // (https://github.com/Microsoft/TypeScript/issues/21673).

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -5,6 +5,8 @@ import {
   DocumentNode,
   GraphQLError,
   GraphQLFormattedError,
+  execute,
+  subscribe,
 } from 'graphql';
 import { GraphQLExtension } from 'graphql-extensions';
 import { CacheControlExtensionOptions } from 'apollo-cache-control';
@@ -50,6 +52,8 @@ export interface GraphQLServerOptions<
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;
   executor?: GraphQLExecutor;
+  executeFn?: typeof execute,
+  subscribeFn?: typeof subscribe,
   formatResponse?: (
     response: GraphQLResponse | null,
     requestContext: GraphQLRequestContext<TContext>,

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -88,6 +88,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   rootValue?: ((document: DocumentNode) => any) | any;
   validationRules?: ValidationRule[];
   executor?: GraphQLExecutor;
+  executeFn?: typeof graphqlExecute;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
 
   dataSources?: () => DataSources<TContext>;
@@ -550,7 +551,7 @@ export async function processGraphQLRequest<TContext>(
         // (eg apollo-engine-reporting) assumes that.
         return await config.executor(requestContext);
       } else {
-        return await graphqlExecute(executionArgs);
+        return await (config.executeFn || graphqlExecute)(executionArgs);
       }
     } finally {
       executionDidEnd();

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -167,6 +167,7 @@ export async function runHttpQuery(
     validationRules: options.validationRules,
     executor: options.executor,
     fieldResolver: options.fieldResolver,
+    executeFn: options.executeFn,
 
     // FIXME: Use proper option types to ensure this
     // The cache is guaranteed to be initialized in ApolloServer, and

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, DocumentNode } from 'graphql';
+import { GraphQLSchema, DocumentNode, execute, subscribe } from 'graphql';
 import {
   SchemaDirectiveVisitor,
   IResolvers,
@@ -110,6 +110,14 @@ export interface Config extends BaseConfig {
   schema?: GraphQLSchema;
   schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>;
   context?: Context | ContextFunction;
+  /**
+   * Custom `execute` function. Replaces `execute` of GraphQL-JS.
+   */
+  executeFn?: typeof execute,
+  /**
+   * Custom `subscribe` function. Replaces `subscribe` of GraphQL-JS.
+   */
+  subscribeFn?: typeof subscribe,
   introspection?: boolean;
   mocks?: boolean | IMocks;
   mockEntireSchema?: boolean;


### PR DESCRIPTION
This Pull Request introduces a way to replace the default execution and subscription runners through new `executeFn` and `subscribeFn` options (could be `customExecute` or even `execute` - I'm open for any suggestions).

Right now, ApolloServer uses `execute` and `subscribe` from `graphql` package and this PR keeps it as a default behavior. 

In some cases developers may want to own the execution or subscription phase, sometime to provide their own logic or to wrap the original functions from GraphQL-JS.

```typescript
import { execute, subscribe } from 'custom-graphql';

const apollo = new ApolloServer({
  /* ... */
  executeFn: execute,
  subscribeFn: subscribe,
});
```