### PR TITLE
Export ContextFunction from apollo-server-express

### DIFF
--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -79,8 +79,13 @@ export interface ExpressContext {
   connection?: ExecutionParams;
 }
 
+export type ExpressContextFunction<ProducedContext = Context> = ContextFunction<
+  ExpressContext,
+  ProducedContext
+>;
+
 export interface ApolloServerExpressConfig extends Config {
-  context?: ContextFunction<ExpressContext, Context> | Context;
+  context?: ExpressContextFunction<Context> | Context;
 }
 
 export class ApolloServer extends ApolloServerBase {

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -26,6 +26,7 @@ export {
   ApolloServer,
   ServerRegistration,
   ApolloServerExpressConfig,
+  ExpressContextFunction as ContextFunction,
 } from './ApolloServer';
 
 export { CorsOptions } from 'cors';


### PR DESCRIPTION
Adds the `ExpressContextFunction` type, which is exported from `apollo-server-express` as simply `ContextFunction`.

When dealing with apollo-server-express, the type of the `ContextFunction`'s `FunctionParams` can be lost easily, e.g. if the `context` function is declared in its own file. In that case, the `context` parameter becomes implicitly 'any' and it can be difficult to recover that type, since the package does not export the `ExpressContext` type.

It is possible to import `ExpressContext` from `apollo-server-express/dist/ApolloServer`, but relying on that seems like the wrong approach given that it isnt exported "publicly".

This fixes that limitation by exporting a subset of `apollo-server-core`'s `ContextFunction` type with the `FunctionParams` preset to `ExpressContext`. That can then be used to type a `context` function without losing the type of the function params.


I wasn't sure how to test this, but I'm happy to do so if someone could point me in the right direction! Thanks 🙇


<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
