### PR TITLE
Change keyValueCache property of HTTPCache from private to protected.

### DIFF
--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -10,7 +10,7 @@ import {
 import { CacheOptions } from './RESTDataSource';
 
 export class HTTPCache {
-  private keyValueCache: KeyValueCache;
+  protected keyValueCache: KeyValueCache;
   private httpFetch: typeof fetch;
 
   constructor(


### PR DESCRIPTION
Apollo docs currently recommend extending the `RESTDataSource` class. This is a useful pattern. The `RESTDataSource` class contains a public property, `httpCache` which is an instance of the `HTTPCache` class. This is also useful for implementing various caching strategies by creating a subclass of `HTTPCache`.

However, this extensibility quickly becomes problematic because the `keyValueCache` property of `HTTPCache` is marked as private. This means that an HTTP cache implementation that needs to access the underlying key-value store must create a separate instance of `PrefixingKeyValueCache` _and_ be sure to use the same hard-coded prefix as `HTTPCache`. This only works for connections to Memcached or Redis. If using `InMemoryLRUCache`, the key value store is not accessible at all. If `keyValueCache` were changed to protected, this would not be a problem.

Some sample use-cases:

- Implementing a method of invalidating or deleting items from the cache.
- Implementing an HTTP cache that can handle surrogate keys.
- [Simulating cache namespaces; invalidating by namespace](https://github.com/memcached/memcached/wiki/ProgrammingTricks#deleting-by-namespace)