### PR TITLE
Allow schema reporting via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The version headers in this history reflect the versions of Apollo Server itself
 - [__CHANGELOG for `@apollo/gateway`__](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-gateway/CHANGELOG.md)
 - [__CHANGELOG for `@apollo/federation`__](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-federation/CHANGELOG.md)
 
+### vNext
+
+- `apollo-engine-reporting`: Add environment variable `APOLLO_SCHEMA_REPORTING` that can enable schema reporting. If `experimental__schemaReporting` is set it will override the environment variables.
+
 ### v2.14.3
 
 - This release only includes patch updates to dependencies.

--- a/packages/apollo-engine-reporting/src/__tests__/plugin.test.ts
+++ b/packages/apollo-engine-reporting/src/__tests__/plugin.test.ts
@@ -58,14 +58,13 @@ describe('schema reporting', () => {
 
   it('starts reporting if enabled', async () => {
     const pluginInstance = plugin(
-      {
-        experimental_schemaReporting: true,
-      },
+      {},
       addTrace,
       {
         startSchemaReporting,
         executableSchemaIdGenerator,
-      },
+        schemaReport: true,
+      }
     );
 
     await pluginTestHarness({
@@ -97,13 +96,13 @@ describe('schema reporting', () => {
   it('uses the override schema', async () => {
     const pluginInstance = plugin(
       {
-        experimental_schemaReporting: true,
         experimental_overrideReportedSchema: typeDefs,
       },
       addTrace,
       {
         startSchemaReporting,
         executableSchemaIdGenerator,
+        schemaReport: true,
       },
     );
 
@@ -145,14 +144,13 @@ describe('schema reporting', () => {
 
   it('uses the same executable schema id for metric reporting', async () => {
     const pluginInstance = plugin(
-      {
-        experimental_schemaReporting: true,
-      },
+      {},
       addTrace,
       {
         startSchemaReporting,
         executableSchemaIdGenerator,
-      },
+        schemaReport: true,
+      }
     );
 
     await pluginTestHarness({

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -389,6 +389,7 @@ export class EngineReportingAgent<TContext = any> {
   };
 
   private readonly tracesEndpointUrl: string;
+  private readonly schemaReport: boolean;
 
   public constructor(options: EngineReportingOptions<TContext> = {}) {
     this.options = options;
@@ -405,6 +406,13 @@ export class EngineReportingAgent<TContext = any> {
       throw new Error(
         `To use EngineReportingAgent, you must specify an API key via the apiKey option or the APOLLO_KEY environment variable.`,
       );
+    }
+
+
+    if (options.experimental_schemaReporting !== undefined) {
+      this.schemaReport = options.experimental_schemaReporting;
+    } else {
+      this.schemaReport = process.env.APOLLO_SCHEMA_REPORTING === "true"
     }
 
     // Since calculating the signature for Engine reporting is potentially an
@@ -469,6 +477,7 @@ export class EngineReportingAgent<TContext = any> {
     return plugin(this.options, this.addTrace.bind(this), {
       startSchemaReporting: this.startSchemaReporting.bind(this),
       executableSchemaIdGenerator: this.executableSchemaIdGenerator.bind(this),
+      schemaReport: this.schemaReport,
     });
   }
 

--- a/packages/apollo-engine-reporting/src/plugin.ts
+++ b/packages/apollo-engine-reporting/src/plugin.ts
@@ -34,6 +34,7 @@ export const plugin = <TContext>(
   {
     startSchemaReporting,
     executableSchemaIdGenerator,
+    schemaReport,
   }: {
     startSchemaReporting: ({
       executableSchema,
@@ -43,6 +44,7 @@ export const plugin = <TContext>(
       executableSchemaId: string;
     }) => void;
     executableSchemaIdGenerator: (schema: string | GraphQLSchema) => string;
+    schemaReport: boolean;
   },
 ): ApolloServerPlugin<TContext> => {
   /**
@@ -57,7 +59,7 @@ export const plugin = <TContext>(
 
   return {
     serverWillStart: function({ schema }) {
-      if (!options.experimental_schemaReporting) return;
+      if (!schemaReport) return;
       startSchemaReporting({
         executableSchema:
           options.experimental_overrideReportedSchema || printSchema(schema),


### PR DESCRIPTION
Allow enabling schema reporting via setting `APOLLO_SCHEMA_REPORTING` to true.