### PR TITLE
Remove dependency on graphql-js internal Maybe type

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - _Nothing yet! Stay tuned._
 
+## 0.16.6
+
+- In-house `Maybe` type which was previously imported from `graphql` and has been moved in `v15.1.0`. [#4230](https://github.com/apollographql/apollo-server/pull/4230)
+
 ## 0.16.5
 
 - Remove federation primitives from SDL during composition. This allows for services to report their *full* SDL from the `{ _service { sdl } }` query as opposed to the previously limited SDL without federation definitions. [#4209](https://github.com/apollographql/apollo-server/pull/4209)

--- a/packages/apollo-federation/src/composition/types.ts
+++ b/packages/apollo-federation/src/composition/types.ts
@@ -5,6 +5,8 @@ import {
   DirectiveDefinitionNode,
 } from 'graphql';
 
+export type Maybe<T> = null | undefined | T;
+
 export type ServiceName = string | null;
 
 export type DefaultRootOperationTypeName =

--- a/packages/apollo-federation/src/composition/utils.ts
+++ b/packages/apollo-federation/src/composition/utils.ts
@@ -31,7 +31,11 @@ import {
   GraphQLDirective,
   OperationTypeNode,
 } from 'graphql';
-import { ExternalFieldDefinition, DefaultRootOperationTypeName, Maybe } from './types';
+import {
+  ExternalFieldDefinition,
+  DefaultRootOperationTypeName,
+  Maybe,
+} from './types';
 import federationDirectives from '../directives';
 
 export function isStringValueNode(node: any): node is StringValueNode {

--- a/packages/apollo-federation/src/composition/utils.ts
+++ b/packages/apollo-federation/src/composition/utils.ts
@@ -31,8 +31,7 @@ import {
   GraphQLDirective,
   OperationTypeNode,
 } from 'graphql';
-import Maybe from 'graphql/tsutils/Maybe';
-import { ExternalFieldDefinition, DefaultRootOperationTypeName } from './types';
+import { ExternalFieldDefinition, DefaultRootOperationTypeName, Maybe } from './types';
 import federationDirectives from '../directives';
 
 export function isStringValueNode(node: any): node is StringValueNode {

--- a/packages/apollo-federation/src/composition/validate/sdl/matchingUnions.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/matchingUnions.ts
@@ -1,7 +1,7 @@
 import { GraphQLError, ASTVisitor, UnionTypeDefinitionNode } from 'graphql';
 import { SDLValidationContext } from 'graphql/validation/ValidationContext';
-import Maybe from 'graphql/tsutils/Maybe';
 import xorBy from 'lodash.xorby';
+import { Maybe } from '../../types';
 import { errorWithCode, logServiceAndType } from '../../utils';
 import {
   existedTypeNameMessage,

--- a/packages/apollo-federation/src/composition/validate/sdl/uniqueFieldDefinitionNames.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/uniqueFieldDefinitionNames.ts
@@ -15,7 +15,7 @@ import {
 } from 'graphql';
 import { SDLValidationContext } from 'graphql/validation/ValidationContext';
 import { TypeMap } from 'graphql/type/schema';
-import Maybe from 'graphql/tsutils/Maybe';
+import { Maybe } from '../../types';
 import { diffTypeNodes, logServiceAndType } from '../../utils';
 
 type TypeNodeWithFields = TypeDefinitionWithFields | TypeExtensionWithFields;

--- a/packages/apollo-federation/src/composition/validate/sdl/uniqueTypeNamesWithFields.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/uniqueTypeNamesWithFields.ts
@@ -7,7 +7,7 @@ import {
 } from 'graphql';
 
 import { SDLValidationContext } from 'graphql/validation/ValidationContext';
-import Maybe from 'graphql/tsutils/Maybe';
+import { Maybe } from '../../types';
 import {
   isTypeNodeAnEntity,
   diffTypeNodes,


### PR DESCRIPTION
Closes #4223

Per https://github.com/graphql/graphql-js/pull/2621#issuecomment-641927660, `Maybe` is an internal type for graphql-js, which is why it isn't re-exported from index.d.ts. They [moved it](https://github.com/graphql/graphql-js/pull/2621) from `tsutils` to `jsutils` in v15.1.0 which breaks the deep import in apollo-federation.

This PR solves the issue by defining `Maybe` internally rather than importing it from graphql-js.
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
