### PR TITLE
feat(apollo-server-plugin-operation-registry): use CDN

### DIFF
--- a/packages/apollo-server-plugin-operation-registry/CHANGELOG.md
+++ b/packages/apollo-server-plugin-operation-registry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 0.4.0:
+
+- __BREAKING__: Use a content delivery network, fetch storage secrets and operation manifests from different domains: https://storage-secrets.api.apollographql.com and https://operations.api.apollographql.com. Please mind any firewall for outgoing traffic.
+
 ### 0.3.1:
 
 - The `schemaTag` option is now deprecated and superseded by `graphVariant`.

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-operation-registry",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Apollo Server operation registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-operation-registry/src/common.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/common.ts
@@ -6,33 +6,25 @@ export const envOverrideOperationManifest =
 
 export const envOverrideStorageSecretBaseUrl = 'APOLLO_STORAGE_SECRET_BASE_URL';
 
-export const fakeTestBaseUrl = 'https://fake-host-for-apollo-op-reg-tests/';
+export const fakeTestBaseUrl = 'https://fake-host-for-apollo-op-reg-tests';
 
 // Generate and cache our desired operation manifest URL.
-export const urlOperationManifestBase: string = ((): string => {
-  const desiredUrl =
-    process.env[envOverrideOperationManifest] ||
-    // See src/__tests__/jestSetup.ts for more details on this env. variable.
-    process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
-      ? fakeTestBaseUrl
-      : 'https://storage.googleapis.com/engine-op-manifest-storage-prod/';
-
-  // Make sure it has NO trailing slash.
-  return desiredUrl.replace(/\/$/, '');
-})();
+export const urlOperationManifestBase: string =
+  // Remove trailing slash if any.
+  process.env[envOverrideOperationManifest]?.replace(/\/$/, '') ||
+  // See src/__tests__/jestSetup.ts for more details on this env. variable.
+  process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
+    ? fakeTestBaseUrl
+    : 'https://operations.api.apollographql.com';
 
 // Generate and cache our desired storage secret URL.
-export const urlStorageSecretBase: string = ((): string => {
-  const desiredUrl =
-    process.env[envOverrideStorageSecretBaseUrl] ||
-    // See src/__tests__/jestSetup.ts for more details on this env. variable.
-    process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
-      ? fakeTestBaseUrl
-      : 'https://storage.googleapis.com/engine-partial-schema-prod/';
-
-  // Make sure it has NO trailing slash.
-  return desiredUrl.replace(/\/$/, '');
-})();
+export const urlStorageSecretBase: string =
+  // Remove trailing slash if any.
+  process.env[envOverrideStorageSecretBaseUrl]?.replace(/\/$/, '') ||
+  // See src/__tests__/jestSetup.ts for more details on this env. variable.
+  process.env['__APOLLO_OPERATION_REGISTRY_TESTS__'] === 'true'
+    ? fakeTestBaseUrl
+    : 'https://storage-secrets.api.apollographql.com';
 
 export const getStoreKey = (signature: string) => `${signature}`;
 


### PR DESCRIPTION
CDN in place, should be ready to go.
Not sure what the release process looks like, so went with `NEXT` in `CHANGELOG.md`.