### PR TITLE
fix(gateway): Handle `@external` validation edge case for interface implementors

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned._
+- Handle `@external` validation edge case for interface implementors [#4284](https://github.com/apollographql/apollo-server/pull/4284)
 
 ## 0.16.7
 

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalUnused.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalUnused.test.ts
@@ -303,42 +303,78 @@ describe('externalUnused', () => {
     expect(warnings).toEqual([]);
   });
 
-  it('does not warn when @external is used on type that is an implementation of an interface', () => {
+  it('does not error when @external is used on a field of a concrete type that implements a shared field of an implemented interface', () => {
     const serviceA = {
       typeDefs: gql`
-        type Car implements Product @key(fields: "id") {
+        type Car implements Vehicle @key(fields: "id") {
           id: ID!
           speed: Int
         }
-
-        interface Product {
+        interface Vehicle {
           id: ID!
+          speed: Int
         }
       `,
       name: 'serviceA',
     };
-
     const serviceB = {
       typeDefs: gql`
-        type Query {
-          products: [Product]
-        }
-
-        extend type Car implements Product @key(fields: "id") {
+        extend type Car implements Vehicle @key(fields: "id") {
           id: ID! @external
           speed: Int @external
         }
-
-        interface Product {
+        interface Vehicle {
           id: ID!
+          speed: Int
         }
       `,
       name: 'serviceB',
-    }
-
-    const serviceList = [serviceA, serviceB,];
+    };
+    const serviceList = [serviceA, serviceB];
     const { schema } = composeServices(serviceList);
-    const warnings = validateExternalUnused({ schema, serviceList });
-    expect(warnings).toEqual([]);
+    const errors = validateExternalUnused({ schema, serviceList });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('does error when @external is used on a field of a concrete type is not shared by its implemented interface', () => {
+    const serviceA = {
+      typeDefs: gql`
+        type Car implements Vehicle @key(fields: "id") {
+          id: ID!
+          speed: Int
+          wheelSize: Int
+        }
+        interface Vehicle {
+          id: ID!
+          speed: Int
+        }
+      `,
+      name: 'serviceA',
+    };
+    const serviceB = {
+      typeDefs: gql`
+        extend type Car implements Vehicle @key(fields: "id") {
+          id: ID! @external
+          speed: Int @external
+          wheelSize: Int @external
+        }
+        interface Vehicle {
+          id: ID!
+          speed: Int
+        }
+      `,
+      name: 'serviceB',
+    };
+    const serviceList = [serviceA, serviceB];
+    const { schema } = composeServices(serviceList);
+    const errors = validateExternalUnused({ schema, serviceList });
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "EXTERNAL_UNUSED",
+          "message": "[serviceB] Car.wheelSize -> is marked as @external but is not used by a @requires, @key, or @provides directive.",
+        },
+      ]
+    `);
   });
 });

--- a/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalUnused.test.ts
+++ b/packages/apollo-federation/src/composition/validate/postComposition/__tests__/externalUnused.test.ts
@@ -302,4 +302,43 @@ describe('externalUnused', () => {
     const warnings = validateExternalUnused({ schema, serviceList });
     expect(warnings).toEqual([]);
   });
+
+  it('does not warn when @external is used on type that is an implementation of an interface', () => {
+    const serviceA = {
+      typeDefs: gql`
+        type Car implements Product @key(fields: "id") {
+          id: ID!
+          speed: Int
+        }
+
+        interface Product {
+          id: ID!
+        }
+      `,
+      name: 'serviceA',
+    };
+
+    const serviceB = {
+      typeDefs: gql`
+        type Query {
+          products: [Product]
+        }
+
+        extend type Car implements Product @key(fields: "id") {
+          id: ID! @external
+          speed: Int @external
+        }
+
+        interface Product {
+          id: ID!
+        }
+      `,
+      name: 'serviceB',
+    }
+
+    const serviceList = [serviceA, serviceB,];
+    const { schema } = composeServices(serviceList);
+    const warnings = validateExternalUnused({ schema, serviceList });
+    expect(warnings).toEqual([]);
+  });
 });


### PR DESCRIPTION
One edge case on the validation of externals being used is when concrete
types need to be defined in multiple services for an interface to be
returned as a type for a field. To return an inteface, you need to
defined its possible implementations to let the schema know what all it
could support but you also need to mark its fields as external (at least
the ones you can resolve) so that you don't try and take over ownership
of an entities fields. The current implementation doesn't take this into
account so you fail validation and can't compose the graph

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/master/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
