### PR TITLE
Add support for passing options to http-cache-semantics in apollo-dat…

### DIFF
--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -1,6 +1,7 @@
 import { fetch, Request, Response, Headers } from 'apollo-server-env';
 
 import CachePolicy = require('http-cache-semantics');
+import { Options as CachePolicyOptions } from 'http-cache-semantics';
 
 import {
   KeyValueCache,
@@ -31,6 +32,7 @@ export class HTTPCache {
       cacheOptions?:
         | CacheOptions
         | ((response: Response, request: Request) => CacheOptions | undefined);
+      cachePolicyOptions?: CachePolicyOptions
     } = {},
   ): Promise<Response> {
     const cacheKey = options.cacheKey ? options.cacheKey : request.url;
@@ -42,6 +44,7 @@ export class HTTPCache {
       const policy = new CachePolicy(
         policyRequestFrom(request),
         policyResponseFrom(response),
+        options.cachePolicyOptions
       );
 
       return this.storeResponseAndReturnClone(

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -13,6 +13,7 @@ import {
 import { ValueOrPromise } from 'apollo-server-types';
 
 import { DataSource, DataSourceConfig } from 'apollo-datasource';
+import { Options as CachePolicyOptions } from 'http-cache-semantics';
 
 import { HTTPCache } from './HTTPCache';
 
@@ -27,6 +28,7 @@ declare module 'apollo-server-env/dist/fetch' {
     cacheOptions?:
       | CacheOptions
       | ((response: Response, request: Request) => CacheOptions | undefined);
+    cachePolicyOptions?: CachePolicyOptions
   }
 }
 
@@ -257,6 +259,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
           const response = await this.httpCache.fetch(request, {
             cacheKey,
             cacheOptions,
+            cachePolicyOptions: options.cachePolicyOptions
           });
           return await this.didReceiveResponse(response, request);
         } catch (error) {

--- a/packages/apollo-datasource-rest/src/__tests__/HTTPCache.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/HTTPCache.test.ts
@@ -473,4 +473,25 @@ describe('HTTPCache', () => {
     expect(customFetch.mock.calls.length).toEqual(1);
     expect(await response.json()).toEqual({ name: 'Ada Lovelace' });
   });
+
+  it('allows options to be passed to http-cache-semantics', async () => {
+    fetch.mockJSONResponseOnce({ name: 'Ada Lovelace' }, {
+      'Cache-Control': 'max-age=60,must-revalidate',
+      'set-cookie': 'whatever=blah; expires=Mon, 01-Jan-2050 00:00:00 GMT; path=/; domain=www.example.com'
+    });
+
+    await httpCache.fetch(new Request('https://api.example.com/people/1'), { cachePolicyOptions: {
+      // http-cache-semantics won't cache a response with a set-cookie header unless opted in
+      shared: false
+    }});
+
+    advanceTimeBy(10000);
+
+    const response = await httpCache.fetch(
+      new Request('https://api.example.com/people/1'),
+    );
+
+    expect(fetch.mock.calls.length).toEqual(1);
+    expect(await response.json()).toEqual({ name: 'Ada Lovelace' });
+  });
 });

--- a/packages/apollo-datasource-rest/src/types/http-cache-semantics/index.d.ts
+++ b/packages/apollo-datasource-rest/src/types/http-cache-semantics/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'http-cache-semantics' {
+declare namespace CachePolicy {
   interface Request {
     url: string;
     method: string;
@@ -10,32 +10,72 @@ declare module 'http-cache-semantics' {
     headers: Headers;
   }
 
-  type Headers = { [name: string]: string };
-
-  class CachePolicy {
-    constructor(request: Request, response: Response);
-
-    storable(): boolean;
-
-    satisfiesWithoutRevalidation(request: Request): boolean;
-    responseHeaders(): Headers;
-
-    age(): number;
-    timeToLive(): number;
-
-    revalidationHeaders(request: Request): Headers;
-    revalidatedPolicy(
-      request: Request,
-      response: Response,
-    ): { policy: CachePolicy; modified: boolean };
-
-    static fromObject(object: object): CachePolicy;
-    toObject(): object;
-
-    _url: string | undefined;
-    _status: number;
-    _rescc: { [key: string]: any };
+  interface Options {
+    /**
+     * If `true`, then the response is evaluated from a perspective of a shared cache (i.e. `private` is not
+     * cacheable and `s-maxage` is respected). If `false`, then the response is evaluated from a perspective
+     * of a single-user cache (i.e. `private` is cacheable and `s-maxage` is ignored).
+     * `true` is recommended for HTTP clients.
+     * @default true
+     */
+    shared?: boolean;
+    /**
+     * A fraction of response's age that is used as a fallback cache duration. The default is 0.1 (10%),
+     * e.g. if a file hasn't been modified for 100 days, it'll be cached for 100*0.1 = 10 days.
+     * @default 0.1
+     */
+    cacheHeuristic?: number;
+    /**
+     * A number of milliseconds to assume as the default time to cache responses with `Cache-Control: immutable`.
+     * Note that [per RFC](https://httpwg.org/specs/rfc8246.html#the-immutable-cache-control-extension)
+     * these can become stale, so `max-age` still overrides the default.
+     * @default 24*3600*1000 (24h)
+     */
+    immutableMinTimeToLive?: number;
+    /**
+     * If `true`, common anti-cache directives will be completely ignored if the non-standard `pre-check`
+     * and `post-check` directives are present. These two useless directives are most commonly found
+     * in bad StackOverflow answers and PHP's "session limiter" defaults.
+     * @default false
+     */
+    ignoreCargoCult?: boolean;
+    /**
+     * If `false`, then server's `Date` header won't be used as the base for `max-age`. This is against the RFC,
+     * but it's useful if you want to cache responses with very short `max-age`, but your local clock
+     * is not exactly in sync with the server's.
+     * @default true
+     */
+    trustServerDate?: boolean;
   }
 
+  type Headers = { [name: string]: string };
+}
+
+declare class CachePolicy {
+  constructor(request: CachePolicy.Request, response: CachePolicy.Response, options?: CachePolicy.Options);
+
+  storable(): boolean;
+
+  satisfiesWithoutRevalidation(request: CachePolicy.Request): boolean;
+  responseHeaders(): CachePolicy.Headers;
+
+  age(): number;
+  timeToLive(): number;
+
+  revalidationHeaders(request: CachePolicy.Request): CachePolicy.Headers;
+  revalidatedPolicy(
+    request: CachePolicy.Request,
+    response: CachePolicy.Response,
+  ): { policy: CachePolicy; modified: boolean };
+
+  static fromObject(object: object): CachePolicy;
+  toObject(): object;
+
+  _url: string | undefined;
+  _status: number;
+  _rescc: { [key: string]: any };
+}
+
+declare module 'http-cache-semantics' {
   export = CachePolicy;
 }


### PR DESCRIPTION
Apollo-datasource-rest uses http-cache-semantics to determine if a response is cachable. I ran into a problem where because of it’s opinionated nature it’s not caching something that I need it to. There are options to change this opinionated behavior, but apollo-datasource-rest isn’t set up in a way that those options can be passed. This PR allows the passing of those options.

Note: This is reopening https://github.com/apollographql/apollo-server/pull/4203 which was against master and automatically closed.
