### PR TITLE
[RESTDataSource] refactor to allow overridding the Error class

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -125,17 +125,16 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     }
   }
 
+  protected errorBaseFromResponseAndMessage(response: Response, message: string): ApolloError {
+    if (response.status === 401) return new AuthenticationError(message);
+    if (response.status === 403) return new ForbiddenError(message);
+    return new ApolloError(message);
+  }
+
   protected async errorFromResponse(response: Response) {
     const message = `${response.status}: ${response.statusText}`;
 
-    let error: ApolloError;
-    if (response.status === 401) {
-      error = new AuthenticationError(message);
-    } else if (response.status === 403) {
-      error = new ForbiddenError(message);
-    } else {
-      error = new ApolloError(message);
-    }
+    const error = this.errorBaseFromResponseAndMessage(response, message);
 
     const body = await this.parseBody(response);
 

--- a/packages/apollo-gateway/src/datasources/RemoteGraphQLDataSource.ts
+++ b/packages/apollo-gateway/src/datasources/RemoteGraphQLDataSource.ts
@@ -200,17 +200,16 @@ export class RemoteGraphQLDataSource<TContext extends Record<string, any> = Reco
     }
   }
 
+  protected errorBaseFromResponseAndMessage(response: Response, message: string): ApolloError {
+    if (response.status === 401) return new AuthenticationError(message);
+    if (response.status === 403) return new ForbiddenError(message);
+    return new ApolloError(message);
+  }
+
   public async errorFromResponse(response: Response) {
     const message = `${response.status}: ${response.statusText}`;
 
-    let error: ApolloError;
-    if (response.status === 401) {
-      error = new AuthenticationError(message);
-    } else if (response.status === 403) {
-      error = new ForbiddenError(message);
-    } else {
-      error = new ApolloError(message);
-    }
+    const error = this.errorBaseFromResponseAndMessage(response, message);
 
     const body = await this.parseBody(response);
 


### PR DESCRIPTION
for example if we want to create a `NotFoundError` that will be used when receiving 404s. This way we need to override the bare minimum like

```
class MyDataSource extends RESTDataSource {
  protected errorBaseFromResponseAndMessage(response: Response, message: string): ApolloError {
    if (response.status === 401) return new NotFoundError(message);

    return super.errorBaseFromResponseAndMessage(response, message);
  }
}
```

Also adding it in the RemoteGraphQLDataSource since it has the same code as RESTDataSource, for symmetry purposes.

Signed-off-by: Eduardo Turiño <eturino@eturino.com>

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
