### PR TITLE
Fixed parsing in  HTTPCache throwing an error when entry is already an object

### DIFF
--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -53,7 +53,17 @@ export class HTTPCache {
       );
     }
 
-    const { policy: policyRaw, ttlOverride, body } = JSON.parse(entry);
+    let entryToUse;
+    try {
+      // Try parsing the entry
+      entryToUse = JSON.parse(entry);
+    }
+    catch (ex) {
+      // Use the entry directly when it is already an object
+      entryToUse = entry;
+    }
+
+    const { policy: policyRaw, ttlOverride, body } = entryToUse;
 
     const policy = CachePolicy.fromObject(policyRaw);
     // Remove url from the policy, because otherwise it would never match a request with a custom cache key


### PR DESCRIPTION
Apparently it can happen that an entry of the InMemoryLRUCache is an object, even though the entry is stringified before it is put in the cache. This causes this line to throw an error: line 56: const { policy: policyRaw, ttlOverride, body } = JSON.parse(entry);

This pull request fixes this [issue](https://github.com/apollographql/apollo-server/issues/4350).