### PR TITLE
Correct GET example in docs/source/requests.md

### DIFF
--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -46,7 +46,7 @@ Apollo Server also accepts GET requests. A GET request must pass query and optio
 Here is the same query from above in a well-formatted GET request to Apollo Server:
 
 ```
-GET /graphql?query=query%20aTest(%24arg1%3A%20String!)%20%7B%20test(who%3A%20%24arg1)%20%7D&operationName=aTest&variables=me
+GET /graphql?query=query%20aTest(%24arg1%3A%20String!)%20%7B%20test(who%3A%20%24arg1)%20%7D&operationName=aTest&variables=%7B%22arg1%22%3A%22me%22%7D
 ```
 
 caveat: Mutations cannot be executed via GET requests.


### PR DESCRIPTION
`variables` URL parameter should be a URL-encoded, JSON-stringified object.

Verified the behavior with [the `apollo-link` unit tests](https://github.com/apollographql/apollo-link/blob/26f2df99bee15cac9749c0aaab78eb4a19f11ae4/packages/apollo-link-http/src/__tests__/httpLink.ts#L89) and the [`apollo-link` GET implementation](https://github.com/apollographql/apollo-link/blob/26f2df99bee15cac9749c0aaab78eb4a19f11ae4/packages/apollo-link-http/src/httpLink.ts#L222).