### PR TITLE
Add mutation planning tests to cradle suite

### DIFF
--- a/packages/apollo-gateway/src/__tests__/build-query-plan.feature
+++ b/packages/apollo-gateway/src/__tests__/build-query-plan.feature
@@ -1222,3 +1222,453 @@ Scenario: deduplicates fields / selections regardless of adjacency and type cond
       }
     }
     """
+
+Scenario: supports basic, single-service mutation
+  Given query
+  """
+  mutation Login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      id
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Fetch",
+      "serviceName": "accounts",
+      "variableUsages": [
+        "username",
+        "password"
+      ],
+      "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){id}}"
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L13
+Scenario: supports mutations with a cross-service request
+  Given query
+  """
+  mutation Login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      reviews {
+        product {
+          upc
+        }
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [
+            "username",
+            "password"
+          ],
+          "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){__typename id}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login",
+            "reviews",
+            "@",
+            "product"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Book",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "isbn"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L48
+Scenario: returning across service boundaries
+  Given query
+  """
+  mutation Review($upc: String!, $body: String!) {
+    reviewProduct(upc: $upc, body: $body) {
+      ... on Furniture {
+        name
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "upc",
+            "body"
+          ],
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "reviewProduct"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Furniture",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "upc"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L75
+Scenario: supports multiple root mutations
+  Given query
+  """
+  mutation LoginAndReview(
+    $username: String!
+    $password: String!
+    $upc: String!
+    $body: String!
+  ) {
+    login(username: $username, password: $password) {
+      reviews {
+        product {
+          upc
+        }
+      }
+    }
+    reviewProduct(upc: $upc, body: $body) {
+      ... on Furniture {
+        name
+      }
+    }
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [
+            "username",
+            "password"
+          ],
+          "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){__typename id}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login",
+            "reviews",
+            "@",
+            "product"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Book",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "isbn"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}"
+          }
+        },
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "upc",
+            "body"
+          ],
+          "operation": "mutation($upc:String!$body:String!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{__typename upc}}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "reviewProduct"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Furniture",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "upc"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Furniture{name}}}"
+          }
+        }
+      ]
+    }
+  }
+  """
+
+# ported from: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/__tests__/integration/mutations.test.ts#L136
+Scenario: multiple root mutations with correct service order
+  Given query
+  """
+  mutation LoginAndReview(
+    $upc: String!
+    $body: String!
+    $updatedReview: UpdateReviewInput!
+    $username: String!
+    $password: String!
+    $reviewId: ID!
+  ) {
+    reviewProduct(upc: $upc, body: $body) {
+      ... on Furniture {
+        upc
+      }
+    }
+    updateReview(review: $updatedReview) {
+      id
+      body
+    }
+    login(username: $username, password: $password) {
+      reviews {
+        product {
+          upc
+        }
+      }
+    }
+    deleteReview(id: $reviewId)
+  }
+  """
+  Then query plan
+  """
+  {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "upc",
+            "body",
+            "updatedReview"
+          ],
+          "operation": "mutation($upc:String!$body:String!$updatedReview:UpdateReviewInput!){reviewProduct(upc:$upc body:$body){__typename ...on Furniture{upc}}updateReview(review:$updatedReview){id body}}"
+        },
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [
+            "username",
+            "password"
+          ],
+          "operation": "mutation($username:String!$password:String!){login(username:$username password:$password){__typename id}}"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{product{__typename ...on Book{__typename isbn}...on Furniture{upc}}}}}}"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "login",
+            "reviews",
+            "@",
+            "product"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "product",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "Book",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "isbn"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{upc}}}"
+          }
+        },
+        {
+          "kind": "Fetch",
+          "serviceName": "reviews",
+          "variableUsages": [
+            "reviewId"
+          ],
+          "operation": "mutation($reviewId:ID!){deleteReview(id:$reviewId)}"
+        }
+      ]
+    }
+  }
+  """


### PR DESCRIPTION
I Ported some tests from the existing mutation integration tests (from the gateway). I commented which those were and their corresponding tests from the gateway package (since I changed some names slightly) so we could go back later when we port _all_ tests to cucumber and remove them from this one mega-file (per the discussion [here](https://github.com/apollographql/rust/issues/103#issuecomment-659458895) :)

I also added a simple, barebones, single-service test to make sure mutations build a simple fetch node to begin with


One this is merged, I'll update [this PR](https://github.com/apollographql/rust/pull/106) with the new tests