### PR TITLE
Add serverWillStop lifecycle hook; call stop() on signals by default

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -163,6 +163,17 @@ new ApolloServer({
   size of 30MiB, which is generally sufficient unless the server is processing
   a high number of unique operations.
 
+* `stopOnTerminationSignals`: `boolean`
+
+By default (when running in Node and when the `NODE_ENV` environment variable does not equal `test`),
+ApolloServer listens for the `SIGINT` and `SIGTERM` signals and calls `await this.stop()` on
+itself when it is received, and then re-sends the signal to itself so that process shutdown can continue.
+Set this to false to disable this behavior, or to true to enable this behavior even when `NODE_ENV` is
+`test`. You can manually invoke `stop()` in other contexts if you'd
+like. Note that `stop()` does not run synchronously so it cannot work usefully in an `process.on('exit')`
+handler.
+
+
 #### Returns
 
 `ApolloServer`
@@ -447,11 +458,8 @@ addMockFunctionsToSchema({
 
 *  `handleSignals`: boolean
 
-   By default, EngineReportingAgent listens for the 'SIGINT' and 'SIGTERM'
-   signals, stops, sends a final report, and re-sends the signal to
-   itself. Set this to false to disable. You can manually invoke 'stop()' and
-   'sendReport()' on other signals if you'd like. Note that 'sendReport()'
-   does not run synchronously so it cannot work usefully in an 'exit' handler.
+  For backwards compatibility only; specifying `new ApolloServer({engine: {handleSignals: false}})` is
+  equivalent to specifying `new ApolloServer({stopOnTerminationSignals: false})`.
 
 *  `rewriteError`: (err: GraphQLError) => GraphQLError | null
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -124,6 +124,7 @@ export interface Config extends BaseConfig {
   playground?: PlaygroundConfig;
   gateway?: GraphQLService;
   experimental_approximateDocumentStoreMiB?: number;
+  stopOnTerminationSignals?: boolean;
 }
 
 export interface FileUploadOptions {

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -62,7 +62,7 @@ describe('apollo-server-express', () => {
     serverOptions: ApolloServerExpressConfig,
     options: Partial<ServerRegistration> = {},
   ) {
-    server = new ApolloServer(serverOptions);
+    server = new ApolloServer({stopOnTerminationSignals: false, ...serverOptions});
     app = express();
 
     server.applyMiddleware({ ...options, app });
@@ -184,13 +184,12 @@ describe('apollo-server-express', () => {
     });
 
     it('renders GraphQL playground using request original url', async () => {
-      const nodeEnv = process.env.NODE_ENV;
-      delete process.env.NODE_ENV;
       const samplePath = '/innerSamplePath';
 
       const rewiredServer = new ApolloServer({
         typeDefs,
         resolvers,
+        playground: true,
       });
       const innerApp = express();
       rewiredServer.applyMiddleware({ app: innerApp });
@@ -218,7 +217,6 @@ describe('apollo-server-express', () => {
             },
           },
           (error, response, body) => {
-            process.env.NODE_ENV = nodeEnv;
             if (error) {
               reject(error);
             } else {

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -64,7 +64,7 @@ describe('apollo-server-fastify', () => {
     options: Partial<ServerRegistration> = {},
     mockDecorators: boolean = false,
   ) {
-    server = new ApolloServer(serverOptions);
+    server = new ApolloServer({ stopOnTerminationSignals: false, ...serverOptions });
     app = fastify();
 
     if (mockDecorators) {

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -155,6 +155,7 @@ const port = 0;
         server = new ApolloServer({
           typeDefs,
           resolvers,
+          stopOnTerminationSignals: false,
         });
         app = new Server({ port });
 
@@ -514,6 +515,7 @@ const port = 0;
           server = new ApolloServer({
             typeDefs,
             resolvers,
+            stopOnTerminationSignals: false,
             context: () => {
               throw new AuthenticationError('valid result');
             },
@@ -562,6 +564,7 @@ const port = 0;
                 },
               },
             },
+            stopOnTerminationSignals: false,
           });
 
           app = new Server({ port });
@@ -609,6 +612,7 @@ const port = 0;
                 },
               },
             },
+            stopOnTerminationSignals: false,
           });
 
           app = new Server({ port });
@@ -653,6 +657,7 @@ const port = 0;
                 },
               },
             },
+            stopOnTerminationSignals: false,
           });
 
           app = new Server({ port });

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -233,6 +233,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
           const { url: uri } = await createApolloServer({
             schema,
+            stopOnTerminationSignals: false,
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -250,6 +251,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
           const { url: uri } = await createApolloServer({
             schema,
+            stopOnTerminationSignals: false,
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -272,6 +274,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const { url: uri } = await createApolloServer({
             schema,
             introspection: true,
+            stopOnTerminationSignals: false,
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -1009,6 +1012,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               },
               formatError,
               debug: true,
+              stopOnTerminationSignals: false,
             });
 
             const apolloFetch = createApolloFetch({ uri });
@@ -1078,6 +1082,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
                 ...engineOptions,
               },
               debug: true,
+              stopOnTerminationSignals: false,
               ...constructorOptions,
             });
 
@@ -1682,6 +1687,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             const { url: uri } = await createApolloServer({
               typeDefs,
               resolvers,
+              stopOnTerminationSignals: false,
               context: () => {
                 throw new AuthenticationError('valid result');
               },
@@ -1743,6 +1749,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               },
             },
           },
+          stopOnTerminationSignals: false,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -1776,6 +1783,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               },
             },
           },
+          stopOnTerminationSignals: false,
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -77,7 +77,7 @@ const resolvers = {
     serverOptions: Config,
     options: Partial<import('../ApolloServer').ServerRegistration> = {},
   ) {
-    server = new ApolloServer(serverOptions);
+    server = new ApolloServer({ stopOnTerminationSignals: false, ...serverOptions });
     app = new Koa();
 
     server.applyMiddleware({ ...options, app });

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -22,7 +22,11 @@ const resolvers = {
 };
 
 async function createServer(options: object = {}): Promise<any> {
-  const apolloServer = new ApolloServer({ typeDefs, resolvers });
+  const apolloServer = new ApolloServer({
+    typeDefs,
+    resolvers,
+    stopOnTerminationSignals: false,
+  });
   const service = micro(apolloServer.createHandler(options));
   const uri = await listen(service);
   return {

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -55,11 +55,17 @@ export {
 
 export interface ApolloServerPlugin<
   TContext extends BaseContext = BaseContext
-> {
-  serverWillStart?(service: GraphQLServiceContext): ValueOrPromise<void>;
+> extends AnyFunctionMap {
+  serverWillStart?(
+    service: GraphQLServiceContext,
+  ): ValueOrPromise<GraphQLServerListener | void>;
   requestDidStart?(
     requestContext: GraphQLRequestContext<TContext>,
   ): GraphQLRequestListener<TContext> | void;
+}
+
+export interface GraphQLServerListener {
+  serverWillStop?(): ValueOrPromise<void>;
 }
 
 export type GraphQLRequestListenerParsingDidEnd = (err?: Error) => void;

--- a/packages/apollo-server-plugin-operation-registry/src/ApolloServerPluginOperationRegistry.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/ApolloServerPluginOperationRegistry.ts
@@ -4,6 +4,7 @@ import {
   GraphQLServiceContext,
   GraphQLRequestListener,
   GraphQLRequestContext,
+  GraphQLServerListener,
 } from 'apollo-server-plugin-base';
 import {
   /**
@@ -97,7 +98,7 @@ for observability purposes, but all operations will be permitted.`,
   return (): ApolloServerPlugin => ({
     async serverWillStart({
       engine,
-    }: GraphQLServiceContext): Promise<void> {
+    }: GraphQLServiceContext): Promise<GraphQLServerListener> {
       logger.debug('Initializing operation registry plugin.');
 
       if (!engine || !engine.serviceID) {
@@ -124,6 +125,12 @@ for observability purposes, but all operations will be permitted.`,
       });
 
       await agent.start();
+
+      return {
+        serverWillStop() {
+          agent.stop();
+        },
+      };
     },
 
     requestDidStart(): GraphQLRequestListener<any> {


### PR DESCRIPTION
Fixes #4273.

This PR adds a serverWillStop plugin lifecycle hook.  The `serverWillStop` hook
is on an object optionally returned from a `serverWillStart` hook, similar to
`executionDidStart`/`executionDidEnd`.

ApolloServerPluginOperationRegistry uses this to stop its agent.

The code that installs SIGINT and SIGTERM handlers unless disabled with
`handleSignals: false` is hoisted from EngineReportingAgent to ApolloServer
itself and renamed to `stopOnTerminationSignals` as a new ApolloServer
option. The new implementation also skips installing the signals handlers by
default if NODE_ENV=test or if you don't appear to be running in Node (and we
update some tests that explicitly set other NODE_ENVs to set handleSignals:
false).

The main effect on existing code is that on one of these signals, any
SubscriptionServer and ApolloGateway will be stopped in addition to any
EngineReportingAgent.
