### PR TITLE
fix: fixed typo with experimental_approximateDocumentStoreMiB parameter

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -176,6 +176,9 @@ export class ApolloServerBase {
       ...requestOptions
     } = config;
 
+    // initialized experimental parameter
+    this.experimental_approximateDocumentStoreMiB = experimental_approximateDocumentStoreMiB;
+
     // Setup logging facilities
     if (config.logger) {
       this.logger = config.logger;


### PR DESCRIPTION
this parameter didn't use even user specify it. i just initialize it in constructor. Also could u explain this comment:

```
// Create ~about~ a 30MiB InMemoryLRUCache.  This is less than precise
      // since the technique to calculate the size of a DocumentNode is
      // only using JSON.stringify on the DocumentNode (and thus doesn't account
      // for unicode characters, etc.), but it should do a reasonable job at
      // providing a caching document store for most operations.
```
```
Math.pow(2, 20) * (this.experimental_approximateDocumentStoreMiB || 30)
```
why is it around 30MiB? we have 30 million keys in lru-cache. I'm not sure that it's true (because each key must be equel 1b).
