### PR TITLE
fix(federation): complex `@key`s result in unparseable CSDL

### DIFF
--- a/packages/apollo-federation-integration-testsuite/src/fixtures/accounts.ts
+++ b/packages/apollo-federation-integration-testsuite/src/fixtures/accounts.ts
@@ -33,13 +33,18 @@ export const typeDefs = gql`
     description: String
   }
 
-  type User @key(fields: "id") {
+  type User @key(fields: "id") @key(fields: "username name { first last }"){
     id: ID!
-    name: String
+    name: Name
     username: String
     birthDate(locale: String): String
     account: AccountType
     metadata: [UserMetadata]
+  }
+
+  type Name {
+    first: String
+    last: String
   }
 
   type Mutation {
@@ -56,14 +61,20 @@ export const typeDefs = gql`
 const users = [
   {
     id: '1',
-    name: 'Ada Lovelace',
+    name: {
+      first: 'Ada',
+      last: 'Lovelace'
+    },
     birthDate: '1815-12-10',
     username: '@ada',
     account: { __typename: 'LibraryAccount', id: '1' },
   },
   {
     id: '2',
-    name: 'Alan Turing',
+    name: {
+      first: 'Alan',
+      last: 'Turing'
+    },
     birthDate: '1912-06-23',
     username: '@complete',
     account: { __typename: 'SMSAccount', number: '8675309' },
@@ -97,6 +108,11 @@ export const resolvers: GraphQLResolverMap<any> = {
   },
   User: {
     __resolveObject(object) {
+      // Nested key example for @key(fields: "username name { first last }")
+      if (object.username && object.name.first && object.name.last) {
+        users.find(user => user.username === object.username);
+      }
+
       return users.find(user => user.id === object.id);
     },
     birthDate(user, args) {

--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
-- _Nothing yet! Stay tuned!_
+- __FIX__: CSDL complex `@key`s shouldn't result in an unparseable document [PR #4490](https://github.com/apollographql/apollo-server/pull/4490)
 
 ## v0.19.1
 

--- a/packages/apollo-federation/src/service/__tests__/printComposedSdl.test.ts
+++ b/packages/apollo-federation/src/service/__tests__/printComposedSdl.test.ts
@@ -1,16 +1,25 @@
 import { fixtures } from 'apollo-federation-integration-testsuite';
 import { composeAndValidate } from '../../composition';
-import { printComposedSdl } from '../printComposedSdl';
+import { parse, GraphQLError } from 'graphql';
 
 describe('printComposedSdl', () => {
-  const { schema, errors } = composeAndValidate(fixtures);
+  let composedSdl: string;
+  let errors: readonly GraphQLError[];
+
+  beforeAll(() => {
+    ({composedSdl, errors} = composeAndValidate(fixtures));
+  })
 
   it('composes without errors', () => {
     expect(errors).toHaveLength(0);
   });
 
+  it('produces a parseable output', () => {
+    expect(() => parse(composedSdl)).not.toThrow();
+  })
+
   it('prints a fully composed schema correctly', () => {
-    expect(printComposedSdl(schema, fixtures)).toMatchInlineSnapshot(`
+    expect(composedSdl).toMatchInlineSnapshot(`
       "schema
         @graph(name: \\"accounts\\", url: \\"https://accounts.api.com\\")
         @graph(name: \\"books\\", url: \\"https://books.api.com\\")
@@ -235,10 +244,7 @@ describe('printComposedSdl', () => {
       type User
         @owner(graph: \\"accounts\\")
         @key(fields: \\"id\\", graph: \\"accounts\\")
-        @key(fields: \\"username,name {
-        first
-        last
-      }\\", graph: \\"accounts\\")
+        @key(fields: \\"username name { first last }\\", graph: \\"accounts\\")
         @key(fields: \\"id\\", graph: \\"inventory\\")
         @key(fields: \\"id\\", graph: \\"product\\")
         @key(fields: \\"id\\", graph: \\"reviews\\")

--- a/packages/apollo-federation/src/service/__tests__/printComposedSdl.test.ts
+++ b/packages/apollo-federation/src/service/__tests__/printComposedSdl.test.ts
@@ -147,6 +147,11 @@ describe('printComposedSdl', () => {
         deleteReview(id: ID!): Boolean @resolve(graph: \\"reviews\\")
       }
 
+      type Name {
+        first: String
+        last: String
+      }
+
       type PasswordAccount
         @owner(graph: \\"accounts\\")
         @key(fields: \\"email\\", graph: \\"accounts\\")
@@ -230,12 +235,16 @@ describe('printComposedSdl', () => {
       type User
         @owner(graph: \\"accounts\\")
         @key(fields: \\"id\\", graph: \\"accounts\\")
+        @key(fields: \\"username,name {
+        first
+        last
+      }\\", graph: \\"accounts\\")
         @key(fields: \\"id\\", graph: \\"inventory\\")
         @key(fields: \\"id\\", graph: \\"product\\")
         @key(fields: \\"id\\", graph: \\"reviews\\")
       {
         id: ID!
-        name: String
+        name: Name
         username: String
         birthDate(locale: String): String
         account: AccountType

--- a/packages/apollo-federation/src/service/__tests__/printFederatedSchema.test.ts
+++ b/packages/apollo-federation/src/service/__tests__/printFederatedSchema.test.ts
@@ -100,6 +100,11 @@ describe('printFederatedSchema', () => {
         deleteReview(id: ID!): Boolean
       }
 
+      type Name {
+        first: String
+        last: String
+      }
+
       type PasswordAccount @key(fields: \\"email\\") {
         email: String!
       }
@@ -171,9 +176,9 @@ describe('printFederatedSchema', () => {
         body: String
       }
 
-      type User @key(fields: \\"id\\") {
+      type User @key(fields: \\"id\\") @key(fields: \\"username name { first last }\\") {
         id: ID!
-        name: String
+        name: Name
         username: String
         birthDate(locale: String): String
         account: AccountType

--- a/packages/apollo-federation/src/service/printComposedSdl.ts
+++ b/packages/apollo-federation/src/service/printComposedSdl.ts
@@ -228,7 +228,7 @@ function printFederationTypeDirectives(type: GraphQLObjectType): string {
       keys
         .map(
           (selections) =>
-            `\n  @key(fields: "${selections.map(print)}", graph: "${service}")`,
+            `\n  @key(fields: "${printFieldSet(selections)}", graph: "${service}")`,
         )
         .join(''),
     )
@@ -318,6 +318,15 @@ export function printWithReducedWhitespace(ast: ASTNode): string {
 }
 
 /**
+ * Federation change: print fieldsets for @key, @requires, and @provides directives
+ *
+ * @param selections
+ */
+function printFieldSet(selections: readonly SelectionNode[]): string {
+  return selections.map(printWithReducedWhitespace).join(' ');
+}
+
+/**
  * Federation change: print @resolve, @requires, and @provides directives
  *
  * @param field
@@ -346,11 +355,11 @@ function printFederationFieldDirectives(
   }
 
   if (requires.length > 0) {
-    printed += ` @requires(fields: "${requires.map(printWithReducedWhitespace).join(' ')}")`;
+    printed += ` @requires(fields: "${printFieldSet(requires)}")`;
   }
 
   if (provides.length > 0) {
-    printed += ` @provides(fields: "${provides.map(printWithReducedWhitespace).join(' ')}")`;
+    printed += ` @provides(fields: "${printFieldSet(provides)}")`;
   }
 
   return printed;

--- a/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
+++ b/packages/apollo-gateway/src/__tests__/executeQueryPlan.test.ts
@@ -1,8 +1,5 @@
 import { GraphQLSchema, GraphQLError, getIntrospectionQuery } from 'graphql';
-import {
-  addResolversToSchema,
-  GraphQLResolverMap,
-} from 'apollo-graphql';
+import { addResolversToSchema, GraphQLResolverMap } from 'apollo-graphql';
 import gql from 'graphql-tag';
 import { GraphQLRequestContext } from 'apollo-server-types';
 import { AuthenticationError } from 'apollo-server-core';
@@ -12,8 +9,7 @@ import { executeQueryPlan } from '../executeQueryPlan';
 import { LocalGraphQLDataSource } from '../datasources/LocalGraphQLDataSource';
 
 import { astSerializer, queryPlanSerializer } from '../snapshotSerializers';
-import { getFederatedTestingSchema, buildLocalService } from './execution-utils';
-import { fixtures } from 'apollo-federation-integration-testsuite';
+import { getFederatedTestingSchema } from './execution-utils';
 
 expect.addSnapshotSerializer(astSerializer);
 expect.addSnapshotSerializer(queryPlanSerializer);
@@ -53,7 +49,10 @@ describe('executeQueryPlan', () => {
       const query = gql`
         query {
           me {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       `;
@@ -83,7 +82,10 @@ describe('executeQueryPlan', () => {
       const query = gql`
         query {
           me {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       `;
@@ -113,7 +115,7 @@ describe('executeQueryPlan', () => {
       );
       expect(response).toHaveProperty(
         'errors.0.extensions.query',
-        '{me{name}}',
+        '{me{name{first last}}}',
       );
       expect(response).toHaveProperty('errors.0.extensions.variables', {});
     });
@@ -130,7 +132,10 @@ describe('executeQueryPlan', () => {
       const query = gql`
         query {
           me {
-            name
+            name {
+              first
+              last
+            }
           }
           topReviews {
             body
@@ -158,7 +163,10 @@ describe('executeQueryPlan', () => {
       const query = gql`
         query {
           me {
-            name
+            name {
+              first
+              last
+            }
           }
           topReviews {
             body
@@ -187,7 +195,10 @@ describe('executeQueryPlan', () => {
         topReviews {
           body
           author {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       }
@@ -208,31 +219,46 @@ describe('executeQueryPlan', () => {
         "topReviews": Array [
           Object {
             "author": Object {
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Love it!",
           },
           Object {
             "author": Object {
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Too expensive.",
           },
           Object {
             "author": Object {
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Could be better.",
           },
           Object {
             "author": Object {
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Prefer something else.",
           },
           Object {
             "author": Object {
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Wish I had read this before.",
           },
@@ -247,13 +273,19 @@ describe('executeQueryPlan', () => {
         first: topReviews(first: $first) {
           body
           author {
-            name
+            name {
+              first
+              last
+            }
           }
         }
         second: topReviews(first: $first) {
           body
           author {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       }
@@ -277,19 +309,28 @@ describe('executeQueryPlan', () => {
         "first": Array [
           Object {
             "author": Object {
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Love it!",
           },
           Object {
             "author": Object {
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Too expensive.",
           },
           Object {
             "author": Object {
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Could be better.",
           },
@@ -297,19 +338,28 @@ describe('executeQueryPlan', () => {
         "second": Array [
           Object {
             "author": Object {
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Love it!",
           },
           Object {
             "author": Object {
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Too expensive.",
           },
           Object {
             "author": Object {
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Could be better.",
           },
@@ -324,7 +374,10 @@ describe('executeQueryPlan', () => {
         topReviews {
           body
           author {
-            name
+            name {
+              first
+              last
+            }
             birthDate(locale: $locale)
           }
         }
@@ -350,35 +403,50 @@ describe('executeQueryPlan', () => {
           Object {
             "author": Object {
               "birthDate": "12/10/1815",
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Love it!",
           },
           Object {
             "author": Object {
               "birthDate": "12/10/1815",
-              "name": "Ada Lovelace",
+              "name": Object {
+                "first": "Ada",
+                "last": "Lovelace",
+              },
             },
             "body": "Too expensive.",
           },
           Object {
             "author": Object {
               "birthDate": "6/23/1912",
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Could be better.",
           },
           Object {
             "author": Object {
               "birthDate": "6/23/1912",
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Prefer something else.",
           },
           Object {
             "author": Object {
               "birthDate": "6/23/1912",
-              "name": "Alan Turing",
+              "name": Object {
+                "first": "Alan",
+                "last": "Turing",
+              },
             },
             "body": "Wish I had read this before.",
           },
@@ -443,7 +511,10 @@ describe('executeQueryPlan', () => {
     const query = gql`
       query {
         user(id: "1") {
-          name
+          name {
+            first
+            last
+          }
           vehicle {
             description
             price
@@ -466,7 +537,10 @@ describe('executeQueryPlan', () => {
     expect(response.data).toMatchInlineSnapshot(`
       Object {
         "user": Object {
-          "name": "Ada Lovelace",
+          "name": Object {
+            "first": "Ada",
+            "last": "Lovelace",
+          },
           "vehicle": Object {
             "description": "Humble Toyota",
             "price": "9990",
@@ -481,7 +555,10 @@ describe('executeQueryPlan', () => {
     const query = gql`
       query {
         user(id: "1") {
-          name
+          name {
+            first
+            last
+          }
           thing {
             ... on Vehicle {
               description
@@ -509,7 +586,10 @@ describe('executeQueryPlan', () => {
     expect(response.data).toMatchInlineSnapshot(`
       Object {
         "user": Object {
-          "name": "Ada Lovelace",
+          "name": Object {
+            "first": "Ada",
+            "last": "Lovelace",
+          },
           "thing": Object {
             "description": "Humble Toyota",
             "price": "9990",

--- a/packages/apollo-gateway/src/__tests__/gateway/reporting.test.ts
+++ b/packages/apollo-gateway/src/__tests__/gateway/reporting.test.ts
@@ -28,7 +28,7 @@ function replaceFieldValuesSerializer(
         value &&
         typeof value === 'object' &&
         !value[alreadyProcessed] &&
-        fieldNames.some(n => n in value)
+        fieldNames.some((n) => n in value)
       );
     },
 
@@ -45,7 +45,7 @@ function replaceFieldValuesSerializer(
       // don't reprocess it ourselves.
       const newValue = { ...value };
       Object.defineProperty(newValue, alreadyProcessed, { value: true });
-      fieldNames.forEach(fn => {
+      fieldNames.forEach((fn) => {
         if (fn in value) {
           const replacement = replacements[fn];
           if (typeof replacement === 'function') {
@@ -92,7 +92,7 @@ describe('reporting', () => {
 
   beforeEach(async () => {
     let reportResolver: (report: any) => void;
-    reportPromise = new Promise<any>(resolve => {
+    reportPromise = new Promise<any>((resolve) => {
       reportResolver = resolve;
     });
 
@@ -138,7 +138,10 @@ describe('reporting', () => {
     const query = gql`
       query {
         me {
-          name
+          name {
+            first
+            last
+          }
         }
         topProducts {
           name
@@ -152,31 +155,34 @@ describe('reporting', () => {
       }),
     );
     expect(result).toMatchInlineSnapshot(`
-                                                                  Object {
-                                                                    "data": Object {
-                                                                      "me": Object {
-                                                                        "name": "Ada Lovelace",
-                                                                      },
-                                                                      "topProducts": Array [
-                                                                        Object {
-                                                                          "name": "Table",
-                                                                        },
-                                                                        Object {
-                                                                          "name": "Couch",
-                                                                        },
-                                                                        Object {
-                                                                          "name": "Chair",
-                                                                        },
-                                                                        Object {
-                                                                          "name": "Structure and Interpretation of Computer Programs (1996)",
-                                                                        },
-                                                                        Object {
-                                                                          "name": "Object Oriented Software Construction (1997)",
-                                                                        },
-                                                                      ],
-                                                                    },
-                                                                  }
-                                        `);
+      Object {
+        "data": Object {
+          "me": Object {
+            "name": Object {
+              "first": "Ada",
+              "last": "Lovelace",
+            },
+          },
+          "topProducts": Array [
+            Object {
+              "name": "Table",
+            },
+            Object {
+              "name": "Couch",
+            },
+            Object {
+              "name": "Chair",
+            },
+            Object {
+              "name": "Structure and Interpretation of Computer Programs (1996)",
+            },
+            Object {
+              "name": "Object Oriented Software Construction (1997)",
+            },
+          ],
+        },
+      }
+    `);
     const reportBody = await reportPromise;
     // nock returns binary bodies as hex strings
     const gzipReportBuffer = Buffer.from(reportBody, 'hex');
@@ -184,7 +190,7 @@ describe('reporting', () => {
     const report = Report.decode(reportBuffer);
 
     // Some handwritten tests to capture salient properties.
-    const statsReportKey = '# -\n{me{name}topProducts{name}}';
+    const statsReportKey = '# -\n{me{name{first last}}topProducts{name}}';
     expect(Object.keys(report.tracesPerQuery)).toStrictEqual([statsReportKey]);
     expect(report.tracesPerQuery[statsReportKey]!.trace!.length).toBe(1);
     const trace = report.tracesPerQuery[statsReportKey]!.trace![0]!;
@@ -215,7 +221,7 @@ describe('reporting', () => {
         "header": "<HEADER>",
         "tracesPerQuery": Object {
           "# -
-      {me{name}topProducts{name}}": Object {
+      {me{name{first last}}topProducts{name}}": Object {
             "trace": Array [
               Object {
                 "clientName": "",
@@ -258,11 +264,27 @@ describe('reporting', () => {
                                 Object {
                                   "child": Array [
                                     Object {
+                                      "child": Array [
+                                        Object {
+                                          "endTime": "45678",
+                                          "parentType": "Name",
+                                          "responseName": "first",
+                                          "startTime": "34567",
+                                          "type": "String",
+                                        },
+                                        Object {
+                                          "endTime": "45678",
+                                          "parentType": "Name",
+                                          "responseName": "last",
+                                          "startTime": "34567",
+                                          "type": "String",
+                                        },
+                                      ],
                                       "endTime": "45678",
                                       "parentType": "User",
                                       "responseName": "name",
                                       "startTime": "34567",
-                                      "type": "String",
+                                      "type": "Name",
                                     },
                                   ],
                                   "endTime": "45678",

--- a/packages/apollo-gateway/src/__tests__/integration/boolean.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/boolean.test.ts
@@ -76,7 +76,10 @@ describe('@skip', () => {
         topReviews {
           body
           author @skip(if: false) {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       }
@@ -88,14 +91,11 @@ describe('@skip', () => {
 
     expect(data).toEqual({
       topReviews: [
-        { body: 'Love it!', author: { name: 'Ada Lovelace' } },
-        { body: 'Too expensive.', author: { name: 'Ada Lovelace' } },
-        { body: 'Could be better.', author: { name: 'Alan Turing' } },
-        { body: 'Prefer something else.', author: { name: 'Alan Turing' } },
-        {
-          body: 'Wish I had read this before.',
-          author: { name: 'Alan Turing' },
-        },
+        { body: 'Love it!', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Too expensive.', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Could be better.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Prefer something else.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Wish I had read this before.', author: { name: { first: 'Alan', last: 'Turing' } } },
       ],
     });
 
@@ -110,7 +110,10 @@ describe('@skip', () => {
         topReviews {
           body
           author @skip(if: $skip) {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       }
@@ -124,14 +127,11 @@ describe('@skip', () => {
 
     expect(data).toEqual({
       topReviews: [
-        { body: 'Love it!', author: { name: 'Ada Lovelace' } },
-        { body: 'Too expensive.', author: { name: 'Ada Lovelace' } },
-        { body: 'Could be better.', author: { name: 'Alan Turing' } },
-        { body: 'Prefer something else.', author: { name: 'Alan Turing' } },
-        {
-          body: 'Wish I had read this before.',
-          author: { name: 'Alan Turing' },
-        },
+        { body: 'Love it!', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Too expensive.', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Could be better.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Prefer something else.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Wish I had read this before.', author: { name: { first: 'Alan', last: 'Turing' } } },
       ],
     });
 
@@ -211,7 +211,10 @@ describe('@include', () => {
         topReviews {
           body
           author @include(if: true) {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       }
@@ -223,14 +226,11 @@ describe('@include', () => {
 
     expect(data).toEqual({
       topReviews: [
-        { body: 'Love it!', author: { name: 'Ada Lovelace' } },
-        { body: 'Too expensive.', author: { name: 'Ada Lovelace' } },
-        { body: 'Could be better.', author: { name: 'Alan Turing' } },
-        { body: 'Prefer something else.', author: { name: 'Alan Turing' } },
-        {
-          body: 'Wish I had read this before.',
-          author: { name: 'Alan Turing' },
-        },
+        { body: 'Love it!', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Too expensive.', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Could be better.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Prefer something else.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Wish I had read this before.', author: { name: { first: 'Alan', last: 'Turing' } } },
       ],
     });
 
@@ -246,7 +246,10 @@ describe('@include', () => {
         topReviews {
           body
           author @include(if: $include) {
-            name
+            name {
+              first
+              last
+            }
           }
         }
       }
@@ -260,14 +263,11 @@ describe('@include', () => {
 
     expect(data).toEqual({
       topReviews: [
-        { body: 'Love it!', author: { name: 'Ada Lovelace' } },
-        { body: 'Too expensive.', author: { name: 'Ada Lovelace' } },
-        { body: 'Could be better.', author: { name: 'Alan Turing' } },
-        { body: 'Prefer something else.', author: { name: 'Alan Turing' } },
-        {
-          body: 'Wish I had read this before.',
-          author: { name: 'Alan Turing' },
-        },
+        { body: 'Love it!', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Too expensive.', author: { name: { first: 'Ada', last: 'Lovelace' } } },
+        { body: 'Could be better.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Prefer something else.', author: { name: { first: 'Alan', last: 'Turing' } } },
+        { body: 'Wish I had read this before.', author: { name: { first: 'Alan', last: 'Turing' } } },
       ],
     });
 

--- a/packages/apollo-gateway/src/__tests__/integration/fragments.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/fragments.test.ts
@@ -104,7 +104,10 @@ it('supports named fragments (one level)', async () => {
 it('supports multiple named fragments (one level, mixed ordering)', async () => {
   const query = `#graphql
     fragment userInfo on User {
-      name
+      name {
+        first
+        last
+      }
     }
     query GetUser {
       me {
@@ -125,7 +128,10 @@ it('supports multiple named fragments (one level, mixed ordering)', async () => 
   expect(data).toEqual({
     me: {
       username: '@ada',
-      name: 'Ada Lovelace',
+      name: {
+        first: 'Ada',
+        last: 'Lovelace',
+      }
     },
   });
 

--- a/packages/apollo-gateway/src/__tests__/integration/provides.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/provides.test.ts
@@ -45,7 +45,10 @@ it('does not load fields provided even when going to other service', async () =>
       topReviews {
         author {
           username
-          name
+          name {
+            first
+            last
+          }
         }
       }
     }
@@ -60,11 +63,11 @@ it('does not load fields provided even when going to other service', async () =>
 
   expect(data).toEqual({
     topReviews: [
-      { author: { username: '@ada', name: 'Ada Lovelace' } },
-      { author: { username: '@ada', name: 'Ada Lovelace' } },
-      { author: { username: '@complete', name: 'Alan Turing' } },
-      { author: { username: '@complete', name: 'Alan Turing' } },
-      { author: { username: '@complete', name: 'Alan Turing' } },
+      { author: { username: '@ada', name: { first: 'Ada', last: 'Lovelace' } } },
+      { author: { username: '@ada', name: { first: 'Ada', last: 'Lovelace' } } },
+      { author: { username: '@complete', name: { first: 'Alan', last: 'Turing' } } },
+      { author: { username: '@complete', name: { first: 'Alan', last: 'Turing' } } },
+      { author: { username: '@complete', name: { first: 'Alan', last: 'Turing' } } },
     ],
   });
 

--- a/packages/apollo-gateway/src/__tests__/integration/variables.test.ts
+++ b/packages/apollo-gateway/src/__tests__/integration/variables.test.ts
@@ -88,7 +88,10 @@ it('works with default variables in the schema', async () => {
       library(id: $libraryId) {
         userAccount(id: $userId) {
           id
-          name
+          name {
+            first
+            last
+          }
         }
       }
     }
@@ -103,7 +106,10 @@ it('works with default variables in the schema', async () => {
     library: {
       userAccount: {
         id: '1',
-        name: 'Ada Lovelace',
+        name: {
+          first: 'Ada',
+          last: 'Lovelace',
+        }
       },
     },
   });


### PR DESCRIPTION
This fix targets a bug in `printComposedSdl` where `@key` directive `fields` args
weren't being printed with reduced whitespace as `@requires` and `@provides` are,
resulting in an invalid / unparseable graphql document.

To reproduce this fix, I first introduced a nested `@key` into our testing fixtures,
which we should have always had at least one of to begin with. The resulting bug
can be seen in the second commit, and then resolved in the third commit.

I've also added a test to `printComposedSdl` to ensure the output is parseable.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
