### PR TITLE
schema-reporting: Check whether overrideReportedSchema is parsable/valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## v2.18.0
 
-- _Nothing yet! Stay tuned!_
+- `apollo-engine-reporting`: Parse and validate any schema passed via `overrideReportedSchema`, and throw accordingly on unparsable or invalid schemas.
 
 ## v2.17.0
 

--- a/packages/apollo-engine-reporting/src/agent.ts
+++ b/packages/apollo-engine-reporting/src/agent.ts
@@ -1,10 +1,12 @@
 import os from 'os';
 import { gzip } from 'zlib';
 import {
+  buildSchema,
   DocumentNode,
   GraphQLError,
   GraphQLSchema,
   printSchema,
+  validateSchema
 } from 'graphql';
 import {
   ReportHeader,
@@ -507,6 +509,26 @@ export class EngineReportingAgent<TContext = any> {
       );
       if (options.schemaReportingInitialDelayMaxMs === undefined) {
         options.schemaReportingInitialDelayMaxMs = options.experimental_schemaReportingInitialDelayMaxMs;
+      }
+    }
+
+    // Ensure a provided override schema can be parsed and validated
+    if (options.overrideReportedSchema) {
+      try {
+        const validationErrors = validateSchema(
+          buildSchema(options.overrideReportedSchema, { noLocation: true })
+        );
+        if (validationErrors.length) {
+          throw new Error(
+            validationErrors.map((error) => error.message)
+              .join('\n')
+          );
+        }
+      } catch (err) {
+        throw new Error(
+          "The schema provided to overrideReportedSchema failed to parse or" +
+          `validate: ${err.message}`
+        )
       }
     }
 


### PR DESCRIPTION
The Apollo API has recently changed such that `reportServerInfo` will now return error for schemas that don't parse or validate.

This PR changes `apollo-engine-reporting` to check in the `EngineReportingAgent` constructor whether override schemas successfully parse and validate, so that we may return early before talking to the Apollo API.
