### PR TITLE
fix(federation): Value type validations - unions, scalars, enums

### DIFF
--- a/packages/apollo-federation/CHANGELOG.md
+++ b/packages/apollo-federation/CHANGELOG.md
@@ -5,6 +5,7 @@
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - __FIX__: CSDL complex `@key`s shouldn't result in an unparseable document [PR #4490](https://github.com/apollographql/apollo-server/pull/4490)
+- __FIX__: Value type validations - restrict unions, scalars, enums [PR #4496](https://github.com/apollographql/apollo-server/pull/4496)
 
 ## v0.19.1
 

--- a/packages/apollo-federation/src/composition/validate/sdl/__tests__/uniqueTypeNamesWithFields.test.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/__tests__/uniqueTypeNamesWithFields.test.ts
@@ -336,12 +336,116 @@ describe('UniqueTypeNamesWithFields', () => {
       const errors = validateSDL(definitions, schema, [
         UniqueTypeNamesWithFields,
       ]);
+
+      expect(errors).toHaveLength(1);
       expect(errors[0]).toMatchInlineSnapshot(`
-                Object {
-                  "code": "VALUE_TYPE_KIND_MISMATCH",
-                  "message": "[serviceA] Product -> Found kind mismatch on expected value type belonging to services \`serviceA\` and \`serviceB\`. \`Product\` is defined as both a \`ObjectTypeDefinition\` and a \`InputObjectTypeDefinition\`. In order to define \`Product\` in multiple places, the kinds must be identical.",
-                }
-            `);
+        Object {
+          "code": "VALUE_TYPE_KIND_MISMATCH",
+          "message": "[serviceA] Product -> Found kind mismatch on expected value type belonging to services \`serviceA\` and \`serviceB\`. \`Product\` is defined as both a \`ObjectTypeDefinition\` and a \`InputObjectTypeDefinition\`. In order to define \`Product\` in multiple places, the kinds must be identical.",
+        }
+      `);
+    });
+
+    it('value types must be of the same kind (scalar)', () => {
+      const [definitions] = createDocumentsForServices([
+        {
+          typeDefs: gql`
+            scalar DateTime
+          `,
+          name: 'serviceA',
+        },
+        {
+          typeDefs: gql`
+            type DateTime {
+              day: Int
+              formatted: String
+              # ...
+            }
+          `,
+          name: 'serviceB',
+        },
+      ]);
+
+      const errors = validateSDL(definitions, schema, [
+        UniqueTypeNamesWithFields,
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchInlineSnapshot(`
+        Object {
+          "code": "VALUE_TYPE_KIND_MISMATCH",
+          "message": "[serviceA] DateTime -> Found kind mismatch on expected value type belonging to services \`serviceA\` and \`serviceB\`. \`DateTime\` is defined as both a \`ObjectTypeDefinition\` and a \`ScalarTypeDefinition\`. In order to define \`DateTime\` in multiple places, the kinds must be identical.",
+        }
+      `);
+    });
+
+    it('value types must be of the same kind (union)', () => {
+      const [definitions] = createDocumentsForServices([
+        {
+          typeDefs: gql`
+            union DateTime = Date | Time
+          `,
+          name: 'serviceA',
+        },
+        {
+          typeDefs: gql`
+            type DateTime {
+              day: Int
+              formatted: String
+              # ...
+            }
+          `,
+          name: 'serviceB',
+        },
+      ]);
+
+      const errors = validateSDL(definitions, schema, [
+        UniqueTypeNamesWithFields,
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchInlineSnapshot(`
+        Object {
+          "code": "VALUE_TYPE_KIND_MISMATCH",
+          "message": "[serviceA] DateTime -> Found kind mismatch on expected value type belonging to services \`serviceA\` and \`serviceB\`. \`DateTime\` is defined as both a \`ObjectTypeDefinition\` and a \`UnionTypeDefinition\`. In order to define \`DateTime\` in multiple places, the kinds must be identical.",
+        }
+      `);
+    });
+
+    it('value types must be of the same kind (enum)', () => {
+      const [definitions] = createDocumentsForServices([
+        {
+          typeDefs: gql`
+            enum DateTime {
+              DATE
+              TIME
+            }
+          `,
+          name: 'serviceA',
+        },
+        {
+          typeDefs: gql`
+            type DateTime {
+              day: Int
+              formatted: String
+              # ...
+            }
+          `,
+          name: 'serviceB',
+        },
+      ]);
+
+      const errors = validateSDL(definitions, schema, [
+        UniqueTypeNamesWithFields,
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchInlineSnapshot(`
+        Object {
+          "code": "VALUE_TYPE_KIND_MISMATCH",
+          "message": "[serviceA] DateTime -> Found kind mismatch on expected value type belonging to services \`serviceA\` and \`serviceB\`. \`DateTime\` is defined as both a \`ObjectTypeDefinition\` and a \`EnumTypeDefinition\`. In order to define \`DateTime\` in multiple places, the kinds must be identical.",
+        }
+      `);
     });
 
     it('value types cannot be entities (part 1)', () => {
@@ -369,11 +473,11 @@ describe('UniqueTypeNamesWithFields', () => {
       ]);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toMatchInlineSnapshot(`
-                Object {
-                  "code": "VALUE_TYPE_NO_ENTITY",
-                  "message": "[serviceA] Product -> Value types cannot be entities (using the \`@key\` directive). Please ensure that the \`Product\` type is extended properly or remove the \`@key\` directive if this is not an entity.",
-                }
-            `);
+        Object {
+          "code": "VALUE_TYPE_NO_ENTITY",
+          "message": "[serviceA] Product -> Value types cannot be entities (using the \`@key\` directive). Please ensure that the \`Product\` type is extended properly or remove the \`@key\` directive if this is not an entity.",
+        }
+      `);
     });
 
     it('value types cannot be entities (part 2)', () => {
@@ -401,11 +505,11 @@ describe('UniqueTypeNamesWithFields', () => {
       ]);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toMatchInlineSnapshot(`
-                Object {
-                  "code": "VALUE_TYPE_NO_ENTITY",
-                  "message": "[serviceB] Product -> Value types cannot be entities (using the \`@key\` directive). Please ensure that the \`Product\` type is extended properly or remove the \`@key\` directive if this is not an entity.",
-                }
-            `);
+        Object {
+          "code": "VALUE_TYPE_NO_ENTITY",
+          "message": "[serviceB] Product -> Value types cannot be entities (using the \`@key\` directive). Please ensure that the \`Product\` type is extended properly or remove the \`@key\` directive if this is not an entity.",
+        }
+      `);
     });
 
     it('no false positives for properly formed entities (that look like value types)', () => {

--- a/packages/apollo-federation/src/composition/validate/sdl/uniqueTypeNamesWithFields.ts
+++ b/packages/apollo-federation/src/composition/validate/sdl/uniqueTypeNamesWithFields.ts
@@ -1,9 +1,7 @@
 import {
   GraphQLError,
   ASTVisitor,
-  ObjectTypeDefinitionNode,
-  InterfaceTypeDefinitionNode,
-  InputObjectTypeDefinitionNode,
+  TypeDefinitionNode,
 } from 'graphql';
 
 import { SDLValidationContext } from 'graphql/validation/ValidationContext';
@@ -14,12 +12,6 @@ import {
   errorWithCode,
   logServiceAndType,
 } from '../../utils';
-
-// Types of nodes this validator is responsible for
-type TypesWithRequiredUniqueNames =
-  | ObjectTypeDefinitionNode
-  | InterfaceTypeDefinitionNode
-  | InputObjectTypeDefinitionNode;
 
 export function duplicateTypeNameMessage(typeName: string): string {
   return `There can be only one type named "${typeName}".`;
@@ -38,25 +30,25 @@ export function UniqueTypeNamesWithFields(
   context: SDLValidationContext,
 ): ASTVisitor {
   const knownTypes: {
-    [typeName: string]: TypesWithRequiredUniqueNames;
+    [typeName: string]: TypeDefinitionNode;
   } = Object.create(null);
   const schema = context.getSchema();
 
   return {
-    // ScalarTypeDefinition: checkTypeName,
+    ScalarTypeDefinition: checkTypeName,
     ObjectTypeDefinition: checkTypeName,
     InterfaceTypeDefinition: checkTypeName,
-    // UnionTypeDefinition: checkTypeName,
-    // EnumTypeDefinition: checkTypeName,
+    UnionTypeDefinition: checkTypeName,
+    EnumTypeDefinition: checkTypeName,
     InputObjectTypeDefinition: checkTypeName,
   };
 
-  function checkTypeName(node: TypesWithRequiredUniqueNames) {
+  function checkTypeName(node: TypeDefinitionNode) {
     const typeName = node.name.value;
     const typeFromSchema = schema && schema.getType(typeName);
     const typeNodeFromSchema =
       typeFromSchema &&
-      (typeFromSchema.astNode as Maybe<TypesWithRequiredUniqueNames>);
+      (typeFromSchema.astNode as Maybe<TypeDefinitionNode>);
 
     const typeNodeFromDefs = knownTypes[typeName];
     const duplicateTypeNode = typeNodeFromSchema || typeNodeFromDefs;
@@ -76,6 +68,30 @@ export function UniqueTypeNamesWithFields(
       const { kind, fields } = diffTypeNodes(node, duplicateTypeNode);
 
       const fieldsDiff = Object.entries(fields);
+
+      // Error if the kinds don't match
+      if (kind.length > 0) {
+        context.reportError(
+          errorWithCode(
+            'VALUE_TYPE_KIND_MISMATCH',
+            `${logServiceAndType(
+              duplicateTypeNode.serviceName!,
+              typeName,
+            )}Found kind mismatch on expected value type belonging to services \`${
+              duplicateTypeNode.serviceName
+            }\` and \`${
+              node.serviceName
+            }\`. \`${typeName}\` is defined as both a \`${
+              kind[0]
+            }\` and a \`${
+              kind[1]
+            }\`. In order to define \`${typeName}\` in multiple places, the kinds must be identical.`,
+            [node, duplicateTypeNode],
+          ),
+        );
+        return;
+      }
+
       const typesHaveSameShape =
         fieldsDiff.length === 0 ||
         fieldsDiff.every(([fieldName, types]) => {
@@ -110,28 +126,6 @@ export function UniqueTypeNamesWithFields(
       if (typesHaveSameShape) {
         // Report errors that were collected while determining the matching shape of the types
         possibleErrors.forEach(error => context.reportError(error));
-
-        // Error if the kinds don't match
-        if (kind.length > 0) {
-          context.reportError(
-            errorWithCode(
-              'VALUE_TYPE_KIND_MISMATCH',
-              `${logServiceAndType(
-                duplicateTypeNode.serviceName!,
-                typeName,
-              )}Found kind mismatch on expected value type belonging to services \`${
-                duplicateTypeNode.serviceName
-              }\` and \`${
-                node.serviceName
-              }\`. \`${typeName}\` is defined as both a \`${
-                kind[0]
-              }\` and a \`${
-                kind[1]
-              }\`. In order to define \`${typeName}\` in multiple places, the kinds must be identical.`,
-              [node, duplicateTypeNode],
-            ),
-          );
-        }
 
         // Error if either is an entity
         if (isTypeNodeAnEntity(node) || isTypeNodeAnEntity(duplicateTypeNode)) {


### PR DESCRIPTION
Validations for `Kind` mismatch for value types are currently too relaxed.
For example, composition validations currently allow 2 services to define
(separately) a `scalar DateTime` and a `type DateTime { ... }`. The result of
composing these is unexpected - no warning and no concept of which one you
should expect in your schema.

This bug affects `scalar`, `union`, and `enum` types. Reintroducing those types
to the existing validator works well - we can validate against _all_ type
definitions sharing a name if the `Kind` is different. 

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
