### PR TITLE
Allow custom json encoded content types

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -117,7 +117,8 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
       contentLength !== '0' &&
       contentType &&
       (contentType.startsWith('application/json') ||
-        contentType.startsWith('application/hal+json'))
+        contentType.startsWith('application/hal+json') ||
+        contentType.endsWith('+json'))
     ) {
       return response.json();
     } else {


### PR DESCRIPTION
Custom content types that feature json encoding usually have a suffix for +json at the end  (+xml is also common).
a check for ends with does the trick
