### PR TITLE
Gateway: pass through errors encountered when running final execute

### DIFF
--- a/packages/apollo-gateway/src/executeQueryPlan.ts
+++ b/packages/apollo-gateway/src/executeQueryPlan.ts
@@ -79,7 +79,7 @@ export async function executeQueryPlan<TContext>(
   // the original query.
   // It is also used to allow execution of introspection queries though.
   try {
-    ({ data } = await execute({
+    const executionResult = await execute({
       schema: operationContext.schema,
       document: {
         kind: Kind.DOCUMENT,
@@ -94,7 +94,11 @@ export async function executeQueryPlan<TContext>(
       // FIXME: It's _possible_ this will change after `graphql-extensions` is
       // deprecated, though not certain. See here, also: https://git.io/Jf8cS.
       fieldResolver: defaultFieldResolverWithAliasSupport,
-    }));
+    });
+    data = executionResult.data;
+    if (executionResult.errors?.length) {
+      errors.push(...executionResult.errors)
+    }
   } catch (error) {
     return { errors: [error] };
   }


### PR DESCRIPTION
Fixes a problem where `@apollo/gateway` hides errors encountered when running final `execute()` from `graphql-js`, which can potentially both throw (e.g. from [here](https://github.com/graphql/graphql-js/blob/fbe8402db3b7751c5b1340886c3b09a7f36aee58/src/execution/execute.js#L375)) *and* return `errors` array in following cases:

- https://github.com/graphql/graphql-js/blob/fbe8402db3b7751c5b1340886c3b09a7f36aee58/src/execution/execute.js#L401-L404 
- https://github.com/graphql/graphql-js/blob/fbe8402db3b7751c5b1340886c3b09a7f36aee58/src/execution/execute.js#L237-L239