### PR TITLE
fixing a misleading `datasources` casing typo

### DIFF
--- a/docs/source/api/apollo-federation.mdx
+++ b/docs/source/api/apollo-federation.mdx
@@ -76,9 +76,9 @@ const typeDefs = gql`
 
 const resolvers = {
   User: {
-    __resolveReference(user, { datasources }){
+    __resolveReference(user, { dataSources }){
       // user will always have at least the `id` and the `__typename` here
-      return datasources.users.fetchUserById(user.id)
+      return dataSources.users.fetchUserById(user.id)
     }
   }
 };


### PR DESCRIPTION
If this is referencing the native Apollo DataSources mechanism I believe it the argument option should be `dataSources` and not `datasources`
