### PR TITLE
updates error when schema reporting is used with federation

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -828,7 +828,8 @@ export class ApolloServerBase {
             [
               'Schema reporting is not yet compatible with federated services.',
               "If you're interested in using schema reporting with federated",
-              'services, please contact Apollo support.',
+              'services, please contact Apollo support. To set up managed federation, see',
+              'https://www.apollographql.com/docs/studio/managed-federation/setup/'
             ].join(' '),
           );
         }
@@ -837,7 +838,8 @@ export class ApolloServerBase {
             [
               "Schema reporting is not yet compatible with the gateway. If you're",
               'interested in using schema reporting with the gateway, please',
-              'contact Apollo support.',
+              'contact Apollo support. To set up managed federation, see',
+              'https://www.apollographql.com/docs/studio/managed-federation/setup/'
             ].join(' '),
           );
         }


### PR DESCRIPTION
it's helpful to have an actionable message when something goes wrong
aside from a simple "contact support" if there is a way to achieve
the action that caused the error. in this case, the user is likely
trying to set up Apollo Studio with their service, which they can do
if they follow along with the documentation. this change adds a link
to said documentation to immediately unblock users who run into this
error.
