### PR TITLE
schema-reporting: Fix error message whitespace, add tests for overrideReportedSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- `apollo-server-core`: Fix typo in error message for unparsable/invalid schemas provided via `overrideReportedSchema`. [PR #4581](https://github.com/apollographql/apollo-server/pull/4581)
+
 ## v2.18.0
 
 - `apollo-server-core`: When Apollo Server is configured with an Apollo API key, the URLs it uses to connect to Apollo's servers have changed. If the environment in which you run your servers requires you to explicitly allow connections by domain, you will need to add the new domain names. Usage reporting previously connected to https://engine-report.apollodata.com/ and now connects to https://usage-reporting.api.apollographql.com/; schema reporting previously connected to https://edge-server-reporting.api.apollographql.com/ and now connects to https://schema-reporting.api.apollographql.com/ . [PR #4453](https://github.com/apollographql/apollo-server/pull/4453)

--- a/packages/apollo-server-core/src/plugin/schemaReporting/__tests__/index.test.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/__tests__/index.test.ts
@@ -1,0 +1,54 @@
+import {
+  ApolloServerPluginSchemaReporting,
+  ApolloServerPluginSchemaReportingOptions,
+} from '..';
+import pluginTestHarness from 'apollo-server-core/dist/utils/pluginTestHarness';
+import { makeExecutableSchema } from 'graphql-tools';
+import { graphql } from 'graphql';
+
+describe('end-to-end', () => {
+  async function runTest({
+    pluginOptions = {},
+  }: {
+    pluginOptions?: ApolloServerPluginSchemaReportingOptions;
+  }) {
+    return await pluginTestHarness({
+      pluginInstance: ApolloServerPluginSchemaReporting(pluginOptions),
+      graphqlRequest: {
+        query: 'query { __typename }',
+      },
+      executor: async ({ request: { query }, context }) => {
+        return await graphql({
+          schema: makeExecutableSchema({ typeDefs: 'type Query { foo: Int }' }),
+          source: query,
+          // context is needed for schema instrumentation to find plugins.
+          contextValue: context,
+        });
+      },
+    });
+  }
+
+  it('fails for unparsable overrideReportedSchema', async () => {
+    await expect(
+      runTest({
+        pluginOptions: {
+          overrideReportedSchema: 'type Query {',
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"The schema provided to overrideReportedSchema failed to parse or validate: Syntax Error: Expected Name, found <EOF>"`,
+    );
+  });
+
+  it('fails for invalid overrideReportedSchema', async () => {
+    await expect(
+      runTest({
+        pluginOptions: {
+          overrideReportedSchema: 'type Query',
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"The schema provided to overrideReportedSchema failed to parse or validate: Type Query must define one or more fields."`,
+    );
+  });
+});

--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -91,7 +91,7 @@ export function ApolloServerPluginSchemaReporting(
           }
         } catch (err) {
           throw new Error(
-            'The schema provided to overrideReportedSchema failed to parse or' +
+            'The schema provided to overrideReportedSchema failed to parse or ' +
               `validate: ${err.message}`,
           );
         }


### PR DESCRIPTION
In accordance with the [feedback here](https://github.com/apollographql/apollo-server/pull/4492#issuecomment-685264551), this PR adds testing for `overrideReportedSchema`. This PR also fixes a bug in the error message where a space was missing.