### PR TITLE
examples/acephei: update for #4561 and #4453

### DIFF
--- a/examples/acephei/README.md
+++ b/examples/acephei/README.md
@@ -24,7 +24,7 @@ cd examples/acephei
 npm install
 ```
 
-* *(Optional)*: Setup [Apollo Studio](https://studio.apollographql.com/) account and create your first graph. You'll need to copy the service API key for later on.
+* *(Optional)*: Set up [Apollo Studio](https://studio.apollographql.com/) account and create your first graph. You'll need to copy the service API key for later on.
 
 ### Quick start script
 
@@ -57,7 +57,7 @@ The launch configurations are defined in the `.vscode/launch.json` folders withi
 
 ## Apollo Studio - Setting up your graph
 
-If you would like to setup this example with the graph you created in your [Apollo Studio](https://studio.apollographql.com/) account, you'll need to register each downstream service using the [Apollo CLI](https://github.com/apollographql/apollo-tooling):
+If you would like to set up this example with the graph you created in your [Apollo Studio](https://studio.apollographql.com/) account, you'll need to register each downstream service using the [Apollo CLI](https://github.com/apollographql/apollo-tooling):
 
 ```
 apollo service:push --key={service:michael-watson:key_1234} --localSchemaFile=./services/accounts/schema.graphql --serviceName=accounts --serviceURL=http://localhost:4001

--- a/examples/acephei/gateway/tsconfig.json
+++ b/examples/acephei/gateway/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": false,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2017", "esnext.asynciterable", "dom"],
-    "types": ["node", "apollo-env"],
+    "types": ["node"],
     "jsx": "react",
     "baseUrl": "."
   },

--- a/examples/acephei/services/accounts/src/index.ts
+++ b/examples/acephei/services/accounts/src/index.ts
@@ -1,4 +1,5 @@
 import { ApolloServer, gql, AuthenticationError } from "apollo-server";
+import { ApolloServerPluginUsageReportingDisabled } from "apollo-server-core";
 import { buildFederatedSchema } from "@apollo/federation";
 import { readFileSync } from "fs";
 import { resolve } from "path";
@@ -48,9 +49,11 @@ interface Context {
 
 const server = new ApolloServer({
   schema: buildFederatedSchema([{ typeDefs, resolvers }]),
-  engine: true,
   context: ({ req }) => ({ userID: req.headers.userid }),
-  dataSources: () => ({ users: new UsersDataSource() })
+  dataSources: () => ({ users: new UsersDataSource() }),
+  // $APOLLO_KEY may be set in this process but that's for the gateway to report,
+  // not this implementing service.
+  plugins: [ApolloServerPluginUsageReportingDisabled()],
 });
 
 const port = process.env.PORT || 4001;

--- a/examples/acephei/services/accounts/tsconfig.json
+++ b/examples/acephei/services/accounts/tsconfig.json
@@ -19,7 +19,7 @@
       "noUnusedLocals": false,
       "forceConsistentCasingInFileNames": true,
       "lib": ["es2017", "esnext.asynciterable", "dom"],
-      "types": ["node", "apollo-env"],
+      "types": ["node"],
       "jsx": "react",
       "baseUrl": "."
     },

--- a/examples/acephei/services/books/src/index.ts
+++ b/examples/acephei/services/books/src/index.ts
@@ -1,4 +1,5 @@
 import { ApolloServer, gql, AuthenticationError } from "apollo-server";
+import { ApolloServerPluginUsageReportingDisabled } from "apollo-server-core";
 import { buildFederatedSchema } from "@apollo/federation";
 import { readFileSync } from "fs";
 import { resolve } from "path";
@@ -45,8 +46,10 @@ interface Context {
 
 const server = new ApolloServer({
   schema: buildFederatedSchema([{ typeDefs, resolvers }]),
-  engine: true,
-  dataSources: () => ({ books: new BooksDataSource() })
+  dataSources: () => ({ books: new BooksDataSource() }),
+  // $APOLLO_KEY may be set in this process but that's for the gateway to report,
+  // not this implementing service.
+  plugins: [ApolloServerPluginUsageReportingDisabled()],
 });
 
 const port = process.env.PORT || 4005;

--- a/examples/acephei/services/books/tsconfig.json
+++ b/examples/acephei/services/books/tsconfig.json
@@ -19,7 +19,7 @@
       "noUnusedLocals": false,
       "forceConsistentCasingInFileNames": true,
       "lib": ["es2017", "esnext.asynciterable", "dom"],
-      "types": ["node", "apollo-env"],
+      "types": ["node"],
       "jsx": "react",
       "baseUrl": "."
     },

--- a/examples/acephei/services/products/src/index.ts
+++ b/examples/acephei/services/products/src/index.ts
@@ -1,4 +1,5 @@
 import { ApolloServer, gql } from "apollo-server";
+import { ApolloServerPluginUsageReportingDisabled } from "apollo-server-core";
 import { buildFederatedSchema } from "@apollo/federation";
 import { readFileSync } from "fs";
 import { resolve } from "path";
@@ -81,10 +82,12 @@ interface Context {
 
 const server = new ApolloServer({
   schema: buildFederatedSchema([{ typeDefs, resolvers }]),
-  engine: true,
   dataSources: () => ({
     products: new ProductsDataSource()
-  })
+  }),
+  // $APOLLO_KEY may be set in this process but that's for the gateway to report,
+  // not this implementing service.
+  plugins: [ApolloServerPluginUsageReportingDisabled()],
 });
 
 const port = process.env.PORT || 4003;

--- a/examples/acephei/services/products/tsconfig.json
+++ b/examples/acephei/services/products/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": false,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2017", "esnext.asynciterable", "dom"],
-    "types": ["node", "apollo-env"],
+    "types": ["node"],
     "jsx": "react",
     "baseUrl": "."
   },

--- a/examples/acephei/services/reviews/src/index.ts
+++ b/examples/acephei/services/reviews/src/index.ts
@@ -1,4 +1,5 @@
 import { ApolloServer, gql } from "apollo-server";
+import { ApolloServerPluginUsageReportingDisabled } from "apollo-server-core";
 import { buildFederatedSchema } from "@apollo/federation";
 import { readFileSync } from "fs";
 import { resolve } from "path";
@@ -112,11 +113,13 @@ interface Context {
 
 const server = new ApolloServer({
   schema: buildFederatedSchema([{ typeDefs, resolvers }]),
-  engine: true,
   dataSources: () => ({
     reviews: new ReviewsDataSource(),
     users: new UsersDataSource()
-  })
+  }),
+  // $APOLLO_KEY may be set in this process but that's for the gateway to report,
+  // not this implementing service.
+  plugins: [ApolloServerPluginUsageReportingDisabled()],
 });
 
 const port = process.env.PORT || 4002;

--- a/examples/acephei/services/reviews/tsconfig.json
+++ b/examples/acephei/services/reviews/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": false,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2017", "esnext.asynciterable", "dom"],
-    "types": ["node", "apollo-env"],
+    "types": ["node"],
     "jsx": "react",
     "baseUrl": "."
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,408 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@apollo/federation": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.20.2.tgz",
+      "integrity": "sha512-SrwUK0dZdlHLDkv/8K/Q5OK1AE/RypNkLmxhBndlOKAb2e5li6dZy6FJGNbErgHBAJQSx2Xp1gCF5CZONbFxpw==",
+      "dev": true,
+      "requires": {
+        "apollo-graphql": "^0.6.0",
+        "apollo-server-env": "^2.4.5",
+        "core-js": "^3.4.0",
+        "lodash.xorby": "^4.7.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        }
+      }
+    },
+    "@apollo/gateway": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@apollo/gateway/-/gateway-0.20.2.tgz",
+      "integrity": "sha512-TGPUQDky7RbBeo79ZfLNu5SN66xVgm5ijcifUShEtZdPuqVWg+LB/f75Ntx/KDzbrwGxSJvnIFcqSF+wC0hQpQ==",
+      "dev": true,
+      "requires": {
+        "@apollo/federation": "^0.20.2",
+        "@apollo/query-planner-wasm": "0.0.4",
+        "@types/node-fetch": "2.5.4",
+        "apollo-engine-reporting-protobuf": "^0.5.2",
+        "apollo-graphql": "^0.6.0",
+        "apollo-server-caching": "^0.5.2",
+        "apollo-server-core": "^2.17.0",
+        "apollo-server-env": "^2.4.5",
+        "apollo-server-errors": "^2.4.2",
+        "apollo-server-types": "^0.5.1",
+        "loglevel": "^1.6.1",
+        "make-fetch-happen": "^8.0.0",
+        "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/node-fetch": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+          "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "agentkeepalive": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.3.tgz",
+          "integrity": "sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "depd": "^1.1.2",
+            "humanize-ms": "^1.2.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.1.tgz",
+          "integrity": "sha512-my2cPw+DAb2qVnIuBcsRKGyS28uIc2vjFxa1NpRoJZe9gK0BWUBk7wzXnIzWy3HZ5Er11e/40MPTUesNfMYNVA==",
+          "dev": true,
+          "requires": {
+            "apollo-engine-reporting-protobuf": "^0.5.2",
+            "apollo-server-caching": "^0.5.2",
+            "apollo-server-env": "^2.4.5"
+          }
+        },
+        "cacache": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+          "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+          "dev": true,
+          "requires": {
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.0",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "http-cache-semantics": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "8.0.9",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.9.tgz",
+          "integrity": "sha512-uHa4gv/NIdm9cUvfOhYb57nxrCY08iyMRXru0jbpaH57Q3NCge/ypY7fOvgCr8tPyucKrGbVndKhjXE0IX0VfQ==",
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^4.1.0",
+            "cacache": "^15.0.0",
+            "http-cache-semantics": "^4.0.4",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.3",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^1.3.0",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^5.0.0",
+            "ssri": "^8.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minipass-fetch": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.1.tgz",
+          "integrity": "sha512-N0ddPAD8OZnoAHUYj1ZH4ZJVna+ucy7if777LrdeIV1ko8f46af4jbyM5EC1gN4xc9Wq5c3C38GnxRJ2gneXRA==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "minipass": "^3.1.0",
+            "minipass-sized": "^1.0.3",
+            "minizlib": "^2.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4",
+            "socks": "^2.3.3"
+          }
+        },
+        "ssri": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+          "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+          "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "@apollo/protobufjs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.3.tgz",
@@ -29,6 +431,12 @@
           "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
         }
       }
+    },
+    "@apollo/query-planner-wasm": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner-wasm/-/query-planner-wasm-0.0.4.tgz",
+      "integrity": "sha512-umCWFC+PXptXsAkeFbA8TIVEFdFhru6Bj4wvhv0zrATYGlENrgrOavHC1+3GITMDDRZb4TQjfWPCaY3yE9gUpw==",
+      "dev": true
     },
     "@apollographql/apollo-tools": {
       "version": "0.4.8",
@@ -5304,6 +5712,15 @@
         "apollo-server-env": "file:packages/apollo-server-env",
         "apollo-server-errors": "file:packages/apollo-server-errors",
         "http-cache-semantics": "^4.0.0"
+      }
+    },
+    "apollo-engine-reporting-protobuf": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.2.tgz",
+      "integrity": "sha512-4wm9FR3B7UvJxcK/69rOiS5CAJPEYKufeRWb257ZLfX7NGFTMqvbc1hu4q8Ch7swB26rTpkzfsftLED9DqH9qg==",
+      "dev": true,
+      "requires": {
+        "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-fetch": {
@@ -16881,6 +17298,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.xorby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
+      "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c=",
       "dev": true
     },
     "log4js": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "graphql-extensions": "file:packages/graphql-extensions"
   },
   "devDependencies": {
+    "@apollo/federation": "^0.20.2",
+    "@apollo/gateway": "^0.20.2",
     "@types/async-retry": "1.4.2",
     "@types/aws-lambda": "8.10.62",
     "@types/body-parser": "1.19.0",


### PR DESCRIPTION
In #4561 we removed `@apollo/federation` and `@apollo/gateway` from the
apollo-server repo. This means that the acephei example doesn't know where to
import them from. Adding them to examples/acephei/package.json led to very
strange errors so let's just add them as top-level dev dependencies.

Additionally, removing `@apollo/federation` seemed to make it so that TypeScript
can't find `apollo-env` any more, but it also seems like maybe the references to
it in the tsconfig.json lines aren't necessary? Not sure what's going on here
but leaving them in led to build errors and removing them didn't.

Finally, update the uses of `engine:` to use the new post-#4453 APIs, and spell
the version "set up" as two words.
