### PR TITLE
chore(deps): move @types to devDependencies

### DIFF
--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -28,12 +28,6 @@
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.26",
     "@koa/cors": "^2.2.1",
-    "@types/accepts": "^1.3.5",
-    "@types/cors": "^2.8.4",
-    "@types/koa": "^2.0.46",
-    "@types/koa-bodyparser": "^4.2.1",
-    "@types/koa-compose": "^3.2.2",
-    "@types/koa__cors": "^2.2.1",
     "accepts": "^1.3.5",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
@@ -45,7 +39,13 @@
     "type-is": "^1.6.16"
   },
   "devDependencies": {
-    "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
+    "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
+    "@types/accepts": "^1.3.5",
+    "@types/cors": "^2.8.4",
+    "@types/koa": "^2.0.46",
+    "@types/koa-bodyparser": "^4.2.1",
+    "@types/koa-compose": "^3.2.2",
+    "@types/koa__cors": "^2.2.1"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"


### PR DESCRIPTION
Avoid declaring `@types/*` packages as `"dependencies"`.

- These are **not direct source dependencies** of the `apollo-server-koa` distributed package, so they don't belong there semantically and/or conceptually.
- They are **not needed**, at all, by people not using Typescript.
- In most cases, VSCode will **automatically download these for you.** Users may also declare them themselves as their own dependencies, if needed.
- It bloats the module with unnecessary source code, **inflating the size of the package download and the final application**. This is specially true on environments where strict size restrictions are in place for uploading and running `node` processes  (i.e.: most cloud runtimes, like AWS).

A fresh `npm i apollo-server-koa` creates all of these under `node_modules`.

![image](https://user-images.githubusercontent.com/476069/94545990-2e6fa600-0245-11eb-8954-243aebc9d7ce.png)

IMHO, and for the reasons outlined above, none of that should be there.
