### PR TITLE
[RedisClusterCache] Allow to pass a Redis.Cluster instance to constructor

### DIFF
--- a/packages/apollo-server-cache-redis/package.json
+++ b/packages/apollo-server-cache-redis/package.json
@@ -22,5 +22,8 @@
     "apollo-server-env": "file:../apollo-server-env",
     "dataloader": "^2.0.0",
     "ioredis": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/ioredis": "^4.17.4"
   }
 }

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -21,7 +21,7 @@ export class RedisClusterCache implements KeyValueCache {
       this.client = new Redis.Cluster(value, options);
     }
 
-    this.loader = new DataLoader(
+    this.loader = new DataLoader<string, string | null>(
       (keys = []) =>
         Promise.all(keys.map(key => this.client.get(key).catch(() => null))),
       { cache: false },

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -1,5 +1,6 @@
 import { KeyValueCache, KeyValueCacheSetOptions } from 'apollo-server-caching';
-import Redis, {
+import {
+  Cluster,
   ClusterOptions,
   ClusterNode,
   Redis as RedisInstance,
@@ -7,19 +8,20 @@ import Redis, {
 import DataLoader from 'dataloader';
 
 export class RedisClusterCache implements KeyValueCache {
-  readonly client: Redis.Cluster;
+  readonly client: Cluster;
   readonly defaultSetOptions: KeyValueCacheSetOptions = {
     ttl: 300,
   };
 
   private loader: DataLoader<string, string | null>;
 
-  constructor(value: ClusterNode[] | Redis.Cluster, options?: ClusterOptions) {
-    if (value instanceof Redis.Cluster) {
+  constructor(value: ClusterNode[] | Cluster, options?: ClusterOptions) {
+    if (value instanceof Cluster) {
       this.client = value;
     } else {
-      this.client = new Redis.Cluster(value, options);
+      this.client = new Cluster(value as ClusterNode[], options);
     }
+    this.client.mget
 
     this.loader = new DataLoader<string, string | null>(
       (keys = []) =>

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -53,7 +53,7 @@ export class RedisClusterCache implements KeyValueCache {
   }
 
   async delete(key: string): Promise<boolean> {
-    return await this.client.del(key);
+    return await this.client.del(key) > 0;
   }
 
   async flush(): Promise<void> {

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -21,7 +21,6 @@ export class RedisClusterCache implements KeyValueCache {
     } else {
       this.client = new Cluster(value as ClusterNode[], options);
     }
-    this.client.mget
 
     this.loader = new DataLoader<string, string | null>(
       (keys = []) =>

--- a/packages/apollo-server-cache-redis/src/__mocks__/ioredis.ts
+++ b/packages/apollo-server-cache-redis/src/__mocks__/ioredis.ts
@@ -1,21 +1,21 @@
 const IORedis = jest.genMockFromModule('ioredis');
 
-const keyValue: Record<string, { value: string, ttl: number | undefined | null }> = {};
+const keyValue: Record<string, { value: string, ttl: number | null }> = {};
 
 const deleteKey = (key: string) => {
   delete keyValue[key];
   return Promise.resolve(true);
 };
 
-const getKey = (key: string): Promise<string | null | undefined> => {
+const getKey = (key: string): Promise<string | null> => {
   if (keyValue[key]) {
     return Promise.resolve(keyValue[key].value);
   }
 
-  return Promise.resolve(undefined);
+  return Promise.resolve(null);
 };
 
-const mGetKey = (key: string, cb: (result: Array<string | null>) => void) : Promise<Array<string | null>> => getKey(key).then(val => [val]);
+const mGetKey = (key: string, cb: (result: Array<string | null>) => void) : Promise<(string | null)[]> => getKey(key).then(val => [val]);
 
 const setKey = (key: string, value: string, type?: string, ttl?: number | null | undefined): Promise<true> => {
   keyValue[key] = {

--- a/packages/apollo-server-cache-redis/src/__mocks__/ioredis.ts
+++ b/packages/apollo-server-cache-redis/src/__mocks__/ioredis.ts
@@ -1,13 +1,13 @@
 const IORedis = jest.genMockFromModule('ioredis');
 
-const keyValue = {};
+const keyValue: Record<string, { value: string, ttl: number | undefined | null }> = {};
 
-const deleteKey = key => {
+const deleteKey = (key: string) => {
   delete keyValue[key];
   return Promise.resolve(true);
 };
 
-const getKey = key => {
+const getKey = (key: string): Promise<string | null | undefined> => {
   if (keyValue[key]) {
     return Promise.resolve(keyValue[key].value);
   }
@@ -15,9 +15,9 @@ const getKey = key => {
   return Promise.resolve(undefined);
 };
 
-const mGetKey = (key, cb) => getKey(key).then(val => [val]);
+const mGetKey = (key: string, cb: (result: Array<string | null>) => void) : Promise<Array<string | null>> => getKey(key).then(val => [val]);
 
-const setKey = (key, value, type, ttl) => {
+const setKey = (key: string, value: string, type?: string, ttl?: number | null | undefined): Promise<true> => {
   keyValue[key] = {
     value,
     ttl,

--- a/packages/apollo-server-cache-redis/src/__tests__/RedisClusterCache.test.ts
+++ b/packages/apollo-server-cache-redis/src/__tests__/RedisClusterCache.test.ts
@@ -1,7 +1,7 @@
-const ioredis = jest.mock('ioredis');
+jest.mock('ioredis');
 
 import { RedisClusterCache } from '../index';
 import { testKeyValueCache } from '../../../apollo-server-caching/src/__tests__/testsuite';
 
 testKeyValueCache(new RedisClusterCache([{ host: 'localhost' }]));
-testKeyValueCache(new RedisClusterCache(new ioredis.Cluster([{ host: 'localhost' }])));
+testKeyValueCache(new RedisClusterCache(new IORedis.Cluster([{ host: 'localhost' }])));

--- a/packages/apollo-server-cache-redis/src/__tests__/RedisClusterCache.test.ts
+++ b/packages/apollo-server-cache-redis/src/__tests__/RedisClusterCache.test.ts
@@ -1,8 +1,7 @@
-jest.mock('ioredis');
+const ioredis = jest.mock('ioredis');
 
-import { Cluster } from 'ioredis';
 import { RedisClusterCache } from '../index';
 import { testKeyValueCache } from '../../../apollo-server-caching/src/__tests__/testsuite';
 
 testKeyValueCache(new RedisClusterCache([{ host: 'localhost' }]));
-testKeyValueCache(new RedisClusterCache(new Cluster([{ host: 'localhost' }])));
+testKeyValueCache(new RedisClusterCache(new ioredis.Cluster([{ host: 'localhost' }])));

--- a/packages/apollo-server-cache-redis/src/__tests__/RedisClusterCache.test.ts
+++ b/packages/apollo-server-cache-redis/src/__tests__/RedisClusterCache.test.ts
@@ -1,6 +1,8 @@
 jest.mock('ioredis');
 
+import { Cluster } from 'ioredis';
 import { RedisClusterCache } from '../index';
 import { testKeyValueCache } from '../../../apollo-server-caching/src/__tests__/testsuite';
 
 testKeyValueCache(new RedisClusterCache([{ host: 'localhost' }]));
+testKeyValueCache(new RedisClusterCache(new Cluster([{ host: 'localhost' }])));


### PR DESCRIPTION
To avoid creating multiple Redis Cluster instances (and connections)
RedisClusterCache constructor now accepts a redis cluster instance or previous node array config
