### PR TITLE
Release 2.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- `apollo-server-core`: Explicitly include `lru-cache` dependency in `apollo-server-core`'s dependencies. [PR #4600](https://github.com/apollographql/apollo-server/pull/4600)
+
 ## v2.18.1
 
 - `apollo-server-core`: Fix support for legacy option `engine: {logger}`, broken in v2.18.0. [PR #4588](https://github.com/apollographql/apollo-server/pull/4588)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+## v2.18.2
+
 - `apollo-server-core`: Explicitly include `lru-cache` dependency in `apollo-server-core`'s dependencies. [PR #4600](https://github.com/apollographql/apollo-server/pull/4600)
 
 ## v2.18.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -5948,6 +5948,7 @@
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
         "loglevel": "^1.6.7",
+        "lru-cache": "^5.0.0",
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "uuid": "^8.0.0",

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "2.18.1",
+	"version": "2.18.2",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -46,6 +46,7 @@
     "graphql-tools": "^4.0.0",
     "graphql-upload": "^8.0.2",
     "loglevel": "^1.6.7",
+    "lru-cache": "^5.0.0",
     "sha.js": "^2.4.11",
     "subscriptions-transport-ws": "^0.9.11",
     "uuid": "^8.0.0",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-testing",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Test utils for apollo-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Production ready GraphQL Server",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/apollo-server/issues?q=label%3A%22%F0%9F%8F%97+release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release of Apollo Server. 🙌   The version in the title of this PR should correspond to the appropriate branch.

Check the appropriate milestone (to the right) for more details on what we hope to get into this release!

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indiciated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
