### PR TITLE
Fix issues #3559 cache hint not working

### DIFF
--- a/packages/apollo-cache-control/src/index.ts
+++ b/packages/apollo-cache-control/src/index.ts
@@ -53,7 +53,7 @@ export const plugin = (
   options: CacheControlExtensionOptions = Object.create(null),
 ): ApolloServerPlugin => ({
   requestDidStart(requestContext) {
-    const defaultMaxAge: number = options.defaultMaxAge || 0;
+    const defaultMaxAge: number | null = options.defaultMaxAge || null;
     const hints: MapResponsePathHints = new Map();
 
 
@@ -111,7 +111,7 @@ export const plugin = (
             hint.maxAge = defaultMaxAge;
           }
 
-          if (hint.maxAge !== undefined || hint.scope !== undefined) {
+          if (hint.maxAge !== null && (hint.maxAge !== undefined || hint.scope !== undefined)) {
             addHint(hints, info.path, hint);
           }
 


### PR DESCRIPTION
Draft MR to help @glasser potentially track down an issue with the caching hint.

Taking the following schema:

```
 type Book @cacheControl(maxAge: 100) { 
    title: String
    author: String
    nestedObject: Object    
  }

  type Query {
    books: Book
  }

  type Object  {
    test: Boolean
  }
```

My expectation would be that `cache-control: max-age=100, public` gets sent for the book query. However that isn't the case because currently `type Object` has no `@cacheControl hint` and it then sets the `defaultMaxAge` to 0.

In this change we only `addHint` when the default is not null

Not sure if the proposed changes are valid but it solved the issue for me. I think this is what is causing alot of confussion from issue #3559 