### PR TITLE
usage-reporting: Report stats about input object fields and enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- `apollo-reporting-protobuf`: Update protobuf to include `per_input_type_stat` for input field stats and `per_enum_type_stat` for enum value stats.
+- `apollo-server-core`: Update the usage reporting plugin to include input field stats and enum value stats in traces.
+
 ## v2.18.2
 
 - `apollo-server-core`: Explicitly include `lru-cache` dependency in `apollo-server-core`'s dependencies. [PR #4600](https://github.com/apollographql/apollo-server/pull/4600)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6142,6 +6142,7 @@
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
+        "iterall": "^1.3.0",
         "loglevel": "^1.6.7",
         "lru-cache": "^5.0.0",
         "sha.js": "^2.4.11",
@@ -6150,6 +6151,11 @@
         "ws": "^6.0.0"
       },
       "dependencies": {
+        "iterall": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+          "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+        },
         "loglevel": {
           "version": "1.6.7",
           "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",

--- a/packages/apollo-cache-control/src/__tests__/cacheControlPlugin.test.ts
+++ b/packages/apollo-cache-control/src/__tests__/cacheControlPlugin.test.ts
@@ -30,7 +30,7 @@ describe('plugin', () => {
       return pluginTestHarness({
         pluginInstance,
         overallCachePolicy,
-        graphqlRequest: { query: 'does not matter' },
+        graphqlRequest: { query: '{ __typename }' }, // query doesn't matter
         executor: () => {
           const response: GraphQLResponse = {
             http: {

--- a/packages/apollo-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-reporting-protobuf/src/reports.proto
@@ -232,6 +232,11 @@ message Trace {
 	// Was this operation forbidden due to lack of safelisting?
 	bool forbidden_operation = 25;
 
+	// These statistics depend on the query's variables and response, and thus
+	// cannot be computed from the trace alone, so we must append them to traces.
+	map<string, InputTypeStat> per_input_type_stat = 29;
+	map<string, EnumTypeStat> per_enum_type_stat = 30;
+
 	// --------------------------------------------------------------
 	// Fields below this line are only set by the old Go engineproxy.
 
@@ -329,6 +334,45 @@ message TypeStat {
 	reserved 1, 2;
 }
 
+message InputFieldStat {
+	// Required. The field's type (e.g. "String!" for User.email:String!).
+	string field_type = 1;
+	// Number of requests where the field is present (either in the operation body
+	// or variables).
+	uint64 request_count = 2;
+	// Number of requests where the field is present (either in the operation body
+	// or variables) and the field is provided null at least once. Note that we
+	// do not count a field with default value null that is provided undefined as
+	// being provided null. Also note that a GraphQL request may encounter no
+	// errors while providing null to a non-nullable input field due to an edge
+	// case in spec (see the usage reporting plugin source for details).
+	uint64 request_count_null = 3;
+	// Number of requests where the field is undefined at least once (either in
+	// the operation body or variables). A field is undefined if either an
+	// ObjectValue of the parent input object type does not have the field
+	// present, or if the field is present with variable value and the variable
+	// is undefined.
+	uint64 request_count_undefined = 4;
+}
+
+message InputTypeStat {
+	// Key is the field's name (e.g. "email" for User.email:String!).
+	map<string, InputFieldStat> per_input_field_stat = 1;
+}
+
+message EnumValueStat {
+	// Number of requests containing the enum value (either in the operation body
+	// or variables).
+	uint64 request_count = 1;
+	// Number of responses containing the enum value.
+	uint64 response_count = 2;
+}
+
+message EnumTypeStat {
+	// Key is the enum value (e.g. "GREEN" for Colors.GREEN).
+	map<string, EnumValueStat> per_enum_value_stat = 1;
+}
+
 message Field {
 	string name = 2; // required; eg "email" for User.email:String!
 	string return_type = 3; // required; eg "String!" for User.email:String!
@@ -372,6 +416,8 @@ message ContextualizedStats {
 	QueryLatencyStats query_latency_stats = 2;
 	// Key is type name.
 	map<string, TypeStat> per_type_stat = 3;
+	map<string, InputTypeStat> per_input_type_stat = 4;
+	map<string, EnumTypeStat> per_enum_type_stat = 5;
 }
 
 // A sequence of traces and stats. An individual trace should either be counted as a stat or trace

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -45,6 +45,7 @@
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^4.0.0",
     "graphql-upload": "^8.0.2",
+    "iterall": "^1.3.0",
     "loglevel": "^1.6.7",
     "lru-cache": "^5.0.0",
     "sha.js": "^2.4.11",

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/addTraceRequestStats.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/addTraceRequestStats.test.ts
@@ -1,0 +1,576 @@
+import { Trace } from "apollo-reporting-protobuf";
+import { addTraceRequestStats } from "../addTraceRequestStats";
+import { VariableValues } from "apollo-server-types";
+import { buildASTSchema, getOperationAST, parse, validate } from "graphql";
+
+describe('Input object field and enum value stats tests', () => {
+  function runTest({
+    schema,
+    operation,
+    operationName,
+    variables,
+    perEnumTypeStat = {},
+    perInputTypeStat = {},
+  }: {
+    schema: string;
+    operation: string;
+    operationName?: string;
+    variables?: VariableValues;
+    perEnumTypeStat?: {
+      [enumTypeName: string]: {
+        [enumValueName: string]: {
+          requestCount?: number;
+        }
+      }
+    };
+    perInputTypeStat?: {
+      [inputObjectTypeName: string]: {
+        [inputFieldName: string]: {
+          fieldType: string;
+          requestCount?: number;
+          requestCountNull?: number;
+          requestCountUndefined?: number;
+        }
+      }
+    }
+  }) {
+    const trace = new Trace();
+    const graphqlSchema = buildASTSchema(parse(schema));
+    const documentAST = parse(operation);
+    const validationErrors = validate(graphqlSchema, documentAST);
+    if (validationErrors.length) {
+      throw Error(`Operation document is invalid: ${
+        validationErrors.map((e) => e.message).join(', ')
+      }`);
+    }
+    const operationAST = getOperationAST(parse(operation), operationName);
+    if (!operationAST) throw Error('Could not get operation from document.');
+    addTraceRequestStats({
+      trace,
+      schema: graphqlSchema,
+      document: documentAST,
+      operation: operationAST,
+      variables,
+    })
+    expect(trace.perEnumTypeStat).toEqual(
+      Object.entries(perEnumTypeStat).map(
+        ([typeName, perEnumValueStat]) => ({
+          key: typeName,
+          value: { perEnumValueStat, }
+        })
+      ).reduce((output, {key, value}) => {
+        output[key] = value
+        return output;
+      }, Object.create(null))
+    );
+    expect(trace.perInputTypeStat).toEqual(
+      Object.entries(perInputTypeStat).map(
+        ([typeName, perInputFieldStat]) => ({
+          key: typeName,
+          value: { perInputFieldStat, }
+        })
+      ).reduce((output, {key, value}) => {
+        output[key] = value
+        return output;
+      }, Object.create(null))
+    );
+  };
+
+  describe('basic examples', () => {
+    const basicSchema = `
+      type Query {
+        foo(input: TestInput, enum: TestEnum): String!
+      }
+
+      directive @bar(input: TestInput, enum: TestEnum) on FIELD
+
+      enum TestEnum {
+        VALUE
+      }
+
+      input TestInput {
+        field: String
+      }
+    `;
+
+    describe.each([
+      ['input field is provided non-null value', false, ''],
+      ['input field is provided null value', false, null],
+      ['input field is undefined', false, undefined],
+      ['enum value', true, 'VALUE'],
+    ])(
+      '%s',
+      (_, isEnumValue: boolean, value: string | null| undefined) => {
+        const basicTraceStats = isEnumValue
+          ? {
+              perEnumTypeStat: {
+                TestEnum: {
+                  [value!]: {
+                    requestCount: 1,
+                  },
+                },
+              },
+            }
+          : value === undefined
+          ? {
+              perInputTypeStat: {
+                TestInput: {
+                  field: {
+                    fieldType: 'String',
+                    requestCountUndefined: 1,
+                  },
+                },
+              },
+            }
+          : value === null
+          ? {
+              perInputTypeStat: {
+                TestInput: {
+                  field: {
+                    fieldType: 'String',
+                    requestCount: 1,
+                    requestCountNull: 1,
+                  },
+                },
+              },
+            }
+          : {
+              perInputTypeStat: {
+                TestInput: {
+                  field: {
+                    fieldType: 'String',
+                    requestCount: 1,
+                  },
+                },
+              },
+            };
+        const basicValue = isEnumValue
+          ? value
+          : value === undefined
+          ? '{}'
+          : value === null
+          ? '{ field: null }'
+          : `{ field: "${value}" }`
+        const basicArg = `${isEnumValue ? 'enum' : 'input'}: ${basicValue}`;
+
+        it('object field argument usage', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query {
+                foo(${basicArg})
+              }
+            `,
+            ...basicTraceStats,
+          });
+        });
+
+        it('object field argument usage with alias', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query {
+                bar: foo(${basicArg})
+              }
+            `,
+            ...basicTraceStats,
+          });
+        });
+
+        it('object field argument usage in inline fragment', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query {
+                ... on Query {
+                  foo(${basicArg})
+                }
+              }
+            `,
+            ...basicTraceStats,
+          });
+        });
+
+        it('object field argument usage in named fragment', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query Foo {
+                ...Bar
+              }
+
+              fragment Bar on Query {
+                foo(${basicArg})
+              }
+            `,
+            ...basicTraceStats,
+          });
+        });
+
+        it('object field argument usage in unused operation', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query Foo {
+                __typename
+              }
+
+              query Unused {
+                foo(${basicArg})
+              }
+            `,
+            operationName: 'Foo',
+          });
+        });
+
+        it('object field argument usage in unused named fragment', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query Foo {
+                __typename
+              }
+
+              query Unused {
+                ...UnusedFragment
+              }
+
+              fragment UnusedFragment on Query {
+                foo(${basicArg})
+              }
+            `,
+            operationName: 'Foo',
+          });
+        });
+
+        it('directive argument usage', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query {
+                foo @bar(${basicArg})
+              }
+            `,
+            ...basicTraceStats,
+          });
+        });
+
+        const basicVarDefinitionWithDefault =
+          `$var: ${isEnumValue ? 'TestEnum' : 'TestInput'} = ${basicValue}`;
+        const basicVarArg =
+          `${isEnumValue ? 'enum' : 'input'}: $var`
+
+        it('default variable usage', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query(${basicVarDefinitionWithDefault}) {
+                foo(${basicVarArg})
+              }
+            `,
+            ...basicTraceStats,
+          });
+        });
+
+        it('default variable usage in unused operation', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query Foo {
+                __typename
+              }
+
+              query Unused(${basicVarDefinitionWithDefault}) {
+                foo(${basicVarArg})
+              }
+            `,
+            operationName: 'Foo',
+          });
+        });
+
+        const basicVarDefinition =
+          `$var: ${isEnumValue ? 'TestEnum' : 'TestInput'}`;
+        const basicVariables = {
+          var: isEnumValue
+            ? value
+            : value === undefined
+            ? {}
+            : { field: value },
+        };
+
+        it('direct variable usage', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query(${basicVarDefinition}) {
+                foo(${basicVarArg})
+              }
+            `,
+            variables: basicVariables,
+            ...basicTraceStats,
+          });
+        });
+
+        it('invalid variables', () => {
+          runTest({
+            schema: basicSchema,
+            operation: `
+              query($badInput: TestInput) {
+                foo1: foo(${basicArg})
+                fooBad: foo(input: $badInput)
+              }
+            `,
+            variables: {
+              badInput: { notField: '' },
+            },
+          });
+        });
+      },
+    );
+
+    describe('input field\'s value is variable', () => {
+      describe.each([
+        ['variable is provided non-null value', ''],
+        ['variable is provided null value', null],
+        ['variable is undefined', undefined],
+      ])(
+        '%s',
+        (_, value: string | null | undefined) => {
+          const basicVariables = value === undefined ? {} : { var: value };
+
+          it('input field and variable types compatible', () => {
+            runTest({
+              schema: basicSchema,
+              operation: `
+                query($var: String) {
+                  foo(input: { field: $var })
+                }
+              `,
+              variables: basicVariables,
+              perInputTypeStat: {
+                TestInput: {
+                  field: {
+                    fieldType: 'String',
+                    requestCount: 1,
+                    ...(value === undefined
+                      ? { requestCountUndefined: 1 }
+                      : value === null
+                      ? { requestCountNull: 1 }
+                      : {}
+                    ),
+                  },
+                },
+              },
+            });
+          });
+
+          describe('input field is non-nullable and variable is nullable', () => {
+            // This is to test a particularly annoying edge case in spec, see
+            // the last section of
+            // https://spec.graphql.org/June2018/#sec-All-Variable-Usages-are-Allowed
+            test.each([[false, true], [true, false], [true, true]])(
+              'input field has default: %s, variable has default: %s',
+              (fieldHasDefault: boolean, variableHasDefault: boolean) => {
+                const edgeCaseSchema = `
+                  type Query {
+                    foo(input: TestInput): String!
+                  }
+
+                  input TestInput {
+                    field: String! ${fieldHasDefault ? '= "field default"': ''}
+                  }
+                `;
+                const edgeCaseOperation = `
+                  query(
+                    $var: String ${variableHasDefault ? ' = "var default"' : ''}
+                  ) {
+                    foo(input: { field: $var })
+                  }
+                `;
+
+                runTest({
+                  schema: edgeCaseSchema,
+                  operation: edgeCaseOperation,
+                  variables: basicVariables,
+                  perInputTypeStat: {
+                    TestInput: {
+                      field: {
+                        fieldType: 'String!',
+                        requestCount: 1,
+                        ...(value === undefined && !variableHasDefault
+                          ? { requestCountUndefined: 1 }
+                          : value === null
+                          ? { requestCountNull: 1 }
+                          : {}
+                        ),
+                      },
+                    },
+                  },
+                });
+              },
+            );
+          });
+        },
+      );
+    });
+  });
+
+  describe('complex examples', () => {
+    it('many types', () => {
+      runTest({
+        schema: `
+          type Query {
+            foo: Foo
+          }
+
+          type Foo {
+            bar(
+              arg1: EnumType1
+              arg2: InputType1
+              arg3: InputType2
+              arg4: InputType4
+            ): String
+          }
+
+          input InputType1 {
+            field1: [String]!
+            field2: Int
+          }
+
+          input InputType2 {
+            field3: EnumType2!
+            field4: Boolean
+          }
+
+          input InputType3 {
+            field5: EnumType3!
+            field6: EnumType4
+          }
+
+          input InputType4 {
+            field7: InputType3!
+            field8: InputType4
+          }
+
+          enum EnumType1 {
+            VALUE_1
+            VALUE_2
+          }
+
+          enum EnumType2 {
+            VALUE_3
+            VALUE_4
+          }
+
+          enum EnumType3 {
+            VALUE_5
+            VALUE_6
+          }
+
+          enum EnumType4 {
+            VALUE_7
+            VALUE_8
+          }
+        `,
+        operation: `
+          query($var1: Int, $var2: InputType2, $var3: InputType4) {
+            foo {
+              bar(
+                arg1: VALUE_2
+                arg2: {
+                  field1: [""]
+                  field2: $var1
+                }
+                arg3: $var2
+                arg4: {
+                  field7: {
+                    field5: VALUE_5
+                  }
+                  field8: $var3
+                }
+              )
+            }
+          }
+        `,
+        variables: {
+          var1: 0,
+          var2: {
+            field3: 'VALUE_3',
+          },
+          var3: {
+            field7: {
+              field5: 'VALUE_6',
+              field6: null,
+            },
+            field8: null,
+          },
+        },
+        perEnumTypeStat: {
+          EnumType1: {
+            VALUE_2: {
+              requestCount: 1,
+            },
+          },
+          EnumType2: {
+            VALUE_3: {
+              requestCount: 1,
+            },
+          },
+          EnumType3: {
+            VALUE_5: {
+              requestCount: 1,
+            },
+            VALUE_6: {
+              requestCount: 1,
+            },
+          },
+        },
+        perInputTypeStat: {
+          InputType1: {
+            field1: {
+              fieldType: '[String]!',
+              requestCount: 1,
+            },
+            field2: {
+              fieldType: 'Int',
+              requestCount: 1,
+            },
+          },
+          InputType2: {
+            field3: {
+              fieldType: 'EnumType2!',
+              requestCount: 1,
+            },
+            field4: {
+              fieldType: 'Boolean',
+              requestCountUndefined: 1,
+            },
+          },
+          InputType3: {
+            field5: {
+              fieldType: 'EnumType3!',
+              requestCount: 1,
+            },
+            field6: {
+              fieldType: 'EnumType4',
+              requestCount: 1,
+              requestCountNull: 1,
+              requestCountUndefined: 1,
+            },
+          },
+          InputType4: {
+            field7: {
+              fieldType: 'InputType3!',
+              requestCount: 1,
+            },
+            field8: {
+              fieldType: 'InputType4',
+              requestCount: 1,
+              requestCountNull: 1,
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
@@ -53,7 +53,7 @@ export function addTraceRequestStats({
   operation,
   variables,
 }: {
-  trace: Trace;
+  trace: Pick<Trace, 'perEnumTypeStat' | 'perInputTypeStat'>;
   schema: GraphQLSchema;
   document: DocumentNode;
   operation: OperationDefinitionNode;
@@ -237,7 +237,7 @@ function addTraceInputValueStats({
   inputValue,
   inputType,
 }: {
-  trace: Trace;
+  trace: Pick<Trace, 'perEnumTypeStat' | 'perInputTypeStat'>;
   inputValue: any;
   inputType: GraphQLInputType;
 }): void {
@@ -379,7 +379,7 @@ function inputFieldIsUsedByRequest({
   isNull,
   isUndefined,
 }: {
-  trace: Trace;
+  trace: Pick<Trace, 'perInputTypeStat'>;
   inputObjectTypeName: string;
   inputFieldName: string;
   inputFieldTypeName: string;
@@ -408,7 +408,7 @@ function enumValueIsPresentInRequest({
   enumTypeName,
   enumValueName,
 }: {
-  trace: Trace;
+  trace: Pick<Trace, 'perEnumTypeStat'>;
   enumTypeName: string;
   enumValueName: string;
 }): void {

--- a/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
@@ -1,0 +1,428 @@
+import {
+  InputFieldStat,
+  InputTypeStat,
+  Trace
+} from 'apollo-reporting-protobuf';
+import {
+  EnumTypeStat,
+  EnumValueStat,
+  IEnumValueStat,
+  IInputFieldStat
+} from "apollo-reporting-protobuf/dist/protobuf";
+import { VariableValues } from 'apollo-server-types';
+import {
+  DocumentNode,
+  EnumValueNode,
+  getNamedType,
+  GraphQLInputType,
+  GraphQLSchema,
+  GraphQLType,
+  isEnumType,
+  isInputObjectType,
+  isInputType,
+  isListType,
+  isNonNullType,
+  isScalarType,
+  ObjectFieldNode,
+  ObjectValueNode,
+  OperationDefinitionNode,
+  separateOperations,
+  typeFromAST,
+  TypeInfo,
+  visit,
+  visitWithTypeInfo
+} from "graphql";
+import { isCollection, forEach } from 'iterall';
+
+// We would like to inform users about what schema changes are safe, specifically:
+// - Can an input object field be safely removed?
+// - Can an input object field's default value be safely removed?
+// - Can an input object field's type be safely changed to non-nullable? Will
+//   this require the addition of a default value?
+// - Can an enum value be safely removed?
+//
+// To give this insight, we need to know whether an operation is using a given
+// enum value or input object field (and whether it supplies null at least once
+// for that field, and similarily whether it supplies undefined at least once
+// for that field). This isn't extractable from a given operation signature,
+// since signatures hide literals and don't include variable structure (as this
+// information can be highly dynamic and/or sensitive). So for each request, we
+// summarize just the data we need and add it to the trace.
+export function addTraceRequestStats({
+  trace,
+  schema,
+  document,
+  operation,
+  variables,
+}: {
+  trace: Trace;
+  schema: GraphQLSchema;
+  document: DocumentNode;
+  operation: OperationDefinitionNode;
+  variables?: VariableValues;
+}): void {
+  try {
+    // Search the variable values for input object fields and enum values. This
+    // code is adapted from coerceVariableValues() in graphql-js.
+    //
+    // Note that we need to keep track of which variables evalulate to null and
+    // undefined, for cases where an input value in the operation body contains
+    // an input object field that is set to a variable.
+    const nullVariableNames = new Set<string>();
+    const undefinedVariableNames = new Set<string>();
+    for (const varDefinition of operation.variableDefinitions ?? []) {
+      const varName = varDefinition.variable.name.value;
+
+      // TS unfortunately doesn't handle overloads and union types as nicely as
+      // Flow, see https://github.com/microsoft/TypeScript/issues/14107
+      let varType: GraphQLType | undefined;
+      switch (varDefinition.type.kind) {
+        case 'ListType':
+          varType = typeFromAST(schema, varDefinition.type);
+          break;
+        case 'NamedType':
+          varType = typeFromAST(schema, varDefinition.type);
+          break;
+        case 'NonNullType':
+          varType = typeFromAST(schema, varDefinition.type);
+          break;
+      }
+
+      if (!varType || !isInputType(varType)) {
+        throw Error('Variable type must be input type.');
+      }
+
+      if (!variables || !Object.prototype.hasOwnProperty.call(variables, varName)) {
+        if (!varDefinition.defaultValue && isNonNullType(varType)) {
+          throw Error('Non-null variable with no default must have value provided.');
+        }
+        if (!varDefinition.defaultValue) {
+          undefinedVariableNames.add(varName)
+        } else if (varDefinition.defaultValue.kind === 'NullValue') {
+          nullVariableNames.add(varName);
+        }
+        continue;
+      }
+
+      const value = variables[varName];
+      if (value === null) {
+        if (isNonNullType(varType)) {
+          throw Error('Non-null variable cannot be provided null value.');
+        }
+        nullVariableNames.add(varName);
+      }
+
+      addTraceInputValueStats({
+        trace,
+        inputValue: value,
+        inputType: varType,
+      });
+    }
+
+    // Search the operation body for input object fields and enum values. Note
+    // that isn't just the operation definition's AST, but also any used
+    // fragment ASTs.
+    const operationDocument = separateOperations(document)[
+      operation.name?.value ?? ''
+    ];
+    const typeInfo = new TypeInfo(schema);
+    visit(operationDocument, visitWithTypeInfo(typeInfo, {
+      ObjectValue(node: ObjectValueNode): void {
+        // The operation has been successfully validated by this stage, so the
+        // non-null assertions here are fine. Look at the Kind.OBJECT_FIELD case
+        // in TypeInfo.enter() in graphql-js, and notice that there's no case
+        // for case for Kind.OBJECT_VALUE for enter/leave. This means that
+        // getInputType() here must return the input object type.
+        const inputType = typeInfo.getInputType()!;
+        const inputObjectType = getNamedType(inputType);
+
+        if (isInputObjectType(inputObjectType)) {
+          const inputFields = inputObjectType.getFields();
+          const operationInputFields = new Set<string>(
+            node.fields.map((inputFieldNode) => inputFieldNode.name.value)
+          );
+
+          for (const inputField of Object.values(inputFields)) {
+            if (!operationInputFields.has(inputField.name)) {
+              inputFieldIsUsedByRequest({
+                trace,
+                inputObjectTypeName: inputObjectType.name,
+                inputFieldName: inputField.name,
+                inputFieldTypeName: inputField.type.toString(),
+                isPresent: false,
+                isNull: false,
+                isUndefined: true,
+              });
+            }
+          }
+        } else {
+          // Similar to the non-null assertion above, this shouldn't happen.
+          throw Error('Unexpected input type.');
+        }
+      },
+      ObjectField(node: ObjectFieldNode): void {
+        // The operation has been successfully validated by this stage, so the
+        // non-null assertions here are fine. Look at the Kind.OBJECT_FIELD case
+        // in TypeInfo.enter() in graphql-js for why this works.
+        const parentInputType = typeInfo.getParentInputType()!;
+        const inputType = typeInfo.getInputType()!;
+
+        // For fields that have variable values, we need to check the variable's
+        // coerced value to see whether null/undefined has been provided. Note
+        // that there's an annoying edge case in spec surrounding permissible
+        // variable values in the last section of
+        // https://spec.graphql.org/June2018/#sec-All-Variable-Usages-are-Allowed
+        //
+        // Specifically, a variable with nullable type can be the value of an
+        // input object field of non-nullable type provided that at least one of
+        // either the variable or field has a default value (and that value is
+        // not null). In this case, if the variable is passed an explicit null,
+        // execution will fail for that field. However, it's possible that the
+        // field is never executed, e.g. due to being in a fragment that's never
+        // executed.
+        //
+        // So we don't consider the request invalid in this case. We instead
+        // consider this particular usage as the field being present and provided
+        // null. This is because:
+        // - Schema changes to remove this input field will make this request
+        //   always fail instead of sometimes (hence why we consider it present).
+        // - Schema changes to change the field's type from nullable to
+        //   non-nullable won't care about these stats, since the field's type
+        //   in this case is non-nullable. At first glance, it might seem like
+        //   we'd want to avoid saying the field is provided null when its type
+        //   is non-nullable because it might be confusing. But this just avoids
+        //   the truth about an ugly edge case in spec. More importantly, with
+        //   this information, we can let users know when their requests are
+        //   doing this, as it may be unintentional on their part.
+        inputFieldIsUsedByRequest({
+          trace,
+          inputObjectTypeName: getNamedType(parentInputType).name,
+          inputFieldName: node.name.value,
+          inputFieldTypeName: inputType.toString(),
+          isPresent: true,
+          isNull: node.value.kind === 'NullValue' || (
+            node.value.kind === 'Variable' &&
+            nullVariableNames.has(node.value.name.value)
+          ),
+          isUndefined: node.value.kind === 'Variable' &&
+            undefinedVariableNames.has(node.value.name.value),
+        });
+      },
+      EnumValue(node: EnumValueNode): void {
+        // The operation has been successfully validated by this stage, so the
+        // non-null assertion here is fine. Look at the Kind.ENUM case in
+        // TypeInfo.enter() in graphql-js for why this works.
+        const inputType = typeInfo.getInputType()!;
+        enumValueIsPresentInRequest({
+          trace,
+          enumTypeName: getNamedType(inputType).name,
+          enumValueName: node.value,
+        });
+      },
+    }));
+  } catch (_) {
+    // At the stage of AS when this is run, variables have not been validated
+    // yet, and accordingly the code that traverses variables may throw. In
+    // those cases, we consider the request itself as invalid. Since the point
+    // of collecting these stats is to understand how schema changes affect
+    // valid operation executions, we collect no stats for invalid requests.
+    trace.perInputTypeStat = Object.create(null);
+    trace.perEnumTypeStat = Object.create(null);
+  }
+}
+
+// This code is adapted from coerceInputValue() in graphql-js. Note that we
+// validate the variables here in addition to collecting stats, as we don't
+// want to collect stats for invalid requests.
+function addTraceInputValueStats({
+  trace,
+  inputValue,
+  inputType,
+}: {
+  trace: Trace;
+  inputValue: any;
+  inputType: GraphQLInputType;
+}): void {
+  if (isNonNullType(inputType)) {
+    if (inputValue !== null) {
+      addTraceInputValueStats({
+        trace,
+        inputValue,
+        inputType: inputType.ofType,
+      })
+      return;
+    }
+    throw Error('Non-null type cannot be provided null value.');
+  }
+
+  // Provided null for nullable type.
+  if (inputValue === null) return;
+
+  if (isListType(inputType)) {
+    const itemType = inputType.ofType;
+    if (isCollection(inputValue)) {
+      const iterator = (itemValue: any) => {
+        addTraceInputValueStats({
+          trace,
+          inputValue: itemValue,
+          inputType: itemType,
+        });
+      }
+      // TS unfortunately doesn't handle overloads and union types as nicely as
+      // Flow, see https://github.com/microsoft/TypeScript/issues/14107
+      if ('length' in inputValue) {
+        forEach(inputValue, iterator);
+      } else {
+        forEach(inputValue, iterator);
+      }
+    } else {
+      // Lists accept a non-list value as a list of one.
+      addTraceInputValueStats({
+        trace,
+        inputValue,
+        inputType: itemType,
+      });
+    }
+    return;
+  }
+
+  if (isInputObjectType(inputType)) {
+    if (typeof inputValue !== 'object') {
+      throw Error('Input object type must be provided object value.');
+    }
+    const inputFields = inputType.getFields();
+
+    for (const inputField of Object.values(inputFields)) {
+      const inputFieldValue = inputValue[inputField.name];
+
+      if (inputFieldValue === undefined) {
+        if (inputField.defaultValue === undefined && isNonNullType(inputField.type)) {
+          throw Error('Non-null input field with no default must have value provided.');
+        }
+        inputFieldIsUsedByRequest({
+          trace,
+          inputObjectTypeName: inputType.name,
+          inputFieldName: inputField.name,
+          inputFieldTypeName: inputField.type.toString(),
+          isPresent: false,
+          isNull: false,
+          isUndefined: true,
+        });
+        continue;
+      }
+
+      inputFieldIsUsedByRequest({
+        trace,
+        inputObjectTypeName: inputType.name,
+        inputFieldName: inputField.name,
+        inputFieldTypeName: inputField.type.toString(),
+        isPresent: true,
+        isNull: inputFieldValue === null,
+        isUndefined: false,
+      });
+
+      addTraceInputValueStats({
+        trace,
+        inputValue: inputFieldValue,
+        inputType: inputField.type,
+      });
+    }
+
+    // Ensure every provided field is defined.
+    for (const fieldName of Object.keys(inputValue)) {
+      if (!inputFields[fieldName]) {
+        throw Error('Input object type does not have provided field name.');
+      }
+    }
+    return;
+  }
+
+  if (isScalarType(inputType)) {
+    let parseResult;
+
+    // Scalars determine if an input value is valid via parseValue(), which can
+    // throw to indicate failure.
+    try {
+      parseResult = inputType.parseValue(inputValue);
+    } catch (error) {
+      throw Error('Scalar type threw while parsing provided value.');
+    }
+    if (parseResult === undefined) {
+      throw Error('Scalar type returned undefined when parsing provided value.');
+    }
+    return;
+  }
+
+  if (isEnumType(inputType)) {
+    if (typeof inputValue === 'string') {
+      const enumValue = inputType.getValue(inputValue);
+      if (enumValue) {
+        enumValueIsPresentInRequest({
+          trace,
+          enumTypeName: inputType.name,
+          enumValueName: enumValue.name,
+        });
+        return;
+      }
+    }
+    throw Error('Enum type does not have provided enum value.');
+  }
+
+  // Not reachable. All possible input types have been considered.
+  throw Error('Unexpected input type.');
+}
+
+function inputFieldIsUsedByRequest({
+  trace,
+  inputObjectTypeName,
+  inputFieldName,
+  inputFieldTypeName,
+  isPresent,
+  isNull,
+  isUndefined,
+}: {
+  trace: Trace;
+  inputObjectTypeName: string;
+  inputFieldName: string;
+  inputFieldTypeName: string;
+  isPresent: boolean;
+  isNull: boolean;
+  isUndefined: boolean;
+}): void {
+  const inputTypeStat =
+    Object.prototype.hasOwnProperty.call(trace.perInputTypeStat, inputObjectTypeName)
+      ? trace.perInputTypeStat[inputObjectTypeName]
+      : (trace.perInputTypeStat[inputObjectTypeName] = new InputTypeStat());
+  const perInputFieldStat = inputTypeStat.perInputFieldStat
+    ?? (inputTypeStat.perInputFieldStat = Object.create(null));
+  const inputFieldStat: IInputFieldStat =
+    Object.prototype.hasOwnProperty.call(perInputFieldStat, inputFieldName)
+      ? perInputFieldStat[inputFieldName]
+      : (perInputFieldStat[inputFieldName] = new InputFieldStat());
+  inputFieldStat.fieldType = inputFieldTypeName;
+  if (isPresent) inputFieldStat.requestCount = 1;
+  if (isNull) inputFieldStat.requestCountNull = 1;
+  if (isUndefined) inputFieldStat.requestCountUndefined = 1;
+}
+
+function enumValueIsPresentInRequest({
+  trace,
+  enumTypeName,
+  enumValueName,
+}: {
+  trace: Trace;
+  enumTypeName: string;
+  enumValueName: string;
+}): void {
+  const enumTypeStat =
+    Object.prototype.hasOwnProperty.call(trace.perEnumTypeStat, enumTypeName)
+      ? trace.perEnumTypeStat[enumTypeName]
+      : (trace.perEnumTypeStat[enumTypeName] = new EnumTypeStat());
+  const perEnumValueStat = enumTypeStat.perEnumValueStat
+    ?? (enumTypeStat.perEnumValueStat = Object.create(null));
+  const enumValueStat: IEnumValueStat =
+    Object.prototype.hasOwnProperty.call(perEnumValueStat, enumValueName)
+      ? perEnumValueStat[enumValueName]
+      : (perEnumValueStat[enumValueName] = new EnumValueStat());
+  enumValueStat.requestCount = 1;
+}

--- a/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
@@ -1,14 +1,12 @@
 import {
+  EnumTypeStat,
+  EnumValueStat,
+  IEnumValueStat,
+  IInputFieldStat,
   InputFieldStat,
   InputTypeStat,
   Trace
 } from 'apollo-reporting-protobuf';
-import {
-  EnumTypeStat,
-  EnumValueStat,
-  IEnumValueStat,
-  IInputFieldStat
-} from "apollo-reporting-protobuf/dist/protobuf";
 import { VariableValues } from 'apollo-server-types';
 import {
   DocumentNode,

--- a/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/addTraceRequestStats.ts
@@ -124,6 +124,9 @@ export function addTraceRequestStats({
     ];
     const typeInfo = new TypeInfo(schema);
     visit(operationDocument, visitWithTypeInfo(typeInfo, {
+      // We handle ObjectValue here specifically so we can track undefined input
+      // object fields (i.e. input object fields that are not present in the
+      // ObjectValue).
       ObjectValue(node: ObjectValueNode): void {
         // The operation has been successfully validated by this stage, so the
         // non-null assertions here are fine. Look at the Kind.OBJECT_FIELD case

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -31,6 +31,7 @@ import { makeTraceDetails } from './traceDetails';
 import { GraphQLSchema, printSchema } from 'graphql';
 import { computeExecutableSchemaId } from '../schemaReporting';
 import type { InternalApolloServerPlugin } from '../internalPlugin';
+import { addTraceRequestStats } from './addTraceRequestStats';
 
 const reportHeaderDefaults = {
   hostname: os.hostname(),
@@ -598,6 +599,14 @@ export function ApolloServerPluginUsageReporting<TContext>(
               // End early if we aren't going to send the trace so we continue to
               // run the tree builder.
               didEnd(requestContext);
+            } else {
+              addTraceRequestStats({
+                trace: treeBuilder.trace,
+                schema,
+                document: requestContext.document,
+                operation: requestContext.operation,
+                variables,
+              });
             }
           },
           executionDidStart() {

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -22,6 +22,7 @@ import {
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import { Dispatcher } from './dispatcher';
 import { generateSchemaHash } from "./schemaHash";
+import { getOperationAST, parse } from 'graphql';
 
 // This test harness guarantees the presence of `query`.
 type IPluginTestHarnessGraphqlRequest = WithRequired<GraphQLRequest, 'query'>;
@@ -118,11 +119,17 @@ export default async function pluginTestHarness<TContext>({
     }
   }
 
+  const document = parse(graphqlRequest.query);
+  const operation = getOperationAST(document, graphqlRequest.operationName);
+  const operationName = operation?.name?.value;
   const requestContext: GraphQLRequestContext<TContext> = {
     logger: logger || console,
     schema,
     schemaHash: generateSchemaHash(schema),
     request: graphqlRequest,
+    document,
+    operation: operation ?? undefined,
+    operationName,
     metrics: Object.create(null),
     source: graphqlRequest.query,
     cache: new InMemoryLRUCache(),


### PR DESCRIPTION
We would like to inform users about what schema changes are safe, specifically:
- Can an input object field be safely removed?
- Can an input object field's default value be safely removed?
- Can an input object field's type be safely changed to non-nullable? Will this require the addition of a default value?
- Can an enum value be safely removed?

This PR changes `ApolloServerPluginUsageReporting` to report stats on input object fields and enum values, which helps us answer these questions.

Note that this only changes the plugin to look at request data. There are currently a few bugs in the `didResolveField` hook that make getting enum value stats from the response difficult, so I'm going to put off those changes until later (see #4667 for more info).