### PR TITLE
Base URL security enhancements for REST DataSource

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -74,14 +74,14 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
   protected resolveURL(request: RequestOptions): ValueOrPromise<URL> {
     let path = request.path;
     if (path.startsWith('/')) {
-      path = path.slice(1);
+      path = encodeURIComponent(path.slice(1));
     }
     const baseURL = this.baseURL;
     if (baseURL) {
       const normalizedBaseURL = baseURL.endsWith('/')
         ? baseURL
         : baseURL.concat('/');
-      return new URL(path, normalizedBaseURL);
+      return new URL(normalizedBaseURL + path);
     } else {
       return new URL(path);
     }


### PR DESCRIPTION
Proposed change based on penetration testing failures. My attempt here was to make the code as secure as possible, but also as backwardly compatible as possible in case anybody out there was actually relying on the relative path functionality. Open to feedback here though!