### PR TITLE
schema-reporting: guard for absence of `apollo` property on `requestContext`.

### DIFF
--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -63,7 +63,7 @@ export function ApolloServerPluginSchemaReporting(
       return 'SchemaReporting';
     },
     async serverWillStart({ apollo, schema, logger }) {
-      const { key, graphId } = apollo;
+      const { key, graphId } = apollo || {};
       if (!key) {
         throw Error(
           'To use ApolloServerPluginSchemaReporting, you must provide an Apollo API ' +


### PR DESCRIPTION
If a user does not provide the `apollo` argument to the server (often from updating from prior versions as in our case) this throws a cryptic error before it hits the handled errors. This provides a default object to destructure then the missing fields can be handled

```
UnhandledPromiseRejectionWarning: TypeError: Cannot destructure property 'key' of 'apollo' as it is undefined.
```


