### PR TITLE
Fix ambiguous and unsound dependency on fast-json-stringify

### DIFF
--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -29,6 +29,7 @@
     "@apollographql/graphql-playground-html": "1.6.26",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
+    "fast-json-stringify": "^2.2.1"",
     "fastify-accepts": "^1.0.0",
     "fastify-cors": "^0.2.0",
     "graphql-subscriptions": "^1.0.0",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -29,7 +29,7 @@
     "@apollographql/graphql-playground-html": "1.6.26",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
-    "fast-json-stringify": "^2.2.1"",
+    "fast-json-stringify": "^2.2.1",
     "fastify-accepts": "^1.0.0",
     "fastify-cors": "^0.2.0",
     "graphql-subscriptions": "^1.0.0",


### PR DESCRIPTION
Fix Yarn PNP error when installing `apollo-server-fastify`.