### PR TITLE
fix Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'

### DIFF
--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -20,7 +20,8 @@ import accepts from 'accepts';
 import typeis from 'type-is';
 import { graphqlExpress } from './expressApollo';
 
-export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
+export { GraphQLExtension } from 'apollo-server-core';
+export type { GraphQLOptions } from 'apollo-server-core';
 
 export interface GetMiddlewareOptions {
   path?: string;


### PR DESCRIPTION
Fix export warning on `isolatedModules` is provided.