### PR TITLE
Export `ExpressContext` from apollo-server-express #3699

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+- `apollo-server-express`: types: Export `ExpressContext` from main module. [PR #4821](https://github.com/apollographql/apollo-server/pull/4821) [Issue #3699](https://github.com/apollographql/apollo-server/issues/3699)
+
 ## v2.19.1
 
 - `apollo-server-core`: The `debugPrintReports` option to `ApolloServerPluginUsageReporting` now prints traces as well. [PR #4805](https://github.com/apollographql/apollo-server/pull/4805)

--- a/packages/apollo-server-express/src/index.ts
+++ b/packages/apollo-server-express/src/index.ts
@@ -27,6 +27,7 @@ export {
   ServerRegistration,
   GetMiddlewareOptions,
   ApolloServerExpressConfig,
+  ExpressContext,
 } from './ApolloServer';
 
 export { CorsOptions } from 'cors';


### PR DESCRIPTION
This just exports the `ExpressContext` interface from the index rather than the source, as per #3699.