### PR TITLE
fix(apollo-reporting-protobuf): added `long` to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6009,7 +6009,9 @@
     "apollo-reporting-protobuf": {
       "version": "file:packages/apollo-reporting-protobuf",
       "requires": {
-        "@apollo/protobufjs": "^1.0.3"
+        "@apollo/protobufjs": "^1.0.3",
+        "@types/long": "4.0.0",
+        "long": "^4.0.0"
       }
     },
     "apollo-server": {

--- a/packages/apollo-reporting-protobuf/package.json
+++ b/packages/apollo-reporting-protobuf/package.json
@@ -31,6 +31,8 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
-    "@apollo/protobufjs": "^1.0.3"
+    "@apollo/protobufjs": "^1.0.3",
+    "@types/long": "4.0.0",
+    "long": "^4.0.0"
   }
 }


### PR DESCRIPTION
The code emitted by the `protobufjs` `pbts` tool includes the `long` dependency. This should be a peer dependency of `protobufjs` (done in apollographql/protobuf.js#6) and therefore also needs to be added to the dependencies of `apollo-reporting-protobuf`.