### PR TITLE
Response example matches mutation name

### DIFF
--- a/docs/source/schema/schema.md
+++ b/docs/source/schema/schema.md
@@ -441,7 +441,7 @@ Our `updateUserEmail` mutation would specify `UpdateUserEmailMutationResponse` a
 ```json
 {
   "data": {
-    "updateUser": {
+    "updateUserEmail": {
       "code": "200",
       "success": true,
       "message": "User email was successfully updated",


### PR DESCRIPTION
This request fixes an name mismatch in the "Schema basics" tutorial.  The section which focuses on creating explicit types for mutations references an earlier mutation which updates the user's email.  The name of the referenced mutation is `updateUserEmail`, however the example API response uses the value `updateUser` which, as I understand it, should match the mutation name.