### PR TITLE
Avoid enabling "graphql-extensions" when none are in use (#4889)

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -659,7 +659,11 @@ export async function processGraphQLRequest<TContext>(
   }
 
   function initializeExtensionStack(): GraphQLExtensionStack<TContext> {
-    enableGraphQLExtensions(config.schema);
+    if (config.extensions?.length) {
+      // graphql-extensions adds some overhead to field resolvers.
+      // Only enable extensions when at least 1 extension has been provided
+      enableGraphQLExtensions(config.schema);
+    }
 
     // If custom extension factories were provided, create per-request extension
     // objects.


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

When a response to an operation has a large number of fields, the cumulative cost of some of the lifecycle hooks in `graphql-extensions` adds up (more info in #4889). This PR will avoid calling `enableGraphQLExtensions` on a schema when no extensions are in use.

I didn't see any tests relating to this functionality, and tests are passing for me locally. Happy to contribute a test for this if y'all want, will just need some pointers 😄 