### PR TITLE
Upgrade graphql-subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,7 +5626,7 @@
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
-        "graphql-subscriptions": "^1.0.0",
+        "graphql-subscriptions": "^1.1.0",
         "graphql-tools": "^4.0.0",
         "parseurl": "^1.3.2",
         "subscriptions-transport-ws": "^0.9.16",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -39,7 +39,7 @@
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "express": "^4.17.1",
-    "graphql-subscriptions": "^1.0.0",
+    "graphql-subscriptions": "^1.1.0",
     "graphql-tools": "^4.0.0",
     "parseurl": "^1.3.2",
     "subscriptions-transport-ws": "^0.9.16",


### PR DESCRIPTION
This allows Apollo Server Express to be used with GraphQL ^15.0.0

I believe I followed the contribution guidelines.  I ran the tests and couldn't see any errors.  Please let me know if there's anything else I can do.  I'm new to the `npm` eco-system.

I'm fine maintaining my fork, but ideally I'd like to track with the `main` of this project.  

Thanks.
