### PR TITLE
Add cosmosdb-data-source link to datasource docs

### DIFF
--- a/docs/source/data/data-sources.md
+++ b/docs/source/data/data-sources.md
@@ -156,6 +156,7 @@ The following data sources are community contributions which offer their own ext
 
 - `SQLDataSource` from [`datasource-sql`](https://github.com/cvburgess/SQLDataSource)
 - `MongoDataSource` from [`apollo-datasource-mongodb`](https://github.com/GraphQLGuide/apollo-datasource-mongodb/)
+- `CosmosDataSource` from [`apollo-datasource-cosmosdb)`](https://github.com/andrejpk/apollo-datasource-cosmosdb)
 
 ## Accessing data sources from resolvers
 

--- a/docs/source/data/data-sources.md
+++ b/docs/source/data/data-sources.md
@@ -156,7 +156,7 @@ The following data sources are community contributions which offer their own ext
 
 - `SQLDataSource` from [`datasource-sql`](https://github.com/cvburgess/SQLDataSource)
 - `MongoDataSource` from [`apollo-datasource-mongodb`](https://github.com/GraphQLGuide/apollo-datasource-mongodb/)
-- `CosmosDataSource` from [`apollo-datasource-cosmosdb)`](https://github.com/andrejpk/apollo-datasource-cosmosdb)
+- `CosmosDataSource` from [`apollo-datasource-cosmosdb`](https://github.com/andrejpk/apollo-datasource-cosmosdb)
 
 ## Accessing data sources from resolvers
 


### PR DESCRIPTION
Adding a link to the Azure CosmosDB data source I wrote based on the MongoDb one listed here.

Any feedback on the datasource itself (which is VERY welcome) should go as [an issue in that repo](https://github.com/andrejpk/apollo-datasource-cosmosdb/issues), please.