### PR TITLE
ts-jest: lowercase C

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -26,7 +26,7 @@ module.exports = {
     clearMocks: true,
     globals: {
       "ts-jest": {
-        tsConfig: "<rootDir>/src/__tests__/tsconfig.json",
+        tsconfig: "<rootDir>/src/__tests__/tsconfig.json",
         diagnostics: false
       }
     }


### PR DESCRIPTION
This should hopefully avoid a ton of warnings like

ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead

with no other effects.
