### PR TITLE
chore: fix npm constraints for Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,11 +2,6 @@
   "extends": [
     "apollo-open-source"
   ],
-  "force": {
-    "constraints": {
-      "node": "< 15.0.0"
-    }
-  },
   "dependencyDashboard": true,
   "automerge": false,
   "packageRules": [


### PR DESCRIPTION
The existing `force` statement is not necessary now and actually causes a problem by overriding the existing detected `constraints` in `package.json`. This results in `npm@latest` being installed.