### PR TITLE
Expose context function args in executeOperation

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -70,6 +70,7 @@ import {
   processGraphQLRequest,
   GraphQLRequestContext,
   GraphQLRequest,
+  GraphQLResponse,
   APQ_CACHE_PREFIX,
 } from './requestPipeline';
 
@@ -964,7 +965,11 @@ export class ApolloServerBase {
 
   // This function is used by the integrations to generate the graphQLOptions
   // from an object containing the request and other integration specific
-  // options
+  // options.
+  //
+  // integrationContextArgument vaies by integration, see
+  // https://www.apollographql.com/docs/apollo-server/api/apollo-server/#middleware-specific-context-fields
+  // or ../../docs/source/api/apollo-server.md
   protected async graphQLServerOptions(
     integrationContextArgument?: Record<string, any>,
   ): Promise<GraphQLServerOptions> {
@@ -1011,8 +1016,11 @@ export class ApolloServerBase {
     };
   }
 
-  public async executeOperation(request: GraphQLRequest) {
-    const options = await this.graphQLServerOptions();
+  public async executeOperation(
+    request: GraphQLRequest,
+    integrationContextArgument?: Record<string, any>,
+  ): Promise<GraphQLResponse> {
+    const options = await this.graphQLServerOptions(integrationContextArgument);
 
     if (typeof options.context === 'function') {
       options.context = (options.context as () => never)();


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-server/issues/2886

Integrations pass implementation-specific arguments to the context
function, but executeOperation passes no arguments. This allows the
caller of executeOperation to specify those arguments, either to emulate
the behavior of an integration or to achieve some other user-specific
behavior. This seems appropriate, as the context function is the
designated entry point for such user-specific behavior.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
