### PR TITLE
Add option to throw error on willStart

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -560,6 +560,9 @@ export class ApolloServerBase {
     try {
       var { schema, schemaHash } = await this.schemaDerivedData;
     } catch (err) {
+      if (this.config.throwOnInitializationErorr) {
+        throw err
+      }
       // The `schemaDerivedData` can throw if the Promise it points to does not
       // resolve with a `GraphQLSchema`. As errors from `willStart` are start-up
       // errors, other Apollo middleware after us will not be called, including

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -129,6 +129,7 @@ export interface Config extends BaseConfig {
   apollo?: ApolloConfigInput;
   // deprecated; see https://go.apollo.dev/s/migration-engine-plugins
   engine?: boolean | EngineReportingOptions<Context>;
+  throwOnInitializationErorr?: boolean
 }
 
 // Configuration for the built-in graphql-upload integration.


### PR DESCRIPTION
This is maybe more of a question than a suggestion.
At work we are experiencing problems with ApolloGateway- it does not crash if it is unable to connect to services on startup. I debugged it and seems that gateway is handling the error correctly- it throws it, however it's being catched in ApolloServerCore.
We solved this, and other problems by extending ApolloGateway class in our code. 
Not so long ago we started using new technological stack, using Nest- and we experienced the issue even more than before. Since we now have less control of the code (if we do not want to fork graphql gateway module ofc.) it's way harder to inject own monkey patches. This behavior makes using gateway harder- we need to either catch the error earlier (for example in AuthenticatedDataSource, where we have no information about gateway/server state), or later (for example using healthchecks).
Because of it we would like to know a best way to catch these errors (or just to allow us to throw errors created during initialization).
Desired behavior seems like this:

Case 1- one or more of the services are unavailable on startup
Gateway crashes

Case 2- one of more of the services crashes after schema is already composed
Gateway handles requests which aren't related to this services

Edit: if there is other way of fixing this issue by making PR to your code I will be happy to create it if it requires reasonable amount of hours to be done.