### PR TITLE
feat: dynamic schema routing

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -47,6 +47,7 @@ module.exports = {
           Integrations: [
             'integrations/middleware',
             'integrations/plugins',
+            'integrations/schema-routing',
           ],
           Deployment: [
             'deployment/heroku',

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -163,6 +163,29 @@ Note that if you are using [file uploads](../data/file-uploads/), you need to ad
 </td>
 </tr>
 
+<tr>
+<td>
+
+
+<tr>
+<td>
+
+###### `schemaRouter`
+
+`Function`
+
+</td>
+
+<td>
+
+A function taking two arguments, the context provided by the [Node.js middleware](../integrations/middleware/) for this request, and the default schema.
+
+The function should return a promise that resolves to a `GraphQLSchema` object, denoting what schema to use for this request. If the function returns a falsy value, the default schema will be used.
+
+See [schema routing](../integrations/schema-routing) for details.
+
+</td>
+</tr>
 
 <tr>
 <td>

--- a/docs/source/integrations/middleware.md
+++ b/docs/source/integrations/middleware.md
@@ -63,3 +63,7 @@ The parameter you provide to `applyMiddleware` is your middleware's top-level re
 When you pass your app to `applyMiddleware`, Apollo Server automatically configures various middleware (including body parsing, the GraphQL Playground frontend, and CORS support), so you don't need to apply them with a mechanism like `app.use`.
 
 > **Note:** When integrating with hapi, call `applyMiddleware` with `await`.
+
+### Dynamic schema routing
+
+See [Schema Routing](./schema-routing) for information on how to switch the schema on a per-request basis.

--- a/docs/source/integrations/schema-routing.md
+++ b/docs/source/integrations/schema-routing.md
@@ -1,0 +1,38 @@
+---
+title: Dynamic schema routing
+sidebar_title: Dynamic schema routing
+description: Dynamically switching the schema on a per-request basis.
+---
+
+In some cases, you might want to expose different schemas to different users based on arbitrary criteria. For instance: presenting privileged users with an augmented version of your schema whilst keeping the public API stable/less complex.
+
+You can use dynamic schema routing to implement this functionality. Here's an Express example that selects a different schema based on a query string:
+
+```js
+const express = require('express');
+const { ApolloServer } = require('apollo-server-express');
+const { publicSchema, protectedSchema } = require('./schemas');
+
+async function startApolloServer() {
+  const app = express();
+  const server = new ApolloServer({
+    schema: publicSchema,
+    schemaRouter: async ({ req }) => {
+      if (req && req.query["role"] === "admin")
+        return protectedSchema;
+    }
+  });
+
+  await server.start();
+
+  server.applyMiddleware({ app });
+
+  await new Promise(resolve => app.listen({ port: 4000 }, resolve));
+  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
+  return { server, app };
+}
+```
+
+In a real world scenario this could be done by having your authentication middleware load the user's session and attach the relevant authorization flags to the request object.
+
+> Note that this should **not** replace proper authorization. You should always secure your schema with proper access control.

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -957,7 +957,6 @@ export class ApolloServerBase {
 
     this.subscriptionServer = SubscriptionServer.create(
       {
-        schema,
         execute,
         subscribe,
         onConnect: onConnect
@@ -994,7 +993,10 @@ export class ApolloServerBase {
             })[0];
           }
 
-          return { ...connection, context };
+          const resolvedSchema = this.config.schemaRouter?.({
+            connection, payload: message.payload }, schema) ?? schema;
+
+          return { ...connection, context, schema: resolvedSchema };
         },
         keepAlive,
         validationRules: this.requestOptions.validationRules,

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -174,6 +174,7 @@ export class ApolloServerBase {
   private toDispose = new Set<() => Promise<void>>();
   private toDisposeLast = new Set<() => Promise<void>>();
   private experimental_approximateDocumentStoreMiB: Config['experimental_approximateDocumentStoreMiB'];
+  private schemaResolverDerivedData: WeakMap<GraphQLSchema, SchemaDerivedData> = new Map();
 
   // The constructor should be universal across all environments. All environment specific behavior should be set by adding or overriding methods
   constructor(config: Config) {
@@ -183,6 +184,7 @@ export class ApolloServerBase {
       context,
       resolvers,
       schema,
+      schemaRouter,
       schemaDirectives,
       modules,
       typeDefs,
@@ -235,9 +237,9 @@ export class ApolloServerBase {
 
     this.apolloConfig = determineApolloConfig(apollo, engine, this.logger);
 
-    if (gateway && (modules || schema || typeDefs || resolvers)) {
+    if (gateway && (modules || schema || typeDefs || resolvers || schemaRouter)) {
       throw new Error(
-        'Cannot define both `gateway` and any of: `modules`, `schema`, `typeDefs`, or `resolvers`',
+        'Cannot define both `gateway` and any of: `modules`, `schema`, `typeDefs`, `schemaRouter`, or `resolvers`',
       );
     }
 
@@ -1217,12 +1219,29 @@ export class ApolloServerBase {
   protected async graphQLServerOptions(
     integrationContextArgument?: Record<string, any>,
   ): Promise<GraphQLServerOptions> {
-    const {
-      schema,
-      schemaHash,
-      documentStore,
-      extensions,
-    } = await this.ensureStarted();
+    let schemaDerivedData = await this.ensureStarted();
+
+    // dynamic schema selection based on integration specific-options
+    if (this.config.schemaRouter) {
+      const schemaRouter = this.config.schemaRouter;
+      // resolve the schema from the router function
+      const resolvedSchema = await schemaRouter(
+        integrationContextArgument || {},
+        schemaDerivedData.schema
+      );
+      // If the schema returned by the schema resolver is the same as the
+      // default schema, we don't need to do anything special here.
+      // Otherwise, we generate new derived data for the schema, then save that
+      // value for use in future calls.
+      if (resolvedSchema) {
+        if (this.schemaResolverDerivedData.has(resolvedSchema)) {
+          schemaDerivedData = this.schemaResolverDerivedData.get(resolvedSchema)!;
+        } else {
+          schemaDerivedData = this.generateSchemaDerivedData(resolvedSchema);
+          this.schemaResolverDerivedData.set(resolvedSchema, schemaDerivedData);
+        }
+      }
+    }
 
     let context: Context = this.context ? this.context : {};
 
@@ -1239,12 +1258,9 @@ export class ApolloServerBase {
     }
 
     return {
-      schema,
-      schemaHash,
+      ...schemaDerivedData,
       logger: this.logger,
       plugins: this.plugins,
-      documentStore,
-      extensions,
       context,
       // Allow overrides from options. Be explicit about a couple of them to
       // avoid a bad side effect of the otherwise useful noUnusedLocals option

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -41,6 +41,11 @@ export type ContextFunction<FunctionParams = any, ProducedContext = object> = (
   context: FunctionParams,
 ) => ValueOrPromise<Context<ProducedContext>>;
 
+export type ResolveSchemaFromContextFunction<FunctionParams = any> = (
+  context: FunctionParams,
+  defaultSchema: GraphQLSchema
+) => ValueOrPromise<GraphQLSchema|void>;
+
 // A plugin can return an interface that matches `ApolloServerPlugin`, or a
 // factory function that returns `ApolloServerPlugin`.
 export type PluginDefinition = ApolloServerPlugin | (() => ApolloServerPlugin);
@@ -110,6 +115,7 @@ export interface Config extends BaseConfig {
   parseOptions?: GraphQLParseOptions;
   resolvers?: IResolvers | Array<IResolvers>;
   schema?: GraphQLSchema;
+  schemaRouter?: ResolveSchemaFromContextFunction;
   schemaDirectives?: Record<string, typeof SchemaDirectiveVisitor>;
   context?: Context | ContextFunction;
   introspection?: boolean;


### PR DESCRIPTION
Previously discussed in #2010.

* :alarm_clock:  Implementing this feature was relatively quick, so I skipped straight to the code, instead of waiting on consensus.
* :bulb: This pull request adds the ability to dynamically switch the schema for specific requests. No intrusive modifications to the server code were made.
* :electric_plug: All integrations should work like normal with no changes necessary.
* :spider: Not a bug fix.
* :book: New tests and documentation are included.
* :pencil2: This PR adds a new configuration option to `ApolloServerBase` called `schemaRouter`, an optional user-supplied function that accepts two arguments: the integration context and the server's current schema. This function is triggered once per request and is responsible for determining the `GraphQLSchema` that the query will be executed against.

## Documentation & Usage

In some cases, you might want to expose different schemas to different users based on arbitrary criteria. For instance: presenting privileged users with an augmented version of your schema whilst keeping the public API stable/less complex.

You can use dynamic schema routing to implement this functionality. Here's an Express example that selects a different schema based on a query string:

```js
const express = require('express');
const { ApolloServer } = require('apollo-server-express');
const { publicSchema, protectedSchema } = require('./schemas');

async function startApolloServer() {
  const app = express();
  const server = new ApolloServer({
    schema: publicSchema,
    schemaRouter: async ({ req }) => {
      if (req && req.query["role"] === "admin")
        return protectedSchema;
    }
  });

  await server.start();

  server.applyMiddleware({ app });

  await new Promise(resolve => app.listen({ port: 4000 }, resolve));
  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
  return { server, app };
}
```

In a real world scenario this could be done by having your authentication middleware load the user's session and attach the relevant authorization flags to the request object.

> Note that this should **not** replace proper authorization. You should always secure your schema with proper access control.


<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
