### PR TITLE
CI: test on Node 16, switch to newer cimg images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,12 +44,14 @@ jobs:
   #     - common_test_steps
 
   NodeJS 8:
-    executor: { name: oss/node, tag: '8' }
+    docker:
+    - image: cimg/node:8.17.0
     steps:
       - common_test_steps
 
   NodeJS 10:
-    executor: { name: oss/node, tag: '10' }
+    docker:
+    - image: cimg/node:10.24.1
     steps:
       - common_test_steps
       # We will save the results of this one particular invocation to use in
@@ -63,12 +65,20 @@ jobs:
             - ./**
 
   NodeJS 12:
-    executor: { name: oss/node, tag: '12' }
+    docker:
+    - image: cimg/node:12.22.1
     steps:
       - common_test_steps
 
   NodeJS 14:
-    executor: { name: oss/node, tag: '14' }
+    docker:
+    - image: cimg/node:14.16.1
+    steps:
+      - common_test_steps
+
+  NodeJS 16:
+    docker:
+    - image: cimg/node:16.0.0
     steps:
       - common_test_steps
 
@@ -124,6 +134,8 @@ workflows:
           <<: *common_non_publish_filters
       - NodeJS 14:
           <<: *common_non_publish_filters
+      - NodeJS 16:
+          <<: *common_non_publish_filters
       - "Check for FIXM\x45"
       - oss/lerna_tarballs:
           name: Package tarballs
@@ -134,6 +146,7 @@ workflows:
             - NodeJS 10
             - NodeJS 12
             - NodeJS 14
+            - NodeJS 16
       - oss/dry_run:
           name: Dry-run
           <<: *common_publish_filters
@@ -143,6 +156,7 @@ workflows:
             - NodeJS 10
             - NodeJS 12
             - NodeJS 14
+            - NodeJS 16
       - oss/confirmation:
           name: Confirmation
           type: approval

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=14 <15",
+    "node": ">=16 <17",
     "npm": "6.x"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coverage:upload": "codecov"
   },
   "engines": {
-    "node": ">=6 <15",
+    "node": ">=6",
     "npm": "^6.14.11"
   },
   "dependencies": {


### PR DESCRIPTION
Node 16.0.0 is now released; we should run CI against it.

The older circleci/node Docker images we use in the Apollo OSS orb do not yet
have 16.0.0. It seems reasonable to switch over to the "non legacy" cimg/node
Docker images anyway. Those images don't have "major version" tags like 16, just
tags like 16.0.0 and 16.0.  So let's switch over to specifying images directly
in config.yml rather than via our orb, and let Renovate update it. See
https://github.com/renovatebot/renovate/blob/92aab2b30f5c0d811056a1574354e97057c42732/lib/manager/circleci/extract.ts#L49
for what Renovate is looking for.

This PR does not convert to using npm v7 (and its new package-lock.json format);
we should do that soon, perhaps on release-3.x.
