### PR TITLE
usage reporting: fix typo in Buffer.byteLength argument

### DIFF
--- a/packages/apollo-server-core/src/plugin/usageReporting/defaultSendOperationsAsTrace.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/defaultSendOperationsAsTrace.ts
@@ -23,7 +23,7 @@ export function defaultSendOperationsAsTrace() {
     // it.
     max: Math.pow(2, 20),
     length: (_val, key) => {
-      return (key && Buffer.byteLength(key, 'uft8')) || 0;
+      return (key && Buffer.byteLength(key)) || 0;
     },
   });
 


### PR DESCRIPTION
Fortunately, it appears that going back at least to Node 8, there's no
difference between passing "utf8", "uft8" (the typo), or no encoding argument,
so there's no bug here. But it's good to remove the typo (and later versions of
`@types/node` consider this to be an error).
