### PR TITLE
Update Hapi to 20.1.2

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -534,7 +534,7 @@ The `context` object passed between Apollo Server resolvers automatically includ
 | Express | <code>{<br/>&nbsp;&nbsp;req: [`express.Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts),<br/>&nbsp;&nbsp;res: [`express.Response`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts#L490-L861)<br/>}</code> |
 | Fastify  | <code>{<br/>&nbsp;&nbsp;request: [`FastifyRequest`](https://github.com/fastify/fastify/blob/1d4dcf2bcde46256c72e96c2cafc843a461c721e/types/request.d.ts#L15),<br/>&nbsp;&nbsp;reply: [`FastifyReply`](https://github.com/fastify/fastify/blob/1d4dcf2bcde46256c72e96c2cafc843a461c721e/types/reply.d.ts#L10)</br>}</code> |
 | Google Cloud Functions  | <code>{ req: [`Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts), res: [`Response`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts#L490-L861) }</code> |
-| hapi  | <code>{<br/>&nbsp;&nbsp;request: [`hapi.Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/hapi/index.d.ts#L396-L605),<br/>&nbsp;&nbsp;h: [`hapi.ResponseToolkit`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/hapi/index.d.ts#L979-L1100)<br/>}</code> |
+| hapi  | <code>{<br/>&nbsp;&nbsp;request: [`hapi.Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05cbc5521f895344fb7dbf5c51902b6ff235aa69/types/hapi__hapi/index.d.ts#L406-L615),<br/>&nbsp;&nbsp;h: [`hapi.ResponseToolkit`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05cbc5521f895344fb7dbf5c51902b6ff235aa69/types/hapi__hapi/index.d.ts#L999-L1113)<br/>}</code> |
 | Koa | <code>{ ctx: [`Koa.Context`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/koa/index.d.ts#L724-L731) }</code> |
 | Micro | <code>{ req: [`MicroRequest`](https://github.com/apollographql/apollo-server/blob/c356bcf3f2864b8d2fcca0add455071e0606ef46/packages/apollo-server-micro/src/types.ts#L3-L5), res: [`ServerResponse`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/node/v10/http.d.ts#L145-L158) }</code> |
 
@@ -806,7 +806,7 @@ The default value is `/graphql`.
 </td>
 <td>
 
-Middleware-specific configuration options for CORS. See available options for your middleware: [express](https://github.com/expressjs/cors#cors) | [hapi](https://hapi.dev/api/?v=20.0.0#-routeoptionscors) | [koa](https://github.com/koajs/cors/)
+Middleware-specific configuration options for CORS. See available options for your middleware: [express](https://github.com/expressjs/cors#cors) | [hapi](https://hapi.dev/api/?v=20.1.2#-routeoptionscors) | [koa](https://github.com/koajs/cors/)
 
 Provide `false` to remove CORS middleware entirely, or `true` to use your middleware's default configuration.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -684,19 +684,9 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
       "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
-      "dev": true,
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
       }
     },
     "@hapi/ammo": {
@@ -721,7 +711,6 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.2.tgz",
       "integrity": "sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==",
-      "dev": true,
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -798,36 +787,30 @@
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
       "dev": true
     },
-    "@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
-      "dev": true
-    },
     "@hapi/hapi": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-19.2.0.tgz",
-      "integrity": "sha512-Isf/BUPQMRMYK+xx4y2B05lrrGw6PSbJKytk1SlaXeV7tXm6m+6tFRBog6c/na0QNgojafb0bjMB+vBg64CwUA==",
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.2.tgz",
+      "integrity": "sha512-yLppH93as7vw+uaAMVcHEB13eBojuzGhcX948y/CGukNRAlnPV+c1EJGbYPLXVffpH8wCNsI7TrTaeifSFS6Vw==",
       "dev": true,
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/call": "8.x.x",
-        "@hapi/catbox": "^11.1.0",
-        "@hapi/catbox-memory": "5.x.x",
-        "@hapi/heavy": "7.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/joi": "17.x.x",
-        "@hapi/mimos": "5.x.x",
-        "@hapi/podium": "4.x.x",
-        "@hapi/shot": "5.x.x",
-        "@hapi/somever": "3.x.x",
-        "@hapi/statehood": "^7.0.2",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^5.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.3",
         "@hapi/subtext": "^7.0.3",
-        "@hapi/teamwork": "4.x.x",
-        "@hapi/topo": "5.x.x"
+        "@hapi/teamwork": "^5.1.0",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
       }
     },
     "@hapi/heavy": {
@@ -844,8 +827,7 @@
     "@hapi/hoek": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
-      "dev": true
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "@hapi/iron": {
       "version": "6.0.0",
@@ -858,19 +840,6 @@
         "@hapi/bourne": "2.x.x",
         "@hapi/cryptiles": "5.x.x",
         "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@hapi/joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
-      "dev": true,
-      "requires": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
       }
     },
     "@hapi/mimos": {
@@ -906,12 +875,6 @@
         "@hapi/nigel": "4.x.x"
       }
     },
-    "@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
-      "dev": true
-    },
     "@hapi/podium": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
@@ -921,14 +884,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/teamwork": "5.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/teamwork": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
-          "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
-          "dev": true
-        }
       }
     },
     "@hapi/shot": {
@@ -982,9 +937,9 @@
       }
     },
     "@hapi/teamwork": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-4.0.0.tgz",
-      "integrity": "sha512-V6xYOrr5aFv/IJqNPneaYCu8vuGTKisamqHVRS3JJnbZr18TrpXdsJOYk9pjPhFti+M2YETPebQLUr820N5NoQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+      "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
       "dev": true
     },
     "@hapi/topo": {
@@ -3338,6 +3293,27 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -3568,26 +3544,20 @@
       "dev": true
     },
     "@types/hapi__hapi": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-19.0.4.tgz",
-      "integrity": "sha512-v+CW2urqOVxSH4aw72R6zY0QdhIRFPiJL76xzGIlM26uoxZGAyEeLwfhvxaPy4cXZMHu0QwQbn6/9JSTZsFB9Q==",
+      "version": "20.0.8",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.8.tgz",
+      "integrity": "sha512-NNslrYq2XQwm4uOqNcSWKpYtaeMr4DkQdrFzSB7p9rKB9ppJLh3mgP2wak9vBZl7/Cnhhb+JVBcUZCOUcW0JPA==",
       "dev": true,
       "requires": {
         "@hapi/boom": "^9.0.0",
         "@hapi/iron": "^6.0.0",
+        "@hapi/podium": "^4.1.3",
         "@types/hapi__catbox": "*",
-        "@types/hapi__joi": "*",
         "@types/hapi__mimos": "*",
-        "@types/hapi__podium": "*",
         "@types/hapi__shot": "*",
-        "@types/node": "*"
+        "@types/node": "*",
+        "joi": "^17.3.0"
       }
-    },
-    "@types/hapi__joi": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-17.1.6.tgz",
-      "integrity": "sha512-y3A1MzNC0FmzD5+ys59RziE1WqKrL13nxtJgrSzjoO7boue5B7zZD2nZLPwrSuUviFjpKFQtgHYSvhDGfIE4jA==",
-      "dev": true
     },
     "@types/hapi__mimos": {
       "version": "4.1.3",
@@ -3596,15 +3566,6 @@
       "dev": true,
       "requires": {
         "@types/mime-db": "*"
-      }
-    },
-    "@types/hapi__podium": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/hapi__podium/-/hapi__podium-4.1.3.tgz",
-      "integrity": "sha512-7rsIdTgjevjEZ18fg4ppfWaHjTYivDMEeSzReTnFjlk4vJeZNxlyMs1ZQJEAeAMeDH7aAcbMhz83f0tVJ/yyUA==",
-      "dev": true,
-      "requires": {
-        "@hapi/podium": "*"
       }
     },
     "@types/hapi__shot": {
@@ -4042,15 +4003,6 @@
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "dev": true
-    },
-    "accept": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-      "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
-      "requires": {
-        "boom": "7.x.x",
-        "hoek": "6.x.x"
-      }
     },
     "accepts": {
       "version": "1.3.5",
@@ -4696,10 +4648,10 @@
       "version": "file:packages/apollo-server-hapi",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.27",
-        "accept": "^3.1.3",
+        "@hapi/accept": "^5.0.2",
+        "@hapi/boom": "^9.1.2",
         "apollo-server-core": "file:packages/apollo-server-core",
-        "apollo-server-types": "file:packages/apollo-server-types",
-        "boom": "^7.3.0"
+        "apollo-server-types": "file:packages/apollo-server-types"
       },
       "dependencies": {
         "@apollographql/graphql-playground-html": {
@@ -4879,7 +4831,7 @@
       "version": "file:packages/apollo-server-micro",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.27",
-        "accept": "^3.1.3",
+        "@hapi/accept": "^5.0.2",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-types": "file:packages/apollo-server-types",
         "micro": "^9.3.4"
@@ -5835,14 +5787,6 @@
             "mime-types": "~2.1.24"
           }
         }
-      }
-    },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "requires": {
-        "hoek": "6.x.x"
       }
     },
     "brace-expansion": {
@@ -9463,11 +9407,6 @@
         "connection-parse": "0.0.x",
         "simple-lru-cache": "0.0.x"
       }
-    },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -13561,6 +13500,19 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-sha256": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "apollo-tracing": "file:packages/apollo-tracing"
   },
   "devDependencies": {
-    "@hapi/hapi": "19.2.0",
+    "@hapi/hapi": "20.1.2",
     "@josephg/resolvable": "1.0.0",
     "@types/async-retry": "1.4.2",
     "@types/aws-lambda": "8.10.66",
@@ -65,7 +65,7 @@
     "@types/cors": "2.8.10",
     "@types/express": "4.17.11",
     "@types/fast-json-stable-stringify": "2.0.0",
-    "@types/hapi__hapi": "19.0.4",
+    "@types/hapi__hapi": "20.0.8",
     "@types/ioredis": "4.26.0",
     "@types/jest": "26.0.9",
     "@types/koa-router": "7.4.2",

--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -8,9 +8,8 @@ This is the Hapi integration of Apollo Server. Apollo Server is a community-main
 npm install apollo-server-hapi graphql
 ```
 
+This package is only tested with `@hapi/hapi` 20.1.2 and higher; that is the minimum version of Hapi that supports Node 16.
 ## Usage
-
-The code below requires Hapi 18 or higher.
 
 ```js
 const { ApolloServer, gql } = require('apollo-server-hapi');

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -27,16 +27,16 @@
   },
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.27",
-    "accept": "^3.1.3",
+    "@hapi/accept": "^5.0.2",
+    "@hapi/boom": "^9.1.2",
     "apollo-server-core": "file:../apollo-server-core",
-    "apollo-server-types": "file:../apollo-server-types",
-    "boom": "^7.3.0"
+    "apollo-server-types": "file:../apollo-server-types"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "@hapi/hapi": "^19.2.0",
+    "@hapi/hapi": "^20.1.2",
     "graphql": "^15.3.0"
   }
 }

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -1,5 +1,5 @@
-import hapi from '@hapi/hapi';
-import { parseAll } from 'accept';
+import type hapi from '@hapi/hapi';
+import { parseAll } from '@hapi/accept';
 import {
   renderPlaygroundPage,
   RenderPageOptions as PlaygroundRenderPageOptions,

--- a/packages/apollo-server-hapi/src/hapiApollo.ts
+++ b/packages/apollo-server-hapi/src/hapiApollo.ts
@@ -1,11 +1,11 @@
-import Boom from 'boom';
-import {
+import Boom from '@hapi/boom';
+import type {
   Server,
   Request,
   RouteOptions,
   ResponseToolkit,
   Plugin as IPlugin
-} from 'hapi__hapi';
+} from '@hapi/hapi';
 import {
   GraphQLOptions,
   runHttpQuery,
@@ -72,7 +72,7 @@ const plugin: IPlugin<HapiPluginOptions> = {
             return response;
           }
 
-          const err = new Boom(error.message, { statusCode: error.statusCode });
+          const err = new Boom.Boom(error.message, { statusCode: error.statusCode });
           if (error.headers) {
             Object.keys(error.headers).forEach(header => {
               err.output.headers[header] = error.headers[header];

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -337,7 +337,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
         expect(result.data).toBeUndefined();
         expect(result.errors).toBeDefined();
         expect(result.errors[0].message).toMatch(
-          /got invalid value 2; Expected type String/,
+          /got invalid value 2; String cannot represent a non string value: 2/,
         );
         expect(result.errors[0].extensions.code).toBe('BAD_USER_INPUT');
       });

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
     "@apollographql/graphql-playground-html": "1.6.27",
-    "accept": "^3.1.3",
+    "@hapi/accept": "^5.0.2",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
     "micro": "^9.3.4"

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -2,7 +2,7 @@ import { ApolloServerBase, GraphQLOptions } from 'apollo-server-core';
 import { ServerResponse } from 'http';
 import { send } from 'micro';
 import { renderPlaygroundPage } from '@apollographql/graphql-playground-html';
-import { parseAll } from 'accept';
+import { parseAll } from '@hapi/accept';
 
 import { graphqlMicro } from './microApollo';
 import { MicroRequest } from './types';


### PR DESCRIPTION
This is the latest release, and the only release that supports Node 16, so it
will be the minimum version that we test again.

Also:
- Update `@types/hapi__hapi` to latest version. Note that you can import from
  `@hapi/hapi` successfully so adjust an import.
- Update `accept` and `boom` to their latest versions, which now have `@hapi/`
  prefix; this includes in apollo-server-micro for some reason.
- release-3.0 couldn't run tests after the last merge from main until this
  change was made; this revealed a failing test of a newly merged feature due to
  a change in a graphql-js error message. Fix that.

This incorporates suggestions from #3273, #3441, and #4254.
