### PR TITLE
apollo-server-core: Remove deprecated ApolloServer.schema field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - While we are working to re-introduce subscriptions with a higher degree of integration, they have been disabled in the initial versions of Apollo Server.  See [the migration guide section on Subscriptions](./docs/source/migration.md#Subscriptions) to bring them back in their current form.
 - The `graphql-extensions` API (e.g., `GraphQLExtensions`, `extensions`) has been dropped in favor of the new [plugins API](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).
 - In order to let the `graphql-upload` package evolve on its own, uploads are no longer integrated directly with Apollo Server.  To bring them back in their current form, see [the migration guide section on File Uploads](./docs/source/migration.md#File-uploads)
+- Removed deprecated `ApolloServer.schema` field, which never worked with gateways. If you'd like to extract your schema from your server, make a plugin with `serverWillStart`, or register `onSchemaChange` on your gateway.
 - Top-level exports have changed. E.g.,
 
   - We no longer re-export the entirety of `graphql-tools` (including `makeExecutableSchema`) from all Apollo Server packages.

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -133,8 +133,6 @@ export class ApolloServerBase {
   private parseOptions: ParseOptions;
   private config: Config;
   private state: ServerState;
-  /** @deprecated: This is undefined for servers operating as gateways, and will be removed in a future release **/
-  protected schema?: GraphQLSchema;
   private toDispose = new Set<() => Promise<void>>();
   private toDisposeLast = new Set<() => Promise<void>>();
   private experimental_approximateDocumentStoreMiB: Config['experimental_approximateDocumentStoreMiB'];
@@ -300,20 +298,16 @@ export class ApolloServerBase {
       this.requestOptions.executor = gateway.executor;
     } else {
       // We construct the schema synchronously so that we can fail fast if the
-      // schema can't be constructed, and so that the deprecated `.schema` field
-      // (which has never worked with the gateway) are available immediately
-      // after the constructor returns.
+      // schema can't be constructed. (This used to be more important because we
+      // used to have a 'schema' field that was publicly accessible immediately
+      // after construction, though that field never actually worked with
+      // gateways.)
       this.state = {
         phase: 'initialized with schema',
         schemaDerivedData: this.generateSchemaDerivedData(
           this.constructSchema(),
         ),
       };
-      // This field is deprecated; users who are interested in learning
-      // their server's schema should instead make a plugin with serverWillStart,
-      // or register onSchemaChange on their gateway. It is only ever
-      // set for non-gateway servers.
-      this.schema = this.state.schemaDerivedData.schema;
     }
 
     // The main entry point (createHandler) to serverless frameworks generally


### PR DESCRIPTION
This field never worked with gateways.

Fixes #5148.
