### PR TITLE
Check for existing SIGINT/SIGTERM handlers

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -388,7 +388,9 @@ export class ApolloServerBase {
           // removed until after the rest of shutdown happens.
           process.kill(process.pid, signal);
         };
-        process.on(signal, handler);
+        if (!process.listeners(signal).some((listener: Function) =>  listener.toString() === handler.toString())) {
+          process.on(signal, handler);
+        }
         this.toDisposeLast.add(async () => {
           process.removeListener(signal, handler);
         });


### PR DESCRIPTION
When running `apollo-server` with `serverless-offline`, I get the following error (after calling the API a few times):

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added. Use emitter.setMaxListeners() to increase limit.
```

After some debugging, I found that this warning was caused by the SIGINT and SIGTERM handlers in the Apollo server initialization code, which are added to the `process` object each time the server is initialized. In a serverless runtime, the server is re-initialized every time the API is called. Meanwhile, the process variable stays constant, and each re-initialization of the server adds more and more event listeners to the `process` object.

In this PR, I addressed this issue by checking if the SIGINT/SIGTERM handler was already set as an event listener, so that it would only get set once. 