### PR TITLE
apollo-server-express: don't promise to support Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-server-caching`: The test suite helper works differently, and the `TestableKeyValueCache` interface is removed.
 - `apollo-datasource-rest`: We no longer officially support overriding the `baseURL` property with a getter, because TypeScript 4 does not allow you to do that.
 - Previously, Apollo Server would automatically add the definition of the `@cacheControl` directive to your schema in some circumstances but not in others; this depended on how precisely you set up your schema, but not on whether you had disabled the cache control feature. In Apollo Server 3, Apollo Server is now consistent: it never automatically adds the directive definition to your schema. If you use `@cacheControl`, just [define it yourself as shown in the docs](https://www.apollographql.com/docs/apollo-server/performance/caching/#in-your-schema-static).
+- `apollo-server-express`: We no longer officially support using this package with the `connect` framework. We have not actively removed any `connect` compatibility code and do still test that it works with `connect`, but we reserve the right to break that compatibility without a major version bump of this package (though it will certainly be noted in the CHANGELOG if we do so).
 - Top-level exports have changed. E.g.,
 
   - We no longer re-export the entirety of `graphql-tools` (including `makeExecutableSchema`) from all Apollo Server packages.

--- a/packages/apollo-server-express/README.md
+++ b/packages/apollo-server-express/README.md
@@ -2,7 +2,7 @@
 [![Read CHANGELOG](https://img.shields.io/badge/read-changelog-blue)](https://github.com/apollographql/apollo-server/blob/HEAD/CHANGELOG.md)
 
 
-This is the Express and Connect integration of GraphQL Server. Apollo Server is a community-maintained open-source GraphQL server that works with many Node.js HTTP server frameworks. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md)
+This is the Express integration of Apollo Server. Apollo Server is a community-maintained open-source GraphQL server that works with many Node.js HTTP server frameworks. [Read the docs](https://www.apollographql.com/docs/apollo-server/). [Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md)
 
 ```shell
 npm install apollo-server-express graphql
@@ -43,51 +43,7 @@ async function startApolloServer() {
 
 ## Connect
 
-> We recommend using `express` rather than `connect`.  However, if you wish to
-> use `connect`, please install [`connect`](https://www.npmjs.com/package/connect)
-> and [`qs-middleware`](https://www.npmjs.com/package/qs-middleware), in addition
-> to `apollo-server-express`.
-
-```shell
-npm install --save connect qs-middleware apollo-server-express graphql
-```
-
-```js
-const connect = require('connect');
-const { ApolloServer, gql } = require('apollo-server-express');
-const query = require('qs-middleware');
-
-async function startApolloServer() {
-  // Construct a schema, using GraphQL schema language
-  const typeDefs = gql`
-    type Query {
-      hello: String
-    }
-  `;
-
-  // Provide resolver functions for your schema fields
-  const resolvers = {
-    Query: {
-      hello: () => 'Hello world!',
-    },
-  };
-
-  const server = new ApolloServer({ typeDefs, resolvers });
-  await server.start();
-
-  const app = connect();
-  const path = '/graphql';
-
-  app.use(query());
-  server.applyMiddleware({ app, path });
-
-  await new Promise(resolve => app.listen({ port: 4000 }, resolve));
-  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
-  return { server, app };
-}
-```
-
-> Note: `qs-middleware` is only required if running outside of Meteor
+Before Apollo Server 3, we officially supported using this package with `connect` as well. `connect` is an older framework that `express` evolved from. For now, we believe that this package is still compatible with `connect` and we even run tests against `connect`, but we may choose to break this compatibility at some point without a major version bump. If you rely on the ability to use Apollo Server with `connect`, you may wish to make your own integration.
 
 ## Principles
 

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-express",
   "version": "3.0.0-alpha.3",
-  "description": "Production-ready Node.js GraphQL server for Express and Connect",
+  "description": "Production-ready Node.js GraphQL server for Express",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
@@ -14,7 +14,6 @@
     "Apollo",
     "Server",
     "Express",
-    "Connect",
     "Javascript"
   ],
   "author": "Apollo <opensource@apollographql.com>",


### PR DESCRIPTION
Connect is a pretty old JS web framework; most users (other than Meteor) moved
to Express many years ago.
    
This PR stops advertising apollo-server-express supports Connect.  It doesn't
actively remove the lines in apollo-server-express which exist for Connect
compatibility and it does continue to test against Connect. However, it does
state that we may choose to remove that compatibility within Apollo Server 3.
    
Fixes #5172.
