### PR TITLE
apollo-server-core: Add option to specify fetcher for schema reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-core`: Fix a race condition where schema reporting could lead to a delay at process shutdown. [PR #5222](https://github.com/apollographql/apollo-server/pull/5222)
+- `apollo-server-core`: Allow the Fetch API implementation to be overridden for the schema reporting plugin and usage reporting plugin. [PR #5179](https://github.com/apollographql/apollo-server/pull/5179)
 
 ## v2.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
 - `apollo-server-core`: Fix a race condition where schema reporting could lead to a delay at process shutdown. [PR #5222](https://github.com/apollographql/apollo-server/pull/5222)
-- `apollo-server-core`: Allow the Fetch API implementation to be overridden for the schema reporting plugin and usage reporting plugin. [PR #5179](https://github.com/apollographql/apollo-server/pull/5179)
+- `apollo-server-core`: Allow the Fetch API implementation to be overridden for the schema reporting and usage reporting plugins via a new `fetcher` option. [PR #5179](https://github.com/apollographql/apollo-server/pull/5179)
 
 ## v2.24.1
 

--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import type { InternalApolloServerPlugin } from '../internalPlugin';
 import { v4 as uuidv4 } from 'uuid';
 import { printSchema, validateSchema, buildSchema } from 'graphql';
-import { fetch } from 'apollo-server-env';
+import type { fetch } from 'apollo-server-env';
 import { SchemaReporter } from './schemaReporter';
 import createSHA from '../../utils/createSHA';
 import { schemaIsFederated } from '../schemaIsFederated';

--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -52,7 +52,7 @@ export interface ApolloServerPluginSchemaReportingOptions {
   /**
    * Specifies which Fetch API implementation to use when reporting schemas.
    */
-  experimental_fetcher?: typeof fetch;
+  fetcher?: typeof fetch;
 }
 
 export function ApolloServerPluginSchemaReporting(
@@ -60,7 +60,7 @@ export function ApolloServerPluginSchemaReporting(
     initialDelayMaxMs,
     overrideReportedSchema,
     endpointUrl,
-    experimental_fetcher,
+    fetcher,
   }: ApolloServerPluginSchemaReportingOptions = Object.create(null),
 ): InternalApolloServerPlugin {
   const bootId = uuidv4();
@@ -168,7 +168,7 @@ export function ApolloServerPluginSchemaReporting(
           Math.random() * (initialDelayMaxMs ?? 10_000),
         ),
         fallbackReportingDelayInMs: 20_000,
-        fetcher: experimental_fetcher,
+        fetcher,
       });
 
       schemaReporter.start();

--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import type { InternalApolloServerPlugin } from '../internalPlugin';
 import { v4 as uuidv4 } from 'uuid';
 import { printSchema, validateSchema, buildSchema } from 'graphql';
+import { fetch } from 'apollo-server-env';
 import { SchemaReporter } from './schemaReporter';
 import createSHA from '../../utils/createSHA';
 import { schemaIsFederated } from '../schemaIsFederated';
@@ -48,6 +49,10 @@ export interface ApolloServerPluginSchemaReportingOptions {
    * Apollo use.
    */
   endpointUrl?: string;
+  /**
+   * Specifies which Fetch API implementation to use when reporting schemas.
+   */
+  experimental_fetcher?: typeof fetch;
 }
 
 export function ApolloServerPluginSchemaReporting(
@@ -55,6 +60,7 @@ export function ApolloServerPluginSchemaReporting(
     initialDelayMaxMs,
     overrideReportedSchema,
     endpointUrl,
+    experimental_fetcher,
   }: ApolloServerPluginSchemaReportingOptions = Object.create(null),
 ): InternalApolloServerPlugin {
   const bootId = uuidv4();
@@ -162,6 +168,7 @@ export function ApolloServerPluginSchemaReporting(
           Math.random() * (initialDelayMaxMs ?? 10_000),
         ),
         fallbackReportingDelayInMs: 20_000,
+        fetcher: experimental_fetcher,
       });
 
       schemaReporter.start();

--- a/packages/apollo-server-core/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/schemaReporter.ts
@@ -49,6 +49,7 @@ export class SchemaReporter {
   private readonly logger: Logger;
   private readonly initialReportingDelayInMs: number;
   private readonly fallbackReportingDelayInMs: number;
+  private readonly fetcher: typeof fetch;
 
   private isStopped: boolean;
   private pollTimer?: NodeJS.Timer;
@@ -62,6 +63,7 @@ export class SchemaReporter {
     logger: Logger;
     initialReportingDelayInMs: number;
     fallbackReportingDelayInMs: number;
+    fetcher?: typeof fetch;
   }) {
     this.headers = new Headers();
     this.headers.set('Content-Type', 'application/json');
@@ -85,6 +87,7 @@ export class SchemaReporter {
     this.logger = options.logger;
     this.initialReportingDelayInMs = options.initialReportingDelayInMs;
     this.fallbackReportingDelayInMs = options.fallbackReportingDelayInMs;
+    this.fetcher = options.fetcher ?? fetch;
   }
 
   public stopped(): Boolean {
@@ -224,7 +227,7 @@ export class SchemaReporter {
       body: JSON.stringify(request),
     });
 
-    const httpResponse = await fetch(httpRequest);
+    const httpResponse = await this.fetcher(httpRequest);
 
     if (!httpResponse.ok) {
       throw new Error(

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   GraphQLRequestContext,
 } from 'apollo-server-types';
-import { RequestAgent } from 'apollo-server-env';
+import type { fetch, RequestAgent } from 'apollo-server-env';
 import type { Trace } from 'apollo-reporting-protobuf';
 
 export interface ApolloServerPluginUsageReportingOptions<TContext> {
@@ -156,6 +156,10 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * Apollo.
    */
   requestAgent?: RequestAgent | false;
+  /**
+   * Specifies which Fetch API implementation to use when sending usage reports.
+   */
+  fetcher?: typeof fetch;
   /**
    * How often to send reports to Apollo. We'll also send reports when the
    * report gets big; see maxUncompressedReportSize.

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -265,12 +265,13 @@ export function ApolloServerPluginUsageReporting<TContext>(
           });
         });
 
-        // Wrap fetch with async-retry for automatic retrying
+        // Wrap fetcher with async-retry for automatic retrying
+        const fetcher = options.fetcher ?? fetch;
         const response: Response = await retry(
           // Retry on network errors and 5xx HTTP
           // responses.
           async () => {
-            const curResponse = await fetch(
+            const curResponse = await fetcher(
               (options.endpointUrl ||
                 'https://usage-reporting.api.apollographql.com') +
                 '/api/ingress/traces',


### PR DESCRIPTION
We've gotten feedback that it would be nice for customers to have the ability to override the HTTP client for schema reporting. This PR adds that ability under a new `experimental_fetcher` option in `ApolloServerPluginSchemaReporting` (the syntax is similar to `GatewayConfigBase.fetcher`). Since there's not significant logic changes involved, we may also want to just forgo marking it experimental, although I'll leave that decision to the reviewer.