### PR TITLE
tests: make `npm audit` happy by inlining apollo-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "@types/type-is": "1.6.3",
         "@types/uuid": "8.3.0",
         "@types/ws": "7.4.1",
-        "apollo-fetch": "0.7.0",
         "apollo-link": "1.2.14",
         "apollo-link-http": "1.5.17",
         "apollo-link-persisted-queries": "0.2.2",
@@ -5345,15 +5344,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/apollo-fetch": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-fetch/-/apollo-fetch-0.7.0.tgz",
-      "integrity": "sha512-0oHsDW3Zxx+Of1wuqcOXruNj4Kv55WN69tkIjwkCQDEIrgCpgA2scjChFsgflSVMy/1mkTKCY1Mc0TYJhNRzmw==",
-      "dev": true,
-      "dependencies": {
-        "cross-fetch": "^1.0.0"
-      }
-    },
     "node_modules/apollo-graphql": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.2.tgz",
@@ -7190,26 +7180,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-1.1.1.tgz",
-      "integrity": "sha512-+VJE04+UfxxmBfcnmAu/lKor53RUCx/1ilOti4p+JgrnLQ4AZZIRoe2OEd76VaHyWQmQxqKnV+TaqjHC4r0HWw==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -7690,7 +7660,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "iconv-lite": "~0.4.13"
       }
@@ -18114,12 +18084,6 @@
         "iconv-lite": "0.4.24"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-      "dev": true
-    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -18874,6 +18838,9 @@
         "apollo-server-express": "file:../apollo-server-express",
         "express": "^4.17.1",
         "stoppable": "^1.1.0"
+      },
+      "devDependencies": {
+        "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
       },
       "peerDependencies": {
         "graphql": "^15.3.0"
@@ -24362,15 +24329,6 @@
         "sha.js": "^2.4.11"
       }
     },
-    "apollo-fetch": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-fetch/-/apollo-fetch-0.7.0.tgz",
-      "integrity": "sha512-0oHsDW3Zxx+Of1wuqcOXruNj4Kv55WN69tkIjwkCQDEIrgCpgA2scjChFsgflSVMy/1mkTKCY1Mc0TYJhNRzmw==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^1.0.0"
-      }
-    },
     "apollo-graphql": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.2.tgz",
@@ -24552,6 +24510,7 @@
       "requires": {
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-express": "file:../apollo-server-express",
+        "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
         "express": "^4.17.1",
         "stoppable": "^1.1.0"
       }
@@ -26753,28 +26712,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "cross-fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-1.1.1.tgz",
-      "integrity": "sha512-+VJE04+UfxxmBfcnmAu/lKor53RUCx/1ilOti4p+JgrnLQ4AZZIRoe2OEd76VaHyWQmQxqKnV+TaqjHC4r0HWw==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -27163,7 +27100,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -35457,12 +35394,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@types/type-is": "1.6.3",
     "@types/uuid": "8.3.0",
     "@types/ws": "7.4.1",
-    "apollo-fetch": "0.7.0",
     "apollo-link": "1.2.14",
     "apollo-link-http": "1.5.17",
     "apollo-link-persisted-queries": "0.2.2",

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -3,7 +3,6 @@ import express from 'express';
 import http from 'http';
 
 import request from 'request';
-import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError } from 'apollo-server-core';
 import {
@@ -15,6 +14,7 @@ import {
 import {
   testApolloServer,
   createServerInfo,
+  createApolloFetch,
 } from 'apollo-server-integration-testsuite';
 
 const typeDefs = gql`

--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -4,10 +4,9 @@ import http, { Server } from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 
-import { createApolloFetch } from 'apollo-fetch';
 import { ApolloServer } from '../ApolloServer';
 
-import { createServerInfo } from 'apollo-server-integration-testsuite';
+import { createServerInfo, createApolloFetch } from 'apollo-server-integration-testsuite';
 import { gql } from '../index';
 import { AddressInfo } from 'net';
 import type { GraphQLResolverMap } from 'apollo-graphql';

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -4,7 +4,6 @@ import fastify from 'fastify';
 import http from 'http';
 
 import request from 'request';
-import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError, Config } from 'apollo-server-core';
 import { ApolloServer, ServerRegistration } from '../ApolloServer';
@@ -12,6 +11,7 @@ import { ApolloServer, ServerRegistration } from '../ApolloServer';
 import {
   testApolloServer,
   createServerInfo,
+  createApolloFetch,
 } from 'apollo-server-integration-testsuite';
 
 const typeDefs = gql`

--- a/packages/apollo-server-fastify/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/datasource.test.ts
@@ -2,10 +2,9 @@ import fastify, { FastifyInstance } from 'fastify';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 
-import { createApolloFetch } from 'apollo-fetch';
 import { ApolloServer } from '../ApolloServer';
 
-import { createServerInfo } from 'apollo-server-integration-testsuite';
+import { createServerInfo, createApolloFetch } from 'apollo-server-integration-testsuite';
 import { gql } from '../index';
 
 const restPort = 4003;

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -1,11 +1,11 @@
 import {
   testApolloServer,
   createServerInfo,
+  createApolloFetch,
 } from 'apollo-server-integration-testsuite';
 
 import http = require('http');
 import request = require('request');
-import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError } from 'apollo-server-core';
 import { ApolloServer } from '../ApolloServer';

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -28,7 +28,7 @@ import {
   ApolloFetch,
   GraphQLRequest,
   ParsedResponse,
-} from 'apollo-fetch';
+} from './apolloFetch';
 import {
   AuthenticationError,
   UserInputError,
@@ -40,7 +40,7 @@ import {
   GraphQLExecutor,
   GraphQLServiceConfig,
 } from 'apollo-server-core';
-import { Headers } from 'apollo-server-env';
+import { Headers, fetch } from 'apollo-server-env';
 import { TracingFormat } from 'apollo-tracing';
 import ApolloServerPluginResponseCache from 'apollo-server-plugin-response-cache';
 import { BaseContext, GraphQLRequestContext, GraphQLRequestContextExecutionDidStart } from 'apollo-server-types';
@@ -1167,11 +1167,6 @@ export function testApolloServer<AS extends ApolloServerBase>(
             const hash = sha256.create().update(TEST_STRING_QUERY).hex();
 
             const result = await apolloFetch({
-              // @ts-ignore The `ApolloFetch` types don't allow `extensions` to be
-              // passed in, in the same way as `variables`, with a request. This
-              // is a typing omission in `apollo-fetch`, as can be seen here:
-              // https://git.io/Jeb63  This will all be going away soon (and
-              // that package is already archived and deprecated.
               extensions: {
                 persistedQuery: {
                   version: VERSION,

--- a/packages/apollo-server-integration-testsuite/src/apolloFetch.ts
+++ b/packages/apollo-server-integration-testsuite/src/apolloFetch.ts
@@ -1,0 +1,202 @@
+import { RequestInit, Response, fetch } from 'apollo-server-env';
+
+export interface ApolloFetch {
+  (operation: GraphQLRequest): Promise<FetchResult>;
+  use: (middlewares: MiddlewareInterface) => ApolloFetch;
+  useAfter: (afterwares: AfterwareInterface) => ApolloFetch;
+}
+
+export interface GraphQLRequest {
+  query?: string;
+  variables?: object;
+  operationName?: string;
+  extensions?: Record<string, unknown>;
+}
+
+interface FetchResult {
+  data: any;
+  errors?: any;
+  extensions?: any;
+}
+
+type MiddlewareInterface = (request: RequestAndOptions, next: Function) => void;
+
+interface RequestAndOptions {
+  request: GraphQLRequest;
+  options: RequestInit;
+}
+
+type AfterwareInterface = (
+  response: ResponseAndOptions,
+  next: Function,
+) => void;
+
+interface ResponseAndOptions {
+  response: ParsedResponse;
+  options: RequestInit;
+}
+
+export interface ParsedResponse extends Response {
+  raw: string;
+  parsed?: any;
+}
+
+interface FetchOptions {
+  uri?: string;
+}
+
+interface FetchError extends Error {
+  response: ParsedResponse;
+  parseError?: Error;
+}
+
+function buildWareStack<M>(
+  funcs: ((modifiedObject: M, next: Function) => void)[],
+  modifiedObject: M,
+  resolve: (modifiedObject: M) => void,
+) {
+  const next = () => {
+    if (funcs.length > 0) {
+      const f = funcs.shift();
+      if (f) {
+        f(modifiedObject, next);
+      }
+    } else {
+      resolve(modifiedObject);
+    }
+  };
+  next();
+}
+
+function constructDefaultOptions(
+  request: GraphQLRequest,
+  options: RequestInit,
+): RequestInit {
+  let body;
+  try {
+    body = JSON.stringify(request);
+  } catch (e) {
+    throw new Error(
+      `Network request failed. Payload is not serializable: ${e.message}`,
+    );
+  }
+
+  return {
+    body,
+    method: 'POST',
+    ...options,
+    headers: {
+      Accept: '*/*',
+      'Content-Type': 'application/json',
+      ...(options.headers || []),
+    },
+  };
+}
+
+function throwHttpError(response: ParsedResponse, error: Error) {
+  const httpError = new Error(
+    response && response.status >= 300
+      ? `Network request failed with status ${response.status} - "${response.statusText}"`
+      : `Network request failed to return valid JSON`,
+  ) as FetchError;
+  httpError.response = response;
+  httpError.parseError = error;
+
+  throw httpError as FetchError;
+}
+
+export function createApolloFetch(params: FetchOptions = {}): ApolloFetch {
+  const _uri = params.uri || '/graphql';
+  const middlewares: MiddlewareInterface[] = [];
+  const afterwares: AfterwareInterface[] = [];
+
+  const applyMiddlewares = (
+    requestAndOptions: RequestAndOptions,
+  ): Promise<RequestAndOptions> => {
+    return new Promise((resolve) => {
+      buildWareStack([...middlewares], requestAndOptions, resolve);
+    });
+  };
+
+  const applyAfterwares = (
+    responseObject: ResponseAndOptions,
+  ): Promise<ResponseAndOptions> => {
+    return new Promise((resolve) => {
+      buildWareStack([...afterwares], responseObject, resolve);
+    });
+  };
+
+  const apolloFetch = function (request: GraphQLRequest): Promise<FetchResult> {
+    let options = {};
+    let parseError: Error | undefined;
+
+    const requestObject = <RequestAndOptions>{
+      request,
+      options,
+    };
+
+    return applyMiddlewares(requestObject)
+      .then((reqOpts) => {
+        const construct = constructDefaultOptions;
+        const request = reqOpts.request;
+        return construct(request, reqOpts.options);
+      })
+      .then((opts) => {
+        options = { ...opts };
+        return fetch(_uri, options);
+      })
+      .then(
+        (response) =>
+          response.text().then((raw) => {
+            try {
+              const parsed = JSON.parse(raw);
+              (response as ParsedResponse).raw = raw;
+              (response as ParsedResponse).parsed = parsed;
+              return <ParsedResponse>response;
+            } catch (e) {
+              parseError = e;
+
+              //pass parsed raw response onto afterware
+              (response as ParsedResponse).raw = raw;
+              return <ParsedResponse>response;
+            }
+          }),
+        //.catch() this should never happen: https://developer.mozilla.org/en-US/docs/Web/API/Body/text
+      )
+      .then((response) =>
+        applyAfterwares({
+          response,
+          options,
+        }),
+      )
+      .then(({ response }) => {
+        if (response.parsed) {
+          return { ...response.parsed };
+        } else {
+          throwHttpError(response, parseError!);
+        }
+      });
+  } as ApolloFetch;
+
+  apolloFetch.use = (middleware: MiddlewareInterface) => {
+    if (typeof middleware === 'function') {
+      middlewares.push(middleware);
+    } else {
+      throw new Error('Middleware must be a function');
+    }
+
+    return apolloFetch;
+  };
+
+  apolloFetch.useAfter = (afterware: AfterwareInterface) => {
+    if (typeof afterware === 'function') {
+      afterwares.push(afterware);
+    } else {
+      throw new Error('Afterware must be a function');
+    }
+
+    return apolloFetch;
+  };
+
+  return apolloFetch as ApolloFetch;
+}

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -33,6 +33,7 @@ import { GraphQLRequestListener } from "apollo-server-plugin-base";
 import { PersistedQueryNotFoundError } from "apollo-server-errors";
 
 export * from './ApolloServer';
+export { createApolloFetch } from './apolloFetch';
 
 const QueryRootType = new GraphQLObjectType({
   name: 'QueryRoot',

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -1,13 +1,13 @@
 import http from 'http';
 
 import request from 'request';
-import { createApolloFetch } from 'apollo-fetch';
 
 import { gql, AuthenticationError, Config } from 'apollo-server-core';
 
 import {
   testApolloServer,
   createServerInfo,
+  createApolloFetch,
 } from 'apollo-server-integration-testsuite';
 
 const typeDefs = gql`

--- a/packages/apollo-server-koa/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/datasource.test.ts
@@ -2,10 +2,9 @@ import http, { Server } from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 
-import { createApolloFetch } from 'apollo-fetch';
-
 import {
   createServerInfo,
+  createApolloFetch,
 } from 'apollo-server-integration-testsuite';
 
 import { gql } from 'apollo-server-core';

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -1,6 +1,6 @@
 import micro from 'micro';
 import listen from 'test-listen';
-import { createApolloFetch } from 'apollo-fetch';
+import { createApolloFetch } from 'apollo-server-integration-testsuite';
 import { gql } from 'apollo-server-core';
 import rp from 'request-promise';
 

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -27,6 +27,9 @@
     "express": "^4.17.1",
     "stoppable": "^1.1.0"
   },
+  "devDependencies": {
+    "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
+  },
   "peerDependencies": {
     "graphql": "^15.3.0"
   }

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { createConnection } from 'net';
 import request from 'request';
-import { createApolloFetch } from 'apollo-fetch';
+import { createApolloFetch } from 'apollo-server-integration-testsuite';
 import resolvable from '@josephg/resolvable';
 
 import { gql, ApolloServer } from '../index';

--- a/packages/apollo-server/src/__tests__/tsconfig.json
+++ b/packages/apollo-server/src/__tests__/tsconfig.json
@@ -3,5 +3,6 @@
   "include": ["**/*"],
   "references": [
     { "path": "../../" },
+    { "path": "../../../apollo-server-integration-testsuite" },
   ]
 }

--- a/tsconfig.test.base.json
+++ b/tsconfig.test.base.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["es2019", "es2019.array", "esnext.asynciterable", "dom"],
+    "lib": ["es2019", "es2019.array", "esnext.asynciterable"],
     "types": ["node", "jest"],
     "paths": {
       "*" : ["types/*"]


### PR DESCRIPTION
Our tests use the deprecated `apollo-fetch` package. This depends on an old
version of the `cross-fetch` polyfill package which itself depends on a version
of `node-fetch` with a minor CVE. This makes `npm audit` noisy, which is sad.

There's no real vulnerability from `node-fetch` here since it's only used in
tests, but it would be nice to quiet `npm audit`. Plus, in #5165 we grudgingly
added `"dom"` to the `lib` in `tsconfig.test.base.json` just to support
`apollo-fetch`.

Updating `cross-fetch` in `apollo-fetch` is not enticing because it does pull in
major version bumps of dependent packages; I wouldn't want to release a new
version of a dead project that makes bad changes in some obscure contexts.

But `apollo-fetch` is a pretty simple package. So instead, I just inlined
`apollo-fetch` into `apollo-server-integration-testsuite`, deleted a bunch of
features we aren't using like batch support, and made it use the
`apollo-server-env` `fetch` rather than a global polyfill.

The only use of `apollo-fetch` that didn't already depend on
`apollo-server-integration-testsuite` was `apollo-server`, so add that
devDependency.

Fixes #5161.
