### PR TITLE
Remove some remaining references to "engine"

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -308,23 +308,6 @@ An object containing configuration options for connecting Apollo Server to [Apol
 </td>
 </tr>
 
-<tr>
-<td>
-
-###### `engine`
-
-`Object` or `Boolean`
-</td>
-<td>
-
-**Deprecated as of Apollo Server v2.18.** New projects should instead use Apollo Server's Studio connection plugins. For details, see [the migration docs](../migration-engine-plugins/).
-
-An object containing configuration options for connecting Apollo Server to [Apollo Studio](https://www.apollographql.com/docs/studio/).
-
-</td>
-</tr>
-
-
 
 <tr>
 <td colspan="2">

--- a/docs/source/api/plugin/inline-trace.md
+++ b/docs/source/api/plugin/inline-trace.md
@@ -46,8 +46,6 @@ Note that when this plugin is installed in your app, any client can request a tr
 
 (Note: in addition to this plugin (which adds a base64-encoded trace to the `ftv1` extension of responses), Apollo Server also contains support for an older JSON-based format which is enabled if you pass `tracing: true` to the `ApolloServer` constructor. This format was designed for use with a no longer supported tool called `engineproxy`, and also is recognized by graphql-playground.  This format was more verbose due to its use of JSON and the way that it represented trace node IDs. Enabling it is not recommended.)
 
-This plugin was introduced in Apollo Server 2.18. In previous versions, inline tracing was configured using the `engine` option to the `ApolloServer` constructor. That option continues to work; see [the migration guide](../../migration-engine-plugins/) for details.
-
 ## Options
 
 <table class="field-table">

--- a/docs/source/api/plugin/schema-reporting.md
+++ b/docs/source/api/plugin/schema-reporting.md
@@ -29,8 +29,6 @@ const server = new ApolloServer({
 });
 ```
 
-This plugin was introduced in Apollo Server 2.18. In previous versions, schema reporting was configured using the `engine` option to the `ApolloServer` constructor. That option continues to work; see [the migration guide](../../migration-engine-plugins/) for details.
-
 ## Options
 
 <table class="field-table">

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -6,8 +6,6 @@ api_reference: true
 
 Apollo Server has a built-in usage reporting plugin that gathers data on how your clients use the operations and fields in your GraphQL schema. The plugin also handles pushing this usage data to [Apollo Studio](https://www.apollographql.com/docs/studio/), as described in [Metrics and logging](../../monitoring/metrics/).
 
-> This plugin was introduced in Apollo Server 2.18. In previous versions, usage reporting is configured by providing the `engine` option to the `ApolloServer` constructor. That option continues to work (but is now deprecated). See [the migration guide](../../migration-engine-plugins/) for details.
-
 ## Default installation
 
 Apollo Server automatically installs and enables this plugin with default settings if you [provide a graph API key to Apollo Server](https://www.apollographql.com/docs/apollo-server/monitoring/metrics/#connecting-to-apollo-studio) (usually by setting the value of the `APOLLO_KEY` environment variable). No other action is required.

--- a/packages/apollo-server-core/src/determineApolloConfig.ts
+++ b/packages/apollo-server-core/src/determineApolloConfig.ts
@@ -1,13 +1,8 @@
 import { ApolloConfig, ApolloConfigInput, Logger } from 'apollo-server-types';
 import createSHA from './utils/createSHA';
 
-// This function combines the newer `apollo` constructor argument, the older
-// `engine` constructor argument, and some environment variables to come up
-// with a full ApolloConfig.
-//
-// The caller ensures that only one of the two constructor arguments is actually
-// provided and warns if `engine` was provided, but it is this function's job
-// to warn if old environment variables are used.
+// This function combines the `apollo` constructor argument and some environment
+// variables to come up with a full ApolloConfig.
 export function determineApolloConfig(
   input: ApolloConfigInput | undefined,
   logger: Logger,
@@ -18,7 +13,6 @@ export function determineApolloConfig(
     APOLLO_KEY,
     APOLLO_GRAPH_ID,
     APOLLO_GRAPH_VARIANT,
-    ENGINE_SCHEMA_TAG,
   } = process.env;
 
   // Determine key.
@@ -53,17 +47,7 @@ export function determineApolloConfig(
   if (input?.graphVariant) {
     apolloConfig.graphVariant = input.graphVariant;
   } else if (APOLLO_GRAPH_VARIANT) {
-    if (ENGINE_SCHEMA_TAG) {
-      throw new Error(
-        '`APOLLO_GRAPH_VARIANT` and `ENGINE_SCHEMA_TAG` (deprecated) environment variables must not both be set.',
-      );
-    }
     apolloConfig.graphVariant = APOLLO_GRAPH_VARIANT;
-  } else if (ENGINE_SCHEMA_TAG) {
-    logger.warn(
-      '[deprecated] The `ENGINE_SCHEMA_TAG` environment variable has been renamed to `APOLLO_GRAPH_VARIANT`.',
-    );
-    apolloConfig.graphVariant = ENGINE_SCHEMA_TAG;
   } else if (apolloConfig.key) {
     // Leave the value 'current' in apolloConfig.graphVariant.
     // We warn if it looks like they're trying to use Apollo registry features, but there's

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -510,7 +510,7 @@ export async function processGraphQLRequest<TContext>(
     if (config.executor) {
       // XXX Nothing guarantees that the only errors thrown or returned
       // in result.errors are GraphQLErrors, even though other code
-      // (eg apollo-engine-reporting) assumes that.
+      // (eg usage reporting) assumes that.
       return await config.executor(requestContext);
     } else {
       return await graphqlExecute(executionArgs);

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -59,19 +59,9 @@ export type GraphQLServiceConfig = {
   executor: GraphQLExecutor;
 };
 
-/**
- * This is an older format for the data that now lives in ApolloConfig.
- */
-export type GraphQLServiceEngineConfig = {
-  apiKeyHash: string;
-  graphId: string;
-  graphVariant?: string;
-};
-
 export interface GraphQLService {
   load(options: {
     apollo?: ApolloConfig;
-    engine?: GraphQLServiceEngineConfig; // deprecated; use `apollo` instead
   }): Promise<GraphQLServiceConfig>;
   onSchemaChange(callback: SchemaChangeCallback): Unsubscriber;
   // Note: The `TContext` typing here is not conclusively behaving as we expect:

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -212,7 +212,7 @@ export default async function pluginTestHarness<TContext>({
 
   requestContext.operation = operation || undefined;
   // We'll set `operationName` to `null` for anonymous operations.  Note that
-  // apollo-engine-reporting relies on the fact that the requestContext passed
+  // usage reporting relies on the fact that the requestContext passed
   // to requestDidStart is mutated to add this field before requestDidEnd is
   // called
   requestContext.operationName =


### PR DESCRIPTION
This branch previously had most references to `engine` options and
`ENGINE_SCHEMA_TAG` removed  but the merge from v2.18 restored some of
them.

Fixes #5191.
