### PR TITLE
apollo-server-core: Fix delayed shutdown bug in schemaReporter.ts

### DIFF
--- a/packages/apollo-server-core/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/schemaReporter.ts
@@ -117,11 +117,13 @@ export class SchemaReporter {
       const result = await this.reportServerInfo(sendNextWithExecutableSchema);
       switch (result.kind) {
         case 'next':
-          this.pollTimer = setTimeout(
-            () =>
-              this.sendOneReportAndScheduleNext(result.withExecutableSchema),
-            result.inSeconds * 1000,
-          );
+          if (!this.stopped()) {
+            this.pollTimer = setTimeout(
+              () =>
+                this.sendOneReportAndScheduleNext(result.withExecutableSchema),
+              result.inSeconds * 1000,
+            );
+          }
           return;
         case 'stop':
           return;
@@ -133,10 +135,12 @@ export class SchemaReporter {
       this.logger.error(
         `Error reporting server info to Apollo during schema reporting: ${error}`,
       );
-      this.pollTimer = setTimeout(
-        () => this.sendOneReportAndScheduleNext(false),
-        this.fallbackReportingDelayInMs,
-      );
+      if (!this.stopped()) {
+        this.pollTimer = setTimeout(
+          () => this.sendOneReportAndScheduleNext(false),
+          this.fallbackReportingDelayInMs,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
In this PR, `schemaReporter.ts` is changed to fix a bug where calling `stop()` may not prevent functions from being executed in the future via `setTimeout()`. The specific case is when:
1. `sendOneReportAndScheduleNext()` is suspended while waiting on a response from Studio.
2. `stop()` is called and finishes execution.
3. `sendOneReportAndScheduleNext()` resumes execution, and calls `setTimeout()` to schedule another invocation of `sendOneReportAndScheduleNext()` some time in the future (usually 60 seconds).
4. `sendOneReportAndScheduleNext()` executes in the future, but early-returns because it checks `this.isStopped()`.

The end result is Node being prevented from clean shutdown for ~60 seconds in such cases.
