### PR TITLE
Deprecate apollo-server-testing; allow ASTs for executeOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 - `apollo-server-core`: Fix a race condition where schema reporting could lead to a delay at process shutdown. [PR #5222](https://github.com/apollographql/apollo-server/pull/5222)
 - `apollo-server-core`: Allow the Fetch API implementation to be overridden for the schema reporting and usage reporting plugins via a new `fetcher` option. [PR #5179](https://github.com/apollographql/apollo-server/pull/5179)
+- `apollo-server-core`: The `server.executeOperation` method (designed for testing) can now take its `query` as a `DocumentNode` (eg, a `gql`-tagged string) in addition to as a string. (This matches the behavior of the `apollo-server-testing` `createTestClient` function which is now deprecated.) We now recommend this method instead of `apollo-server-testing` in our docs. [Issue #4952](https://github.com/apollographql/apollo-server/issues/4952)
+- `apollo-server-testing`: Replace README with a deprecation notice explaining how to use `server.executeOperation` instead. [Issue #4952](https://github.com/apollographql/apollo-server/issues/4952)
 
 ## v2.24.1
 

--- a/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
+++ b/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
@@ -1,6 +1,6 @@
 import { ApolloServerBase } from '../ApolloServer';
 import { buildServiceDefinition } from '@apollographql/apollo-tools';
-import gql from 'graphql-tag';
+import { gql } from '../';
 import { Logger } from 'apollo-server-types';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import type { GraphQLSchema } from 'graphql';
@@ -9,6 +9,7 @@ const typeDefs = gql`
   type Query {
     hello: String
     error: Boolean
+    contextFoo: String
   }
 `;
 
@@ -19,6 +20,9 @@ const resolvers = {
     },
     error() {
       throw new Error('A test error');
+    },
+    contextFoo(_root: any, _args: any, context: any) {
+      return context.foo;
     },
   },
 };
@@ -180,6 +184,60 @@ describe('ApolloServerBase executeOperation', () => {
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].extensions?.code).toBe('INTERNAL_SERVER_ERROR');
     expect(result.errors?.[0].extensions?.exception?.stacktrace).toBeDefined();
+  });
+
+  it('works with string', async () => {
+    const server = new ApolloServerBase({
+      typeDefs,
+      resolvers,
+    });
+
+    const result = await server.executeOperation({ query: '{ hello }' });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.hello).toBe('world');
+  });
+
+  it('works with AST', async () => {
+    const server = new ApolloServerBase({
+      typeDefs,
+      resolvers,
+    });
+
+    const result = await server.executeOperation({
+      query: gql`
+        {
+          hello
+        }
+      `,
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.hello).toBe('world');
+  });
+
+  it('parse errors', async () => {
+    const server = new ApolloServerBase({
+      typeDefs,
+      resolvers,
+    });
+
+    const result = await server.executeOperation({ query: '{' });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors?.[0].extensions?.code).toBe('GRAPHQL_PARSE_FAILED');
+  });
+
+  it('passes its second argument to context function', async () => {
+    const server = new ApolloServerBase({
+      typeDefs,
+      resolvers,
+      context: ({ fooIn }) => ({ foo: fooIn }),
+    });
+
+    const result = await server.executeOperation(
+      { query: '{ contextFoo }' },
+      { fooIn: 'bla' },
+    );
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.contextFoo).toBe('bla');
   });
 });
 

--- a/packages/apollo-server-testing/README.md
+++ b/packages/apollo-server-testing/README.md
@@ -1,7 +1,23 @@
 # apollo-server-testing
 
-[![npm version](https://badge.fury.io/js/apollo-server-testing.svg)](https://badge.fury.io/js/apollo-server-testing)
-[![Build Status](https://circleci.com/gh/apollographql/apollo-server/tree/main.svg?style=svg)](https://circleci.com/gh/apollographql/apollo-server)
+This deprecated package contains a function `createTestClient` which is a very thin wrapper around the Apollo Server `server.executeOperation` method.
 
-This is the testing module of the Apollo community GraphQL Server. [Read the docs.](https://www.apollographql.com/docs/apollo-server/)
-[Read the CHANGELOG.](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md)
+Code that uses this package looks like the following, where `server` is an `ApolloServer`:
+
+```js
+const { createTestClient } = require('apollo-server-testing');
+
+const { query, mutate } = createTestClient(server);
+
+await query({ query: QUERY });
+await mutate({ mutation: MUTATION });
+```
+
+We recommend you stop using this package and replace the above code with the equivalent:
+
+```js
+await server.executeOperation({ query: QUERY });
+await server.executeOperation({ query: MUTATION });
+```
+
+This package will not be distributed as part of Apollo Server 3.


### PR DESCRIPTION
The `apollo-server-testing` package exports one small function which is
just a tiny wrapper around `server.executeOperation`. The one main
advantage it provides is that you can pass in operations as ASTs rather
than only as strings.

This extra layer doesn't add much value but does require us to update
things in two places (which cross a package barrier and thus can be
installed at skewed versions). So for example when adding the second
argument to `executeOperation` in #4166 I did not bother to add it to
`apollo-server-testing` too. We've also found that users have been
confused by the `createTestClient` API (eg #5111) and that some linters
get confused by the unbound methods it returns (#4724).

So the simplest thing is to just teach people how to use the real
`ApolloServer` method instead of an unrelated API.

This PR allows you to pass an AST to `server.executeOperation` (just
like with the `apollo-server-testing` API), and changes the docs to
recommend `executeOperation` instead of `apollo-server-testing`. It also
makes some other suggestions about how to test Apollo Server code in a
more end-to-end fashion, and adds some basic tests for
`executeOperation`.

Fixes #4952.
