### PR TITLE
Docs: adding link to CDK SST Lambda tutorial

### DIFF
--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -6,7 +6,7 @@ description: How to deploy Apollo Server with AWS Lambda
 
 AWS Lambda is a service that allows users to run code without provisioning or managing servers. Cost is based on the compute time that is consumed, and there is no charge when code is not running.
 
-This guide explains how to setup Apollo Server 2 to run on AWS Lambda.
+This guide explains how to setup Apollo Server 2 to run on AWS Lambda using Serverless Framework. To use CDK and SST instead, [follow this tutorial](https://serverless-stack.com/examples/how-to-create-an-apollo-graphql-api-with-serverless.html).
 
 ## Prerequisites
 


### PR DESCRIPTION
Adding a quick edit to the Lambda deployment doc with a link to a tutorial using CDK and SST.

Fixes #5235