### PR TITLE
Release 2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The version headers in this history reflect the versions of Apollo Server itself
 ## v2.25.0
 
 - `apollo-server-core`: You may now specify your Studio graph as a graph ref (`id@variant`) via the `APOLLO_GRAPH_REF` environment variable or `new ApolloServer({apollo: {graphRef}})` instead of specifying graph ID and graph variant separately. The `apollo` object passed to plugin `serverWillStart` and to gateway `load` now contains a `graphRef` field.
-- `apollo-server-core`: If you specify an Apollo key but do not specify a graph ID or graph ref, a deprecation warning is logged. The behavior where your graph ID can be inferred from the structure of your API key will be removed in Apollo Server 3.
 - `apollo-server-core`: Fix a race condition where schema reporting could lead to a delay at process shutdown. [PR #5222](https://github.com/apollographql/apollo-server/pull/5222)
 - `apollo-server-core`: Allow the Fetch API implementation to be overridden for the schema reporting and usage reporting plugins via a new `fetcher` option. [PR #5179](https://github.com/apollographql/apollo-server/pull/5179)
 - `apollo-server-core`: The `server.executeOperation` method (designed for testing) can now take its `query` as a `DocumentNode` (eg, a `gql`-tagged string) in addition to as a string. (This matches the behavior of the `apollo-server-testing` `createTestClient` function which is now deprecated.) We now recommend this method instead of `apollo-server-testing` in our docs. [Issue #4952](https://github.com/apollographql/apollo-server/issues/4952)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 > The changes noted within this `vNEXT` section have not been released yet.  New PRs and commits which introduce changes should include an entry in this `vNEXT` section as part of their development.  With few exceptions, the format of the entry should follow convention (i.e., prefix with package name, use markdown `backtick formatting` for package names and code, suffix with a link to the change-set à la `[PR #YYY](https://link/pull/YYY)`, etc.).  When a release is being prepared, a new header will be (manually) created below and the appropriate changes within that release will be moved into the new section.
 
+## v2.25.0
+
 - `apollo-server-core`: You may now specify your Studio graph as a graph ref (`id@variant`) via the `APOLLO_GRAPH_REF` environment variable or `new ApolloServer({apollo: {graphRef}})` instead of specifying graph ID and graph variant separately. The `apollo` object passed to plugin `serverWillStart` and to gateway `load` now contains a `graphRef` field.
 - `apollo-server-core`: If you specify an Apollo key but do not specify a graph ID or graph ref, a deprecation warning is logged. The behavior where your graph ID can be inferred from the structure of your API key will be removed in Apollo Server 3.
 - `apollo-server-core`: Fix a race condition where schema reporting could lead to a delay at process shutdown. [PR #5222](https://github.com/apollographql/apollo-server/pull/5222)

--- a/packages/apollo-cache-control/package.json
+++ b/packages/apollo-cache-control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-control",
-  "version": "0.14.0-alpha.0",
+  "version": "0.14.0",
   "description": "A GraphQL extension for cache control",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/apollo-cache-control/package.json
+++ b/packages/apollo-cache-control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-control",
-  "version": "0.13.0",
+  "version": "0.14.0-alpha.0",
   "description": "A GraphQL extension for cache control",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/apollo-datasource-rest/package.json
+++ b/packages/apollo-datasource-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-rest",
-  "version": "0.13.0",
+  "version": "0.14.0-alpha.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-datasource-rest/package.json
+++ b/packages/apollo-datasource-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-rest",
-  "version": "0.14.0-alpha.0",
+  "version": "0.14.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-reporting-protobuf/package.json
+++ b/packages/apollo-reporting-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-reporting-protobuf",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0",
   "description": "Protobuf format for Apollo usage reporting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-reporting-protobuf/package.json
+++ b/packages/apollo-reporting-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-reporting-protobuf",
-  "version": "0.7.0",
+  "version": "0.8.0-alpha.0",
   "description": "Protobuf format for Apollo usage reporting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "2.25.0-alpha.1",
+	"version": "2.25.0",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "2.25.0-alpha.0",
+	"version": "2.25.0-alpha.1",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "2.24.1",
+	"version": "2.25.0-alpha.0",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/src/determineApolloConfig.ts
+++ b/packages/apollo-server-core/src/determineApolloConfig.ts
@@ -128,7 +128,6 @@ export function determineApolloConfig(
       apolloConfig.graphVariant = apolloConfig.graphRef.substring(at + 1);
     }
   } else {
-    let usedKeyParser = false;
     // Graph ref not specified. Let's try harder to get ID/variant, then join them.
     if (!apolloConfig.graphId && apolloConfig.key) {
       // If the given key is a graph token (starts with 'service:'), then use the
@@ -136,7 +135,6 @@ export function determineApolloConfig(
       const parts = apolloConfig.key.split(':', 2);
       if (parts[0] === 'service') {
         apolloConfig.graphId = parts[1];
-        usedKeyParser = true;
       } else {
         throw Error(
           'You have specified an API key in `apollo.key` or `APOLLO_KEY`, ' +
@@ -152,13 +150,6 @@ export function determineApolloConfig(
 
     if (apolloConfig.graphId) {
       apolloConfig.graphRef = `${apolloConfig.graphId}@${apolloConfig.graphVariant}`;
-      if (usedKeyParser) {
-        logger.warn(
-          'Deprecation warning: Setting your graph ref based on parsing your API key. ' +
-            'API key parsing will be removed in Apollo Server 3. To be compatible with ' +
-            `Apollo Server 3, set \`APOLLO_GRAPH_REF\` to '${apolloConfig.graphRef}'.`,
-        );
-      }
     }
   }
 

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Express and Connect",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-base",
-  "version": "0.13.0-alpha.0",
+  "version": "0.13.0",
   "description": "Apollo Server plugin base classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-base",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha.0",
   "description": "Apollo Server plugin base classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-operation-registry",
-  "version": "0.11.0-alpha.0",
+  "version": "0.11.0",
   "description": "Apollo Server operation registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-operation-registry",
-  "version": "0.10.0",
+  "version": "0.11.0-alpha.0",
   "description": "Apollo Server operation registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-response-cache",
-  "version": "0.8.0",
+  "version": "0.9.0-alpha.0",
   "description": "Apollo Server full query response cache",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-response-cache",
-  "version": "0.9.0-alpha.0",
+  "version": "0.9.0",
   "description": "Apollo Server full query response cache",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-testing",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Test utils for apollo-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-testing",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Test utils for apollo-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-testing/package.json
+++ b/packages/apollo-server-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-testing",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Test utils for apollo-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-types",
-  "version": "0.9.0-alpha.0",
+  "version": "0.9.0",
   "description": "Apollo Server shared types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-types",
-  "version": "0.8.0",
+  "version": "0.9.0-alpha.0",
   "description": "Apollo Server shared types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.25.0-alpha.0",
+  "version": "2.25.0-alpha.1",
   "description": "Production ready GraphQL Server",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.24.1",
+  "version": "2.25.0-alpha.0",
   "description": "Production ready GraphQL Server",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "2.25.0-alpha.1",
+  "version": "2.25.0",
   "description": "Production ready GraphQL Server",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",

--- a/packages/apollo-tracing/package.json
+++ b/packages/apollo-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-tracing",
-  "version": "0.15.0-alpha.0",
+  "version": "0.15.0",
   "description": "Collect and expose trace data for GraphQL requests",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/apollo-tracing/package.json
+++ b/packages/apollo-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-tracing",
-  "version": "0.14.0",
+  "version": "0.15.0-alpha.0",
   "description": "Collect and expose trace data for GraphQL requests",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/graphql-extensions/package.json
+++ b/packages/graphql-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-extensions",
-  "version": "0.15.0-alpha.0",
+  "version": "0.15.0",
   "description": "Add extensions to GraphQL servers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/graphql-extensions/package.json
+++ b/packages/graphql-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-extensions",
-  "version": "0.14.0",
+  "version": "0.15.0-alpha.0",
   "description": "Add extensions to GraphQL servers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/apollo-server/issues?q=label%3A%22%F0%9F%8F%97+release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release of Apollo Server. 🙌   The version in the title of this PR should correspond to the appropriate branch.

Check the appropriate milestone (to the right) for more details on what we hope to get into this release!

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.
