### PR TITLE
docs: Update schema-reporting.md and usage-reporting.md for fetcher option

### DIFF
--- a/docs/source/api/plugin/schema-reporting.md
+++ b/docs/source/api/plugin/schema-reporting.md
@@ -111,7 +111,7 @@ The URL to use for reporting schemas. Primarily for testing and internal Apollo 
 </td>
 <td>
 
-Specifies which Fetch API implementation to use when reporting schemas.
+Specifies which [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) function implementation to use when reporting schemas.
 </td>
 </tr>
 

--- a/docs/source/api/plugin/schema-reporting.md
+++ b/docs/source/api/plugin/schema-reporting.md
@@ -102,5 +102,18 @@ The URL to use for reporting schemas. Primarily for testing and internal Apollo 
 </td>
 </tr>
 
+<tr>
+<td>
+
+###### `fetcher`
+
+`typeof fetch`
+</td>
+<td>
+
+Specifies which Fetch API implementation to use when reporting schemas.
+</td>
+</tr>
+
 </tbody>
 </table>

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -215,7 +215,7 @@ An HTTP(S) agent to use for reporting. Can be either an [`http.Agent`](https://n
 </td>
 <td>
 
-Specifies which Fetch API implementation to use when sending usage reports.
+Specifies which [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) function implementation to use when sending usage reports.
 </td>
 </tr>
 

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -209,6 +209,19 @@ An HTTP(S) agent to use for reporting. Can be either an [`http.Agent`](https://n
 <tr>
 <td>
 
+###### `fetcher`
+
+`typeof fetch`
+</td>
+<td>
+
+Specifies which Fetch API implementation to use when sending usage reports.
+</td>
+</tr>
+
+<tr>
+<td>
+
 ###### `reportIntervalMs`
 
 `number`


### PR DESCRIPTION
In #5179, we added a new `fetcher` option for the schema reporting plugin and the usage reporting plugin, but forgot to update the docs. This PR updates the docs to include this option.