### PR TITLE
Make the health-check path configurable.

### DIFF
--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -24,6 +24,7 @@ export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
 
 export interface GetMiddlewareOptions {
   path?: string;
+  healthCheckPath?: string;
   cors?: corsMiddleware.CorsOptions | corsMiddleware.CorsOptionsDelegate | boolean;
   bodyParserConfig?: OptionsJson | boolean;
   onHealthCheck?: (req: express.Request) => Promise<any>;
@@ -115,12 +116,14 @@ export class ApolloServer extends ApolloServerBase {
   // Hapi) which must be `async`.
   public getMiddleware({
     path,
+    healthCheckPath,
     cors,
     bodyParserConfig,
     disableHealthCheck,
     onHealthCheck,
   }: GetMiddlewareOptions = {}): express.Router {
     if (!path) path = '/graphql';
+    if (!healthCheckPath) healthCheckPath = '/.well-known/apollo/server-health';
 
     // In case the user didn't bother to call and await the `start` method, we
     // kick it off in the background (with any errors getting logged
@@ -130,7 +133,7 @@ export class ApolloServer extends ApolloServerBase {
     const router = express.Router();
 
     if (!disableHealthCheck) {
-      router.use('/.well-known/apollo/server-health', (req, res) => {
+      router.use(healthCheckPath, (req, res) => {
         // Response follows https://tools.ietf.org/html/draft-inadarei-api-health-check-01
         res.type('application/health+json');
 

--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -18,6 +18,7 @@ const fastJson = require('fast-json-stringify');
 
 export interface ServerRegistration {
   path?: string;
+  healthCheckPath?: string;
   cors?: object | boolean;
   onHealthCheck?: (req: FastifyRequest<IncomingMessage>) => Promise<any>;
   disableHealthCheck?: boolean;
@@ -80,11 +81,13 @@ export class ApolloServer extends ApolloServerBase {
 
   public createHandler({
     path,
+    healthCheckPath,
     cors,
     disableHealthCheck,
     onHealthCheck,
   }: ServerRegistration = {}) {
     this.graphqlPath = path ? path : '/graphql';
+    if (!healthCheckPath) healthCheckPath = '/.well-known/apollo/server-health';
 
     // In case the user didn't bother to call and await the `start` method, we
     // kick it off in the background (with any errors getting logged
@@ -95,7 +98,7 @@ export class ApolloServer extends ApolloServerBase {
       app: FastifyInstance<Server, IncomingMessage, ServerResponse>,
     ) => {
       if (!disableHealthCheck) {
-        app.get('/.well-known/apollo/server-health', async (req, res) => {
+        app.get(healthCheckPath, async (req, res) => {
           // Response follows https://tools.ietf.org/html/draft-inadarei-api-health-check-01
           res.type('application/health+json');
 

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -56,6 +56,7 @@ export class ApolloServer extends ApolloServerBase {
     app,
     cors,
     path,
+    healthCheckPath,
     route,
     disableHealthCheck,
     onHealthCheck,
@@ -66,6 +67,7 @@ export class ApolloServer extends ApolloServerBase {
     this.ensureStarting();
 
     if (!path) path = '/graphql';
+    if (!healthCheckPath) healthCheckPath = '/.well-known/apollo/server-health';
 
     await app.ext({
       type: 'onRequest',
@@ -108,7 +110,7 @@ export class ApolloServer extends ApolloServerBase {
     if (!disableHealthCheck) {
       await app.route({
         method: '*',
-        path: '/.well-known/apollo/server-health',
+        path: healthCheckPath,
         options: {
           cors: cors !== undefined ? cors : true,
         },
@@ -151,6 +153,7 @@ export class ApolloServer extends ApolloServerBase {
 export interface ServerRegistration {
   app?: hapi.Server;
   path?: string;
+  healthCheckPath?: string;
   cors?: boolean | hapi.RouteOptionsCors;
   route?: hapi.RouteOptions;
   onHealthCheck?: (request: hapi.Request) => Promise<any>;

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -22,6 +22,7 @@ export { GraphQLOptions, GraphQLExtension } from 'apollo-server-core';
 
 export interface GetMiddlewareOptions {
   path?: string;
+  healthCheckPath?: string;
   cors?: corsMiddleware.Options | boolean;
   bodyParserConfig?: bodyParser.Options | boolean;
   onHealthCheck?: (ctx: Koa.Context) => Promise<any>;
@@ -94,12 +95,14 @@ export class ApolloServer extends ApolloServerBase {
   // order to align the API with other integrations.
   public getMiddleware({
     path,
+    healthCheckPath,
     cors,
     bodyParserConfig,
     disableHealthCheck,
     onHealthCheck,
   }: GetMiddlewareOptions = {}): Middleware {
     if (!path) path = '/graphql';
+    if (!healthCheckPath) healthCheckPath = '/.well-known/apollo/server-health';
 
     // In case the user didn't bother to call and await the `start` method, we
     // kick it off in the background (with any errors getting logged
@@ -111,7 +114,7 @@ export class ApolloServer extends ApolloServerBase {
     if (!disableHealthCheck) {
       middlewares.push(
         middlewareFromPath(
-          '/.well-known/apollo/server-health',
+          healthCheckPath,
           (ctx: Koa.Context) => {
             // Response follows https://tools.ietf.org/html/draft-inadarei-api-health-check-01
             ctx.set('Content-Type', 'application/health+json');

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -52,6 +52,7 @@ export interface CreateHandlerOptions<EventT extends APIGatewayProxyEventV1OrV2 
     credentials?: boolean;
     maxAge?: number;
   };
+  healthCheckPath?: string;
   uploadsConfig?: FileUploadOptions;
   onHealthCheck?: (req: EventT) => Promise<any>;
 }
@@ -124,8 +125,9 @@ export class ApolloServer<EventT extends APIGatewayProxyEventV1OrV2 = APIGateway
   }
 
   public createHandler(
-    { cors, onHealthCheck }: CreateHandlerOptions<EventT> = {
+    { cors, onHealthCheck, healthCheckPath }: CreateHandlerOptions<EventT> = {
       cors: undefined,
+      healthCheckPath: undefined,
       onHealthCheck: undefined,
     },
   ) {
@@ -233,7 +235,8 @@ export class ApolloServer<EventT extends APIGatewayProxyEventV1OrV2 = APIGateway
           };
         }
 
-        if (eventPath(event).endsWith('/.well-known/apollo/server-health')) {
+        if (!healthCheckPath) healthCheckPath = '/.well-known/apollo/server-health';
+        if (eventPath(event).endsWith(healthCheckPath)) {
           if (onHealthCheck) {
             try {
               await onHealthCheck(event);

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -13,6 +13,7 @@ import { MicroRequest } from './types';
 
 export interface ServerRegistration {
   path?: string;
+  healthCheckPath?: string;
   disableHealthCheck?: boolean;
   onHealthCheck?: (req: MicroRequest) => Promise<any>;
 }
@@ -30,6 +31,7 @@ export class ApolloServer extends ApolloServerBase {
   // GraphQL requests.
   public createHandler({
     path,
+    healthCheckPath,
     disableHealthCheck,
     onHealthCheck,
   }: ServerRegistration = {}) {
@@ -49,6 +51,7 @@ export class ApolloServer extends ApolloServerBase {
         req,
         res,
         disableHealthCheck,
+        healthCheckPath,
         onHealthCheck,
       })) ||
         this.handleGraphqlRequestsWithPlayground({ req, res }) ||
@@ -73,6 +76,7 @@ export class ApolloServer extends ApolloServerBase {
     req,
     res,
     disableHealthCheck,
+    healthCheckPath,
     onHealthCheck,
   }: {
     req: MicroRequest;
@@ -82,9 +86,11 @@ export class ApolloServer extends ApolloServerBase {
   }): Promise<boolean> {
     let handled = false;
 
+    if (!healthCheckPath) healthCheckPath = '/.well-known/apollo/server-health';
+
     if (
       !disableHealthCheck &&
-      req.url === '/.well-known/apollo/server-health'
+      req.url === healthCheckPath
     ) {
       // Response follows
       // https://tools.ietf.org/html/draft-inadarei-api-health-check-01

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -28,18 +28,21 @@ export class ApolloServer extends ApolloServerBase {
   private httpServer?: stoppable.StoppableServer;
   private cors?: CorsOptions | boolean;
   private onHealthCheck?: (req: express.Request) => Promise<any>;
+  private healthCheckPath?: string;
   private stopGracePeriodMillis: number;
 
   constructor(
     config: ApolloServerExpressConfig & {
       cors?: CorsOptions | boolean;
       onHealthCheck?: (req: express.Request) => Promise<any>;
+      healthCheckPath?: string;
       stopGracePeriodMillis?: number;
     },
   ) {
     super(config);
     this.cors = config && config.cors;
     this.onHealthCheck = config && config.onHealthCheck;
+    this.healthCheckPath = config && config.healthCheckPath;
     this.stopGracePeriodMillis = config?.stopGracePeriodMillis ?? 10_000;
   }
 
@@ -117,6 +120,7 @@ export class ApolloServer extends ApolloServerBase {
     super.applyMiddleware({
       app,
       path: '/',
+      healthCheckPath: this.healthCheckPath,
       bodyParserConfig: { limit: '50mb' },
       onHealthCheck: this.onHealthCheck,
       cors:


### PR DESCRIPTION
This is especially desirable for `apollo-server` package, which is OOTB pre-configured for quick usage, however, in few cases configuring the health-check endpoint is desired.

Certainly not set on the name of the property - better names welcome. I also think I've covered all integrations which support health checks out of the box, but LMK if I've missed any.

Closes #3577