### PR TITLE
Make error handling around APQs more consistent

### DIFF
--- a/packages/apollo-server-core/src/__tests__/errors.test.ts
+++ b/packages/apollo-server-core/src/__tests__/errors.test.ts
@@ -8,9 +8,6 @@ import {
   ValidationError,
   UserInputError,
   SyntaxError,
-  hasPersistedQueryError,
-  PersistedQueryNotFoundError,
-  PersistedQueryNotSupportedError,
 } from 'apollo-server-errors';
 
 describe('Errors', () => {
@@ -189,39 +186,6 @@ describe('Errors', () => {
 
       expect(formattedError.extensions.exception.field1).toEqual('property1');
       expect(formattedError.extensions.exception.field2).toEqual('property2');
-    });
-  });
-  describe('hasPersistedQueryError', () => {
-    it('should return true if errors contain error of type PersistedQueryNotFoundError', () => {
-      const errors = [
-        new PersistedQueryNotFoundError(),
-        new AuthenticationError('401'),
-      ];
-      const result = hasPersistedQueryError(errors);
-      expect(result).toBe(true);
-    });
-
-    it('should return true if errors contain error of type PersistedQueryNotSupportedError', () => {
-      const errors = [
-        new PersistedQueryNotSupportedError(),
-        new AuthenticationError('401'),
-      ];
-      const result = hasPersistedQueryError(errors);
-      expect(result).toBe(true);
-    });
-
-    it('should return false if errors does not contain PersistedQuery error', () => {
-      const errors = [
-        new ForbiddenError('401'),
-        new AuthenticationError('401'),
-      ];
-      const result = hasPersistedQueryError(errors);
-      expect(result).toBe(false);
-    });
-
-    it('should return false if illegally passed an object instead of an array', () => {
-      const result = hasPersistedQueryError({} as any);
-      expect(result).toBe(false);
     });
   });
 });

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -32,7 +32,6 @@ export {
   GraphQLRequestMetrics,
   GraphQLRequestContext,
   ValidationRule,
-  InvalidGraphQLRequestError,
   GraphQLExecutor,
   GraphQLExecutionResult,
 } from 'apollo-server-types';

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -1,9 +1,9 @@
 import { GraphQLError, DocumentNode } from 'graphql';
 import {
   GraphQLRequestContextDidResolveOperation,
-  GraphQLRequestContextDidEncounterErrors,
   Logger,
   GraphQLRequestContext,
+  GraphQLRequestContextWillSendResponse,
 } from 'apollo-server-types';
 import type { fetch, RequestAgent } from 'apollo-server-env';
 import type { Trace } from 'apollo-reporting-protobuf';
@@ -63,7 +63,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    * phase, which permits tracing based on dynamic properties, e.g., HTTP
    * headers or the `operationName` (when available). Otherwise it will receive
    * the request context in the
-   * [`GraphQLRequestContextDidEncounterError`](https://www.apollographql.com/docs/apollo-server/integrations/plugins/#didencountererrors)
+   * [`GraphQLRequestContextWillSendResponse`](https://www.apollographql.com/docs/apollo-server/integrations/plugins/#willsendresponse)
    * phase:
    *
    * (If you don't want any usage reporting, don't use this plugin; if you are
@@ -92,7 +92,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
   includeRequest?: (
     request:
       | GraphQLRequestContextDidResolveOperation<TContext>
-      | GraphQLRequestContextDidEncounterErrors<TContext>,
+      | GraphQLRequestContextWillSendResponse<TContext>,
   ) => Promise<boolean>;
   /**
    * By default, this plugin associates client information such as name

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -181,6 +181,10 @@ export default async function pluginTestHarness<TContext>({
         'didEncounterErrors',
         requestContext as GraphQLRequestContextDidEncounterErrors<TContext>,
       );
+      await dispatcher.invokeHookAsync(
+        "willSendResponse",
+        requestContext as GraphQLRequestContextWillSendResponse<TContext>,
+      );
 
       return requestContext as GraphQLRequestContextWillSendResponse<TContext>;
     }
@@ -201,6 +205,10 @@ export default async function pluginTestHarness<TContext>({
       await dispatcher.invokeHookAsync(
         'didEncounterErrors',
         requestContext as GraphQLRequestContextDidEncounterErrors<TContext>,
+      );
+      await dispatcher.invokeHookAsync(
+        "willSendResponse",
+        requestContext as GraphQLRequestContextWillSendResponse<TContext>,
       );
       return requestContext as GraphQLRequestContextWillSendResponse<TContext>;
     } else {

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -298,13 +298,3 @@ export function formatApolloErrors(
     }
   }) as Array<ApolloError>;
 }
-
-export function hasPersistedQueryError(errors: Array<Error>): boolean {
-  return Array.isArray(errors)
-    ? errors.some(
-        error =>
-          error instanceof PersistedQueryNotFoundError ||
-          error instanceof PersistedQueryNotSupportedError,
-      )
-    : false;
-}

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -128,6 +128,11 @@ export class ApolloServer extends ApolloServerBase {
 
           if (true === error.isGraphQLError) {
             const response = h.response(error.message);
+            if (error.headers) {
+              Object.entries(error.headers).forEach(([headerName, value]) => {
+                response.header(headerName, value);
+              });
+            }
             response.code(error.statusCode);
             response.type('application/json');
             return response;

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -492,6 +492,9 @@ export default ({
           expect(res.body.errors[0].message).toEqual(
             'PersistedQueryNotSupported',
           );
+          expect(res.headers['cache-control']).toBe(
+            'private, no-cache, must-revalidate',
+          );
         });
       });
 
@@ -517,6 +520,9 @@ export default ({
           expect(res.body.errors[0].message).toEqual(
             'PersistedQueryNotSupported',
           );
+          expect(res.headers['cache-control']).toBe(
+            'private, no-cache, must-revalidate',
+          );
         });
       });
 
@@ -538,6 +544,9 @@ export default ({
           expect(res.body.errors).toBeDefined();
           expect(res.body.errors.length).toEqual(1);
           expect(res.body.errors[0].message).toEqual('PersistedQueryNotFound');
+          expect(res.headers['cache-control']).toBe(
+            'private, no-cache, must-revalidate',
+          );
         });
       });
 
@@ -559,6 +568,9 @@ export default ({
           expect(res.body.errors).toBeDefined();
           expect(res.body.errors.length).toEqual(1);
           expect(res.body.errors[0].message).toEqual('PersistedQueryNotFound');
+          expect(res.headers['cache-control']).toBe(
+            'private, no-cache, must-revalidate',
+          );
         });
       });
 

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -158,8 +158,6 @@ export interface GraphQLRequestContext<TContext = Record<string, any>> {
 
 export type ValidationRule = (context: ValidationContext) => ASTVisitor;
 
-export class InvalidGraphQLRequestError extends GraphQLError {}
-
 export type GraphQLExecutor<TContext = Record<string, any>> = (
   requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
 ) => ValueOrPromise<GraphQLExecutionResult>;


### PR DESCRIPTION
Previously, almost every case where the request pipeline called
didEncounterErrors, it also called willSendResponse. But there were
several special cases for historical reasons, where a few errors (mostly
relating to APQs) could call didEncounterErrors without calling
willSendResponse. Among other things, this added a bunch of complexity
to the usage reporting plugin.

This PR:

- Changes all APQ-related errors to go through `sendErrorResponse`
  instead of `emitErrorAndThrow` (which can be deleted), so
  `willSendResponse` is called for them.
- Removes special-case handling of HTTP status code/headers for
  persisted query headers in `runHttpQuery.ts` and of `HttpQueryError`s
  thrown by `didResolveOperation` callbacks. Instead, we just make sure
  to handle some existing `http` fields more consistently. Specifically:
  + `sendResponse` now can take `http` on its given `GraphQLResponse`
  + `didEncounterErrors` copies the status code and headers from
    `HttpQueryError` and sets appropriate status code and errors for PQ
    errors (and skips an unnecessary conversion of them with
    fromGraphQLError)
  + `runHttpQuery` looks for `response.http.headers` both when calling
    `throwHttpGraphQLError` and in the success case
  + The `hasPersistedQueryError` function is no longer needed.
- Fixes a hapi-specific bug where `headers` on a thrown GraphQL error
  were ignored.
- Changes the error when there is no query or extensions.persistedQuery
  to be a bit more explicit (and also to be formatted as a full JSON
  GraphQL response).
- Simplifies the usage reporting plugin to no longer handle
  didEncounterErrors but just handle errors in willSendResponse. Note
  that this means that the includeRequest plugin takes a slightly
  different type. Don't bother to call `didEnd` (ie,
  `treeBuilder.stopTiming`) if shouldIncludeRequest returns false,
  because it doesn't actually clean up any resources.
- Removes InvalidGraphQLRequestError which was no longer used for much.
- Unrelated, but noticed during this work (separate commit):
  We've already done #3465, so we no longer need a single const to
  represent "either the actual resolved operation name that definitely
  points to a real parsed and validated operation, or else what the user
  wrote in the request". We can use the latter in the one case where we
  report an unexecuted operation name, and the former otherwise.

Fixes #5156.
