### PR TITLE
Make the plugin (and gateway) API almost entirely async

### DIFF
--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -113,7 +113,7 @@ The only properties of the reported error you can modify are its `message` and i
 
 Specify this asynchronous function to configure which requests are included in usage reports sent to Apollo Studio. For example, you can omit requests that execute a particular operation or requests that include a particular HTTP header.
 
-This function is called for each received request. It takes a [`GraphQLRequestContext`](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-types/src/index.ts#L115-L150) object and must return a `Promise<Boolean>` that indicates whether to include the request. It's called either after the operation is successfully resolved (via [the `didResolveOperation` event](https://www.apollographql.com/docs/apollo-server/integrations/plugins/#didresolveoperation)), or after it generates an error (via [the `didEncounterErrors` event](https://www.apollographql.com/docs/apollo-server/integrations/plugins/#didencountererrors)).
+This function is called for each received request. It takes a [`GraphQLRequestContext`](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-types/src/index.ts#L115-L150) object and must return a `Promise<Boolean>` that indicates whether to include the request. It's called either after the operation is successfully resolved (via [the `didResolveOperation` event](https://www.apollographql.com/docs/apollo-server/integrations/plugins/#didresolveoperation)), or when sending the final error response if the operation was not successfully resolved (via [the `willSendResponse` event](https://www.apollographql.com/docs/apollo-server/integrations/plugins/#willsendresponse)).
 
 By default, all requests are included in usage reports.
 

--- a/docs/source/monitoring/metrics.md
+++ b/docs/source/monitoring/metrics.md
@@ -92,23 +92,21 @@ For a list of available lifecycle events and their descriptions, see [Plugins](.
 
 ```js
 const myPlugin = {
-
   // Fires whenever a GraphQL request is received from a client.
-  requestDidStart(requestContext) {
+  async requestDidStart(requestContext) {
     console.log('Request started! Query:\n' +
       requestContext.request.query);
 
     return {
-
       // Fires whenever Apollo Server will parse a GraphQL
       // request to create its associated document AST.
-      parsingDidStart(requestContext) {
+      async parsingDidStart(requestContext) {
         console.log('Parsing started!');
       },
 
       // Fires whenever Apollo Server will validate a
       // request's document AST against your GraphQL schema.
-      validationDidStart(requestContext) {
+      async validationDidStart(requestContext) {
         console.log('Validation started!');
       },
 

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -448,9 +448,8 @@ export class ApolloServerBase {
       if (taggedServerListenersWithRenderLandingPage.length > 1) {
         throw Error('Only one plugin can implement renderLandingPage.');
       } else if (taggedServerListenersWithRenderLandingPage.length) {
-        this.landingPage =
-          taggedServerListenersWithRenderLandingPage[0].serverListener
-            .renderLandingPage!();
+        this.landingPage = await taggedServerListenersWithRenderLandingPage[0]
+          .serverListener.renderLandingPage!();
       } else {
         this.landingPage = null;
       }

--- a/packages/apollo-server-core/src/__tests__/logger.test.ts
+++ b/packages/apollo-server-core/src/__tests__/logger.test.ts
@@ -23,7 +23,7 @@ async function triggerLogMessage(loggerToUse: Logger) {
     logger: loggerToUse,
     plugins: [
       {
-        requestDidStart({ logger }) {
+        async requestDidStart({ logger }) {
           logger.debug(KNOWN_DEBUG_MESSAGE);
         },
       },

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -446,7 +446,7 @@ describe('runQuery', () => {
           queryString: '{ testString }',
           plugins: [
             {
-              requestDidStart() {
+              async requestDidStart() {
                 return {
                   didResolveSource,
                 };
@@ -470,7 +470,7 @@ describe('runQuery', () => {
           queryString: '{ testStringWithParseError: }',
           plugins: [
             {
-              requestDidStart() {
+              async requestDidStart() {
                 return {
                   parsingDidStart,
                 };
@@ -489,7 +489,7 @@ describe('runQuery', () => {
           queryString: '{ testString }',
           plugins: [
             {
-              requestDidStart() {
+              async requestDidStart() {
                 return {
                   parsingDidStart,
                 };
@@ -511,7 +511,7 @@ describe('runQuery', () => {
           queryString: '{ testString }',
           plugins: [
             {
-              requestDidStart() {
+              async requestDidStart() {
                 return {
                   executionDidStart,
                 };
@@ -525,35 +525,11 @@ describe('runQuery', () => {
       });
 
       describe('executionDidEnd', () => {
-        it('works as a function returned from "executionDidStart"', async () => {
-          const executionDidEnd = jest.fn();
-          const executionDidStart = jest.fn(
-            (): GraphQLRequestListenerExecutionDidEnd => executionDidEnd);
-
-          await runQuery({
-            schema,
-            queryString: '{ testString }',
-            plugins: [
-              {
-                requestDidStart() {
-                  return {
-                    executionDidStart,
-                  };
-                },
-              },
-            ],
-            request: new MockReq(),
-          });
-
-          expect(executionDidStart).toHaveBeenCalledTimes(1);
-          expect(executionDidEnd).toHaveBeenCalledTimes(1);
-        });
-
         it('works as a listener on an object returned from "executionDidStart"',
           async () => {
             const executionDidEnd = jest.fn();
             const executionDidStart = jest.fn(
-              (): GraphQLRequestExecutionListener => ({
+              async (): Promise<GraphQLRequestExecutionListener> => ({
                 executionDidEnd,
               }),
             );
@@ -563,7 +539,7 @@ describe('runQuery', () => {
               queryString: '{ testString }',
               plugins: [
                 {
-                  requestDidStart() {
+                  async requestDidStart() {
                     return {
                       executionDidStart,
                     };
@@ -585,7 +561,7 @@ describe('runQuery', () => {
           const willResolveField = jest.fn();
           const executionDidEnd = jest.fn();
           const executionDidStart = jest.fn(
-            (): GraphQLRequestExecutionListener => ({
+            async (): Promise<GraphQLRequestExecutionListener> => ({
               willResolveField,
               executionDidEnd,
             }),
@@ -596,7 +572,7 @@ describe('runQuery', () => {
             queryString: '{ testString }',
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return {
                     executionDidStart,
                   };
@@ -615,7 +591,7 @@ describe('runQuery', () => {
           const willResolveField = jest.fn();
           const executionDidEnd = jest.fn();
           const executionDidStart = jest.fn(
-            (): GraphQLRequestExecutionListener => ({
+            async (): Promise<GraphQLRequestExecutionListener> => ({
               willResolveField,
               executionDidEnd,
             }),
@@ -626,7 +602,7 @@ describe('runQuery', () => {
             queryString: '{ testString again:testString }',
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return {
                     executionDidStart,
                   };
@@ -650,9 +626,9 @@ describe('runQuery', () => {
               queryString: '{ testString }',
               plugins: [
                 {
-                  requestDidStart() {
+                  async requestDidStart() {
                     return {
-                      executionDidStart: () => ({
+                      executionDidStart: async () => ({
                         willResolveField,
                       }),
                     };
@@ -678,9 +654,9 @@ describe('runQuery', () => {
               queryString: '{ testObject { testString } }',
               plugins: [
                 {
-                  requestDidStart() {
+                  async requestDidStart() {
                     return {
-                      executionDidStart: () => ({
+                      executionDidStart: async () => ({
                         willResolveField,
                       }),
                     };
@@ -717,9 +693,9 @@ describe('runQuery', () => {
               queryString: '{ testString }',
               plugins: [
                 {
-                  requestDidStart() {
+                  async requestDidStart() {
                     return {
-                      executionDidStart: () => ({
+                      executionDidStart: async () => ({
                         willResolveField,
                       }),
                     };
@@ -743,9 +719,9 @@ describe('runQuery', () => {
               queryString: '{ testArgumentValue(base: 99) }',
               plugins: [
                 {
-                  requestDidStart() {
+                  async requestDidStart() {
                     return {
-                      executionDidStart: () => ({
+                      executionDidStart: async () => ({
                         willResolveField,
                       }),
                     };
@@ -767,7 +743,7 @@ describe('runQuery', () => {
           const willResolveField = jest.fn(() => didResolveField);
           const executionDidEnd = jest.fn();
           const executionDidStart = jest.fn(
-            (): GraphQLRequestExecutionListener => ({
+            async (): Promise<GraphQLRequestExecutionListener> => ({
               willResolveField,
               executionDidEnd,
             }),
@@ -778,7 +754,7 @@ describe('runQuery', () => {
             queryString: '{ testString }',
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return {
                     executionDidStart,
                   };
@@ -800,7 +776,7 @@ describe('runQuery', () => {
           const willResolveField = jest.fn(() => didResolveField);
           const executionDidEnd = jest.fn();
           const executionDidStart = jest.fn(
-            (): GraphQLRequestExecutionListener => ({
+            async (): Promise<GraphQLRequestExecutionListener> => ({
               willResolveField,
               executionDidEnd,
             }),
@@ -811,7 +787,7 @@ describe('runQuery', () => {
             queryString: '{ testString again: testString }',
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return {
                     executionDidStart,
                   };
@@ -863,8 +839,8 @@ describe('runQuery', () => {
 
           const plugins: ApolloServerPlugin[] = [
             {
-              requestDidStart: () => ({
-                executionDidStart: () => ({
+              requestDidStart: async () => ({
+                executionDidStart: async () => ({
                   willResolveField,
                 }),
               })
@@ -909,7 +885,7 @@ describe('runQuery', () => {
       const didEncounterErrors = jest.fn();
       const plugins: ApolloServerPlugin[] = [
         {
-          requestDidStart() {
+          async requestDidStart() {
             return { didEncounterErrors };
           },
         },
@@ -969,24 +945,29 @@ describe('runQuery', () => {
         let stopAwaiting: Function;
         const toBeAwaited = new Promise(resolve => stopAwaiting = resolve);
 
-        const parsingDidEnd: GraphQLRequestListenerParsingDidEnd =
-          jest.fn(() => callOrder.push('parsingDidEnd'));
+        const parsingDidEnd: GraphQLRequestListenerParsingDidEnd = jest.fn(
+          async () => {
+            callOrder.push('parsingDidEnd');
+          },
+        );
         const parsingDidStart: GraphQLRequestListener['parsingDidStart'] =
-          jest.fn(() => {
+          jest.fn(async () => {
             callOrder.push('parsingDidStart');
             return parsingDidEnd;
           });
 
         const validationDidEnd: GraphQLRequestListenerValidationDidEnd =
-          jest.fn(() => callOrder.push('validationDidEnd'));
+          jest.fn(async () => {
+            callOrder.push('validationDidEnd');
+          });
         const validationDidStart: GraphQLRequestListener['validationDidStart'] =
-          jest.fn(() => {
+          jest.fn(async () => {
             callOrder.push('validationDidStart');
             return validationDidEnd;
           });
 
         const didResolveSource: GraphQLRequestListener['didResolveSource'] =
-          jest.fn(() => { callOrder.push('didResolveSource') });
+          jest.fn(async () => { callOrder.push('didResolveSource') });
 
         const didResolveField: GraphQLRequestListenerDidResolveField =
           jest.fn(() => callOrder.push("didResolveField"));
@@ -996,11 +977,14 @@ describe('runQuery', () => {
           return didResolveField;
         });
 
-        const executionDidEnd: GraphQLRequestListenerExecutionDidEnd =
-          jest.fn(() => callOrder.push('executionDidEnd'));
+        const executionDidEnd: GraphQLRequestListenerExecutionDidEnd = jest.fn(
+          async () => {
+            callOrder.push('executionDidEnd');
+          },
+        );
 
         const executionDidStart = jest.fn(
-          (): GraphQLRequestExecutionListener => {
+          async (): Promise<GraphQLRequestExecutionListener> => {
             callOrder.push("executionDidStart");
             return { willResolveField, executionDidEnd };
           },
@@ -1030,7 +1014,7 @@ describe('runQuery', () => {
           queryString: '{ testString }',
           plugins: [
             {
-              requestDidStart() {
+              async requestDidStart() {
                 return {
                   parsingDidStart,
                   validationDidStart,
@@ -1074,7 +1058,7 @@ describe('runQuery', () => {
 
       const plugins: ApolloServerPlugin[] = [
         {
-          requestDidStart() {
+          async requestDidStart() {
             return {
               validationDidStart,
               parsingDidStart,

--- a/packages/apollo-server-core/src/plugin/cacheControl/__tests__/cacheControlPlugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/__tests__/cacheControlPlugin.test.ts
@@ -36,7 +36,7 @@ describe('plugin', () => {
         overallCachePolicy,
         // This query needs to pass graphql validation
         graphqlRequest: { query: 'query { hello }' },
-        executor: () => {
+        executor: async () => {
           const response: GraphQLResponse = {
             http: {
               headers: new Headers(),

--- a/packages/apollo-server-core/src/plugin/cacheControl/index.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/index.ts
@@ -90,7 +90,7 @@ export function ApolloServerPluginCacheControl(
       return 'CacheControl';
     },
 
-    serverWillStart({ schema }) {
+    async serverWillStart({ schema }) {
       // Set the size of the caches to be equal to the number of composite types
       // and fields in the schema respectively. This generally means that the
       // cache will always have room for all the cache hints in the active
@@ -108,15 +108,16 @@ export function ApolloServerPluginCacheControl(
         Object.values(schema.getTypeMap())
           .filter(isInterfaceType)
           .flatMap((t) => Object.values(t.getFields())).length;
+      return undefined;
     },
 
-    requestDidStart(requestContext) {
+    async requestDidStart(requestContext) {
       const defaultMaxAge: number = options.defaultMaxAge ?? 0;
       const calculateHttpHeaders = options.calculateHttpHeaders ?? true;
       const { __testing__cacheHints } = options;
 
       return {
-        executionDidStart: () => {
+        async executionDidStart() {
           // Did something set the overall cache policy before we've even
           // started? If so, consider that as an override and don't touch it.
           // Just put set up fake `info.cacheControl` objects and otherwise
@@ -238,7 +239,7 @@ export function ApolloServerPluginCacheControl(
           };
         },
 
-        willSendResponse(requestContext) {
+        async willSendResponse(requestContext) {
           const { response, overallCachePolicy } = requestContext;
 
           const policyIfCacheable = overallCachePolicy.policyIfCacheable();

--- a/packages/apollo-server-core/src/plugin/inlineTrace/index.ts
+++ b/packages/apollo-server-core/src/plugin/inlineTrace/index.ts
@@ -38,7 +38,7 @@ export function ApolloServerPluginInlineTrace(
     __internal_plugin_id__() {
       return 'InlineTrace';
     },
-    serverWillStart({ schema, logger }) {
+    async serverWillStart({ schema, logger }) {
       // Handle the case that the plugin was implicitly installed. We only want it
       // to actually be active if the schema appears to be federated. If you don't
       // like the log line, just install `ApolloServerPluginInlineTrace()` in
@@ -53,7 +53,7 @@ export function ApolloServerPluginInlineTrace(
         }
       }
     },
-    requestDidStart({ request: { http } }) {
+    async requestDidStart({ request: { http } }) {
       if (!enabled) {
         return;
       }
@@ -70,17 +70,19 @@ export function ApolloServerPluginInlineTrace(
       treeBuilder.startTiming();
 
       return {
-        executionDidStart: () => ({
-          willResolveField({ info }) {
-            return treeBuilder.willResolveField(info);
-          },
-        }),
+        async executionDidStart() {
+          return {
+            willResolveField({ info }) {
+              return treeBuilder.willResolveField(info);
+            },
+          };
+        },
 
-        didEncounterErrors({ errors }) {
+        async didEncounterErrors({ errors }) {
           treeBuilder.didEncounterErrors(errors);
         },
 
-        willSendResponse({ response }) {
+        async willSendResponse({ response }) {
           // We record the end time at the latest possible time: right before serializing the trace.
           // If we wait any longer, the time we record won't actually be sent anywhere!
           treeBuilder.stopTiming();

--- a/packages/apollo-server-core/src/plugin/landingPage/graphqlPlayground/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/graphqlPlayground/index.ts
@@ -29,9 +29,9 @@ export function ApolloServerPluginLandingPageGraphQLPlayground(
 ): ImplicitlyInstallablePlugin {
   return {
     __internal_installed_implicitly__: false,
-    serverWillStart(): GraphQLServerListener {
+    async serverWillStart(): Promise<GraphQLServerListener> {
       return {
-        renderLandingPage() {
+        async renderLandingPage() {
           return {
             html: renderPlaygroundPage({
               version: defaultPlaygroundVersion,

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -417,9 +417,9 @@ function parseGraphQLRequest(
 // GET operations should only be queries (not mutations). We want to throw
 // a particular HTTP error in that case.
 const checkOperationPlugin: ApolloServerPlugin = {
-  requestDidStart() {
+  async requestDidStart() {
     return {
-      didResolveOperation({ request, operation }) {
+      async didResolveOperation({ request, operation }) {
         if (!request.http) return;
 
         if (request.http.method === 'GET' && operation.operation !== 'query') {

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -56,15 +56,15 @@ export type GraphQLServiceConfig = {
 
 export interface GraphQLService {
   load(options: {
-    apollo?: ApolloConfig;
+    apollo: ApolloConfig;
   }): Promise<GraphQLServiceConfig>;
   onSchemaChange(callback: SchemaChangeCallback): Unsubscriber;
   // Note: The `TContext` typing here is not conclusively behaving as we expect:
   // https://github.com/apollographql/apollo-server/pull/3811#discussion_r387381605
   executor<TContext>(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
-  ): ValueOrPromise<GraphQLExecutionResult>;
-  stop?(): Promise<void>;
+  ): Promise<GraphQLExecutionResult>;
+  stop(): Promise<void>;
 }
 
 // This configuration is shared between all integrations and should include

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -308,7 +308,7 @@ export default ({
             schema,
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return { didEncounterErrors };
                 },
               },
@@ -346,7 +346,7 @@ export default ({
             schema,
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return { didEncounterErrors };
                 },
               },
@@ -1227,7 +1227,7 @@ export default ({
             schema,
             plugins: [
               {
-                requestDidStart() {
+                async requestDidStart() {
                   return {
                     didResolveSource,
                     didEncounterErrors,

--- a/packages/apollo-server-plugin-operation-registry/src/ApolloServerPluginOperationRegistry.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/ApolloServerPluginOperationRegistry.ts
@@ -21,7 +21,7 @@ import { ForbiddenError, ApolloError } from 'apollo-server-errors';
 import Agent from './agent';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import loglevel from 'loglevel';
-import { fetch } from "apollo-server-env";
+import { fetch } from 'apollo-server-env';
 
 type ForbidUnregisteredOperationsPredicate = (
   requestContext: GraphQLRequestContext,
@@ -99,7 +99,7 @@ for observability purposes, but all operations will be permitted.`,
       // Make available to requestDidStart.
       logger.debug('Initializing operation registry plugin.');
 
-      const {graphRef, keyHash} = apollo;
+      const { graphRef, keyHash } = apollo;
 
       if (!keyHash) {
         const messageApolloConfigurationRequired =
@@ -112,8 +112,7 @@ for observability purposes, but all operations will be permitted.`,
         throw new Error(`${pluginName}: ${messageApolloConfigurationRequired}`);
       }
 
-      logger.debug(
-        `Operation registry is configured for '${graphRef}'.`);
+      logger.debug(`Operation registry is configured for '${graphRef}'.`);
 
       // An LRU store with no `maxSize` is effectively an InMemoryStore and
       // exactly what we want for this purpose.
@@ -126,7 +125,7 @@ for observability purposes, but all operations will be permitted.`,
           ...apollo,
           // Convince TypeScript that these fields are not undefined.
           graphRef,
-          keyHash
+          keyHash,
         },
         store,
         logger,
@@ -136,13 +135,13 @@ for observability purposes, but all operations will be permitted.`,
       await agent.start();
 
       return {
-        serverWillStop() {
+        async serverWillStop() {
           agent.stop();
         },
       };
     },
 
-    requestDidStart(): GraphQLRequestListener<any> {
+    async requestDidStart(): Promise<GraphQLRequestListener<any>> {
       return {
         async didResolveOperation(requestContext) {
           const documentFromRequestContext = requestContext.document;
@@ -227,9 +226,8 @@ for observability purposes, but all operations will be permitted.`,
             );
 
             try {
-              const predicateResult = options.forbidUnregisteredOperations(
-                requestContext,
-              );
+              const predicateResult =
+                options.forbidUnregisteredOperations(requestContext);
 
               logger.debug(
                 `${logSignature}: The 'forbidUnregisteredOperations' predicate function returned ${predicateResult}`,

--- a/packages/apollo-server-plugin-response-cache/src/ApolloServerPluginResponseCache.ts
+++ b/packages/apollo-server-plugin-response-cache/src/ApolloServerPluginResponseCache.ts
@@ -135,9 +135,9 @@ export default function plugin(
   options: Options = Object.create(null),
 ): ApolloServerPlugin {
   return {
-    requestDidStart(
+    async requestDidStart(
       outerRequestContext: GraphQLRequestContext<any>,
-    ): GraphQLRequestListener<any> {
+    ): Promise<GraphQLRequestListener<any>> {
       const cache = new PrefixingKeyValueCache(
         options.cache || outerRequestContext.cache!,
         'fqc:',

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -160,7 +160,7 @@ export type ValidationRule = (context: ValidationContext) => ASTVisitor;
 
 export type GraphQLExecutor<TContext = Record<string, any>> = (
   requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
-) => ValueOrPromise<GraphQLExecutionResult>;
+) => Promise<GraphQLExecutionResult>;
 
 export type GraphQLExecutionResult = {
   data?: Record<string, any> | null;


### PR DESCRIPTION
Before this PR, some plugin methods were sync, some were async, and some
returned ValueOrPromise (ie, could be sync or async). This led to a lack
of functionality for the never-async methods, confusing inconsistency,
and generally vagueness as to what types things are.

It's 2021: making a function async is as simple as adding the word
`async` and maybe wrapping a return type in `Promise<>`. This PR
simplifies matters by making almost every plugin and gateway method
always async.

The one exception is `willResolveField`, which is called far more than
any other plugin method. We already know that schema instrumentation has
unfortunate performance overhead so adding to it by adding more Promises
to every field doesn't seem like a good idea for now. We reserve the
write to change `willResolveField` to a `PromiseOrValue` sometimes-async
method later.

(Note that in practice, we usually either `await` or call `Promise.all`
on the return values from plugins rather than directly calling `.then`,
so if you're not using TypeScript you can probably get away with writing
sync methods; and if you are using TypeScript the compiler will quickly
show you where you're missing your `async`s.)

Specifically, this PR:
- Makes the following formerly-`ValueOrPromise` methods into async
  methods: `serverWillStart`, `serverWillStop`, `didResolveSource`,
  `didResolveOperation`, `didEncounterErrors`, `responseForOperation`,
  `willSendResponse`
- Makes the following formerly-sync methods into async methods:
  `requestDidStart`, `renderLandingPage`, `parsingDidStart` and its stop
  hook, `validationDidStart` and its stop hook, `executionDidStart`,
  `executionDidEnd`
- `executionWillStart` can no longer longer return an end hook as a
  function; `executionWillEnd` must be returned in an object (which was
  one of two options before)
- Changes the methods on `Dispatcher` so that there's only one "sync"
  method (for `willResolveField`) and the other methods aren't explicitly
  named with `Async`
- Simplifies the `GraphQLService` interface (used for `@apollo/gateway`)
  to require the `stop` method to exist, to require `executor` to be
  async, and to note that we always pass `apollo` to `load`. (All recent
  versions of `@apollo/gateway` satisfy this.) Also require the
  `GraphQLExecutor` function type to be async.

Note that we allow `options` and `context` functions to still have
`ValueOrPromise` semantics.
