### PR TITLE
Rename GraphQLService to GatewayInterface

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -29,7 +29,7 @@ import {
   Context,
   ContextFunction,
   PluginDefinition,
-  GraphQLService,
+  GatewayInterface,
 } from './types';
 
 import { generateSchemaHash } from './utils/schemaHash';
@@ -85,7 +85,7 @@ type SchemaDerivedData = {
 
 type ServerState =
   | { phase: 'initialized with schema'; schemaDerivedData: SchemaDerivedData }
-  | { phase: 'initialized with gateway'; gateway: GraphQLService }
+  | { phase: 'initialized with gateway'; gateway: GatewayInterface }
   | { phase: 'starting'; barrier: Resolvable<void> }
   | {
       phase: 'invoking serverWillStart';
@@ -550,7 +550,7 @@ export class ApolloServerBase {
   }
 
   private async startGatewayAndLoadSchema(
-    gateway: GraphQLService,
+    gateway: GatewayInterface,
   ): Promise<GraphQLSchema> {
     // Store the unsubscribe handles, which are returned from
     // `onSchemaChange`, for later disposal when the server stops

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -1,8 +1,6 @@
 import type { GraphQLSchema, DocumentNode, ParseOptions } from 'graphql';
 import type { IMocks } from '@graphql-tools/mock';
-import type {
-  IResolvers,
-} from '@graphql-tools/utils';
+import type { IResolvers } from '@graphql-tools/utils';
 import type {
   ApolloConfig,
   ValueOrPromise,
@@ -54,10 +52,8 @@ export type GraphQLServiceConfig = {
   executor: GraphQLExecutor;
 };
 
-export interface GraphQLService {
-  load(options: {
-    apollo: ApolloConfig;
-  }): Promise<GraphQLServiceConfig>;
+export interface GatewayInterface {
+  load(options: { apollo: ApolloConfig }): Promise<GraphQLServiceConfig>;
   onSchemaChange(callback: SchemaChangeCallback): Unsubscriber;
   // Note: The `TContext` typing here is not conclusively behaving as we expect:
   // https://github.com/apollographql/apollo-server/pull/3811#discussion_r387381605
@@ -66,6 +62,10 @@ export interface GraphQLService {
   ): Promise<GraphQLExecutionResult>;
   stop(): Promise<void>;
 }
+
+// This was the name used for GatewayInterface in AS2; continue to export it so
+// that older versions of `@apollo/gateway` build against AS3.
+export interface GraphQLService extends GatewayInterface {}
 
 // This configuration is shared between all integrations and should include
 // fields that are not specific to a single integration
@@ -81,7 +81,7 @@ export interface Config extends BaseConfig {
   mockEntireSchema?: boolean;
   plugins?: PluginDefinition[];
   persistedQueries?: PersistedQueryOptions | false;
-  gateway?: GraphQLService;
+  gateway?: GatewayInterface;
   experimental_approximateDocumentStoreMiB?: number;
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -37,7 +37,7 @@ import {
   Config,
   ApolloServerBase,
   PluginDefinition,
-  GraphQLService,
+  GatewayInterface,
   GraphQLExecutor,
   GraphQLServiceConfig,
   ApolloServerPluginInlineTrace,
@@ -145,7 +145,7 @@ const makeGatewayMock = ({
     triggerSchemaChange: null as ((newSchema: GraphQLSchema) => void) | null,
   };
 
-  const mockedGateway: GraphQLService = {
+  const mockedGateway: GatewayInterface = {
     executor,
     load: async (options) => {
       optionsSpy(options);


### PR DESCRIPTION
`GraphQLService` was a confusing name. It's not related to
`GraphQLServiceContext` (which is the type of the argument to
`serverWillStart`) nor is it related to "service", the old name for a
graph in Studio... or "implementing service", the old name for a
subgraph... It's the type of the `gateway` option, so giving it a
gateway name seems reasonable.

But we keep exporting the old name so that we can have builds of
`@apollo/gateway` that work with both AS2 and AS3.

Fixes #4919.
