### PR TITLE
Make CORS handling more consistent

### DIFF
--- a/packages/apollo-server-azure-functions/src/ApolloServer.ts
+++ b/packages/apollo-server-azure-functions/src/ApolloServer.ts
@@ -32,22 +32,22 @@ export class ApolloServer extends ApolloServerBase {
   }
 
   public createHandler({ cors }: CreateHandlerOptions = { cors: undefined }) {
-    const corsHeaders: HttpResponse['headers'] = {};
+    const staticCorsHeaders: HttpResponse['headers'] = {};
 
     if (cors) {
       if (cors.methods) {
         if (typeof cors.methods === 'string') {
-          corsHeaders['Access-Control-Allow-Methods'] = cors.methods;
+          staticCorsHeaders['Access-Control-Allow-Methods'] = cors.methods;
         } else if (Array.isArray(cors.methods)) {
-          corsHeaders['Access-Control-Allow-Methods'] = cors.methods.join(',');
+          staticCorsHeaders['Access-Control-Allow-Methods'] = cors.methods.join(',');
         }
       }
 
       if (cors.allowedHeaders) {
         if (typeof cors.allowedHeaders === 'string') {
-          corsHeaders['Access-Control-Allow-Headers'] = cors.allowedHeaders;
+          staticCorsHeaders['Access-Control-Allow-Headers'] = cors.allowedHeaders;
         } else if (Array.isArray(cors.allowedHeaders)) {
-          corsHeaders[
+          staticCorsHeaders[
             'Access-Control-Allow-Headers'
           ] = cors.allowedHeaders.join(',');
         }
@@ -55,19 +55,19 @@ export class ApolloServer extends ApolloServerBase {
 
       if (cors.exposedHeaders) {
         if (typeof cors.exposedHeaders === 'string') {
-          corsHeaders['Access-Control-Expose-Headers'] = cors.exposedHeaders;
+          staticCorsHeaders['Access-Control-Expose-Headers'] = cors.exposedHeaders;
         } else if (Array.isArray(cors.exposedHeaders)) {
-          corsHeaders[
+          staticCorsHeaders[
             'Access-Control-Expose-Headers'
           ] = cors.exposedHeaders.join(',');
         }
       }
 
       if (cors.credentials) {
-        corsHeaders['Access-Control-Allow-Credentials'] = 'true';
+        staticCorsHeaders['Access-Control-Allow-Credentials'] = 'true';
       }
       if (cors.maxAge) {
-        corsHeaders['Access-Control-Max-Age'] = cors.maxAge;
+        staticCorsHeaders['Access-Control-Max-Age'] = cors.maxAge;
       }
     }
 
@@ -81,8 +81,11 @@ export class ApolloServer extends ApolloServerBase {
             landingPage = this.getLandingPage();
           }
 
+          const corsHeaders: HttpResponse['headers'] = {...staticCorsHeaders};
           const originHeader = req.headers['Origin'] || req.headers['origin'];
-          if (cors && cors.origin) {
+          if (cors === undefined) {
+            corsHeaders['Access-Control-Allow-Origin'] = '*';
+          } else if (cors && cors.origin) {
             if (typeof cors.origin === 'string') {
               corsHeaders['Access-Control-Allow-Origin'] = cors.origin;
             } else if (

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -94,8 +94,11 @@ export class ApolloServer extends ApolloServerBase {
 
     this.graphqlPath = path;
 
-    if (cors === true) {
-      middlewares.push(middlewareFromPath(path, corsMiddleware()));
+    if (cors === true || cors === undefined) {
+      // Unlike the express `cors` package, `fastify-cors`, or Hapi, Koa's cors
+      // handling defaults to reflecting the incoming origin instead of '*'.
+      // Let's make it match.
+      middlewares.push(middlewareFromPath(path, corsMiddleware({origin: '*'})));
     } else if (cors !== false) {
       middlewares.push(middlewareFromPath(path, corsMiddleware(cors)));
     }


### PR DESCRIPTION
In Apollo Server 2, some integrations apply `ACAO: *` by default, some
reflect the origin by default, and some do no CORS by default.

In AS3, we've already converted `apollo-server-lambda` and
`apollo-server-cloud-functions` into wrappers around
`apollo-server-express`, which means they now have the same default cors
behavior as ASE (`ACAO: *`). This PR changes two more integrations whose
defaults previously were not `ACAO: *`. Previously,
`apollo-server-azure-functions` defaulted to no CORS headers and
`apollo-server-koa` defaulted to reflecting the origin; now they both
default to `access-control-allow-origin: *`.

Now all of the ApolloServer flavors have the same CORS defaults, except
for two packages which don't allow any CORS configuration at all (Micro
and Cloudflare, the two least supported integrations).

Fixes #4859.
