### PR TITLE
Make web framework integrations into peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Certain undersupported and underused Apollo Server features have been removed in
   - If you've written your _own_ handler that calls the handler returned by `createHandler` with a callback, you'll need to handle its `Promise` return value instead.
 - `apollo-server-lambda`: Improved support for running behind an Application Load Balancer (ALB).
 - `apollo-server-fastify` is now compatible with Fastify v3 instead of Fastify v2.
+- The non-serverless integrations now depend on their corresponding web frameworks via peer dependencies rather than direct dependencies.
 - All integrations that allow CORS headers to be customized now default to `access-control-allow-origin: *`. This was already the case for `apollo-server`, Express, Fastify, and Hapi; it is now also the same for Koa (which previously reflected the request's origin), Lambda, Cloud Functions, and Azure Functions as well (which did not set CORS by default). Micro and CloudFlare do not have a built-in way of setting CORS headers.
 
 ## vNEXT

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "connect": "3.7.0",
         "deep-freeze": "0.0.1",
         "express": "4.17.1",
-        "fastify": "3.15.1",
+        "fastify": "3.17.0",
         "form-data": "4.0.0",
         "graphql": "15.3.0",
         "graphql-tag": "2.12.4",
@@ -1027,9 +1027,16 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
+      "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
+      "dependencies": {
+        "ajv": "^6.12.6"
+      }
+    },
     "node_modules/@fastify/forwarded": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -1037,7 +1044,6 @@
     },
     "node_modules/@fastify/proxy-addr": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/forwarded": "^1.0.0",
@@ -1046,7 +1052,6 @@
     },
     "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -6146,7 +6151,6 @@
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -6299,7 +6303,6 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -6578,7 +6581,6 @@
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/are-we-there-yet": {
@@ -6781,7 +6783,6 @@
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -6801,7 +6802,6 @@
     },
     "node_modules/avvio": {
       "version": "7.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archy": "^1.0.0",
@@ -6812,7 +6812,6 @@
     },
     "node_modules/avvio/node_modules/debug": {
       "version": "4.3.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -6828,7 +6827,6 @@
     },
     "node_modules/avvio/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/aws-sign2": {
@@ -7366,6 +7364,7 @@
     "node_modules/bytes": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8758,7 +8757,6 @@
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9581,12 +9579,10 @@
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9663,9 +9659,9 @@
       "license": "MIT"
     },
     "node_modules/fast-json-stringify": {
-      "version": "2.7.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.6.tgz",
+      "integrity": "sha512-ezem8qpAgpad6tXeUhK0aSCS8Fi2vjxTorI9i5M+xrq6UUbTl7/bBTxL1SjRI2zy+qpPkdD4+UblUCQdxRpvIg==",
       "dependencies": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
@@ -9683,7 +9679,6 @@
     },
     "node_modules/fast-redact": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9691,17 +9686,16 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastify": {
-      "version": "3.15.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.17.0.tgz",
+      "integrity": "sha512-Jjmqsxtnu7827KPNZWNdz2NUuFCQMojnGgflQ4D8RRatC4DAYA+fx3EDxKsbHim3tFFPLT8qig43K2yMNlUzMA==",
       "dependencies": {
+        "@fastify/ajv-compiler": "^1.0.0",
         "@fastify/proxy-addr": "^3.0.0",
         "abstract-logging": "^2.0.0",
-        "ajv": "^6.12.2",
         "avvio": "^7.1.2",
         "fast-json-stringify": "^2.5.2",
         "fastify-error": "^0.3.0",
@@ -9733,7 +9727,6 @@
     },
     "node_modules/fastify-error": {
       "version": "0.3.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastify-plugin": {
@@ -9758,12 +9751,10 @@
     },
     "node_modules/fastify-warning": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastify/node_modules/semver": {
       "version": "7.3.5",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -9777,7 +9768,6 @@
     },
     "node_modules/fastq": {
       "version": "1.11.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -9882,7 +9872,6 @@
     },
     "node_modules/find-my-way": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1",
@@ -9908,7 +9897,6 @@
     },
     "node_modules/flatstr": {
       "version": "1.0.12",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/flatted": {
@@ -14074,7 +14062,6 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
@@ -14570,7 +14557,6 @@
     },
     "node_modules/light-my-request": {
       "version": "4.4.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^6.12.2",
@@ -15497,6 +15483,7 @@
     "node_modules/micro": {
       "version": "9.3.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "arg": "4.1.0",
         "content-type": "1.0.4",
@@ -15513,6 +15500,7 @@
     "node_modules/micro/node_modules/depd": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15520,6 +15508,7 @@
     "node_modules/micro/node_modules/http-errors": {
       "version": "1.6.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
@@ -15533,6 +15522,7 @@
     "node_modules/micro/node_modules/iconv-lite": {
       "version": "0.4.19",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15540,6 +15530,7 @@
     "node_modules/micro/node_modules/raw-body": {
       "version": "2.3.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -15552,7 +15543,8 @@
     },
     "node_modules/micro/node_modules/setprototypeof": {
       "version": "1.0.3",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "3.1.10",
@@ -17095,7 +17087,6 @@
     },
     "node_modules/pino": {
       "version": "6.11.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-redact": "^3.0.0",
@@ -17111,7 +17102,6 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pirates": {
@@ -17319,7 +17309,6 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17379,7 +17368,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17398,7 +17386,6 @@
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/quick-lru": {
@@ -17672,7 +17659,6 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -18215,7 +18201,6 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -18224,7 +18209,6 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/right-align": {
@@ -18320,7 +18304,6 @@
     },
     "node_modules/safe-regex2": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ret": "~0.2.0"
@@ -18328,7 +18311,6 @@
     },
     "node_modules/safe-regex2/node_modules/ret": {
       "version": "0.2.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18399,7 +18381,6 @@
     },
     "node_modules/secure-json-parse": {
       "version": "2.4.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
@@ -18412,7 +18393,6 @@
     },
     "node_modules/semver-store": {
       "version": "0.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send": {
@@ -18488,7 +18468,6 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.4.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/set-value": {
@@ -18860,7 +18839,6 @@
     },
     "node_modules/sonic-boom": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -19176,7 +19154,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -19221,7 +19198,6 @@
     },
     "node_modules/string-similarity": {
       "version": "4.0.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/string-width": {
@@ -19711,7 +19687,6 @@
     },
     "node_modules/tiny-lru": {
       "version": "7.0.6",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6"
@@ -20291,7 +20266,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.2.2",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -20329,7 +20303,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-promisify": {
@@ -21525,7 +21498,6 @@
         "apollo-server-types": "file:../apollo-server-types",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
-        "express": "^4.17.1",
         "parseurl": "^1.3.3"
       },
       "devDependencies": {
@@ -21535,6 +21507,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
+        "express": "^4.17.1",
         "graphql": "^15.3.0"
       }
     },
@@ -21558,6 +21531,7 @@
       "dependencies": {
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-types": "file:../apollo-server-types",
+        "fast-json-stringify": "^2.7.6",
         "fastify-accepts": "^2.0.1",
         "fastify-cors": "^6.0.0"
       },
@@ -21568,6 +21542,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
+        "fastify": "^3.17.0",
         "graphql": "^15.3.0"
       }
     },
@@ -21623,7 +21598,6 @@
         "accepts": "^1.3.7",
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-types": "file:../apollo-server-types",
-        "koa": "2.13.1",
         "koa-bodyparser": "^4.3.0",
         "koa-compose": "^4.1.0"
       },
@@ -21634,7 +21608,8 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0",
+        "koa": "2.13.1"
       }
     },
     "packages/apollo-server-koa/node_modules/@koa/cors": {
@@ -21727,11 +21702,13 @@
         "@hapi/accept": "^5.0.2",
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-types": "file:../apollo-server-types",
-        "micro": "^9.3.4",
         "type-is": "^1.6.18"
       },
       "devDependencies": {
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
+      },
+      "peerDependencies": {
+        "micro": "^9.3.4"
       }
     },
     "packages/apollo-server-plugin-base": {
@@ -22773,21 +22750,26 @@
         }
       }
     },
+    "@fastify/ajv-compiler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-1.1.0.tgz",
+      "integrity": "sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==",
+      "requires": {
+        "ajv": "^6.12.6"
+      }
+    },
     "@fastify/forwarded": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "@fastify/proxy-addr": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "@fastify/forwarded": "^1.0.0",
         "ipaddr.js": "^2.0.0"
       },
       "dependencies": {
         "ipaddr.js": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
@@ -26593,8 +26575,7 @@
       }
     },
     "abstract-logging": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "accepts": {
       "version": "1.3.7",
@@ -26690,7 +26671,6 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27129,7 +27109,6 @@
         "apollo-server-types": "file:../apollo-server-types",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
-        "express": "^4.17.1",
         "parseurl": "^1.3.3"
       },
       "dependencies": {
@@ -27153,6 +27132,7 @@
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
         "apollo-server-types": "file:../apollo-server-types",
+        "fast-json-stringify": "^2.7.6",
         "fastify-accepts": "^2.0.1",
         "fastify-cors": "^6.0.0"
       },
@@ -27196,7 +27176,6 @@
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
         "apollo-server-types": "file:../apollo-server-types",
-        "koa": "2.13.1",
         "koa-bodyparser": "^4.3.0",
         "koa-compose": "^4.1.0"
       },
@@ -27259,7 +27238,6 @@
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
         "apollo-server-types": "file:../apollo-server-types",
-        "micro": "^9.3.4",
         "type-is": "^1.6.18"
       }
     },
@@ -27486,8 +27464,7 @@
       "dev": true
     },
     "archy": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -27619,8 +27596,7 @@
       "dev": true
     },
     "atomic-sleep": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "auto-bind": {
       "version": "4.0.0",
@@ -27630,7 +27606,6 @@
     },
     "avvio": {
       "version": "7.2.1",
-      "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "debug": "^4.0.0",
@@ -27640,14 +27615,12 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "dev": true
+          "version": "2.1.2"
         }
       }
     },
@@ -28019,7 +27992,8 @@
       "dev": true
     },
     "bytes": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "peer": true
     },
     "cacache": {
       "version": "15.0.6",
@@ -29030,8 +29004,7 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "dev": true
+      "version": "4.2.2"
     },
     "defaults": {
       "version": "1.0.3",
@@ -29592,12 +29565,10 @@
       "dev": true
     },
     "fast-decode-uri-component": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
     },
     "fast-glob": {
       "version": "3.2.5",
@@ -29650,8 +29621,9 @@
       "version": "2.1.0"
     },
     "fast-json-stringify": {
-      "version": "2.7.1",
-      "dev": true,
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.6.tgz",
+      "integrity": "sha512-ezem8qpAgpad6tXeUhK0aSCS8Fi2vjxTorI9i5M+xrq6UUbTl7/bBTxL1SjRI2zy+qpPkdD4+UblUCQdxRpvIg==",
       "requires": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
@@ -29664,20 +29636,19 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "fast-safe-stringify": {
-      "version": "2.0.7",
-      "dev": true
+      "version": "2.0.7"
     },
     "fastify": {
-      "version": "3.15.1",
-      "dev": true,
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.17.0.tgz",
+      "integrity": "sha512-Jjmqsxtnu7827KPNZWNdz2NUuFCQMojnGgflQ4D8RRatC4DAYA+fx3EDxKsbHim3tFFPLT8qig43K2yMNlUzMA==",
       "requires": {
+        "@fastify/ajv-compiler": "^1.0.0",
         "@fastify/proxy-addr": "^3.0.0",
         "abstract-logging": "^2.0.0",
-        "ajv": "^6.12.2",
         "avvio": "^7.1.2",
         "fast-json-stringify": "^2.5.2",
         "fastify-error": "^0.3.0",
@@ -29695,7 +29666,6 @@
       "dependencies": {
         "semver": {
           "version": "7.3.5",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -29710,8 +29680,7 @@
       }
     },
     "fastify-error": {
-      "version": "0.3.1",
-      "dev": true
+      "version": "0.3.1"
     },
     "fastify-plugin": {
       "version": "2.3.4",
@@ -29728,12 +29697,10 @@
       }
     },
     "fastify-warning": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "fastq": {
       "version": "1.11.0",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -29814,7 +29781,6 @@
     },
     "find-my-way": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "fast-decode-uri-component": "^1.0.1",
         "fast-deep-equal": "^3.1.3",
@@ -29831,8 +29797,7 @@
       }
     },
     "flatstr": {
-      "version": "1.0.12",
-      "dev": true
+      "version": "1.0.12"
     },
     "flatted": {
       "version": "2.0.2",
@@ -32570,8 +32535,7 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -32942,7 +32906,6 @@
     },
     "light-my-request": {
       "version": "4.4.1",
-      "dev": true,
       "requires": {
         "ajv": "^6.12.2",
         "cookie": "^0.4.0",
@@ -33629,6 +33592,7 @@
     },
     "micro": {
       "version": "9.3.4",
+      "peer": true,
       "requires": {
         "arg": "4.1.0",
         "content-type": "1.0.4",
@@ -33637,10 +33601,12 @@
       },
       "dependencies": {
         "depd": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "peer": true
         },
         "http-errors": {
           "version": "1.6.2",
+          "peer": true,
           "requires": {
             "depd": "1.1.1",
             "inherits": "2.0.3",
@@ -33649,10 +33615,12 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.19"
+          "version": "0.4.19",
+          "peer": true
         },
         "raw-body": {
           "version": "2.3.2",
+          "peer": true,
           "requires": {
             "bytes": "3.0.0",
             "http-errors": "1.6.2",
@@ -33661,7 +33629,8 @@
           }
         },
         "setprototypeof": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "peer": true
         }
       }
     },
@@ -34713,7 +34682,6 @@
     },
     "pino": {
       "version": "6.11.3",
-      "dev": true,
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.7",
@@ -34724,8 +34692,7 @@
       }
     },
     "pino-std-serializers": {
-      "version": "3.2.0",
-      "dev": true
+      "version": "3.2.0"
     },
     "pirates": {
       "version": "4.0.1",
@@ -34866,8 +34833,7 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "q": {
       "version": "1.5.1",
@@ -34900,12 +34866,10 @@
       }
     },
     "queue-microtask": {
-      "version": "1.2.3",
-      "dev": true
+      "version": "1.2.3"
     },
     "quick-format-unescaped": {
-      "version": "4.0.3",
-      "dev": true
+      "version": "4.0.3"
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -35097,7 +35061,6 @@
     },
     "readable-stream": {
       "version": "3.6.0",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -35489,12 +35452,10 @@
       "version": "0.12.0"
     },
     "reusify": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "rfdc": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "right-align": {
       "version": "0.1.3",
@@ -35548,14 +35509,12 @@
     },
     "safe-regex2": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "ret": "~0.2.0"
       },
       "dependencies": {
         "ret": {
-          "version": "0.2.2",
-          "dev": true
+          "version": "0.2.2"
         }
       }
     },
@@ -35608,16 +35567,14 @@
       "dev": true
     },
     "secure-json-parse": {
-      "version": "2.4.0",
-      "dev": true
+      "version": "2.4.0"
     },
     "semver": {
       "version": "5.7.1",
       "dev": true
     },
     "semver-store": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "send": {
       "version": "0.17.1",
@@ -35678,8 +35635,7 @@
       "dev": true
     },
     "set-cookie-parser": {
-      "version": "2.4.8",
-      "dev": true
+      "version": "2.4.8"
     },
     "set-value": {
       "version": "2.0.1",
@@ -35944,7 +35900,6 @@
     },
     "sonic-boom": {
       "version": "1.4.1",
-      "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"
@@ -36168,7 +36123,6 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -36201,8 +36155,7 @@
       }
     },
     "string-similarity": {
-      "version": "4.0.4",
-      "dev": true
+      "version": "4.0.4"
     },
     "string-width": {
       "version": "4.2.2",
@@ -36538,8 +36491,7 @@
       }
     },
     "tiny-lru": {
-      "version": "7.0.6",
-      "dev": true
+      "version": "7.0.6"
     },
     "title-case": {
       "version": "3.0.3",
@@ -36929,7 +36881,6 @@
     },
     "uri-js": {
       "version": "4.2.2",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -36956,8 +36907,7 @@
       "dev": true
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "util-promisify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "connect": "3.7.0",
     "deep-freeze": "0.0.1",
     "express": "4.17.1",
-    "fastify": "3.15.1",
+    "fastify": "3.17.0",
     "form-data": "4.0.0",
     "graphql": "15.3.0",
     "graphql-tag": "2.12.4",

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -36,13 +36,13 @@
     "apollo-server-types": "file:../apollo-server-types",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
-    "express": "^4.17.1",
     "parseurl": "^1.3.3"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0",
+    "express": "^4.17.1"
   }
 }

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -29,12 +29,14 @@
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
     "fastify-accepts": "^2.0.1",
-    "fastify-cors": "^6.0.0"
+    "fastify-cors": "^6.0.0",
+    "fast-json-stringify": "^2.7.6"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0",
+    "fastify": "^3.17.0"
   }
 }

--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -4,10 +4,10 @@ import {
   GraphQLOptions,
   runHttpQuery,
 } from 'apollo-server-core';
-import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import accepts from 'fastify-accepts';
-
-const fastJson = require('fast-json-stringify');
+import fastifyCors from 'fastify-cors';
+import fastJson from 'fast-json-stringify';
 
 export interface ServerRegistration {
   path?: string;
@@ -68,9 +68,9 @@ export class ApolloServer extends ApolloServerBase {
         async (instance) => {
           instance.register(accepts);
           if (cors === true) {
-            instance.register(require('fastify-cors'));
+            instance.register(fastifyCors);
           } else if (cors !== false) {
-            instance.register(require('fastify-cors'), cors);
+            instance.register(fastifyCors, cors);
           }
 
           instance.setNotFoundHandler((_request, reply) => {

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -35,7 +35,6 @@
     "accepts": "^1.3.7",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
-    "koa": "2.13.1",
     "koa-bodyparser": "^4.3.0",
     "koa-compose": "^4.1.0"
   },
@@ -43,6 +42,7 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0",
+    "koa": "2.13.1"
   }
 }

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -1,4 +1,5 @@
-import Koa, { ParameterizedContext, Middleware } from 'koa';
+import type Koa from 'koa';
+import type { ParameterizedContext, Middleware } from 'koa';
 import corsMiddleware from '@koa/cors';
 import bodyParser from 'koa-bodyparser';
 import compose from 'koa-compose';

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -27,10 +27,12 @@
     "@hapi/accept": "^5.0.2",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
-    "type-is": "^1.6.18",
-    "micro": "^9.3.4"
+    "type-is": "^1.6.18"
   },
   "devDependencies": {
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
+  },
+  "peerDependencies": {
+    "micro": "^9.3.4"
   }
 }


### PR DESCRIPTION
Notably, have any sort of dependency at all on fastify (and
fast-json-stringify!) from `apollo-server-fastify`.

For now I've chosen the latest version for the peer dependencies because
carefully researching "did every API we are using exist in
fastify@3.0.0" seems like unnecessary work, but we can relax these later
upon request.

I think in practice this shouldn't affect how these packages are used
because you should generally already be using your web framework in your
app.

Fixes #5210. See also #5139.
