### PR TITLE
Update APQ docs and tests to Apollo Client 3

### DIFF
--- a/docs/source/performance/apq.md
+++ b/docs/source/performance/apq.md
@@ -44,8 +44,10 @@ Add the persisted query link anywhere in the chain before the terminating link. 
 ```js
 import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
 import { createPersistedQueryLink } from "@apollo/client/link/persisted-queries";
+import { sha256 } from 'crypto-hash';
 
-const linkChain = createPersistedQueryLink().concat(new HttpLink({ uri: "http://localhost:4000/graphql" }));
+const linkChain = createPersistedQueryLink({ sha256 }).concat(
+  new HttpLink({ uri: "http://localhost:4000/graphql" }));
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
@@ -139,29 +141,23 @@ After this step, Apollo Server will serve the HTTP `Cache-Control` header on ful
 
 Often, GraphQL requests are big POST requests and most CDNs will only cache GET requests. Additionally, GET requests generally work best when the URL has a bounded size. Enabling automatic persisted queries means that short hashes are sent over the wire instead of full queries, and Apollo Client can be configured to use GET requests for those hashed queries.
 
-To do this, update the **client** code. First, add the package:
-
-```
-npm install apollo-link-persisted-queries
-```
-
-Then, add the persisted queries link to the Apollo Client constructor before the HTTP link:
+To do this, update the **client** code. Add the persisted queries link to the Apollo Client constructor before the HTTP link:
 
 ```js
-import { createPersistedQueryLink } from "apollo-link-persisted-queries";
-import { createHttpLink } from "apollo-link-http";
-import { InMemoryCache } from "apollo-cache-inmemory";
-import { ApolloLink } from "apollo-link";
-import ApolloClient from "apollo-client";
+import { ApolloClient, InMemoryCache, HttpLink } from "@apollo/client";
+import { createPersistedQueryLink } from "@apollo/client/link/persisted-queries";
+import { sha256 } from 'crypto-hash';
 
-const link = ApolloLink.from([
-  createPersistedQueryLink({ useGETForHashedQueries: true }),
-  createHttpLink({ uri: "/graphql" })
-]);
+const link = createPersistedQueryLink({
+  sha256,
+  useGETForHashedQueries: true
+}).concat(
+  new HttpLink({ uri: "/graphql" })
+);
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: link
+  link,
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "apollo-server-types": "file:packages/apollo-server-types"
       },
       "devDependencies": {
+        "@apollo/client": "3.3.20",
         "@graphql-codegen/cli": "1.21.4",
         "@graphql-codegen/typescript-operations": "1.18.0",
         "@graphql-tools/mock": "8.1.2",
@@ -73,9 +74,6 @@
         "@types/type-is": "1.6.3",
         "@types/uuid": "8.3.0",
         "@vendia/serverless-express": "4.3.9",
-        "apollo-link": "1.2.14",
-        "apollo-link-http": "1.5.17",
-        "apollo-link-persisted-queries": "0.2.2",
         "azure-functions-ts-essentials": "1.3.2",
         "body-parser": "1.19.0",
         "bunyan": "1.8.15",
@@ -114,6 +112,85 @@
         "node": ">=12",
         "npm": "7.x"
       }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+      "integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.7.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/@wry/equality": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+      "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@apollo/client/node_modules/@wry/equality/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
+    },
+    "node_modules/@apollo/client/node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/@apollo/client/node_modules/ts-invariant": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+      "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@apollo/client/node_modules/ts-invariant/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
     },
     "node_modules/@apollo/protobufjs": {
       "version": "1.2.2",
@@ -1992,6 +2069,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
     },
     "node_modules/@hapi/accept": {
       "version": "5.0.2",
@@ -6113,6 +6199,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+      "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==",
+      "dev": true
+    },
     "node_modules/@vendia/serverless-express": {
       "version": "4.3.9",
       "resolved": "https://registry.npmjs.org/@vendia/serverless-express/-/serverless-express-4.3.9.tgz",
@@ -6122,13 +6214,41 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wry/equality": {
-      "version": "0.1.9",
+    "node_modules/@wry/context": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "dev": true
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -6420,58 +6540,6 @@
         "graphql": "^14.2.1 || ^15.0.0"
       }
     },
-    "node_modules/apollo-link": {
-      "version": "1.2.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-http": {
-      "version": "1.5.17",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-http-common": {
-      "version": "0.2.16",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/apollo-link-persisted-queries": {
-      "version": "0.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "apollo-link": "^1.2.1",
-        "hash.js": "^1.1.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
-      }
-    },
     "node_modules/apollo-reporting-protobuf": {
       "resolved": "packages/apollo-reporting-protobuf",
       "link": true
@@ -6559,20 +6627,6 @@
     "node_modules/apollo-server-types": {
       "resolved": "packages/apollo-server-types",
       "link": true
-    },
-    "node_modules/apollo-utilities": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
-      }
     },
     "node_modules/aproba": {
       "version": "2.0.0",
@@ -10780,15 +10834,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hashring": {
       "version": "3.2.0",
       "license": "MIT",
@@ -10811,6 +10856,21 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+      "dev": true
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
     "node_modules/hosted-git-info": {
@@ -15603,11 +15663,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "license": "ISC",
@@ -16550,6 +16605,16 @@
     "node_modules/only": {
       "version": "0.0.2"
     },
+    "node_modules/optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "dev": true,
+      "dependencies": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "dev": true,
@@ -17247,6 +17312,23 @@
       "dependencies": {
         "read": "1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/propagate": {
       "version": "2.0.1",
@@ -19810,14 +19892,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      }
-    },
     "node_modules/ts-is-defined": {
       "version": "1.0.0",
       "license": "MIT",
@@ -20939,15 +21013,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/zen-observable-ts": {
-      "version": "0.8.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
-    },
     "packages/apollo-datasource": {
       "version": "0.300.0-preview.0",
       "license": "MIT",
@@ -21546,6 +21611,69 @@
     }
   },
   "dependencies": {
+    "@apollo/client": {
+      "version": "3.3.20",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz",
+      "integrity": "sha512-hS7UmBwJweudw/J3M0RAcusMHNiRuGqkRH6g91PM2ev8cXScIMdXr/++9jo7wD1nAITMCMF4HQQ3LFaw/Or0Bw==",
+      "dev": true,
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.12.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.0",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.7.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "@wry/equality": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.1.tgz",
+          "integrity": "sha512-FZKbdpbcVcbDxQrKcaBClNsQaMg9nof1RKM7mReJe5DKUzM5u8S7T+PqwNqvib5O2j2xxF1R4p5O3+b6baTrbw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+              "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+              "dev": true
+            }
+          }
+        },
+        "symbol-observable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+          "dev": true
+        },
+        "ts-invariant": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.7.3.tgz",
+          "integrity": "sha512-UWDDeovyUTIMWj+45g5nhnl+8oo+GhxL5leTaHn5c8FkQWfh8v66gccLd2/YzVmV5hoQUjCEjhrXnQqVDJdvKA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+              "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "@apollo/protobufjs": {
       "version": "1.2.2",
       "requires": {
@@ -23086,6 +23214,13 @@
           "dev": true
         }
       }
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "dev": true,
+      "requires": {}
     },
     "@hapi/accept": {
       "version": "5.0.2",
@@ -26048,16 +26183,49 @@
       "version": "13.0.0",
       "dev": true
     },
+    "@types/zen-observable": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+      "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==",
+      "dev": true
+    },
     "@vendia/serverless-express": {
       "version": "4.3.9",
       "resolved": "https://registry.npmjs.org/@vendia/serverless-express/-/serverless-express-4.3.9.tgz",
       "integrity": "sha512-lfnnnJ/J9rpa4tDqkPzDMmJr+c489YI81i7P9JWZyf3zAKowaF0t1SeR3g9zUJYmTOn9glmqjiaG+OvNvxY7UQ=="
     },
-    "@wry/equality": {
-      "version": "0.1.9",
+    "@wry/context": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.0.tgz",
+      "integrity": "sha512-sAgendOXR8dM7stJw3FusRxFHF/ZinU0lffsA2YTyyIOfic86JX02qlPqPVqJNZJPAxFt+2EE8bvq6ZlS0Kf+Q==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+          "dev": true
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.0.tgz",
+      "integrity": "sha512-Yw1akIogPhAT6XPYsRHlZZIS0tIGmAl9EYXHi2scf7LPKKqdqmow/Hu4kEqP2cJR3EjaU/9L0ZlAjFf3hFxmug==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+          "dev": true
+        }
       }
     },
     "abab": {
@@ -26255,42 +26423,6 @@
         "core-js-pure": "^3.10.2",
         "lodash.sortby": "^4.7.0",
         "sha.js": "^2.4.11"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.14",
-      "dev": true,
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.21"
-      }
-    },
-    "apollo-link-http": {
-      "version": "1.5.17",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-link-http-common": "^0.2.16",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-http-common": {
-      "version": "0.2.16",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-link-persisted-queries": {
-      "version": "0.2.2",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.1",
-        "hash.js": "^1.1.3"
       }
     },
     "apollo-reporting-protobuf": {
@@ -26651,16 +26783,6 @@
         "apollo-reporting-protobuf": "file:../apollo-reporting-protobuf",
         "apollo-server-caching": "file:../apollo-server-caching",
         "apollo-server-env": "file:../apollo-server-env"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.2",
-      "dev": true,
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
       }
     },
     "aproba": {
@@ -29586,14 +29708,6 @@
         }
       }
     },
-    "hash.js": {
-      "version": "1.1.7",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "hashring": {
       "version": "3.2.0",
       "requires": {
@@ -29615,6 +29729,23 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
           "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "dev": true
         }
       }
@@ -32866,10 +32997,6 @@
       "version": "1.0.1",
       "dev": true
     },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "requires": {
@@ -33520,6 +33647,16 @@
     "only": {
       "version": "0.0.2"
     },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "dev": true,
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "dev": true,
@@ -33987,6 +34124,25 @@
       "dev": true,
       "requires": {
         "read": "1"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
       }
     },
     "propagate": {
@@ -35770,13 +35926,6 @@
       "version": "1.3.0",
       "dev": true
     },
-    "ts-invariant": {
-      "version": "0.4.4",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "ts-is-defined": {
       "version": "1.0.0",
       "requires": {
@@ -36536,14 +36685,6 @@
     "zen-observable": {
       "version": "0.8.15",
       "dev": true
-    },
-    "zen-observable-ts": {
-      "version": "0.8.21",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "apollo-server-types": "file:packages/apollo-server-types"
   },
   "devDependencies": {
+    "@apollo/client": "3.3.20",
     "@graphql-codegen/cli": "1.21.4",
     "@graphql-codegen/typescript-operations": "1.18.0",
     "@graphql-tools/mock": "8.1.2",
@@ -92,9 +93,6 @@
     "@types/type-is": "1.6.3",
     "@types/uuid": "8.3.0",
     "@vendia/serverless-express": "4.3.9",
-    "apollo-link": "1.2.14",
-    "apollo-link-http": "1.5.17",
-    "apollo-link-persisted-queries": "0.2.2",
     "azure-functions-ts-essentials": "1.3.2",
     "body-parser": "1.19.0",
     "bunyan": "1.8.15",

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -17,12 +17,10 @@ import {
   ResponsePath,
 } from 'graphql';
 
-import { execute } from 'apollo-link';
-import { createHttpLink } from 'apollo-link-http';
-import {
-  createPersistedQueryLink as createPersistedQuery,
-  VERSION,
-} from 'apollo-link-persisted-queries';
+// Note that by doing deep imports here we don't need to install React.
+import { execute } from '@apollo/client/link/core';
+import { createHttpLink } from '@apollo/client/link/http';
+import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries';
 
 import {
   createApolloFetch,
@@ -1126,7 +1124,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             const result = await apolloFetch({
               extensions: {
                 persistedQuery: {
-                  version: VERSION,
+                  version: 1,
                   sha256Hash: hash,
                 },
               },
@@ -1696,7 +1694,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
       const hash = sha256.create().update(TEST_STRING_QUERY).hex();
       const extensions = {
         persistedQuery: {
-          version: VERSION,
+          version: 1,
           sha256Hash: hash,
         },
       };
@@ -1773,7 +1771,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
           await apolloFetch({
             extensions: {
               persistedQuery: {
-                version: VERSION,
+                version: 1,
                 sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               },
             },
@@ -1788,7 +1786,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
       it('returns correct result for persisted query link', (done) => {
         const variables = { id: 1 };
-        const link = createPersistedQuery().concat(
+        const link = createPersistedQueryLink({sha256}).concat(
           createHttpLink({ uri, fetch } as any),
         );
 
@@ -1800,7 +1798,8 @@ export function testApolloServer<AS extends ApolloServerBase>(
 
       it('returns correct result for persisted query link using get request', (done) => {
         const variables = { id: 1 };
-        const link = createPersistedQuery({
+        const link = createPersistedQueryLink({
+          sha256,
           useGETForHashedQueries: true,
         }).concat(createHttpLink({ uri, fetch } as any));
 

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -1,6 +1,5 @@
 // persisted query tests
 import { sha256 } from 'js-sha256';
-import { VERSION } from 'apollo-link-persisted-queries';
 
 import {
   GraphQLSchema,
@@ -1298,14 +1297,14 @@ export default ({
       const hash = sha256.create().update(query).hex();
       const extensions = {
         persistedQuery: {
-          version: VERSION,
+          version: 1,
           sha256Hash: hash,
         },
       };
 
       const extensions2 = {
         persistedQuery: {
-          version: VERSION,
+          version: 1,
           sha256Hash: sha256.create().update(query2).hex(),
         },
       };
@@ -1446,7 +1445,7 @@ export default ({
             extensions: JSON.stringify({
               persistedQuery: {
                 // Version intentionally wrong.
-                version: VERSION + 1,
+                version: 2,
                 sha256Hash: extensions.persistedQuery.sha256Hash,
               },
             }),
@@ -1653,7 +1652,7 @@ export default ({
           .send({
             extensions: {
               persistedQuery: {
-                version: VERSION,
+                version: 1,
                 sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               },
             },


### PR DESCRIPTION
Move from the old separate link packages to `@apollo/client`. Note that
this had been partially done in the docs but (a) only in one of two
relevant places and (b) the one place it was changed didn't include the
newly required `sha256` option.

A major motivation for this is that `apollo-link-persisted-queries` has
a peer dependency on `graphql` that doesn't include v15.
