### PR TITLE
fix: extensions argument ignored by ForbiddenError and AuthorizationError

### DIFF
--- a/packages/apollo-server-errors/src/__tests__/ApolloError.test.ts
+++ b/packages/apollo-server-errors/src/__tests__/ApolloError.test.ts
@@ -1,4 +1,4 @@
-import { ApolloError } from '..';
+import { ApolloError, ForbiddenError, AuthenticationError } from '..';
 
 describe('ApolloError', () => {
   it("doesn't overwrite extensions when provided in the constructor", () => {
@@ -48,3 +48,29 @@ describe('ApolloError', () => {
     ).toThrow(/Pass extensions directly/);
   });
 });
+
+describe("ForbiddenError", () => {
+  it("supports abritrary data being passed", () => {
+    const error = new ForbiddenError('My message', {
+      arbitrary: 'user_data',
+    });
+
+    expect(error.extensions).toEqual({
+      code: 'FORBIDDEN',
+      arbitrary: 'user_data',
+    });
+  })
+})
+
+describe("AuthenticationError", () => {
+  it("supports abritrary data being passed", () => {
+    const error = new AuthenticationError('My message', {
+      arbitrary: 'user_data',
+    });
+
+    expect(error.extensions).toEqual({
+      code: 'UNAUTHENTICATED',
+      arbitrary: 'user_data',
+    });
+  })
+})

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -177,16 +177,16 @@ export class ValidationError extends ApolloError {
 }
 
 export class AuthenticationError extends ApolloError {
-  constructor(message: string) {
-    super(message, 'UNAUTHENTICATED');
+  constructor(message: string, extensions?: Record<string, any>) {
+    super(message, 'UNAUTHENTICATED', extensions);
 
     Object.defineProperty(this, 'name', { value: 'AuthenticationError' });
   }
 }
 
 export class ForbiddenError extends ApolloError {
-  constructor(message: string) {
-    super(message, 'FORBIDDEN');
+  constructor(message: string, extensions?: Record<string, any>) {
+    super(message, 'FORBIDDEN', extensions);
 
     Object.defineProperty(this, 'name', { value: 'ForbiddenError' });
   }


### PR DESCRIPTION
As raised [here](https://github.com/apollographql/apollo-server/issues/5307), currently only `UserInputError` supports passing arbitrary data in the extensions argument but the docs imply all ApolloError's support this.

This MR allows passing the extra extensions argument to the underlying constructor.

I did also attempt to apply this to all the Error classes (except persisted ones) but ran into some typescript errors caused by invalid `sendErrorResponse` calls in `apollo-server-core/src/requestPipeline.ts` so I just applied the changes to `ForbiddenError` and `AuthorizationError`.

Perhaps this inconsistency means the docs should also be updated to clarify which error constructors support extensions too but thought I'd get the ball rolling with this fix MR