### PR TITLE
Introduce ApolloServerPluginLandingPageDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,11 @@ Certain undersupported and underused Apollo Server features have been removed in
   - This interface is the type used to provide a federated gateway instance to Apollo Server. Its name has been changed to reduce ambiguity.
   - The previous name is still exported for backward compatibility purposes.
 - Added support for serving a custom landing page at Apollo Server's base URL.
-  - Servers in dev mode still default to serving GraphQL Playground (this might change before release), but plugins can define a new `renderLandingPage` hook that returns an HTML page to serve to browsers.
-  - Removed the `playground` option provided to the `ApolloServer` constructor. You can customize GraphQL Playground or enable it in a production environment by installing the new `ApolloServerPluginLandingPageGraphQLPlayground` plugin.
-  - To disable GraphQL Playground, either install the new `ApolloServerPluginLandingPageDisabled` plugin or install any other plugin that implements `renderLandingPage`.
-  - Apollo Server packages no longer export `defaultPlaygroundOptions`, `PlaygroundConfig`, or `PlaygroundRenderPageOptions`. By default, no GraphQL Playground settings are overridden, including the endpoint, which now defaults to `window.location.href` (with most query parameters removed). This means you typically don't have to manually configure the endpoint.
+  - Plugins can define a new `renderLandingPage` hook that returns an HTML page to serve to browsers.
+  - New plugins (`ApolloServerPluginLandingPageProductionDefault` and `ApolloServerPluginLandingPageLocalDefault`) are installed by default (the former when `NODE_ENV` is `production`, the latter otherwise) with instructions on how to communicate with the server, links to Apollo Studio Sandbox, etc.
+  - A new `ApolloServerPluginLandingPageGraphQLPlayground` plugin can be installed instead to continue to use GraphQL Playground instead. The `playground` option provided to the `ApolloServer` constructor has been removed; to customize GraphQL Playground you can provide an argument to the new playground plugin. By default, no GraphQL Playground settings are overridden, including the endpoint, which now defaults to `window.location.href` (with most query parameters removed). This means you typically don't have to manually configure the endpoint when using GraphQL Playground.
+  - To disable all landing pages, install the new `ApolloServerPluginLandingPageDisabled` plugin.
+  - Apollo Server packages no longer export `defaultPlaygroundOptions`, `PlaygroundConfig`, or `PlaygroundRenderPageOptions`.
 - Bad request errors (invalid JSON, missing body, etc) are more consistent across integrations and consistently return 4xx status codes instead of sometimes returning 5xx status codes.
 - Setting `requestContext.response.http.status` now affects successful GraphQL responses, not just errors.
 

--- a/docs/source/deployment/azure-functions.md
+++ b/docs/source/deployment/azure-functions.md
@@ -223,7 +223,7 @@ az group delete \
 
 It is also possible to publish your project from VS Code using the Azure Functions Extension, we recommend referring to [Microsoft's documentation on publishing to Azure from VS Code](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code#publish-the-project-to-azure).
 
-Once deployment is complete, view the output in VS Code and you should be able to see the url of your GraphQL endpoint. It will look something like **https://our-graphql-project.azurewebsites.net/api/graphql**. Navigate to the url and you should find GraphQL Playground.
+Once deployment is complete, view the output in VS Code and you should be able to see the url of your GraphQL endpoint. It will look something like **https://our-graphql-project.azurewebsites.net/api/graphql**. Navigate to the url and you should find your server's landing page.
 
 Need more details? See the [Docs](https://www.npmjs.com/package/apollo-server-azure-functions)
  at the NPM repository.

--- a/docs/source/deployment/gcp-functions.mdx
+++ b/docs/source/deployment/gcp-functions.mdx
@@ -52,7 +52,7 @@ From your Google Cloud Console, go to the [Cloud Functions page](https://console
 
 Click **Create Function**. Give the function a name and set the **Trigger type** to `HTTP`.
 
-For quick setup and access to the GraphQL endpoint/playground, choose to **Allow unauthenticated invocations**. To require authentication for this endpoint, you can manage authorized users via [Cloud IAM](https://console.cloud.google.com/iam-admin/iam).
+For quick setup and access to the GraphQL endpoint/landing page, choose to **Allow unauthenticated invocations**. To require authentication for this endpoint, you can manage authorized users via [Cloud IAM](https://console.cloud.google.com/iam-admin/iam).
 
 Save your configuration changes in the Trigger section. Copy the trigger's URL for later and click **Next**.
 
@@ -122,11 +122,11 @@ For more information, see the official [Cloud Functions docs](https://cloud.goog
 
 ## Testing the function
 
-After deployment completes, navigate to your function's trigger URL. If deployment succeeded, GraphQL Playground opens.
+After deployment completes, navigate to your function's trigger URL. If deployment succeeded, you should see your server's landing page.
 
 > If you can't access your trigger URL, you might need to [add `allAuthenticatedUsers` or `allUsers` permissions](https://cloud.google.com/iam/docs/overview#all-authenticated-users) to your function.
 
-You can use GraphQL Playground to test the following query:
+Click <q>Query your Server</q> and use Apollo Sandbox to test the following query:
 
 ```graphql
 query TestQuery {

--- a/docs/source/deployment/netlify.md
+++ b/docs/source/deployment/netlify.md
@@ -88,13 +88,9 @@ const server = new ApolloServer({
 exports.handler = server.createHandler();
 ```
 
-Now, make sure you've run `NODE_ENV=development npm run start:lambda`, and navigate to `localhost:9000/graphql` in your browser. You should see GraphQL Playground, where you can run queries against your API!
+Now, make sure you've run `NODE_ENV=development npm run start:lambda`, and navigate to `localhost:9000/graphql` in your browser. You should see your server's landing page!
 
-*Note - The GraphQL Playground will only run if your `NODE_ENV` is set to `development`. If you don't pass this, or your `NODE_ENV` is set to `production`, you will not see the GraphQL Playground.*
-
-![Local GraphQL Server](../images/graphql.png)
-
-If you can see GraphQL Playground and run a simple query, you've done everything properly. Now, let's add Apollo Client to the frontend.
+If your `NODE_ENV` is not set to `production`, you will see a link <q>Query your Server</q> which should take you to Apollo Sandbox where you can query your app. If you can see the landing page and run a simple query from Sandbox, you've done everything properly. Now, let's add Apollo Client to the frontend.
 
 ### Add endpoint to Apollo Client
 

--- a/docs/source/integrations/plugins.md
+++ b/docs/source/integrations/plugins.md
@@ -305,7 +305,7 @@ const server = new ApolloServer({
 ### `renderLandingPage`
 
 The `renderLandingPage` event is fired once by Apollo Server after all `serverWillStart` events run.
-You define your `renderLandingPage` handler in the object returned by your [`serverWillStart`](#serverwillstart) handler, which allows it to read the values passed to `serverWillStart`. **At most one plugin in your server may define a `renderLandingPage` handler.** If your server has a `renderLandingPage` handler, it should return a `LandingPage`, which is just an object with a string `html` field. The value of that field will be served as HTML for any requests with `accept: text/html` headers. (By default, Apollo Server installs `ApolloServerPluginLandingPageGraphQLPlayground` which serves GraphQL Playground as a landingPage page.)
+You define your `renderLandingPage` handler in the object returned by your [`serverWillStart`](#serverwillstart) handler, which allows it to read the values passed to `serverWillStart`. **At most one plugin in your server may define a `renderLandingPage` handler.** If your server has a `renderLandingPage` handler, it should return a `LandingPage`, which is just an object with a string `html` field. The value of that field will be served as HTML for any requests with `accept: text/html` headers. (By default, Apollo Server installs `ApolloServerPluginLandingPageLocalDefault` (if `NODE_ENV` is not `production`) or `ApolloServerPluginLandingPageProductionDefault` (if `NODE_ENV` is `production) which serves a simple landing page. `apollo-server-core` also includes `ApolloServerPluginLandingPageGraphQLPlayground` which serves GraphQL Playground as a landing page.)
 
 #### Example
 

--- a/docs/source/testing/graphql-playground.mdx
+++ b/docs/source/testing/graphql-playground.mdx
@@ -30,6 +30,8 @@ Sandbox automatically attempts to connect to a GraphQL server running at `http:/
 
 [GraphQL Playground](https://github.com/graphql/graphql-playground) is a graphical, interactive, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on [GraphiQL](https://github.com/graphql/graphiql).
 
+(Note: This whole page needs to be updated for AS3 now that Playground is not the default.)
+
 In development, Apollo Server enables GraphQL Playground on the same URL as the GraphQL server itself (e.g. `http://localhost:4000/graphql`) and automatically serves the GUI to web browsers.  When `NODE_ENV` is set to `production`, GraphQL Playground (as well as introspection) is disabled as a production best-practice. It does this by installing the `ApolloServerPluginLandingPageGraphQLPlayground` plugin with default settings.
 
 ![GraphQL Playground](../images/graphql-playground.png)

--- a/packages/apollo-server-azure-functions/src/__tests__/azureFunctionApollo.test.ts
+++ b/packages/apollo-server-azure-functions/src/__tests__/azureFunctionApollo.test.ts
@@ -155,7 +155,7 @@ describe('integration:AzureFunctions', () => {
     handler(context as any, request as any);
   });
 
-  it('can return playground html', (done) => {
+  it('can return landing page', (done) => {
     const server = new ApolloServer({ schema: Schema });
     const handler = server.createHandler({});
     const request = {
@@ -175,7 +175,7 @@ describe('integration:AzureFunctions', () => {
         }
         try {
           expect(result.status).toEqual(200);
-          expect(result.body).toMatch(/GraphQL Playground/gi);
+          expect(result.body).toMatch(/apollo-server-landing-page.cdn.apollographql.com\/_latest/);
           expect(result.headers['Content-Type']).toEqual('text/html');
           done();
         } catch (e) {

--- a/packages/apollo-server-cloud-functions/README.md
+++ b/packages/apollo-server-cloud-functions/README.md
@@ -52,7 +52,7 @@ From your Google Cloud Console, go to the [Cloud Functions page](https://console
 
 Click **Create Function**. Give the function a name and set the **Trigger type** to `HTTP`.
 
-For quick setup and access to the GraphQL endpoint/playground, choose to **Allow unauthenticated invocations**. To require authentication for this endpoint, you can manage authorized users via [Cloud IAM](https://console.cloud.google.com/iam-admin/iam).
+For quick setup and access to the GraphQL endpoint/landing page, choose to **Allow unauthenticated invocations**. To require authentication for this endpoint, you can manage authorized users via [Cloud IAM](https://console.cloud.google.com/iam-admin/iam).
 
 Save your configuration changes in the Trigger section. Copy the trigger's URL for later and click **Next**.
 
@@ -122,11 +122,11 @@ For more information, see the official [Cloud Functions docs](https://cloud.goog
 
 ## Testing the function
 
-After deployment completes, navigate to your function's trigger URL. If deployment succeeded, GraphQL Playground opens.
+After deployment completes, navigate to your function's trigger URL. If deployment succeeded, you should see your server's landing page.
 
 > If you can't access your trigger URL, you might need to [add `allAuthenticatedUsers` or `allUsers` permissions](https://cloud.google.com/iam/docs/overview#all-authenticated-users) to your function.
 
-You can use GraphQL Playground to test the following query:
+Click <q>Query your Server</q> and use Apollo Sandbox to test the following query:
 
 ```graphql
 query TestQuery {

--- a/packages/apollo-server-core/src/plugin/index.ts
+++ b/packages/apollo-server-core/src/plugin/index.ts
@@ -91,6 +91,30 @@ export function ApolloServerPluginLandingPageDisabled(): ApolloServerPlugin {
   return plugin;
 }
 
+import type {
+  ApolloServerPluginLandingPageLocalDefaultOptions,
+  ApolloServerPluginLandingPageProductionDefaultOptions,
+} from './landingPage/default';
+export type {
+  ApolloServerPluginLandingPageDefaultBaseOptions,
+  ApolloServerPluginLandingPageLocalDefaultOptions,
+  ApolloServerPluginLandingPageProductionDefaultOptions,
+} from './landingPage/default';
+export function ApolloServerPluginLandingPageLocalDefault(
+  options?: ApolloServerPluginLandingPageLocalDefaultOptions,
+): ApolloServerPlugin {
+  return require('./landingPage/default').ApolloServerPluginLandingPageLocalDefault(
+    options,
+  );
+}
+export function ApolloServerPluginLandingPageProductionDefault(
+  options?: ApolloServerPluginLandingPageProductionDefaultOptions,
+): ApolloServerPlugin {
+  return require('./landingPage/default').ApolloServerPluginLandingPageProductionDefault(
+    options,
+  );
+}
+
 import type { ApolloServerPluginLandingPageGraphQLPlaygroundOptions } from './landingPage/graphqlPlayground';
 export type { ApolloServerPluginLandingPageGraphQLPlaygroundOptions } from './landingPage/graphqlPlayground';
 export function ApolloServerPluginLandingPageGraphQLPlayground(

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -1,0 +1,125 @@
+import type { ImplicitlyInstallablePlugin } from '../../../ApolloServer';
+
+export interface ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * By default, the landing page plugin uses the latest version of the landing
+   * page published to Apollo's CDN. If you'd like to pin the current version,
+   * pass the SHA served at
+   * https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt
+   * here.
+   */
+  version?: string;
+  // For Apollo use only.
+  __internal_apolloStudioEnv__?: 'staging' | 'prod';
+}
+
+export interface ApolloServerPluginLandingPageLocalDefaultOptions
+  extends ApolloServerPluginLandingPageDefaultBaseOptions {}
+
+export interface ApolloServerPluginLandingPageProductionDefaultOptions
+  extends ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * If specified, provide a link (with opt-in auto-redirect) to the Studio page
+   * for the given graphRef. (You need to explicitly pass this here rather than
+   * relying on the server's ApolloConfig, because if your server is publicly
+   * accessible you may not want to display the graph ref publicly.)
+   */
+  graphRef?: string;
+}
+
+// The actual config object read by the landing page's React component.
+interface LandingPageConfig {
+  graphRef?: string | undefined;
+  isProd?: boolean;
+  apolloStudioEnv?: 'staging' | 'prod';
+}
+
+export function ApolloServerPluginLandingPageLocalDefault(
+  options?: ApolloServerPluginLandingPageLocalDefaultOptions,
+): ImplicitlyInstallablePlugin {
+  return ApolloServerPluginLandingPageDefault(
+    options?.version,
+    encodeConfig({
+      isProd: false,
+      apolloStudioEnv: options?.__internal_apolloStudioEnv__,
+    }),
+  );
+}
+
+export function ApolloServerPluginLandingPageProductionDefault(
+  options?: ApolloServerPluginLandingPageProductionDefaultOptions,
+): ImplicitlyInstallablePlugin {
+  return ApolloServerPluginLandingPageDefault(
+    options?.version,
+    encodeConfig({
+      isProd: true,
+      apolloStudioEnv: options?.__internal_apolloStudioEnv__,
+      graphRef: options?.graphRef,
+    }),
+  );
+}
+
+// A triple encoding! Wow! First we use JSON.stringify to turn our object into a
+// string. Then we encodeURIComponent so we don't have to stress about what
+// would happen if the config contained `</script>`. Finally, we JSON.stringify
+// it again, which in practice just wraps it in a pair of double quotes (since
+// there shouldn't be any backslashes left after encodeURIComponent). The
+// consumer of this needs to decodeURIComponent and then JSON.parse; there's
+// only one JSON.parse because the outermost JSON string is parsed by the JS
+// parser itself.
+function encodeConfig(config: LandingPageConfig): string {
+  return JSON.stringify(encodeURIComponent(JSON.stringify(config)));
+}
+
+// Helper for the two actual plugin functions.
+function ApolloServerPluginLandingPageDefault(
+  maybeVersion: string | undefined,
+  encodedConfig: string,
+): ImplicitlyInstallablePlugin {
+  const version = maybeVersion ?? '_latest';
+  return {
+    __internal_installed_implicitly__: false,
+    async serverWillStart() {
+      return {
+        async renderLandingPage() {
+          const html = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link
+      rel="icon"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${version}/assets/favicon.png"
+    />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap"
+      rel="stylesheet"
+    />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Apollo server landing page" />
+    <link
+      rel="apple-touch-icon"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${version}/assets/favicon.png"
+    />
+    <link
+      rel="manifest"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${version}/manifest.json"
+    />
+    <title>Apollo Server</title>
+  </head>
+  <body style="margin: 0; overflow-x: hidden; overflow-y: hidden">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="react-root" style="width: 100vw; height: 100vh"></div>
+    <script>window.landingPage = ${encodedConfig};</script>
+    <script src="https://apollo-server-landing-page.cdn.apollographql.com/${version}/static/js/main.js"></script>
+  </body>
+</html>
+          `;
+          return { html };
+        },
+      };
+    },
+  };
+}

--- a/packages/apollo-server-core/src/plugin/landingPage/graphqlPlayground/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/graphqlPlayground/index.ts
@@ -5,8 +5,7 @@
 // specifying `version` when installing the plugin.
 
 import { renderPlaygroundPage } from '@apollographql/graphql-playground-html';
-import { GraphQLServerListener } from 'apollo-server-plugin-base';
-import type { ImplicitlyInstallablePlugin } from '../../../ApolloServer';
+import { ApolloServerPlugin, GraphQLServerListener } from 'apollo-server-plugin-base';
 
 // This specifies the React version of our fork of GraphQL Playground,
 // `@apollographql/graphql-playground-react`.  It is related to, but not to
@@ -26,9 +25,8 @@ export type ApolloServerPluginLandingPageGraphQLPlaygroundOptions = Parameters<
 
 export function ApolloServerPluginLandingPageGraphQLPlayground(
   options: ApolloServerPluginLandingPageGraphQLPlaygroundOptions = Object.create(null),
-): ImplicitlyInstallablePlugin {
+): ApolloServerPlugin {
   return {
-    __internal_installed_implicitly__: false,
     async serverWillStart(): Promise<GraphQLServerListener> {
       return {
         async renderLandingPage() {

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -105,7 +105,7 @@ describe('apollo-server-express', () => {
       expect(result.errors).toBeUndefined();
     });
 
-    it('renders GraphQL playground by default when browser requests', async () => {
+    it('renders landing page by default when browser requests', async () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
@@ -118,7 +118,7 @@ describe('apollo-server-express', () => {
           'accept',
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
         )
-        .expect(200, /GraphQLPlayground/);
+        .expect(200, /apollo-server-landing-page.cdn.apollographql.com\/_latest/);
     });
 
     it('accepts cors configuration', async () => {

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -144,7 +144,7 @@ describe('apollo-server-fastify', () => {
       expect(result.errors).toBeUndefined();
     });
 
-    it('renders GraphQL playground by default when browser requests', async () => {
+    it('renders landing page by default when browser requests', async () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
@@ -157,7 +157,7 @@ describe('apollo-server-fastify', () => {
           'accept',
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
         )
-        .expect(200, /GraphQLPlayground/);
+        .expect(200, /apollo-server-landing-page.cdn.apollographql.com\/_latest/);
     });
 
     it('accepts cors configuration', async () => {

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -107,7 +107,7 @@ describe('apollo-server-hapi', () => {
       expect(result.errors).toBeUndefined();
     });
 
-    it('renders GraphQL playground by default when browser requests', async () => {
+    it('renders landing page by default when browser requests', async () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
@@ -120,7 +120,7 @@ describe('apollo-server-hapi', () => {
           'accept',
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
         )
-        .expect(200, /GraphQLPlayground/);
+        .expect(200, /apollo-server-landing-page.cdn.apollographql.com\/_latest/);
     });
 
     it('accepts cors configuration', async () => {

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -96,7 +96,7 @@ describe('apollo-server-koa', () => {
       expect(result.errors).toBeUndefined();
     });
 
-    it('renders GraphQL playground by default when browser requests', async () => {
+    it('renders landing page by default when browser requests', async () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
@@ -109,7 +109,7 @@ describe('apollo-server-koa', () => {
           'accept',
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
         )
-        .expect(200, /GraphQLPlayground/);
+        .expect(200, /apollo-server-landing-page.cdn.apollographql.com\/_latest/);
     });
     it('accepts cors configuration', async () => {
       const { url: uri } = await createServer(

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -81,8 +81,7 @@ describe('apollo-server-micro', function() {
         service.close();
       });
 
-      it('should render a GraphQL playground when a browser sends in a request', async function () {
-        // Playground is on by default with unset NODE_ENV.
+      it('should render a landing page when a browser sends in a request', async function () {
         const { service, uri } = await createServer(
           {},
           { __testing_nodeEnv__: undefined },
@@ -96,7 +95,7 @@ describe('apollo-server-micro', function() {
               'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
           },
         });
-        expect(body).toMatch('GraphQLPlayground');
+        expect(body).toMatch(/apollo-server-landing-page.cdn.apollographql.com\/_latest/);
         service.close();
       });
     });

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -186,7 +186,7 @@ describe('apollo-server', () => {
       expect(result.errors).toBeUndefined();
     });
 
-    it('renders GraphQL playground when browser requests', async () => {
+    it('renders landing page when browser requests', async () => {
       server = new ApolloServer({
         typeDefs,
         resolvers,
@@ -201,7 +201,7 @@ describe('apollo-server', () => {
           'accept',
           'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
         )
-        .expect(200, /GraphQLPlayground/);
+        .expect(200, /apollo-server-landing-page.cdn.apollographql.com\/_latest/);
     });
 
     it('configures cors', async () => {


### PR DESCRIPTION
As part of reducing Apollo Server's key dependencies on third-party
software (especially retired software) we are changing the default
landing page from GraphQL Playground to a simple splash page welcoming
the user to Apollo Server and providing them with links to docs, to the
Apollo Studio Sandbox, etc. (Sandbox is a new feature that will allow
you to use Explorer and other Studio features without any need for a
Studio account.)

This commit adds a pair of new landing page plugins,
ApolloServerPluginLandingPageLocalDefault and
ApolloServerPluginLandingPageProductionDefault, which serves variants of
this landing page from a CDN.
