### PR TITLE
Add a blurb about the Usage Plugin's reporting frequency to the docs

### DIFF
--- a/docs/source/monitoring/metrics.md
+++ b/docs/source/monitoring/metrics.md
@@ -27,6 +27,10 @@ $ APOLLO_KEY=YOUR_API_KEY APOLLO_GRAPH_REF=my-graph@my-variant \
   node start-server.js
 ```
 
+#### Communicating with Studio
+
+By default, Apollo Server aggregates your traces and sends them in batches to Studio every minute. This behavior is highly configurable, and you can change the parameters in the [Usage Reporting plugin's configuration](https://www.apollographql.com/docs/apollo-server/api/plugin/usage-reporting/#custom-installation). 
+
 ### Identifying distinct clients
 
 Apollo Studio's [client awareness feature](https://www.apollographql.com/docs/studio/client-awareness/) enables you to view metrics for distinct versions


### PR DESCRIPTION
One of the common questions in Studio's customer support is how the mechanics of the reporting plugin work and how often it sends data to Studio. The plugin is highly configurable, but the configuration isn't very discoverable, so this adds a little blurb about how the plugin works and links to the configuration docs from a more discoverable place.