### PR TITLE
Automatically call start() from the testing executeOperation()

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -642,6 +642,8 @@ The async `start` method instructs Apollo Server to prepare to handle incoming o
 
 Always call `await server.start()` *before* calling `server.applyMiddleware` and starting your HTTP server. This allows you to react to Apollo Server startup failures by crashing your process instead of starting to serve traffic.
 
+If the only thing you are doing with your server is calling [`executeOperation`](../../testing/testing/) on it (ie, you're not actually starting an HTTP server), you don't have to call `start()`; `executeOperation` will do that for you.
+
 This method was optional in Apollo Server 2 but is required in Apollo Server 3.
 
 ##### Triggered actions

--- a/docs/source/testing/testing.md
+++ b/docs/source/testing/testing.md
@@ -35,7 +35,6 @@ it('fetches single launch', async () => {
     dataSources: () => ({ userAPI, launchAPI }),
     context: () => ({ user: { id: 1, email: 'a@a.a' } }),
   });
-  await server.start();
 
   // mock the dataSource's underlying fetch methods
   launchAPI.get = jest.fn(() => [mockLaunchResponse]);
@@ -59,6 +58,8 @@ You can use `executeOperation` to execute queries and mutations. Because the int
 In addition to `query`, the first argument to `executeOperation` can take `operationName`, `variables`, `extensions`, and `http` keys.
 
 Note that errors in parsing, validating, and executing your operation are returned in the `errors` field of the result (just like in a GraphQL response) rather than thrown.
+
+You don't have to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`; it will be called automatically for you if it has not been called, and any startup errors will be thrown.
 
 
 ## End-to-end testing

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -879,6 +879,16 @@ export class ApolloServerBase {
     },
     integrationContextArgument?: Record<string, any>,
   ) {
+    // Since this function is mostly for testing, you don't need to explicitly
+    // start your server before calling it. (That also means you can use it with
+    // `apollo-server` which doesn't support `start()`.)
+    if (
+      this.state.phase === 'initialized with gateway' ||
+      this.state.phase === 'initialized with schema'
+    ) {
+      await this._start();
+    }
+
     const options = await this.graphQLServerOptions(integrationContextArgument);
 
     if (typeof options.context === 'function') {

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -186,6 +186,18 @@ describe('apollo-server', () => {
       expect(result.errors).toBeUndefined();
     });
 
+    it('can use executeOperation', async () => {
+      server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+      const result = await server.executeOperation({
+        query: '{hello}',
+      });
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({ hello: 'hi' });
+    });
+
     it('renders landing page when browser requests', async () => {
       server = new ApolloServer({
         typeDefs,


### PR DESCRIPTION
It wasn't possible to use executeOperation with `apollo-server` otherwise,
because there's no user-accessible `start` in that package.
