### PR TITLE
TS: enable noImplicitOverride, add overrides

### DIFF
--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -53,7 +53,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     super();
   }
 
-  initialize(config: DataSourceConfig<TContext>): void {
+  override initialize(config: DataSourceConfig<TContext>): void {
     this.context = config.context;
     this.httpCache = new HTTPCache(config.cache, this.httpFetch);
   }

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -24,7 +24,7 @@ describe('RESTDataSource', () => {
   describe('constructing requests', () => {
     it('interprets paths relative to the base URL', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -43,7 +43,7 @@ describe('RESTDataSource', () => {
 
     it('interprets paths with a leading slash relative to the base URL', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com/bar';
+        override baseURL = 'https://api.example.com/bar';
 
         getFoo() {
           return this.get('/foo');
@@ -64,7 +64,7 @@ describe('RESTDataSource', () => {
 
     it('adds a trailing slash to the base URL if needed', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://example.com/api';
+        override baseURL = 'https://example.com/api';
 
         getFoo() {
           return this.get('foo');
@@ -83,7 +83,7 @@ describe('RESTDataSource', () => {
 
     it('allows resolving a base URL asynchronously', async () => {
       const dataSource = new (class extends RESTDataSource {
-        async resolveURL(request: RequestOptions) {
+        override async resolveURL(request: RequestOptions) {
           if (!this.baseURL) {
             this.baseURL = 'https://api.example.com';
           }
@@ -106,7 +106,7 @@ describe('RESTDataSource', () => {
 
     it('allows passing in query string parameters', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getPostsForUser(
           username: string,
@@ -134,9 +134,9 @@ describe('RESTDataSource', () => {
 
     it('allows setting default query string parameters', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
-        willSendRequest(request: RequestOptions) {
+        override willSendRequest(request: RequestOptions) {
           request.params.set('api_key', this.context.token);
         }
 
@@ -160,9 +160,9 @@ describe('RESTDataSource', () => {
 
     it('allows setting default fetch options', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
-        willSendRequest(request: RequestOptions) {
+        override willSendRequest(request: RequestOptions) {
           request.credentials = 'include';
         }
 
@@ -184,9 +184,9 @@ describe('RESTDataSource', () => {
 
     it('allows setting request headers', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
-        willSendRequest(request: RequestOptions) {
+        override willSendRequest(request: RequestOptions) {
           request.headers.set('Authorization', this.context.token);
         }
 
@@ -224,7 +224,7 @@ describe('RESTDataSource', () => {
 
     it('serializes a request body that is an object as JSON', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         postFoo(foo: object) {
           return this.post('foo', foo);
@@ -242,7 +242,7 @@ describe('RESTDataSource', () => {
 
     it('serializes a request body that is an array as JSON', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         postFoo(foo: string[]) {
           return this.post('foo', foo);
@@ -260,7 +260,7 @@ describe('RESTDataSource', () => {
 
     it('serializes a request body that has a toJSON method as JSON', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         postFoo(foo: Model) {
           return this.post('foo', foo);
@@ -289,7 +289,7 @@ describe('RESTDataSource', () => {
 
     it('does not serialize a request body that is not an object', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         postFoo(foo: FormData) {
           return this.post('foo', foo);
@@ -318,7 +318,7 @@ describe('RESTDataSource', () => {
 
     for (const method of ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']) {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -359,7 +359,7 @@ describe('RESTDataSource', () => {
   describe('response parsing', () => {
     it('returns data as parsed JSON when Content-Type is application/json', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -380,7 +380,7 @@ describe('RESTDataSource', () => {
 
     it('returns data as parsed JSON when Content-Type is application/hal+json', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -401,7 +401,7 @@ describe('RESTDataSource', () => {
 
     it('returns data as a string when Content-Type is text/plain', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -419,7 +419,7 @@ describe('RESTDataSource', () => {
 
     it('attempts to return data as a string when no Content-Type header is returned', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -437,7 +437,7 @@ describe('RESTDataSource', () => {
 
     it('returns data as a string when response status code is 204 no content', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('');
@@ -455,7 +455,7 @@ describe('RESTDataSource', () => {
 
     it('returns empty object when response content length is 0', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('');
@@ -478,7 +478,7 @@ describe('RESTDataSource', () => {
   describe('memoization', () => {
     it('deduplicates requests with the same cache key', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo(id: number) {
           return this.get(`foo/${id}`);
@@ -499,7 +499,7 @@ describe('RESTDataSource', () => {
 
     it('does not deduplicate requests with a different cache key', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo(id: number) {
           return this.get(`foo/${id}`);
@@ -524,7 +524,7 @@ describe('RESTDataSource', () => {
 
     it('does not deduplicate non-GET requests', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         postFoo(id: number) {
           return this.post(`foo/${id}`);
@@ -543,7 +543,7 @@ describe('RESTDataSource', () => {
 
     it('non-GET request removes memoized request with the same cache key', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo(id: number) {
           return this.get(`foo/${id}`);
@@ -577,9 +577,9 @@ describe('RESTDataSource', () => {
 
     it('allows specifying a custom cache key', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
-        cacheKeyFor(request: Request) {
+        override cacheKeyFor(request: Request) {
           const url = new URL(request.url);
           url.search = '';
           return url.toString();
@@ -609,7 +609,7 @@ describe('RESTDataSource', () => {
   describe('error handling', () => {
     it('throws an AuthenticationError when the response status is 401', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -635,7 +635,7 @@ describe('RESTDataSource', () => {
 
     it('throws a ForbiddenError when the response status is 403', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -661,7 +661,7 @@ describe('RESTDataSource', () => {
 
     it('throws an ApolloError when the response status is 500', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -686,7 +686,7 @@ describe('RESTDataSource', () => {
 
     it('puts JSON error responses on the error as an object', async () => {
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
@@ -730,13 +730,13 @@ describe('RESTDataSource', () => {
     it('is called once per request', async () => {
       const traceMock = jest.fn()
       const dataSource = new (class extends RESTDataSource {
-        baseURL = 'https://api.example.com';
+        override baseURL = 'https://api.example.com';
 
         getFoo() {
           return this.get('foo');
         }
 
-        trace = traceMock;
+        override trace = traceMock;
       })();
 
       dataSource.httpCache = httpCache;

--- a/packages/apollo-server-azure-functions/src/ApolloServer.ts
+++ b/packages/apollo-server-azure-functions/src/ApolloServer.ts
@@ -17,7 +17,7 @@ export interface CreateHandlerOptions {
 }
 
 export class ApolloServer extends ApolloServerBase {
-  protected serverlessFramework(): boolean {
+  protected override serverlessFramework(): boolean {
     return true;
   }
 

--- a/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
+++ b/packages/apollo-server-cache-redis/src/RedisClusterCache.ts
@@ -14,7 +14,7 @@ export class RedisClusterCache extends BaseRedisCache {
     this.clusterClient = clusterClient;
   }
 
-  async flush(): Promise<void> {
+  override async flush(): Promise<void> {
     const masters = this.clusterClient.nodes('master') || [];
     await Promise.all(masters.map((node: RedisInstance) => node.flushdb()));
   }

--- a/packages/apollo-server-cloud-functions/src/ApolloServer.ts
+++ b/packages/apollo-server-cloud-functions/src/ApolloServer.ts
@@ -20,7 +20,7 @@ function defaultExpressAppFromMiddleware(
 }
 
 export class ApolloServer extends ApolloServerExpress {
-  protected serverlessFramework(): boolean {
+  protected override serverlessFramework(): boolean {
     return true;
   }
 

--- a/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
+++ b/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
@@ -115,7 +115,7 @@ describe('ApolloServerBase start', () => {
     };
 
     class ServerlessApolloServer extends ApolloServerBase {
-      serverlessFramework() {
+      override serverlessFramework() {
         return true;
       }
     }

--- a/packages/apollo-server-core/src/__tests__/logger.test.ts
+++ b/packages/apollo-server-core/src/__tests__/logger.test.ts
@@ -45,7 +45,7 @@ describe("logger", () => {
         });
       }
 
-      log(info: any) {
+      override log(info: any) {
         sink(info);
       }
     };

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -8,7 +8,7 @@ import {
 
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
-  readonly name!: string;
+  override readonly name!: string;
   readonly locations: ReadonlyArray<SourceLocation> | undefined;
   readonly path: ReadonlyArray<string | number> | undefined;
   readonly source: Source | undefined;

--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -97,7 +97,7 @@ describe('apollo-server-express', () => {
       resolvers,
       dataSources: () => ({
         id: new class extends IdAPI {
-          baseURL = restUrl;
+          override baseURL = restUrl;
         },
       }),
     });
@@ -130,7 +130,7 @@ describe('apollo-server-express', () => {
       resolvers,
       dataSources: () => ({
         id: new class extends IdAPI {
-          baseURL = restUrl;
+          override baseURL = restUrl;
         },
       }),
     });

--- a/packages/apollo-server-fastify/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/datasource.test.ts
@@ -10,7 +10,7 @@ import { gql } from '../index';
 const restPort = 4003;
 
 export class IdAPI extends RESTDataSource {
-  baseURL = `http://localhost:${restPort}/`;
+  override baseURL = `http://localhost:${restPort}/`;
 
   async getId(id: string) {
     return this.get(`id/${id}`);

--- a/packages/apollo-server-koa/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/datasource.test.ts
@@ -101,7 +101,7 @@ describe('apollo-server-koa', () => {
       resolvers,
       dataSources: () => ({
         id: new class extends IdAPI {
-          baseURL = restUrl;
+          override baseURL = restUrl;
         },
       }),
     });
@@ -134,7 +134,7 @@ describe('apollo-server-koa', () => {
       resolvers,
       dataSources: () => ({
         id: new class extends IdAPI {
-          baseURL = restUrl;
+          override baseURL = restUrl;
         },
       }),
     });

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -24,7 +24,7 @@ function defaultExpressAppFromMiddleware(
   return app;
 }
 export class ApolloServer extends ApolloServerExpress {
-  protected serverlessFramework(): boolean {
+  protected override serverlessFramework(): boolean {
     return true;
   }
 
@@ -51,7 +51,7 @@ export class ApolloServer extends ApolloServerExpress {
   // response. It fetches the Lambda context as well (from a global variable,
   // which is safe because the Lambda runtime doesn't invoke multiple operations
   // concurrently).
-  async createGraphQLServerOptions(
+  override async createGraphQLServerOptions(
     req: express.Request,
     res: express.Response,
   ): Promise<GraphQLOptions> {

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -69,13 +69,13 @@ export class ApolloServer extends ApolloServerBase {
     };
   }
 
-  public applyMiddleware() {
+  public override applyMiddleware() {
     throw new Error(
       'To use Apollo Server with an existing express application, please use apollo-server-express',
     );
   }
 
-  public async start(): Promise<void> {
+  public override async start(): Promise<void> {
     throw new Error(
       "When using the `apollo-server` package, you don't need to call start(); just call listen().",
     );
@@ -131,7 +131,7 @@ export class ApolloServer extends ApolloServerBase {
     return this.createServerInfo(httpServer);
   }
 
-  public async stop() {
+  public override async stop() {
     if (this.httpServer) {
       const httpServer = this.httpServer;
       await new Promise<void>((resolve) => httpServer.stop(() => resolve()));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
     "strict": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
This is a nice new feature of TypeScript 4.3. When you're intentionally
overriding a superclass method, you can include `override` so that TS
can verify that you're actually overriding it properly (so that, eg, if
the superclass method gets renamed or its type changes, then an error
will occur). The new noImplicitOverride flag ensures you don't forget to
write `override` when you're overriding. Note that this only affects
subclassing (`extends`), not interface implementation. As far as I can
tell this has no effect on generated `.d.ts` files so it doesn't require
folks using AS to use TS 4.3.
