### PR TITLE
GraphQLRequestContext.overallCachePolicy should be readonly

### DIFF
--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -153,7 +153,7 @@ export interface GraphQLRequestContext<TContext = Record<string, any>> {
 
   debug?: boolean;
 
-  overallCachePolicy: CachePolicy;
+  readonly overallCachePolicy: CachePolicy;
 }
 
 export type ValidationRule = (context: ValidationContext) => ASTVisitor;


### PR DESCRIPTION
You can mutate it by calling methods like replace or restrict on it, but
let's not overwrite it.
