### PR TITLE
Make default CORS behavior even more consistent

### DIFF
--- a/packages/apollo-server-hapi/README.md
+++ b/packages/apollo-server-hapi/README.md
@@ -29,8 +29,6 @@ async function StartServer() {
     app,
   });
 
-  await server.installSubscriptionHandlers(app.listener);
-
   await app.start();
 }
 

--- a/packages/apollo-server-hapi/src/ApolloServer.ts
+++ b/packages/apollo-server-hapi/src/ApolloServer.ts
@@ -69,7 +69,7 @@ export class ApolloServer extends ApolloServerBase {
         method: '*',
         path: '/.well-known/apollo/server-health',
         options: {
-          cors: cors !== undefined ? cors : true,
+          cors: cors !== undefined ? cors : { origin: 'ignore' },
         },
         handler: async function (request, h) {
           if (onHealthCheck) {
@@ -93,7 +93,7 @@ export class ApolloServer extends ApolloServerBase {
       method: ['GET', 'POST'],
       path,
       options: route ?? {
-        cors: cors ?? true,
+        cors: cors ?? { origin: 'ignore' },
       },
       handler: async (request, h) => {
         try {
@@ -113,10 +113,8 @@ export class ApolloServer extends ApolloServerBase {
 
           const response = h.response(graphqlResponse);
           if (responseInit.headers) {
-            Object.entries(
-              responseInit.headers,
-            ).forEach(([headerName, value]) =>
-              response.header(headerName, value),
+            Object.entries(responseInit.headers).forEach(
+              ([headerName, value]) => response.header(headerName, value),
             );
           }
           response.code(responseInit.status || 200);

--- a/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
@@ -40,5 +40,5 @@ describe('koaApollo', () => {
 });
 
 describe('integration:Koa', () => {
-  testSuite({ createApp, destroyApp });
+  testSuite({ createApp, destroyApp, integrationName: 'koa' });
 });


### PR DESCRIPTION
In #5297 I attempted to make the default CORS behavior consistent across
integrations but did not write tests. Turns out that the Hapi default
behavior was slightly different (reflected `access-control-allow-origin`
rather than `*`), and the Azure Functions behavior was quite different.
This PR adds tests for the default CORS behavior, fixes Hapi to do
`ACAO: *` by default, and makes a few improvements to Azure Functions.

Specifically, for Azure Functions we:
- Stop stressing about what case we'll receive headers in and just
  convert all header names to lower-case. Fixes #4178.
- Only apply dynamic `access-control-allow-headers` in OPTIONS (that's
  the only time we need it) but do apply it if `cors` is unset. Also set
  `vary: access-control-request-headers`, like the `cors` npm package
  does.
- Also mirror `access-control-request-method` to
  `access-control-allow-methods` by default.
