### PR TITLE
Clean package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8544,8 +8544,6 @@
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
         "@types/cors": "2.8.10",
-        "@types/express": "^4.17.12",
-        "@types/express-serve-static-core": "^4.17.21",
         "accepts": "^1.3.5",
         "apollo-server-core": "file:packages/apollo-server-core",
         "apollo-server-types": "file:packages/apollo-server-types",


### PR DESCRIPTION
While making a minor update in https://github.com/apollographql/apollo-server/pull/5445, I noticed that a clean `npm install` was actually changing the root lock file and figured I'd submit this to clean things up and avoid rouge changes in future PRs.