### PR TITLE
Fix Lambda `context` function typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+- `apollo-server-lambda`: Fix TypeScript types for `context` function. (In 3.0.0, the TS types for the `context` function were accidentally inherited from `apollo-server-express` instead of using the correct Lambda-specific types). [PR #5481](https://github.com/apollographql/apollo-server/pull/5481)
+
 ## v3.0.0
 
 ### BREAKING CHANGES

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -69,13 +69,14 @@ export interface GraphQLService extends GatewayInterface {}
 
 // This configuration is shared between all integrations and should include
 // fields that are not specific to a single integration
-export interface Config extends BaseConfig {
+export interface Config<ContextFunctionParams = any>
+  extends BaseConfig {
   modules?: GraphQLSchemaModule[];
   typeDefs?: DocumentNode | Array<DocumentNode> | string | Array<string>;
   parseOptions?: ParseOptions;
   resolvers?: IResolvers | Array<IResolvers>;
   schema?: GraphQLSchema;
-  context?: Context | ContextFunction;
+  context?: Context | ContextFunction<ContextFunctionParams>;
   introspection?: boolean;
   mocks?: boolean | IMocks;
   mockEntireSchema?: boolean;

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -4,8 +4,6 @@ import { json, OptionsJson } from 'body-parser';
 import {
   GraphQLOptions,
   ApolloServerBase,
-  ContextFunction,
-  Context,
   Config,
   runHttpQuery,
   HttpQueryError,
@@ -41,15 +39,11 @@ export interface ExpressContext {
   res: express.Response;
 }
 
-export interface ApolloServerExpressConfig extends Config {
-  context?: ContextFunction<ExpressContext, Context> | Context;
-}
+export type ApolloServerExpressConfig = Config<ExpressContext>;
 
-export class ApolloServer extends ApolloServerBase {
-  constructor(config: ApolloServerExpressConfig) {
-    super(config);
-  }
-
+export class ApolloServer<
+  ContextFunctionParams = ExpressContext,
+> extends ApolloServerBase<ContextFunctionParams> {
   // This translates the arguments from the middleware into graphQL options It
   // provides typings for the integration specific behavior, ideally this would
   // be propagated with a generic to the super class
@@ -57,7 +51,8 @@ export class ApolloServer extends ApolloServerBase {
     req: express.Request,
     res: express.Response,
   ): Promise<GraphQLOptions> {
-    return super.graphQLServerOptions({ req, res });
+    const contextParams: ExpressContext = { req, res };
+    return super.graphQLServerOptions(contextParams);
   }
 
   public applyMiddleware({ app, ...rest }: ServerRegistration) {

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import http from 'http';
 import stoppable from 'stoppable';
 import {
-  ApolloServer as ApolloServerBase,
+  ApolloServer as ApolloServerExpress,
   CorsOptions,
   ApolloServerExpressConfig,
 } from 'apollo-server-express';
@@ -24,7 +24,7 @@ export interface ServerInfo {
   server: http.Server;
 }
 
-export class ApolloServer extends ApolloServerBase {
+export class ApolloServer extends ApolloServerExpress {
   private httpServer?: stoppable.StoppableServer;
   private cors?: CorsOptions | boolean;
   private onHealthCheck?: (req: express.Request) => Promise<any>;


### PR DESCRIPTION
In AS3 we made apollo-server-lambda inherit from apollo-server-express,
but didn't realize that it also inherited the more precise TS typings on
its constructor that meant that its `context` function would take
Express-specific parameters (rather than the default unconstrained
parameter).

This change makes it easier for any ApolloServer subclass to declare its
context function typing, and updates apollo-server-express and
apollo-server-lambda to do so. The other integrations are left with the
vaguer defaults.

Tests didn't catch this before because they didn't pass a `context`
function *directly* to the Lambda ApolloServer constructor, just via a
function with a looser signature.

Fixes #5480.
