### PR TITLE
Use `nvm use` instead of `nvm install` if it works.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,7 +11,13 @@ if ! [ -f "$NVM_PATH" ]; then
   curl -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 fi
 . "${NVM_PATH}"
-nvm use
+
+# `nvm use` will set up the environment to use some version matching what we have
+# in .nvmrc without talking to the network, assuming that there is any matching
+# version already downloaded. If there isn't (eg, you're just getting started, or
+# we just did a major version upgrade) then it will fail and `nvm install` will
+# download a matching version.
+nvm use || nvm install
 
 # Let you run npm-installed binaries without npx.
 layout node

--- a/.envrc
+++ b/.envrc
@@ -11,7 +11,7 @@ if ! [ -f "$NVM_PATH" ]; then
   curl -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 fi
 . "${NVM_PATH}"
-nvm install
+nvm use
 
 # Let you run npm-installed binaries without npx.
 layout node


### PR DESCRIPTION
Most of the time, `nvm use` is good enough; `nvm install` is only needed the first time you use a given major version on your machine.

Without this, my `nvm` installation attempts to install everything I have defined in my personal configuration's default packages (`~/.nvm/default-packages) each time it's invoked.  (Often!)