### PR TITLE
apollo-server-types: move info.cacheControl 'declare module' here

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+- `apollo-server-types`: TypeScript typings for `info.cacheControl` are now added to `GraphQLResolveInfo` as part of `apollo-server-types` rather than a nested file in `apollo-server-core`, and the field now has a named type, `ResolveInfoCacheControl`. [PR #5512](https://github.com/apollographql/apollo-server/pull/5512)
+
 ## v3.0.1
 
 - `apollo-server-core`: The default `maxAge` (which defaults to 0) for a field should only be applied if no dynamic cache control hint is set. Specifically, if you call the (new in 3.0.0) function `info.cacheControl.cacheHint.restrict({ maxAge: 60 })`, it should set `maxAge` to 60 even if the default max age is lower. (This bug fix is the behavior that was intended for 3.0.0, and primarily affects the behavior of functions added in Apollo Server 3. This does mean that checking `info.cacheControl.cacheHint` now only shows explicitly-set `maxAge` and not the default, but this seems like it will be helpful since it lets you differentiate between the two similar circumstances.) [PR #5492](https://github.com/apollographql/apollo-server/pull/5492)

--- a/packages/apollo-server-core/src/plugin/cacheControl/index.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/index.ts
@@ -1,8 +1,4 @@
-import type {
-  CacheAnnotation,
-  CacheHint,
-  CachePolicy,
-} from 'apollo-server-types';
+import type { CacheAnnotation, CacheHint } from 'apollo-server-types';
 import { CacheScope } from 'apollo-server-types';
 import {
   DirectiveNode,
@@ -35,18 +31,6 @@ export interface ApolloServerPluginCacheControlOptions {
   calculateHttpHeaders?: boolean;
   // For testing only.
   __testing__cacheHints?: Map<string, CacheHint>;
-}
-
-declare module 'graphql/type/definition' {
-  interface GraphQLResolveInfo {
-    cacheControl: {
-      cacheHint: CachePolicy;
-      // Shorthand for `cacheHint.replace(hint)`; also for compatibility with
-      // the Apollo Server 2.x API.
-      setCacheHint(hint: CacheHint): void;
-      cacheHintFromType(t: GraphQLCompositeType): CacheHint | undefined;
-    };
-  }
 }
 
 export function ApolloServerPluginCacheControl(

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -1,5 +1,5 @@
-import { Request, Response } from 'apollo-server-env';
-import {
+import type { Request, Response } from 'apollo-server-env';
+import type {
   GraphQLSchema,
   ValidationContext,
   ASTVisitor,
@@ -8,11 +8,12 @@ import {
   DocumentNode,
   GraphQLError,
   GraphQLResolveInfo,
+  GraphQLCompositeType,
 } from 'graphql';
 
 // This seems like it could live in this package too.
-import { KeyValueCache } from 'apollo-server-caching';
-import { Trace } from 'apollo-reporting-protobuf';
+import type { KeyValueCache } from 'apollo-server-caching';
+import type { Trace } from 'apollo-reporting-protobuf';
 
 export type BaseContext = Record<string, any>;
 
@@ -275,4 +276,22 @@ export interface CachePolicy extends CacheHint {
    * `CacheHint` with both fields defined. Otherwise return null.
    */
   policyIfCacheable(): Required<CacheHint> | null;
+}
+
+/**
+ * When using Apollo Server with the cache control plugin (on by default), an
+ * object of this kind is available to resolvers on `info.cacheControl`.
+ */
+export interface ResolveInfoCacheControl {
+  cacheHint: CachePolicy;
+  // Shorthand for `cacheHint.replace(hint)`; also for compatibility with
+  // the Apollo Server 2.x API.
+  setCacheHint(hint: CacheHint): void;
+  cacheHintFromType(t: GraphQLCompositeType): CacheHint | undefined;
+}
+
+declare module 'graphql/type/definition' {
+  interface GraphQLResolveInfo {
+    cacheControl: ResolveInfoCacheControl;
+  }
 }


### PR DESCRIPTION
This makes `info.cacheControl` available to TypeScript packages that
depend on `apollo-server-types` rather than only being declared deep
inside `apollo-server-core`. Additionally, it gives a name to type used
for `info.cacheControl`.

Intended for use cases like
https://github.com/apollographql/federation/pull/870

We've run into tricky issues with `declare module` before so if this
ends up causing more problems than it's worth, we may revert it.

Also change some more imports to `import type`.