### PR TITLE
Allow overriding URL/method in RemoteGraphQLDataSource

### DIFF
--- a/packages/apollo-server-env/src/fetch.d.ts
+++ b/packages/apollo-server-env/src/fetch.d.ts
@@ -37,9 +37,9 @@ export declare class Body {
 export declare class Request extends Body {
   constructor(input: Request | string, init?: RequestInit);
 
-  readonly method: string;
-  readonly url: string;
-  readonly headers: Headers;
+  method: string;
+  url: string;
+  headers: Headers;
 
   clone(): Request;
 }

--- a/packages/apollo-server-env/src/fetch.d.ts
+++ b/packages/apollo-server-env/src/fetch.d.ts
@@ -39,7 +39,7 @@ export declare class Request extends Body {
 
   method: string;
   url: string;
-  headers: Headers;
+  readonly headers: Headers;
 
   clone(): Request;
 }


### PR DESCRIPTION
I'm currently attempting to override the fetched URL/method in `RemoteGraphQLDataSource`. Although it's possible with a custom fetcher, it really should be easier.

I'm currently attempting to do something like:

```ts
return new RemoteGraphQLDataSource<SharedContext>({
  url,
  willSendRequest({ request, context }) {
    if(context.urlOverride && request.http) {
      request.http.url = context.urlOverride;
    }
  },
});
```

However, due to the `readonly` modifier on `Request.url`, this is impossible, even though it would work as per the code.

`method` should also work the same.

From what I can see by a brief look, this would not affect any other parts of the application (plus, it is a type-only change).
