### PR TITLE
apollo-server-micro: only serve landing page from graphql path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 ## vNEXT
 
 - `apollo-server-types`: TypeScript typings for `info.cacheControl` are now added to `GraphQLResolveInfo` as part of `apollo-server-types` rather than a nested file in `apollo-server-core`, and the field now has a named type, `ResolveInfoCacheControl`. [PR #5512](https://github.com/apollographql/apollo-server/pull/5512)
+- `apollo-server-micro`: Like the other framework integrations, only serve landing pages from the GraphQL path (`/graphql` by default, configurable via the `path` option to `createHandler`). [PR #5516](https://github.com/apollographql/apollo-server/pull/5516)
 
 ## v3.0.1
 

--- a/packages/apollo-server-micro/README.md
+++ b/packages/apollo-server-micro/README.md
@@ -72,6 +72,7 @@ npm install micro micro-cors apollo-server-micro graphql
 ```js
 const cors = require('micro-cors')(); // highlight-line
 const { ApolloServer, gql } = require('apollo-server-micro');
+const { send } = require('micro');
 
 const typeDefs = gql`
   type Query {
@@ -89,8 +90,8 @@ const resolvers = {
 
 const apolloServer = new ApolloServer({ typeDefs, resolvers });
 module.exports = apolloServer.start().then(() => {
-  const handler = apolloServer.createHandler(); // highlight-line
-  return cors((req, res) => req.method === 'OPTIONS' ? res.end() : handler(req, res)) // highlight-line
+  const handler = apolloServer.createHandler();
+  return cors((req, res) => req.method === 'OPTIONS' ? send(res, 200, 'ok') : handler(req, res))
 });
 ```
 

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -122,7 +122,8 @@ export class ApolloServer extends ApolloServerBase {
   }): boolean {
     let handled = false;
 
-    if (req.method === 'GET') {
+    const url = req.url!.split('?')[0];
+    if (req.method === 'GET' && url === this.graphqlPath) {
       const accept = parseAll(req.headers);
       const types = accept.mediaTypes as string[];
       const prefersHtml =

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -91,7 +91,7 @@ describe('apollo-server-micro', function () {
         );
 
         const body = await rp({
-          uri,
+          uri: `${uri}/graphql`,
           method: 'GET',
           headers: {
             accept:


### PR DESCRIPTION
ie, by default, serve 404 on root.

This makes it consistent with the other framework integrations. This
also means that if you're using the playground or local default landing
page, you won't manage to load a UI at an URL that doesn't also serve
GraphQL and then get confused when it can't talk to your server.

Also fixes #5513, a doc issue around CORS.
