### PR TITLE
docs: add variable assignment to subscription server instance

### DIFF
--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -97,7 +97,7 @@ Then, complete the following:
 1. Create the `SubscriptionServer`.
 
     ```javascript
-    SubscriptionServer.create({
+    const subscriptionServer = SubscriptionServer.create({
        // This is the `schema` we just created.
        schema,
        // These are imported from `graphql`.

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -150,10 +150,16 @@ import typeDefs from "./typeDefs";
   await server.start();
   server.applyMiddleware({ app });
 
-  SubscriptionServer.create(
+  const subscriptionServer = SubscriptionServer.create(
     { schema, execute, subscribe },
     { server: httpServer, path: server.graphqlPath }
   );
+  
+  // Shut down in the case of interrupt and termination signals
+  // We expect to handle this more cleanly in the future. See (#5074)[https://github.com/apollographql/apollo-server/issues/5074] for reference.
+  ['SIGINT', 'SIGTERM'].forEach(signal => {
+    process.on(signal, () => subscriptionServer.close());
+  });
 
   const PORT = 4000;
   httpServer.listen(PORT, () =>


### PR DESCRIPTION
The code in step 5 of the [subscription details](https://www.apollographql.com/docs/apollo-server/migration/#reenabling-subscriptions) in the migration guide for Apollo Server 3 currently does not assign the created `SubscriptionServer` instance to a variable, however an implied variable is used (`subscriptionServer.close()`). This PR assigns the created instance to a variable for clarity.