### PR TITLE
Fix typo: change "above" to "below" in Usage Reporting Plugin docs

### DIFF
--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -376,7 +376,7 @@ Specify this function to create a signature for a query. This option is not reco
 | Object | Description |
 |--------|-------------|
 | `{ none: true }` | If you provide this object, no request header names or values are sent to Apollo Studio. This is the default behavior. |
-| `{ all: true }` |  If you provide this object, **all** GraphQL header names and values are sent to Apollo Studio, except for the protected headers listed above. |
+| `{ all: true }` |  If you provide this object, **all** GraphQL header names and values are sent to Apollo Studio, except for the protected headers listed below. |
 | `{ onlyNames: ["apple", "orange"]}`| If you provide an object with this structure, only names and values of the request headers with names that appear in the array are sent to Apollo Studio. Case-insensitive. |
 | `{ exceptNames: ["apple", "orange"]}`| If you provide an object with this structure, all GraphQL header values **except** values of headers with names that appear in the array are sent to Apollo Studio. Case-insensitive. |
 


### PR DESCRIPTION
Hi! :smile: A part the documentation for the Usage Reporting Plugin mentions that the protected headers list is "above" a certain table, but it's actually [right below it](https://github.com/apollographql/apollo-server/tree/main/docs/source/api/plugin/usage-reporting.md#L383-L387) (from lines 383 to 387).

Sure hope this change isn't pedantic ᕕ( ᐛ )ᕗ. Just kinda lost a good 20+ minutes trying to find the list and re-reading everything, only to discover that the "above" word was just a typo.

If the patch is not welcomed let me know and I'll close the PR.

Have a nice day! :heart:
