### PR TITLE
Fix broken error extensions link in migration docs

### DIFF
--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -693,7 +693,7 @@ In Apollo Server 3, these errors are handled in a more consistent manner across 
 
 #### Initializing an error
 
-In Apollo Server 2, [error extensions](http://localhost:8000/data/errors/#including-custom-error-details) can be passed to the `ApolloError` constructor either as the third argument, *or* as an `extensions` option on the third argument.
+In Apollo Server 2, [error extensions](../data/errors/#including-custom-error-details) can be passed to the `ApolloError` constructor either as the third argument, *or* as an `extensions` option on the third argument.
 
 In other words, these two lines are equivalent with Apollo Server 2:
 


### PR DESCRIPTION
A very small one, the error extensions links to localhost :)