### PR TITLE
Remove link to source for defaultFieldResolver function

### DIFF
--- a/docs/source/data/resolvers.mdx
+++ b/docs/source/data/resolvers.mdx
@@ -427,7 +427,7 @@ A resolver function's return value is treated differently by Apollo Server depen
 
 ## Default resolvers
 
-If you don't define a resolver for a particular schema field, Apollo Server defines a default resolver for it ([see the source](https://github.com/graphql/graphql-js/blob/master/src/execution/execute.js#L1147-L1195)).
+If you don't define a resolver for a particular schema field, Apollo Server defines a default resolver for it.
 
 The default resolver function uses the following logic:
 


### PR DESCRIPTION
There is a link called [see the source](https://github.com/graphql/graphql-js/blob/master/src/execution/execute.js#L1147-L1195) in the [Fetching data > Resolvers > Default resolvers](https://www.apollographql.com/docs/apollo-server/data/resolvers/#default-resolvers) section of the docs that is broken.

The current (as of 2021-07-30) correct link to the `defaultFieldResolver` function is https://github.com/graphql/graphql-js/blob/master/src/execution/execute.ts#L999-L1015. This will obviously change as lines are added or removed above this function and linking directly to the current commit hash will lead to stale docs. The mermaid diagram summarizes the function so a direct link to it really isn't needed.