### PR TITLE
Fix snippet in migration docs for Playground plugin

### DIFF
--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -290,16 +290,18 @@ import { ApolloServerPluginLandingPageGraphQLPlayground } from 'apollo-server-co
 new ApolloServer({
   plugins: [
     ApolloServerPluginLandingPageGraphQLPlayground({
-      'some.setting': true,
-      'general.betaUpdates': false,
-      'editor.theme': 'dark' as Theme,
-      'editor.cursorShape': 'line' as CursorShape,
-      'editor.reuseHeaders': true,
-      'tracing.hideTracingResponse': true,
-      'queryPlan.hideQueryPlanResponse': true,
-      'editor.fontSize': 14,
-      'editor.fontFamily': `'Source Code Pro', 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace`,
-      'request.credentials': 'omit',
+      settings: {
+        'some.setting': true,
+        'general.betaUpdates': false,
+        'editor.theme': 'dark',
+        'editor.cursorShape': 'line',
+        'editor.reuseHeaders': true,
+        'tracing.hideTracingResponse': true,
+        'queryPlan.hideQueryPlanResponse': true,
+        'editor.fontSize': 14,
+        'editor.fontFamily': `'Source Code Pro', 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace`,
+        'request.credentials': 'omit',
+      },
     }),
   ],
 });


### PR DESCRIPTION
Options need to be wrapped in a `settings` object. Also removed the casted types in there since I couldn't find their definition, and they don't seem to be necessary anyways
