### PR TITLE
apollo-server-lambda: Fix callback requirement for handler

### DIFF
--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import type { Callback, Context } from 'aws-lambda';
+import type { Context } from 'aws-lambda';
 import {
   ApolloServer as ApolloServerExpress,
   ExpressContext,
@@ -34,7 +34,6 @@ function defaultExpressAppFromMiddleware(
 type Handler<TEvent = any, TResult = any> = (
   event: TEvent,
   context: Context,
-  callback?: Callback<TResult>,
 ) => void | Promise<TResult>
 
 export class ApolloServer extends ApolloServerExpress<LambdaContextFunctionParams> {

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -1,4 +1,4 @@
-import type { Handler } from 'aws-lambda';
+import type { Callback, Context } from 'aws-lambda';
 import {
   ApolloServer as ApolloServerExpress,
   ExpressContext,
@@ -30,6 +30,13 @@ function defaultExpressAppFromMiddleware(
   app.use(middleware);
   return app;
 }
+
+type Handler<TEvent = any, TResult = any> = (
+  event: TEvent,
+  context: Context,
+  callback?: Callback<TResult>,
+) => void | Promise<TResult>
+
 export class ApolloServer extends ApolloServerExpress<LambdaContextFunctionParams> {
   protected override serverlessFramework(): boolean {
     return true;


### PR DESCRIPTION
This is for #5592.

I copied the definition of `Handler` from `@types/aws-lambda` and made `callback` optional, which fixes the issue.

Hope this approach is alright, please let me know your thoughts.

Thanks!