### PR TITLE
apollo-server-micro: add the body field to the request object

### DIFF
--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -26,6 +26,14 @@ function setHeaders(
   });
 }
 
+// Parses the incoming request body as JSON and saves this within the body
+// field as a side-effect.
+async function getJson(req: MicroRequest): Promise<object> {
+  const body = await json(req);
+  req.body = body;
+  return body;
+}
+
 // Build and return an async function that passes incoming GraphQL requests
 // over to Apollo Server for processing, then fires the results/response back
 // using Micro's `send` functionality.
@@ -51,7 +59,7 @@ export function graphqlMicro(
             req.headers['content-length'] &&
             req.headers['content-length'] !== '0' &&
             typeis.is(contentType, 'application/json') &&
-            (await json(req)))
+            (await getJson(req)))
         : url.parse(req.url!, true).query;
 
     try {

--- a/packages/apollo-server-micro/src/types.ts
+++ b/packages/apollo-server-micro/src/types.ts
@@ -2,4 +2,5 @@ import { IncomingMessage } from 'http';
 
 export interface MicroRequest extends IncomingMessage {
   filePayload?: object;
+  body?: object;
 }


### PR DESCRIPTION
Every `MicroRequest` contains a buffered payload which can only be read once. After calling the `json` function on the `req` object, the buffer is completely read and the data is gone.

This PR adds a `body` field to the `MicroRequest` object so that external dependencies have access to the body sent within the request. 

For example, currently it is not possible to create a context based on data within the body, as I'm trying to achieve within this code example: 

```
const context = async ({ req, res }): Promise<Context> => {
  const localeWithCountry = req.body.variables?.localeWithCountry;
  const localeContext = localeWithCountry ? getLocaleContext(localeWithCountry) : null;

  return {
    localeContext,
  };
};
```
