### PR TITLE
Remove unnecessary boolean checks

### DIFF
--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -107,7 +107,7 @@ export class HTTPCache {
       | CacheOptions
       | ((response: Response, request: Request) => CacheOptions | undefined),
   ): Promise<Response> {
-    if (cacheOptions && typeof cacheOptions === 'function') {
+    if (typeof cacheOptions === 'function') {
       cacheOptions = cacheOptions(response, request);
     }
 

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -211,7 +211,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
       init.params = new URLSearchParams(init.params);
     }
 
-    if (!(init.headers && init.headers instanceof Headers)) {
+    if (!(init.headers instanceof Headers)) {
       init.headers = new Headers(init.headers || Object.create(null));
     }
 

--- a/packages/apollo-server-core/src/plugin/schemaIsFederated.ts
+++ b/packages/apollo-server-core/src/plugin/schemaIsFederated.ts
@@ -18,7 +18,7 @@ import { GraphQLSchema, isObjectType, isScalarType } from 'graphql';
 //    it's attempted.
 export function schemaIsFederated(schema: GraphQLSchema): boolean {
   const serviceType = schema.getType('_Service');
-  if (!(serviceType && isObjectType(serviceType))) {
+  if (!isObjectType(serviceType)) {
     return false;
   }
   const sdlField = serviceType.getFields().sdl;

--- a/packages/apollo-server-core/src/utils/dispatcher.ts
+++ b/packages/apollo-server-core/src/utils/dispatcher.ts
@@ -17,7 +17,7 @@ export class Dispatcher<T extends AnyFunctionMap> {
   ): ReturnType<AsFunction<T[TMethodName]>>[] {
     return targets.map((target) => {
       const method = target[methodName];
-      if (method && typeof method === 'function') {
+      if (typeof method === 'function') {
         return method.apply(target, args);
       }
     });
@@ -39,7 +39,7 @@ export class Dispatcher<T extends AnyFunctionMap> {
   ): Promise<StripPromise<ReturnType<AsFunction<T[TMethodName]>>> | null> {
     for (const target of this.targets) {
       const method = target[methodName];
-      if (!(method && typeof method === 'function')) {
+      if (typeof method !== 'function') {
         continue;
       }
       const value = await method.apply(target, args);
@@ -85,7 +85,7 @@ export class Dispatcher<T extends AnyFunctionMap> {
 
     for (const target of this.targets) {
       const method = target[methodName];
-      if (method && typeof method === 'function') {
+      if (typeof method === 'function') {
         const didEndHook = method.apply(target, args);
         if (didEndHook) {
           didEndHooks.push(didEndHook);


### PR DESCRIPTION
It should safe to use `typeof` & `instanceof` on any value including `null` and `undefined`.
Also `isObjectType` accepts any value so no need to prefix it with nullable check.
I spot these places during #5609