### PR TITLE
Remove root redirect and build deploy previews at /

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,5 +1,3 @@
-/ /docs/apollo-server/
-
 # The v3 docs were beta for a while, and non-default, but now that they are
 # default, the v3 docs don't exist anymore.  So redirect them to the default!
 /docs/apollo-server/v3 /docs/apollo-server

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,6 @@
 [build.environment]
   NODE_VERSION = "16"
   NPM_VERSION  = "7"
+
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch removes the root-level redirect in the docs and forces deploy previews to be deployed at the root to account for this change.