### PR TITLE
Fixes experimental_approximateDocumentStoreMiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
-- _Nothing yet! Stay tuned!_
+- `apollo-server-core`: Fix `experimental_approximateDocumentStoreMiB` option, which seems to have never worked before. [PR #5629](https://github.com/apollographql/apollo-server/pull/5629)
 
 ## v3.1.2
 

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -177,6 +177,7 @@ export class ApolloServerBase<
 
     this.parseOptions = parseOptions;
     this.context = context;
+    this.experimental_approximateDocumentStoreMiB = experimental_approximateDocumentStoreMiB;
 
     // Allow tests to override process.env.NODE_ENV. As a bonus, this means
     // we're only reading the env var once in the constructor, which is faster

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -177,7 +177,8 @@ export class ApolloServerBase<
 
     this.parseOptions = parseOptions;
     this.context = context;
-    this.experimental_approximateDocumentStoreMiB = experimental_approximateDocumentStoreMiB;
+    this.experimental_approximateDocumentStoreMiB =
+      experimental_approximateDocumentStoreMiB;
 
     // Allow tests to override process.env.NODE_ENV. As a bonus, this means
     // we're only reading the env var once in the constructor, which is faster


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

The ApolloServer documentation calls out a setting for `experimental_approximateDocumentStoreMiB` allowing you to set max size of the internal documentStore.

Current code for `initializeDocumentStore`:

```js
private initializeDocumentStore(): InMemoryLRUCache<DocumentNode> {
    return new InMemoryLRUCache<DocumentNode>({
      // Create ~about~ a 30MiB InMemoryLRUCache.  This is less than precise
      // since the technique to calculate the size of a DocumentNode is
      // only using JSON.stringify on the DocumentNode (and thus doesn't account
      // for unicode characters, etc.), but it should do a reasonable job at
      // providing a caching document store for most operations.
      maxSize:
        Math.pow(2, 20) * (this.experimental_approximateDocumentStoreMiB || 30),
      sizeCalculator: approximateObjectSize,
    });
  }
```

That code relies on `this.experimental_approximateDocumentStoreMiB `, but that variable is never set in the constructor. This PR fixes that.

That being said, I would actually like to go one step further, to allow passing a custom `documentStore` as part of the constructor. One of our graphql server processes maintains 20 different `ApolloServer` that host different versions of schema-stitched APIs (cms-v1, cms-v2, cms-v3, dms-v1 etc). It would be nice if I could re-use the document store between all of those instances since there is considerable overlap in the queries between the different versions of the graphql servers. Right now it gobbles up memory because we end up with 30mb x 20 servers. I didn't want to do that step, because that's really more of a feature request, but I'd be willing to update this PR, or spin a new one to include that functionality if it's acceptable.