### PR TITLE
Disc 5634 pluggable document store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ The version headers in this history reflect the versions of Apollo Server itself
 - [`@apollo/gateway`](https://github.com/apollographql/federation/blob/HEAD/gateway-js/CHANGELOG.md)
 - [`@apollo/federation`](https://github.com/apollographql/federation/blob/HEAD/federation-js/CHANGELOG.md)
 
-## vNEXT
+## vNEXT (minor)
 
+- `apollo-server-core`: You can now specify your own `DocumentStore` (a `KeyValueStore<DocumentNode>`) for Apollo Server's cache of parsed and validated GraphQL operation abstract syntax trees via the new `documentStore` constructor option. This replaces the `experimental_approximateDocumentStoreMiB` option. You can replace `new ApolloServer({experimental_approximateDocumentStoreMiB: approximateDocumentStoreMiB, ...moreOptions})` with:
+  ```typescript
+  import { InMemoryLRUCache } from 'apollo-server-caching';
+  import type { DocumentNode } from 'graphql';
+  new ApolloServer({
+    documentStore: new InMemoryLRUCache<DocumentNode>({
+      maxSize: Math.pow(2, 20) * approximateDocumentStoreMiB,
+      sizeCalculator: InMemoryLRUCache.jsonBytesSizeCalculator,
+    }),
+    ...moreOptions,
+  })
+  ```
+  [PR #5644](https://github.com/apollographql/apollo-server/pull/5644) [Issue #5634](https://github.com/apollographql/apollo-server/issues/5634)
 - `apollo-server-core`: For ease of testing, you can specify the node environment via `new ApolloServer({nodeEnv})` in addition to via the `NODE_ENV` environment variable. The environment variable is now only read during server startup (and in some error cases) rather than on every request. [PR #5657](https://github.com/apollographql/apollo-server/pull/5657)
 - `apollo-server-koa`: The peer dependency on `koa` (added in v3.0.0) should be a `^` range dependency rather than depending on exactly one version, and it should not be automatically increased when new versions of `koa` are released. [PR #5759](https://github.com/apollographql/apollo-server/pull/5759)
 - `apollo-server-fastify`: Export `ApolloServerFastifyConfig` and `FastifyContext` TypeScript types. [PR #5743](https://github.com/apollographql/apollo-server/pull/5743)

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -190,6 +190,22 @@ An array containing custom functions to use as additional [validation rules](htt
 
 
 <tr>
+<td>
+
+##### `documentStore`
+
+`KeyValueCache<DocumentNode>` or `boolean`
+</td>
+<td>
+
+The server checks the SHA-256 hash of each incoming operation against DocumentNodes cached in the `documentStore` and skips unnecessary parsing and validation if a match is found. The `documentStore` does not store the results of queries. Set this value when you want to change the cache size or store the cache information in an alternate location. Do not re-use a cache between multiple `ApolloServer` instances unless you prefix the entries uniquely per `ApolloServer` (for example using [PrefixingKeyValueCache](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-caching/src/PrefixingKeyValueCache.ts)).
+
+The default value is an [InMemoryLRUCache](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-caching/src/InMemoryLRUCache.ts) with a default size of 30MiB, which is usually sufficient unless the server processes a large number of unique operations. Pass `false` to disable caching entirely.
+</td>
+</tr>
+
+
+<tr>
 <td colspan="2">
 
 **Networking options**

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -50,4 +50,11 @@ export class InMemoryLRUCache<V = string> implements KeyValueCache<V> {
   async getTotalSize() {
     return this.store.length;
   }
+
+  // This is a size calculator based on the number of bytes in a JSON
+  // encoding of the stored object. It happens to be what ApolloServer
+  // uses for its default DocumentStore and may be helpful to others as well.
+  static jsonBytesSizeCalculator<T>(obj: T): number {
+    return Buffer.byteLength(JSON.stringify(obj), 'utf8');
+  }
 }

--- a/packages/apollo-server-core/src/__tests__/documentStore.test.ts
+++ b/packages/apollo-server-core/src/__tests__/documentStore.test.ts
@@ -97,41 +97,20 @@ describe('ApolloServerBase documentStore', () => {
     expect(setSpy.mock.calls.length).toBe(1);
   });
 
-  it('documentStore - false', async () => {
+  it('documentStore - null', async () => {
     const server = new ApolloServerObservable({
       typeDefs,
       resolvers,
-      documentStore: false,
+      documentStore: null,
     });
 
     await server.start();
 
     const options = await server.graphQLServerOptions();
-    expect(options.documentStore).toBe(undefined);
+    expect(options.documentStore).toBe(null);
 
     const result = await server.executeOperation(operations.simple.op);
 
     expect(result.data).toEqual({ hello: 'world' });
-  });
-
-  it('documentStore - true', async () => {
-    const server = new ApolloServerObservable({
-      typeDefs,
-      resolvers,
-      documentStore: true,
-    });
-
-    await server.start();
-
-    const options = await server.graphQLServerOptions();
-    const embeddedStore = options.documentStore as any;
-    expect(embeddedStore).toBeInstanceOf(InMemoryLRUCache);
-
-    await server.executeOperation(operations.simple.op);
-
-    expect(await embeddedStore.getTotalSize()).toBe(403);
-    expect(await embeddedStore.get(operations.simple.hash)).toMatchObject(
-      documentNodeMatcher,
-    );
   });
 });

--- a/packages/apollo-server-core/src/__tests__/documentStore.test.ts
+++ b/packages/apollo-server-core/src/__tests__/documentStore.test.ts
@@ -1,0 +1,137 @@
+import gql from 'graphql-tag';
+import type { DocumentNode } from 'graphql';
+
+import { ApolloServerBase } from '../ApolloServer';
+import { InMemoryLRUCache } from 'apollo-server-caching';
+
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`;
+
+const resolvers = {
+  Query: {
+    hello() {
+      return 'world';
+    },
+  },
+};
+
+// allow us to access internals of the class
+class ApolloServerObservable extends ApolloServerBase {
+  override graphQLServerOptions() {
+    return super.graphQLServerOptions();
+  }
+}
+
+const documentNodeMatcher = {
+  kind: 'Document',
+  definitions: expect.any(Array),
+  loc: {
+    start: 0,
+    end: 15,
+  },
+};
+
+const operations = {
+  simple: {
+    op: { query: 'query { hello }' },
+    hash: 'ec2e01311ab3b02f3d8c8c712f9e579356d332cd007ac4c1ea5df727f482f05f',
+  },
+};
+
+describe('ApolloServerBase documentStore', () => {
+  it('documentStore - undefined', async () => {
+    const server = new ApolloServerObservable({
+      typeDefs,
+      resolvers,
+    });
+
+    await server.start();
+
+    const options = await server.graphQLServerOptions();
+    const embeddedStore = options.documentStore as any;
+    expect(embeddedStore).toBeInstanceOf(InMemoryLRUCache);
+
+    await server.executeOperation(operations.simple.op);
+
+    expect(await embeddedStore.getTotalSize()).toBe(403);
+    expect(await embeddedStore.get(operations.simple.hash)).toMatchObject(
+      documentNodeMatcher,
+    );
+  });
+
+  it('documentStore - custom', async () => {
+    const documentStore = {
+      get: async function (key: string) {
+        return cache[key];
+      },
+      set: async function (key: string, val: DocumentNode) {
+        cache[key] = val;
+      },
+      delete: async function () {},
+    };
+    const cache: Record<string, DocumentNode> = {};
+
+    const getSpy = jest.spyOn(documentStore, 'get');
+    const setSpy = jest.spyOn(documentStore, 'set');
+
+    const server = new ApolloServerBase({
+      typeDefs,
+      resolvers,
+      documentStore,
+    });
+    await server.start();
+
+    await server.executeOperation(operations.simple.op);
+
+    expect(Object.keys(cache)).toEqual([operations.simple.hash]);
+    expect(cache[operations.simple.hash]).toMatchObject(documentNodeMatcher);
+
+    await server.executeOperation(operations.simple.op);
+
+    expect(Object.keys(cache)).toEqual([operations.simple.hash]);
+
+    expect(getSpy.mock.calls.length).toBe(2);
+    expect(setSpy.mock.calls.length).toBe(1);
+  });
+
+  it('documentStore - false', async () => {
+    const server = new ApolloServerObservable({
+      typeDefs,
+      resolvers,
+      documentStore: false,
+    });
+
+    await server.start();
+
+    const options = await server.graphQLServerOptions();
+    expect(options.documentStore).toBe(undefined);
+
+    const result = await server.executeOperation(operations.simple.op);
+
+    expect(result.data).toEqual({ hello: 'world' });
+  });
+
+  it('documentStore - true', async () => {
+    const server = new ApolloServerObservable({
+      typeDefs,
+      resolvers,
+      documentStore: true,
+    });
+
+    await server.start();
+
+    const options = await server.graphQLServerOptions();
+    const embeddedStore = options.documentStore as any;
+    expect(embeddedStore).toBeInstanceOf(InMemoryLRUCache);
+
+    await server.executeOperation(operations.simple.op);
+
+    expect(await embeddedStore.getTotalSize()).toBe(403);
+    expect(await embeddedStore.get(operations.simple.hash)).toMatchObject(
+      documentNodeMatcher,
+    );
+  });
+});

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -1107,12 +1107,6 @@ describe('runQuery', () => {
       return '{\n' + query + '}';
     }
 
-    // This should use the same logic as the calculation in InMemoryLRUCache:
-    // https://github.com/apollographql/apollo-server/blob/94b98ff3/packages/apollo-server-caching/src/InMemoryLRUCache.ts#L23
-    function approximateObjectSize<T>(obj: T): number {
-      return Buffer.byteLength(JSON.stringify(obj), 'utf8');
-    }
-
     it('validates each time when the documentStore is not present', async () => {
       expect.assertions(4);
 
@@ -1167,12 +1161,12 @@ describe('runQuery', () => {
       // size of the two smaller queries.  All three of these queries will never
       // fit into this cache, so we'll roll through them all.
       const maxSize =
-        approximateObjectSize(parse(querySmall1)) +
-        approximateObjectSize(parse(querySmall2));
+        InMemoryLRUCache.jsonBytesSizeCalculator(parse(querySmall1)) +
+        InMemoryLRUCache.jsonBytesSizeCalculator(parse(querySmall2));
 
       const documentStore = new InMemoryLRUCache<DocumentNode>({
         maxSize,
-        sizeCalculator: approximateObjectSize,
+        sizeCalculator: InMemoryLRUCache.jsonBytesSizeCalculator,
       });
 
       await runRequest({ plugins, documentStore, queryString: querySmall1 });

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -7,7 +7,7 @@ import type {
   GraphQLFormattedError,
   ParseOptions,
 } from 'graphql';
-import type { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
+import type { KeyValueCache } from 'apollo-server-caching';
 import type { DataSource } from 'apollo-datasource';
 import type { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import type {
@@ -18,6 +18,7 @@ import type {
   Logger,
   SchemaHash,
 } from 'apollo-server-types';
+import type { DocumentStore } from './types';
 
 /*
  * GraphQLServerOptions
@@ -56,7 +57,7 @@ export interface GraphQLServerOptions<
   cache?: KeyValueCache;
   persistedQueries?: PersistedQueryOptions;
   plugins?: ApolloServerPlugin[];
-  documentStore?: InMemoryLRUCache<DocumentNode>;
+  documentStore?: DocumentStore;
   parseOptions?: ParseOptions;
   nodeEnv?: string;
 }

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -57,7 +57,7 @@ export interface GraphQLServerOptions<
   cache?: KeyValueCache;
   persistedQueries?: PersistedQueryOptions;
   plugins?: ApolloServerPlugin[];
-  documentStore?: DocumentStore;
+  documentStore?: DocumentStore | null;
   parseOptions?: ParseOptions;
   nodeEnv?: string;
 }

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -87,7 +87,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   ) => GraphQLResponse | null;
 
   plugins?: ApolloServerPlugin[];
-  documentStore?: DocumentStore;
+  documentStore?: DocumentStore | null;
 
   parseOptions?: ParseOptions;
 }

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -53,16 +53,13 @@ import type {
 } from 'apollo-server-plugin-base';
 
 import { Dispatcher } from './utils/dispatcher';
-import {
-  InMemoryLRUCache,
-  KeyValueCache,
-  PrefixingKeyValueCache,
-} from 'apollo-server-caching';
+import { KeyValueCache, PrefixingKeyValueCache } from 'apollo-server-caching';
 
 export { GraphQLRequest, GraphQLResponse, GraphQLRequestContext };
 
 import createSHA from './utils/createSHA';
 import { HttpQueryError } from './runHttpQuery';
+import type { DocumentStore } from './types';
 import { Headers } from 'apollo-server-env';
 
 export const APQ_CACHE_PREFIX = 'apq:';
@@ -90,7 +87,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   ) => GraphQLResponse | null;
 
   plugins?: ApolloServerPlugin[];
-  documentStore?: InMemoryLRUCache<DocumentNode>;
+  documentStore?: DocumentStore;
 
   parseOptions?: ParseOptions;
 }

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -99,9 +99,8 @@ export interface Config<ContextFunctionParams = any> extends BaseConfig {
   plugins?: PluginDefinition[];
   persistedQueries?: PersistedQueryOptions | false;
   gateway?: GatewayInterface;
-  experimental_approximateDocumentStoreMiB?: number;
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
-  documentStore?: DocumentStore | boolean;
+  documentStore?: DocumentStore | null;
 }

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -18,7 +18,8 @@ import type { GraphQLSchemaModule } from '@apollographql/apollo-tools';
 
 export type { GraphQLSchemaModule };
 
-export { KeyValueCache } from 'apollo-server-caching';
+import type { KeyValueCache } from 'apollo-server-caching';
+export type { KeyValueCache };
 
 export type Context<T = object> = T;
 export type ContextFunction<FunctionParams = any, ProducedContext = object> = (
@@ -81,6 +82,8 @@ export interface GatewayInterface {
 // that older versions of `@apollo/gateway` build against AS3.
 export interface GraphQLService extends GatewayInterface {}
 
+export type DocumentStore = KeyValueCache<DocumentNode>;
+
 // This configuration is shared between all integrations and should include
 // fields that are not specific to a single integration
 export interface Config<ContextFunctionParams = any> extends BaseConfig {
@@ -100,4 +103,5 @@ export interface Config<ContextFunctionParams = any> extends BaseConfig {
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
+  documentStore?: DocumentStore | boolean;
 }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

This was discussed in https://github.com/apollographql/apollo-server/discussions/5634 . I wasn't sure if you wanted me to revoke the `experimental_approximateDocumentStoreMiB` or, since that would become a breaking change, if you wanted to keep it out of this PR. I kept it, so that it functions exactly as it did prior. If we are going to keep it, we should probably add a test to the documentStore test file to verify it's actually passing in correctly.

Couple key things I want to call out:

* Added a document entry, it's a little verbose, but this feature doesn't seem to warrant it's own page, and it really should be rarely used, so it seems good enough.
* I added a `DocumentStore` to `types.ts` this way we aren't re-specifying the contents of `documentStore` across many different files. It's definition is using `KeyValueCache` as suggested.
* The feature supports `true`, `false`, `undefined` or custom object. The downstream code already handled an undefined store luckily so I didn't have to change that at all.
* I am normalizing the value of documentStore so that downstream code always receives a `DocumentStore` rather than the `DocumentStore | boolean` complexity that the external constructor accepts.
* To test it I needed to a extension of the main `ApolloServerBase` so that I could externally call the protected `graphQLServerOptions`. There might be a better way to accomplish this...

Let me know what you'd like to tweak.