### PR TITLE
Remove access to process.env from hot code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+- `apollo-server-core`: For ease of testing, you can specify the node environment via `new ApolloServer({nodeEnv})` in addition to via the `NODE_ENV` environment variable. The environment variable is now only read during server startup (and in some error cases) rather than on every request. [PR #5657](https://github.com/apollographql/apollo-server/pull/5657)
 - `apollo-server-koa`: The peer dependency on `koa` (added in v3.0.0) should be a `^` range dependency rather than depending on exactly one version, and it should not be automatically increased when new versions of `koa` are released. [PR #5759](https://github.com/apollographql/apollo-server/pull/5759)
 - `apollo-server-fastify`: Export `ApolloServerFastifyConfig` and `FastifyContext` TypeScript types. [PR #5743](https://github.com/apollographql/apollo-server/pull/5743)
 - `apollo-server-core`: Only generate the schema hash once on startup rather than twice. [PR #5757](https://github.com/apollographql/apollo-server/pull/5757)

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -390,6 +390,19 @@ The default value is `true`. Set this to `false` to use mocked resolvers only fo
 </td>
 </tr>
 
+<tr>
+<td>
+
+##### `nodeEnv`
+
+`String`
+</td>
+<td>
+
+If this is set to any string value, use that value instead of the environment variable `NODE_ENV` for the features whose defaults depend on `NODE_ENV` (like the [`debug`](#introspection) and [`introspection`](#introspection) options). Note that passing the empty string here is equivalent to running with the `NODE_ENV` environment variable unset. This is primarily meant for testing the effects of the `NODE_ENV` environment variable.
+</td>
+</tr>
+
 </tbody>
 </table>
 

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -44,6 +44,8 @@ export interface CacheOptions {
 export type Body = BodyInit | object;
 export { Request };
 
+const NODE_ENV = process.env.NODE_ENV;
+
 export abstract class RESTDataSource<TContext = any> extends DataSource {
   httpCache!: HTTPCache;
   context!: TContext;
@@ -282,7 +284,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
     request: Request,
     fn: () => Promise<TResult>,
   ): Promise<TResult> {
-    if (process.env.NODE_ENV === 'development') {
+    if (NODE_ENV === 'development') {
       // We're not using console.time because that isn't supported on Cloudflare
       const startTime = Date.now();
       try {

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -153,7 +153,7 @@ export class ApolloServerBase<
     if (!config) throw new Error('ApolloServer requires options.');
     this.config = {
       ...config,
-      nodeEnv: 'nodeEnv' in config ? config.nodeEnv : process.env.NODE_ENV,
+      nodeEnv: config.nodeEnv ?? process.env.NODE_ENV,
     };
     const {
       context,

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -151,12 +151,10 @@ export class ApolloServerBase<
   // The constructor should be universal across all environments. All environment specific behavior should be set by adding or overriding methods
   constructor(config: Config<ContextFunctionParams>) {
     if (!config) throw new Error('ApolloServer requires options.');
-
     this.config = {
       ...config,
-      nodeEnv: config.nodeEnv ?? process.env.NODE_ENV,
+      nodeEnv: 'nodeEnv' in config ? config.nodeEnv : process.env.NODE_ENV,
     };
-
     const {
       context,
       resolvers,

--- a/packages/apollo-server-core/src/__tests__/runHttpQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runHttpQuery.test.ts
@@ -29,6 +29,7 @@ describe('runHttpQuery', () => {
         query: '{ testString }',
       },
       options: {
+        debug: false,
         schema,
         schemaHash: generateSchemaHash(schema),
       },

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -58,7 +58,7 @@ export interface GraphQLServerOptions<
   plugins?: ApolloServerPlugin[];
   documentStore?: InMemoryLRUCache<DocumentNode>;
   parseOptions?: ParseOptions;
-  nodeEnv?: string | undefined;
+  nodeEnv?: string;
 }
 
 export type DataSources<TContext> = {

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -58,7 +58,7 @@ export interface GraphQLServerOptions<
   plugins?: ApolloServerPlugin[];
   documentStore?: InMemoryLRUCache<DocumentNode>;
   parseOptions?: ParseOptions;
-  __testing_nodeEnv__?: string | undefined;
+  nodeEnv?: string | undefined;
 }
 
 export type DataSources<TContext> = {

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -131,7 +131,8 @@ export async function runHttpQuery(
     // The options can be generated asynchronously, so we don't have access to
     // the normal options provided by the user, such as: formatError,
     // debug. Therefore, we need to do some unnatural things, such
-    // as use NODE_ENV to determine the debug settings
+    // as use NODE_ENV to determine the debug settings. Please note that this
+    // will not be sensitive to any runtime changes made to NODE_ENV.
     return throwHttpGraphQLError(500, [e as Error], {
       debug: debugFromNodeEnv(),
     });

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -120,7 +120,7 @@ export async function runHttpQuery(
   handlerArguments: Array<any>,
   request: HttpQueryRequest,
 ): Promise<HttpQueryResponse> {
-  function debugFromNodeEnv(nodeEnv: string | undefined) {
+  function debugFromNodeEnv(nodeEnv: string | undefined = NODE_ENV) {
     return nodeEnv !== 'production' && nodeEnv !== 'test';
   }
 
@@ -133,14 +133,12 @@ export async function runHttpQuery(
     // debug. Therefore, we need to do some unnatural things, such
     // as use NODE_ENV to determine the debug settings
     return throwHttpGraphQLError(500, [e as Error], {
-      debug: debugFromNodeEnv(NODE_ENV),
+      debug: debugFromNodeEnv(),
     });
   }
 
   if (options.debug === undefined) {
-    const nodeEnv =
-      '__testing_nodeEnv__' in options ? options.__testing_nodeEnv__ : NODE_ENV;
-    options.debug = debugFromNodeEnv(nodeEnv);
+    options.debug = debugFromNodeEnv(options.nodeEnv);
   }
 
   // TODO: Errors thrown while resolving the context in

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -120,7 +120,7 @@ export async function runHttpQuery(
   handlerArguments: Array<any>,
   request: HttpQueryRequest,
 ): Promise<HttpQueryResponse> {
-  function debugFromNodeEnv(nodeEnv: string | undefined = NODE_ENV) {
+  function debugFromNodeEnv(nodeEnv: string | undefined) {
     return nodeEnv !== 'production' && nodeEnv !== 'test';
   }
 
@@ -133,7 +133,7 @@ export async function runHttpQuery(
     // debug. Therefore, we need to do some unnatural things, such
     // as use NODE_ENV to determine the debug settings
     return throwHttpGraphQLError(500, [e as Error], {
-      debug: debugFromNodeEnv(),
+      debug: debugFromNodeEnv(NODE_ENV),
     });
   }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -120,7 +120,7 @@ export async function runHttpQuery(
   handlerArguments: Array<any>,
   request: HttpQueryRequest,
 ): Promise<HttpQueryResponse> {
-  function debugFromNodeEnv(nodeEnv: string | undefined) {
+  function debugFromNodeEnv(nodeEnv: string | undefined = NODE_ENV) {
     return nodeEnv !== 'production' && nodeEnv !== 'test';
   }
 
@@ -133,7 +133,7 @@ export async function runHttpQuery(
     // debug. Therefore, we need to do some unnatural things, such
     // as use NODE_ENV to determine the debug settings
     return throwHttpGraphQLError(500, [e as Error], {
-      debug: debugFromNodeEnv(NODE_ENV),
+      debug: debugFromNodeEnv(),
     });
   }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -114,13 +114,13 @@ export function throwHttpGraphQLError<E extends Error>(
   );
 }
 
-const NODE_ENV = process.env.NODE_ENV;
+const NODE_ENV = process.env.NODE_ENV ?? '';
 
 export async function runHttpQuery(
   handlerArguments: Array<any>,
   request: HttpQueryRequest,
 ): Promise<HttpQueryResponse> {
-  function debugFromNodeEnv(nodeEnv: string | undefined = NODE_ENV) {
+  function debugFromNodeEnv(nodeEnv: string = NODE_ENV) {
     return nodeEnv !== 'production' && nodeEnv !== 'test';
   }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -114,6 +114,8 @@ export function throwHttpGraphQLError<E extends Error>(
   );
 }
 
+const NODE_ENV = process.env.NODE_ENV;
+
 export async function runHttpQuery(
   handlerArguments: Array<any>,
   request: HttpQueryRequest,
@@ -131,15 +133,13 @@ export async function runHttpQuery(
     // debug. Therefore, we need to do some unnatural things, such
     // as use NODE_ENV to determine the debug settings
     return throwHttpGraphQLError(500, [e as Error], {
-      debug: debugFromNodeEnv(process.env.NODE_ENV),
+      debug: debugFromNodeEnv(NODE_ENV),
     });
   }
 
   if (options.debug === undefined) {
     const nodeEnv =
-      '__testing_nodeEnv__' in options
-        ? options.__testing_nodeEnv__
-        : process.env.NODE_ENV;
+      '__testing_nodeEnv__' in options ? options.__testing_nodeEnv__ : NODE_ENV;
     options.debug = debugFromNodeEnv(nodeEnv);
   }
 

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -99,5 +99,5 @@ export interface Config<ContextFunctionParams = any> extends BaseConfig {
   experimental_approximateDocumentStoreMiB?: number;
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;
-  nodeEnv?: string | undefined;
+  nodeEnv?: string;
 }

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -99,12 +99,5 @@ export interface Config<ContextFunctionParams = any> extends BaseConfig {
   experimental_approximateDocumentStoreMiB?: number;
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;
-  // Apollo Server only uses process.env.NODE_ENV to determine defaults for
-  // other behavior which have other mechanisms of setting explicitly. Sometimes
-  // our tests want to test the exact logic of how NODE_ENV affects defaults;
-  // they can set this parameter, but there's no reason to do so other than for
-  // tests. Note that an explicit `__testing_nodeEnv__: undefined` means "act as
-  // if the environment variable is not set", whereas the absence of
-  // `__testing_nodeEnv__` means to honor the environment variable.
-  __testing_nodeEnv__?: string | undefined;
+  nodeEnv?: string | undefined;
 }

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -120,7 +120,7 @@ describe('apollo-server-express', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        __testing_nodeEnv__: undefined, // default landing page
+        nodeEnv: undefined, // default landing page
       });
 
       await request(httpServer)
@@ -265,7 +265,7 @@ describe('apollo-server-express', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -296,7 +296,7 @@ describe('apollo-server-express', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -326,7 +326,7 @@ describe('apollo-server-express', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -355,7 +355,7 @@ describe('apollo-server-express', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-express/src/__tests__/ApolloServer.test.ts
@@ -120,7 +120,7 @@ describe('apollo-server-express', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        nodeEnv: undefined, // default landing page
+        nodeEnv: '', // default landing page
       });
 
       await request(httpServer)
@@ -265,7 +265,7 @@ describe('apollo-server-express', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -296,7 +296,7 @@ describe('apollo-server-express', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -178,7 +178,7 @@ describe('apollo-server-fastify', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        nodeEnv: undefined, // default landing page
+        nodeEnv: '', // default landing page
       });
 
       await request(httpServer)
@@ -283,7 +283,7 @@ describe('apollo-server-fastify', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -314,7 +314,7 @@ describe('apollo-server-fastify', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -178,7 +178,7 @@ describe('apollo-server-fastify', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        __testing_nodeEnv__: undefined, // default landing page
+        nodeEnv: undefined, // default landing page
       });
 
       await request(httpServer)
@@ -283,7 +283,7 @@ describe('apollo-server-fastify', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -314,7 +314,7 @@ describe('apollo-server-fastify', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -344,7 +344,7 @@ describe('apollo-server-fastify', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -373,7 +373,7 @@ describe('apollo-server-fastify', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -116,7 +116,7 @@ describe('non-integration tests', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        __testing_nodeEnv__: undefined, // default landing page
+        nodeEnv: undefined, // default landing page
       });
 
       await request(httpServer)
@@ -288,7 +288,7 @@ describe('non-integration tests', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -319,7 +319,7 @@ describe('non-integration tests', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -349,7 +349,7 @@ describe('non-integration tests', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -378,7 +378,7 @@ describe('non-integration tests', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/ApolloServer.test.ts
@@ -116,7 +116,7 @@ describe('non-integration tests', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        nodeEnv: undefined, // default landing page
+        nodeEnv: '', // default landing page
       });
 
       await request(httpServer)
@@ -288,7 +288,7 @@ describe('non-integration tests', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -319,7 +319,7 @@ describe('non-integration tests', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -248,7 +248,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const { url: uri } = await createApolloServer({
             schema,
             stopOnTerminationSignals: false,
-            __testing_nodeEnv__: undefined,
+            nodeEnv: undefined,
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -262,7 +262,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const { url: uri } = await createApolloServer({
             schema,
             stopOnTerminationSignals: false,
-            __testing_nodeEnv__: 'production',
+            nodeEnv: 'production',
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -281,7 +281,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             schema,
             introspection: true,
             stopOnTerminationSignals: false,
-            __testing_nodeEnv__: 'production',
+            nodeEnv: 'production',
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -979,7 +979,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               ],
               debug: true,
               stopOnTerminationSignals: false,
-              __testing_nodeEnv__: undefined,
+              nodeEnv: undefined,
               ...constructorOptions,
             });
 
@@ -1595,7 +1595,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               typeDefs,
               resolvers,
               stopOnTerminationSignals: false,
-              __testing_nodeEnv__: undefined,
+              nodeEnv: undefined,
               context: () => {
                 throw new AuthenticationError('valid result');
               },
@@ -1653,7 +1653,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             },
           },
           stopOnTerminationSignals: false,
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -1683,7 +1683,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             },
           },
           stopOnTerminationSignals: false,
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -1714,7 +1714,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             },
           },
           stopOnTerminationSignals: false,
-          __testing_nodeEnv__: 'development',
+          nodeEnv: 'development',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -2922,7 +2922,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             })),
           ],
           // dev mode, so we get the local landing page
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         };
       }
 

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -248,7 +248,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
           const { url: uri } = await createApolloServer({
             schema,
             stopOnTerminationSignals: false,
-            nodeEnv: undefined,
+            nodeEnv: '',
           });
 
           const apolloFetch = createApolloFetch({ uri });
@@ -979,7 +979,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               ],
               debug: true,
               stopOnTerminationSignals: false,
-              nodeEnv: undefined,
+              nodeEnv: '',
               ...constructorOptions,
             });
 
@@ -1595,7 +1595,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
               typeDefs,
               resolvers,
               stopOnTerminationSignals: false,
-              nodeEnv: undefined,
+              nodeEnv: '',
               context: () => {
                 throw new AuthenticationError('valid result');
               },
@@ -2922,7 +2922,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             })),
           ],
           // dev mode, so we get the local landing page
-          nodeEnv: undefined,
+          nodeEnv: '',
         };
       }
 

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -118,7 +118,7 @@ describe('apollo-server-koa', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        nodeEnv: undefined, // default landing page
+        nodeEnv: '', // default landing page
       });
 
       await request(httpServer)
@@ -254,7 +254,7 @@ describe('apollo-server-koa', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -285,7 +285,7 @@ describe('apollo-server-koa', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          nodeEnv: undefined,
+          nodeEnv: '',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -118,7 +118,7 @@ describe('apollo-server-koa', () => {
       const { httpServer } = await createServer({
         typeDefs,
         resolvers,
-        __testing_nodeEnv__: undefined, // default landing page
+        nodeEnv: undefined, // default landing page
       });
 
       await request(httpServer)
@@ -254,7 +254,7 @@ describe('apollo-server-koa', () => {
             throw new AuthenticationError('valid result');
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -285,7 +285,7 @@ describe('apollo-server-koa', () => {
             },
           },
           // Stack trace not included for NODE_ENV=test
-          __testing_nodeEnv__: undefined,
+          nodeEnv: undefined,
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -315,7 +315,7 @@ describe('apollo-server-koa', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });
@@ -344,7 +344,7 @@ describe('apollo-server-koa', () => {
               },
             },
           },
-          __testing_nodeEnv__: 'production',
+          nodeEnv: 'production',
         });
 
         const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -85,10 +85,7 @@ describe('apollo-server-micro', function () {
       });
 
       it('should render a landing page when a browser sends in a request', async function () {
-        const { service, uri } = await createServer(
-          {},
-          { __testing_nodeEnv__: undefined },
-        );
+        const { service, uri } = await createServer({}, { nodeEnv: undefined });
 
         const body = await rp({
           uri: `${uri}/graphql`,

--- a/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/ApolloServer.test.ts
@@ -85,7 +85,7 @@ describe('apollo-server-micro', function () {
       });
 
       it('should render a landing page when a browser sends in a request', async function () {
-        const { service, uri } = await createServer({}, { nodeEnv: undefined });
+        const { service, uri } = await createServer({}, { nodeEnv: '' });
 
         const body = await rp({
           uri: `${uri}/graphql`,

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -203,7 +203,7 @@ describe('apollo-server', () => {
         typeDefs,
         resolvers,
         stopOnTerminationSignals: false,
-        nodeEnv: undefined,
+        nodeEnv: '',
       });
 
       const { server: httpServer } = await server.listen({ port: 0 });

--- a/packages/apollo-server/src/__tests__/index.test.ts
+++ b/packages/apollo-server/src/__tests__/index.test.ts
@@ -203,7 +203,7 @@ describe('apollo-server', () => {
         typeDefs,
         resolvers,
         stopOnTerminationSignals: false,
-        __testing_nodeEnv__: undefined,
+        nodeEnv: undefined,
       });
 
       const { server: httpServer } = await server.listen({ port: 0 });


### PR DESCRIPTION
Removes access to `process.env` from hot code paths. My understanding on this is admittedly somewhat limited, but there is a performance penalty that occurs when accessing `process.env` (or perhaps just `process`) because Node needs to drop down to C which is (apparently) quite expensive. The penalty wouldn't be noticeable as a one time thing, but for things that are running often at scale, it can really add up.

I _vaguely_ recall this being an issue in React SSR early on... remember reading something about this being discovered and remedied, leading to immediate perf improvements. Can't find the article about it... and now I'm wondering if my memory is failing me... but I recall this being the first thing that made me aware of the process.env penalty.

(Edit: I think it was this: https://reactjs.org/blog/2017/09/26/react-v16.0.html#better-server-side-rendering) 

Offhand, I know express [recommends](https://expressjs.com/en/advanced/best-practice-performance.html) this, too. 

From what I could tell, these aren't transpiled out (I looked in the `dist` directory that gets installed in `node_modules`). Perhaps this is already being handled differently, making this PR moot, but figured I'd throw this up and get your thoughts.

There are other spots I saw doing this, but they looked like they were only being done when the server started, so the penalty wouldn't be noticeable at all. Suppose it could be done across the board for consistency.
