### PR TITLE
fix: change the execute call signature which is removed in GraphQL.js 16

### DIFF
--- a/packages/apollo-server-core/src/utils/schemaHash.ts
+++ b/packages/apollo-server-core/src/utils/schemaHash.ts
@@ -8,8 +8,11 @@ import { SchemaHash } from 'apollo-server-types';
 
 export function generateSchemaHash(schema: GraphQLSchema): SchemaHash {
   const introspectionQuery = getIntrospectionQuery();
-  const documentAST = parse(introspectionQuery);
-  const result = execute(schema, documentAST) as ExecutionResult;
+  const document = parse(introspectionQuery);
+  const result = execute({
+    schema,
+    document,
+  }) as ExecutionResult;
 
   // If the execution of an introspection query results in a then-able, it
   // indicates that one or more of its resolvers is behaving in an asynchronous


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

I am currently testing the GraphQL.js 16 RC and this is causing issues.  https://github.com/n1ru4l/graphql-js/blob/0fef3c49907b63b1ea5a4ff1da7011775f465fc2/src/execution/execute.ts

Using the single object argument signature is fine with older GraphQL.js versions. This is a non-breaking change.

```
FAIL packages/plugins/apollo-server-errors/test/apollo-server-errors.spec.ts (545 MB heap size)
  ● useApolloServerErrors › should return the same output when Error is thrown from a resolver (debug=false)

    Must provide document.

       8 | describe('useApolloServerErrors', () => {
       9 |   const executeBoth = async (schema: GraphQLSchema, query: string, debug: boolean) => {
    > 10 |     const apolloServer = new ApolloServerBase({ schema, debug });
         |                          ^
      11 |     const envelopRuntime = envelop({ plugins: [useSchema(schema), useApolloServerErrors({ debug })] })({});
      12 |
      13 |     return {

      at devAssert (node_modules/graphql/jsutils/devAssert.js:12:11)
      at assertValidExecutionArguments (node_modules/graphql/execution/execute.js:145:40)
      at Object.execute (node_modules/graphql/execution/execute.js:74:3)
      at Object.generateSchemaHash (node_modules/apollo-server-core/src/utils/schemaHash.ts:12:18)
      at ApolloServerBase.generateSchemaDerivedData (node_modules/apollo-server-core/src/ApolloServer.ts:671:24)
      at Object.schemaDerivedDataProvider (node_modules/apollo-server-core/src/ApolloServer.ts:288:18)
      at new SchemaManager (node_modules/apollo-server-core/src/utils/schemaManager.ts:75:15)
      at new ApolloServerBase (node_modules/apollo-server-core/src/ApolloServer.ts:283:24)
      at executeBoth (packages/plugins/apollo-server-errors/test/apollo-server-errors.spec.ts:10:26)
      at Object.<anonymous> (packages/plugins/apollo-server-errors/test/apollo-server-errors.spec.ts:35:27)
```