### PR TITLE
Change validationRules docs from object to array

### DIFF
--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -180,7 +180,7 @@ Providing a function is useful if you want to use a different root value dependi
 
 ##### `validationRules`
 
-`Array`
+`Array<Function>`
 </td>
 <td>
 

--- a/docs/source/api/apollo-server.md
+++ b/docs/source/api/apollo-server.md
@@ -180,11 +180,11 @@ Providing a function is useful if you want to use a different root value dependi
 
 ##### `validationRules`
 
-`Object`
+`Array`
 </td>
 <td>
 
-An object containing custom functions to use as additional [validation rules](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) when validating the schema.
+An array containing custom functions to use as additional [validation rules](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) when validating the schema.
 </td>
 </tr>
 


### PR DESCRIPTION
Corrects mistake about `validationRules` in the docs so that it says it's an array instead of an object.

Resolves issue #5656.
