### PR TITLE
TypeScript: switch to importsNotUsedAsValues: error

### DIFF
--- a/packages/apollo-datasource-rest/src/HTTPCache.ts
+++ b/packages/apollo-datasource-rest/src/HTTPCache.ts
@@ -7,7 +7,7 @@ import {
   InMemoryLRUCache,
   PrefixingKeyValueCache,
 } from 'apollo-server-caching';
-import { CacheOptions } from './RESTDataSource';
+import type { CacheOptions } from './RESTDataSource';
 
 export class HTTPCache {
   private keyValueCache: KeyValueCache;

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -10,7 +10,7 @@ import {
   fetch,
 } from 'apollo-server-env';
 
-import { ValueOrPromise } from 'apollo-server-types';
+import type { ValueOrPromise } from 'apollo-server-types';
 
 import { DataSource, DataSourceConfig } from 'apollo-datasource';
 

--- a/packages/apollo-datasource/src/index.ts
+++ b/packages/apollo-datasource/src/index.ts
@@ -1,4 +1,4 @@
-import { KeyValueCache } from 'apollo-server-caching';
+import type { KeyValueCache } from 'apollo-server-caching';
 
 export interface DataSourceConfig<TContext> {
   context: TContext;

--- a/packages/apollo-server-azure-functions/src/ApolloServer.ts
+++ b/packages/apollo-server-azure-functions/src/ApolloServer.ts
@@ -1,9 +1,9 @@
-import { Context, HttpRequest } from '@azure/functions';
-import { HttpResponse } from 'azure-functions-ts-essentials';
+import type { Context, HttpRequest } from '@azure/functions';
+import type { HttpResponse } from 'azure-functions-ts-essentials';
 import { ApolloServerBase } from 'apollo-server-core';
-import { GraphQLOptions } from 'apollo-server-core';
+import type { GraphQLOptions } from 'apollo-server-core';
 import { graphqlAzureFunction } from './azureFunctionApollo';
-import { LandingPage } from 'apollo-server-plugin-base';
+import type { LandingPage } from 'apollo-server-plugin-base';
 
 export interface CreateHandlerOptions {
   cors?: {

--- a/packages/apollo-server-azure-functions/src/__tests__/azureFunctionApollo.test.ts
+++ b/packages/apollo-server-azure-functions/src/__tests__/azureFunctionApollo.test.ts
@@ -3,9 +3,9 @@ import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 import url from 'url';
-import { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import typeis from 'type-is';
 
 const createAzureFunction = async (options: CreateAppOptions = {}) => {

--- a/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
+++ b/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
@@ -1,11 +1,11 @@
-import { Context, HttpRequest, AzureFunction } from '@azure/functions';
+import type { Context, HttpRequest, AzureFunction } from '@azure/functions';
 import {
   GraphQLOptions,
   isHttpQueryError,
   runHttpQuery,
 } from 'apollo-server-core';
 import { Headers } from 'apollo-server-env';
-import { ValueOrPromise } from 'apollo-server-types';
+import type { ValueOrPromise } from 'apollo-server-types';
 
 export interface AzureFunctionGraphQLOptionsFunction {
   (request: HttpRequest, context: Context): ValueOrPromise<GraphQLOptions>;

--- a/packages/apollo-server-cache-memcached/src/index.ts
+++ b/packages/apollo-server-cache-memcached/src/index.ts
@@ -1,4 +1,7 @@
-import { KeyValueCache, KeyValueCacheSetOptions } from 'apollo-server-caching';
+import type {
+  KeyValueCache,
+  KeyValueCacheSetOptions,
+} from 'apollo-server-caching';
 import Memcached from 'memcached';
 import { promisify } from 'util';
 

--- a/packages/apollo-server-cache-redis/src/BaseRedisCache.ts
+++ b/packages/apollo-server-cache-redis/src/BaseRedisCache.ts
@@ -1,4 +1,7 @@
-import { KeyValueCache, KeyValueCacheSetOptions } from 'apollo-server-caching';
+import type {
+  KeyValueCache,
+  KeyValueCacheSetOptions,
+} from 'apollo-server-caching';
 import DataLoader from 'dataloader';
 
 interface BaseRedisClient {

--- a/packages/apollo-server-caching/src/InMemoryLRUCache.ts
+++ b/packages/apollo-server-caching/src/InMemoryLRUCache.ts
@@ -1,5 +1,5 @@
 import LRUCache from 'lru-cache';
-import { KeyValueCache } from './KeyValueCache';
+import type { KeyValueCache } from './KeyValueCache';
 
 function defaultLengthCalculation(item: any) {
   if (Array.isArray(item) || typeof item === 'string') {

--- a/packages/apollo-server-caching/src/PrefixingKeyValueCache.ts
+++ b/packages/apollo-server-caching/src/PrefixingKeyValueCache.ts
@@ -1,4 +1,4 @@
-import { KeyValueCache, KeyValueCacheSetOptions } from './KeyValueCache';
+import type { KeyValueCache, KeyValueCacheSetOptions } from './KeyValueCache';
 
 // PrefixingKeyValueCache wraps another cache and adds a prefix to all keys used
 // by all operations.  This allows multiple features to share the same

--- a/packages/apollo-server-caching/src/testsuite.ts
+++ b/packages/apollo-server-caching/src/testsuite.ts
@@ -1,4 +1,4 @@
-import { KeyValueCache } from './KeyValueCache';
+import type { KeyValueCache } from './KeyValueCache';
 
 /**
  * runKeyValueCacheTests is a function you can call from a test that exercises

--- a/packages/apollo-server-cloud-functions/src/__tests__/googleCloudApollo.test.ts
+++ b/packages/apollo-server-cloud-functions/src/__tests__/googleCloudApollo.test.ts
@@ -3,7 +3,7 @@ import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 import express = require('express');
 import bodyParser = require('body-parser');
 import request from 'supertest';

--- a/packages/apollo-server-cloudflare/src/ApolloServer.ts
+++ b/packages/apollo-server-cloudflare/src/ApolloServer.ts
@@ -2,8 +2,8 @@ import { graphqlCloudflare } from './cloudflareApollo';
 
 import { ApolloServerBase } from 'apollo-server-core';
 export { GraphQLOptions } from 'apollo-server-core';
-import { GraphQLOptions } from 'apollo-server-core';
-import { Request } from 'apollo-server-env';
+import type { GraphQLOptions } from 'apollo-server-core';
+import type { Request } from 'apollo-server-env';
 
 export class ApolloServer extends ApolloServerBase {
   // This translates the arguments from the middleware into graphQL options It

--- a/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
+++ b/packages/apollo-server-cloudflare/src/cloudflareApollo.ts
@@ -5,7 +5,7 @@ import {
 } from 'apollo-server-core';
 
 import { Request, Response, URL } from 'apollo-server-env';
-import { ValueOrPromise } from 'apollo-server-types';
+import type { ValueOrPromise } from 'apollo-server-types';
 
 // Design principles:
 // - You can issue a GET or POST with your query.

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -22,9 +22,14 @@ import type {
   LandingPage,
 } from 'apollo-server-plugin-base';
 
-import { GraphQLServerOptions } from './graphqlOptions';
+import type { GraphQLServerOptions } from './graphqlOptions';
 
-import { Config, Context, ContextFunction, PluginDefinition } from './types';
+import type {
+  Config,
+  Context,
+  ContextFunction,
+  PluginDefinition,
+} from './types';
 
 import { generateSchemaHash } from './utils/schemaHash';
 import {
@@ -36,7 +41,7 @@ import {
 
 import { Headers } from 'apollo-server-env';
 import { buildServiceDefinition } from '@apollographql/apollo-tools';
-import { Logger, SchemaHash, ApolloConfig } from 'apollo-server-types';
+import type { Logger, SchemaHash, ApolloConfig } from 'apollo-server-types';
 import { cloneObject } from './runHttpQuery';
 import isNodeLike from './utils/isNodeLike';
 import { determineApolloConfig } from './determineApolloConfig';

--- a/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
+++ b/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
@@ -1,9 +1,9 @@
 import { ApolloServerBase } from '../ApolloServer';
 import { buildServiceDefinition } from '@apollographql/apollo-tools';
 import { gql } from '../';
-import { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import type { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import type { GraphQLSchema } from 'graphql';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from 'apollo-server-types';
 
 const typeDefs = gql`
   type Query {

--- a/packages/apollo-server-core/src/__tests__/logger.test.ts
+++ b/packages/apollo-server-core/src/__tests__/logger.test.ts
@@ -1,5 +1,5 @@
 import { ApolloServerBase } from '../..';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from 'apollo-server-types';
 import { PassThrough } from 'stream';
 import gql from 'graphql-tag';
 

--- a/packages/apollo-server-core/src/__tests__/runQuery.test.ts
+++ b/packages/apollo-server-core/src/__tests__/runQuery.test.ts
@@ -10,12 +10,15 @@ import {
   DocumentNode,
 } from 'graphql';
 
-import { GraphQLResponse } from 'apollo-server-types';
+import type { GraphQLResponse } from 'apollo-server-types';
 
 import { processGraphQLRequest, GraphQLRequest } from '../requestPipeline';
-import { Request } from 'apollo-server-env';
-import { GraphQLOptions, Context as GraphQLContext } from 'apollo-server-core';
-import {
+import type { Request } from 'apollo-server-env';
+import type {
+  GraphQLOptions,
+  Context as GraphQLContext,
+} from 'apollo-server-core';
+import type {
   ApolloServerPlugin,
   GraphQLRequestExecutionListener,
   GraphQLRequestListener,

--- a/packages/apollo-server-core/src/determineApolloConfig.ts
+++ b/packages/apollo-server-core/src/determineApolloConfig.ts
@@ -1,4 +1,4 @@
-import { ApolloConfig, ApolloConfigInput } from 'apollo-server-types';
+import type { ApolloConfig, ApolloConfigInput } from 'apollo-server-types';
 import createSHA from './utils/createSHA';
 
 // This function combines the `apollo` constructor argument and some environment

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   GraphQLSchema,
   ValidationContext,
   GraphQLFieldResolver,
@@ -7,10 +7,10 @@ import {
   GraphQLFormattedError,
   ParseOptions,
 } from 'graphql';
-import { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
-import { DataSource } from 'apollo-datasource';
-import { ApolloServerPlugin } from 'apollo-server-plugin-base';
-import {
+import type { KeyValueCache, InMemoryLRUCache } from 'apollo-server-caching';
+import type { DataSource } from 'apollo-datasource';
+import type { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import type {
   GraphQLExecutor,
   ValueOrPromise,
   GraphQLResponse,

--- a/packages/apollo-server-core/src/index.ts
+++ b/packages/apollo-server-core/src/index.ts
@@ -41,7 +41,7 @@ export {
 
 // This currently provides the ability to have syntax highlighting as well as
 // consistency between client and server gql tags
-import { DocumentNode } from 'graphql';
+import type { DocumentNode } from 'graphql';
 import gqlTag from 'graphql-tag';
 export const gql: (
   template: TemplateStringsArray | string,

--- a/packages/apollo-server-core/src/nodeHttpToRequest.ts
+++ b/packages/apollo-server-core/src/nodeHttpToRequest.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'http';
 import { Request, Headers } from 'apollo-server-env';
 
 export function convertNodeHttpToRequest(req: IncomingMessage): Request {

--- a/packages/apollo-server-core/src/plugin/cacheControl/__tests__/cacheControlPlugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/__tests__/cacheControlPlugin.test.ts
@@ -5,7 +5,7 @@ import {
   ApolloServerPluginCacheControl,
   ApolloServerPluginCacheControlOptions,
 } from '../';
-import {
+import type {
   GraphQLRequestContextWillSendResponse,
   GraphQLResponse,
 } from 'apollo-server-plugin-base';

--- a/packages/apollo-server-core/src/plugin/cacheControl/__tests__/collectCacheControlHints.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/__tests__/collectCacheControlHints.ts
@@ -1,5 +1,5 @@
 import { GraphQLSchema, graphql } from 'graphql';
-import { CacheHint } from 'apollo-server-types';
+import type { CacheHint } from 'apollo-server-types';
 import {
   ApolloServerPluginCacheControl,
   ApolloServerPluginCacheControlOptions,

--- a/packages/apollo-server-core/src/plugin/cacheControl/__tests__/dynamicCacheControl.test.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/__tests__/dynamicCacheControl.test.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   GraphQLScalarType,
   GraphQLFieldResolver,
   GraphQLTypeResolver,

--- a/packages/apollo-server-core/src/plugin/cacheControl/index.ts
+++ b/packages/apollo-server-core/src/plugin/cacheControl/index.ts
@@ -1,5 +1,5 @@
 import type { CacheAnnotation, CacheHint } from 'apollo-server-types';
-import { CacheScope } from 'apollo-server-types';
+import type { CacheScope } from 'apollo-server-types';
 import {
   DirectiveNode,
   getNamedType,

--- a/packages/apollo-server-core/src/plugin/landingPage/graphqlPlayground/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/graphqlPlayground/index.ts
@@ -5,7 +5,7 @@
 // specifying `version` when installing the plugin.
 
 import { renderPlaygroundPage } from '@apollographql/graphql-playground-html';
-import {
+import type {
   ApolloServerPlugin,
   GraphQLServerListener,
 } from 'apollo-server-plugin-base';

--- a/packages/apollo-server-core/src/plugin/schemaReporting/__tests__/schemaReporter.test.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/__tests__/schemaReporter.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import { schemaReportGql, SchemaReporter } from '../schemaReporter';
-import {
+import type {
   SchemaReportMutation,
   ReportSchemaResponse,
   SchemaReportMutationVariables,

--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -6,7 +6,7 @@ import type { fetch } from 'apollo-server-env';
 import { SchemaReporter } from './schemaReporter';
 import createSHA from '../../utils/createSHA';
 import { schemaIsFederated } from '../schemaIsFederated';
-import { SchemaReport } from './operations';
+import type { SchemaReport } from './operations';
 
 export interface ApolloServerPluginSchemaReportingOptions {
   /**

--- a/packages/apollo-server-core/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/schemaReporter.ts
@@ -1,8 +1,8 @@
 import { gql } from '../..';
 import { fetch, Headers, Request } from 'apollo-server-env';
-import { GraphQLRequest, Logger } from 'apollo-server-types';
+import type { GraphQLRequest, Logger } from 'apollo-server-types';
 import { print } from 'graphql';
-import {
+import type {
   SchemaReport,
   SchemaReportMutationVariables,
   SchemaReportMutation,

--- a/packages/apollo-server-core/src/plugin/traceTreeBuilder.ts
+++ b/packages/apollo-server-core/src/plugin/traceTreeBuilder.ts
@@ -2,7 +2,7 @@
 // ApolloServerPluginInlineTrace.
 import { GraphQLError, GraphQLResolveInfo, ResponsePath } from 'graphql';
 import { Trace, google } from 'apollo-reporting-protobuf';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from 'apollo-server-types';
 
 function internalError(message: string) {
   return new Error(`[internal apollo-server error] ${message}`);

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/plugin.test.ts
@@ -12,7 +12,7 @@ import { Trace, Report, ITrace } from 'apollo-reporting-protobuf';
 import pluginTestHarness from '../../../utils/pluginTestHarness';
 import nock from 'nock';
 import { gunzipSync } from 'zlib';
-import { ApolloServerPluginUsageReportingOptions } from '../options';
+import type { ApolloServerPluginUsageReportingOptions } from '../options';
 
 const quietLogger = loglevel.getLogger('quiet');
 quietLogger.setLevel(loglevel.levels.WARN);

--- a/packages/apollo-server-core/src/plugin/usageReporting/iterateOverTrace.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/iterateOverTrace.ts
@@ -1,4 +1,4 @@
-import { Trace } from 'apollo-reporting-protobuf';
+import type { Trace } from 'apollo-reporting-protobuf';
 
 /**
  * Iterates over the entire trace, calling `f` on each Trace.Node found. It

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -1,5 +1,5 @@
-import { GraphQLError, DocumentNode } from 'graphql';
-import {
+import type { GraphQLError, DocumentNode } from 'graphql';
+import type {
   GraphQLRequestContextDidResolveOperation,
   Logger,
   GraphQLRequestContext,

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -4,7 +4,7 @@ import retry from 'async-retry';
 import { defaultUsageReportingSignature } from 'apollo-graphql';
 import { Report, ReportHeader, Trace } from 'apollo-reporting-protobuf';
 import { Response, fetch, Headers } from 'apollo-server-env';
-import {
+import type {
   GraphQLRequestListener,
   GraphQLServerListener,
 } from 'apollo-server-plugin-base';
@@ -16,7 +16,7 @@ import {
   GraphQLRequestContextWillSendResponse,
 } from 'apollo-server-types';
 import { createSignatureCache, signatureCacheKey } from './signatureCache';
-import {
+import type {
   ApolloServerPluginUsageReportingOptions,
   SendValuesBaseOptions,
 } from './options';

--- a/packages/apollo-server-core/src/plugin/usageReporting/signatureCache.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/signatureCache.ts
@@ -1,5 +1,5 @@
 import LRUCache from 'lru-cache';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from 'apollo-server-types';
 
 export function createSignatureCache({
   logger,

--- a/packages/apollo-server-core/src/plugin/usageReporting/traceDetails.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/traceDetails.ts
@@ -1,5 +1,5 @@
 import { Trace } from 'apollo-reporting-protobuf';
-import { VariableValueOptions } from './options';
+import type { VariableValueOptions } from './options';
 
 // Creates trace details from request variables, given a specification for modifying
 // values of private or sensitive variables.

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -13,8 +13,8 @@ import {
   Kind,
   ParseOptions,
 } from 'graphql';
-import { DataSource } from 'apollo-datasource';
-import { PersistedQueryOptions } from './graphqlOptions';
+import type { DataSource } from 'apollo-datasource';
+import type { PersistedQueryOptions } from './graphqlOptions';
 import {
   symbolExecutionDispatcherWillResolveField,
   enablePluginsForSchemaResolvers,
@@ -30,7 +30,7 @@ import {
   formatApolloErrors,
   UserInputError,
 } from 'apollo-server-errors';
-import {
+import type {
   GraphQLRequest,
   GraphQLResponse,
   GraphQLRequestContext,
@@ -38,7 +38,7 @@ import {
   GraphQLExecutionResult,
   ValidationRule,
 } from 'apollo-server-types';
-import {
+import type {
   ApolloServerPlugin,
   GraphQLRequestListener,
   GraphQLRequestContextDidResolveSource,

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -10,8 +10,8 @@ import {
   GraphQLRequestContext,
   GraphQLResponse,
 } from './requestPipeline';
-import { ApolloServerPlugin } from 'apollo-server-plugin-base';
-import {
+import type { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import type {
   WithRequired,
   GraphQLExecutionResult,
   ValueOrPromise,

--- a/packages/apollo-server-core/src/utils/dispatcher.ts
+++ b/packages/apollo-server-core/src/utils/dispatcher.ts
@@ -1,4 +1,4 @@
-import { AnyFunction, AnyFunctionMap } from 'apollo-server-types';
+import type { AnyFunction, AnyFunctionMap } from 'apollo-server-types';
 
 type Args<F> = F extends (...args: infer A) => any ? A : never;
 type AsFunction<F> = F extends AnyFunction ? F : never;

--- a/packages/apollo-server-core/src/utils/pluginTestHarness.ts
+++ b/packages/apollo-server-core/src/utils/pluginTestHarness.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CacheHint,
   WithRequired,
   GraphQLRequest,
@@ -17,7 +17,7 @@ import {
   enablePluginsForSchemaResolvers,
   symbolExecutionDispatcherWillResolveField,
 } from './schemaInstrumentation';
-import {
+import type {
   ApolloServerPlugin,
   GraphQLRequestExecutionListener,
   GraphQLServerListener,

--- a/packages/apollo-server-core/src/utils/schemaHash.ts
+++ b/packages/apollo-server-core/src/utils/schemaHash.ts
@@ -2,9 +2,9 @@ import { parse } from 'graphql/language';
 import { execute, ExecutionResult } from 'graphql/execution';
 import { getIntrospectionQuery, IntrospectionSchema } from 'graphql/utilities';
 import stableStringify from 'fast-json-stable-stringify';
-import { GraphQLSchema } from 'graphql/type';
+import type { GraphQLSchema } from 'graphql/type';
 import createSHA from './createSHA';
-import { SchemaHash } from 'apollo-server-types';
+import type { SchemaHash } from 'apollo-server-types';
 
 export function generateSchemaHash(schema: GraphQLSchema): SchemaHash {
   const introspectionQuery = getIntrospectionQuery();

--- a/packages/apollo-server-core/src/utils/schemaInstrumentation.ts
+++ b/packages/apollo-server-core/src/utils/schemaInstrumentation.ts
@@ -7,8 +7,8 @@ import {
   GraphQLFieldResolver,
 } from 'graphql/type';
 import { defaultFieldResolver } from 'graphql/execution';
-import { FieldNode } from 'graphql/language';
-import { GraphQLRequestExecutionListener } from 'apollo-server-plugin-base';
+import type { FieldNode } from 'graphql/language';
+import type { GraphQLRequestExecutionListener } from 'apollo-server-plugin-base';
 import type { GraphQLObjectResolver } from '@apollographql/apollo-tools';
 
 export const symbolExecutionDispatcherWillResolveField = Symbol(

--- a/packages/apollo-server-core/src/utils/schemaManager.ts
+++ b/packages/apollo-server-core/src/utils/schemaManager.ts
@@ -1,12 +1,12 @@
-import { GraphQLSchema } from 'graphql';
-import {
+import type { GraphQLSchema } from 'graphql';
+import type {
   ApolloConfig,
   GraphQLExecutor,
   GraphQLSchemaContext,
   Logger,
 } from 'apollo-server-types';
-import { GatewayInterface, Unsubscriber } from '../types';
-import { SchemaDerivedData } from '../ApolloServer';
+import type { GatewayInterface, Unsubscriber } from '../types';
+import type { SchemaDerivedData } from '../ApolloServer';
 
 type SchemaDerivedDataProvider = (
   apiSchema: GraphQLSchema,

--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 
-import http, { Server } from 'http';
+import type http from 'http';
+import type { Server } from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 
@@ -11,7 +12,7 @@ import {
   createApolloFetch,
 } from 'apollo-server-integration-testsuite';
 import { gql } from '../index';
-import { AddressInfo } from 'net';
+import type { AddressInfo } from 'net';
 import type { GraphQLResolverMap } from 'apollo-graphql';
 
 export class IdAPI extends RESTDataSource {

--- a/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/ApolloServer.test.ts
@@ -1,4 +1,4 @@
-import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import fastify from 'fastify';
 import request from 'supertest';
 

--- a/packages/apollo-server-fastify/src/__tests__/fastifyApollo.test.ts
+++ b/packages/apollo-server-fastify/src/__tests__/fastifyApollo.test.ts
@@ -4,7 +4,7 @@ import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 import type { ApolloServerPlugin } from 'apollo-server-plugin-base';
 
 describe('fastifyApollo', () => {

--- a/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
+++ b/packages/apollo-server-hapi/src/__tests__/hapiApollo.test.ts
@@ -1,5 +1,5 @@
 import { ApolloServer } from '../ApolloServer';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 
 import testSuite, {
   schema as Schema,

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -47,7 +47,7 @@ import {
 } from 'apollo-server-core';
 import { Headers, fetch } from 'apollo-server-env';
 import ApolloServerPluginResponseCache from 'apollo-server-plugin-response-cache';
-import {
+import type {
   BaseContext,
   GraphQLRequestContext,
   GraphQLRequestContextExecutionDidStart,
@@ -55,7 +55,7 @@ import {
 
 import resolvable, { Resolvable } from '@josephg/resolvable';
 import FakeTimers from '@sinonjs/fake-timers';
-import { AddressInfo } from 'net';
+import type { AddressInfo } from 'net';
 import request from 'supertest';
 
 const quietLogger = loglevel.getLogger('quiet');

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -28,8 +28,8 @@ import {
   ApolloServerPluginCacheControl,
 } from 'apollo-server-core';
 import gql from 'graphql-tag';
-import { GraphQLResponse, ValueOrPromise } from 'apollo-server-types';
-import { GraphQLRequestListener } from 'apollo-server-plugin-base';
+import type { GraphQLResponse, ValueOrPromise } from 'apollo-server-types';
+import type { GraphQLRequestListener } from 'apollo-server-plugin-base';
 import { PersistedQueryNotFoundError } from 'apollo-server-errors';
 
 export * from './ApolloServer';

--- a/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/ApolloServer.test.ts
@@ -15,7 +15,7 @@ import {
   createServerInfo,
   createApolloFetch,
 } from 'apollo-server-integration-testsuite';
-import { ApolloServer } from '../ApolloServer';
+import type { ApolloServer } from '../ApolloServer';
 
 const typeDefs = gql`
   type Query {

--- a/packages/apollo-server-koa/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/datasource.test.ts
@@ -1,4 +1,5 @@
-import http, { Server } from 'http';
+import type http from 'http';
+import type { Server } from 'http';
 
 import { RESTDataSource } from 'apollo-datasource-rest';
 
@@ -9,7 +10,7 @@ import {
 
 import { gql } from 'apollo-server-core';
 import type { GraphQLResolverMap } from 'apollo-graphql';
-import { AddressInfo } from 'net';
+import type { AddressInfo } from 'net';
 
 export class IdAPI extends RESTDataSource {
   // We will set this inside tests.

--- a/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/koaApollo.test.ts
@@ -2,7 +2,7 @@ import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 
 async function createApp(options: CreateAppOptions = {}) {
   const Koa = require('koa');

--- a/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts
+++ b/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts
@@ -3,7 +3,7 @@ import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 import { createMockServer as createAPIGatewayMockServer } from './mockAPIGatewayServer';
 import { createMockServer as createALBMockServer } from './mockALBServer';
 

--- a/packages/apollo-server-lambda/src/__tests__/mockALBServer.ts
+++ b/packages/apollo-server-lambda/src/__tests__/mockALBServer.ts
@@ -1,6 +1,6 @@
 import url from 'url';
-import { IncomingMessage, ServerResponse } from 'http';
-import {
+import type { IncomingMessage, ServerResponse } from 'http';
+import type {
   Context as LambdaContext,
   ALBHandler,
   ALBEvent,

--- a/packages/apollo-server-lambda/src/__tests__/mockAPIGatewayServer.ts
+++ b/packages/apollo-server-lambda/src/__tests__/mockAPIGatewayServer.ts
@@ -1,5 +1,5 @@
 import url from 'url';
-import { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyStructuredResultV2,

--- a/packages/apollo-server-micro/src/ApolloServer.ts
+++ b/packages/apollo-server-micro/src/ApolloServer.ts
@@ -1,11 +1,11 @@
 import { ApolloServerBase, GraphQLOptions } from 'apollo-server-core';
-import { ServerResponse } from 'http';
+import type { ServerResponse } from 'http';
 import { send } from 'micro';
 import { parseAll } from '@hapi/accept';
 
 import { graphqlMicro } from './microApollo';
-import { MicroRequest } from './types';
-import { LandingPage } from 'apollo-server-plugin-base';
+import type { MicroRequest } from './types';
+import type { LandingPage } from 'apollo-server-plugin-base';
 
 export interface ServerRegistration {
   path?: string;

--- a/packages/apollo-server-micro/src/__tests__/microApollo.test.ts
+++ b/packages/apollo-server-micro/src/__tests__/microApollo.test.ts
@@ -3,7 +3,7 @@ import testSuite, {
   schema as Schema,
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
-import { Config } from 'apollo-server-core';
+import type { Config } from 'apollo-server-core';
 
 import { ApolloServer } from '../ApolloServer';
 

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -6,11 +6,11 @@ import {
 } from 'apollo-server-core';
 import { send, json, RequestHandler } from 'micro';
 import url from 'url';
-import { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import typeis from 'type-is';
 
-import { MicroRequest } from './types';
-import { ValueOrPromise } from 'apollo-server-types';
+import type { MicroRequest } from './types';
+import type { ValueOrPromise } from 'apollo-server-types';
 
 // Allowed Micro Apollo Server options.
 export interface MicroGraphQLOptionsFunction {

--- a/packages/apollo-server-micro/src/types.ts
+++ b/packages/apollo-server-micro/src/types.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'http';
+import type { IncomingMessage } from 'http';
 
 export interface MicroRequest extends IncomingMessage {
   filePayload?: object;

--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AnyFunctionMap,
   BaseContext,
   GraphQLServiceContext,

--- a/packages/apollo-server-plugin-operation-registry/src/ApolloServerPluginOperationRegistry.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/ApolloServerPluginOperationRegistry.ts
@@ -1,5 +1,5 @@
 import { pluginName, getStoreKey, signatureForLogging } from './common';
-import {
+import type {
   ApolloServerPlugin,
   GraphQLServiceContext,
   GraphQLRequestListener,
@@ -21,7 +21,7 @@ import { ForbiddenError, ApolloError } from 'apollo-server-errors';
 import Agent from './agent';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 import loglevel from 'loglevel';
-import { fetch } from 'apollo-server-env';
+import type { fetch } from 'apollo-server-env';
 
 type ForbidUnregisteredOperationsPredicate = (
   requestContext: GraphQLRequestContext,

--- a/packages/apollo-server-plugin-operation-registry/src/__tests__/ApolloServerPluginOperationRegistry.test.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/__tests__/ApolloServerPluginOperationRegistry.test.ts
@@ -25,8 +25,8 @@ import {
   genericStorageSecret,
 } from './helpers.test-helpers';
 import { Headers } from 'apollo-server-env';
-import { GraphQLRequest } from 'apollo-server-plugin-base';
-import { ApolloConfigInput } from 'apollo-server-types';
+import type { GraphQLRequest } from 'apollo-server-plugin-base';
+import type { ApolloConfigInput } from 'apollo-server-types';
 
 // While not ideal, today, Apollo Server has a very real expectation of an HTTP
 // request context.  That will change in the future.  While we can sometimes

--- a/packages/apollo-server-plugin-operation-registry/src/__tests__/agent.test.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/__tests__/agent.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { InMemoryLRUCache } from 'apollo-server-caching';
+import type { InMemoryLRUCache } from 'apollo-server-caching';
 import { resolve as urlResolve } from 'url';
 import {
   defaultAgentOptions,
@@ -14,14 +14,14 @@ import {
   genericApiKeyHash,
 } from './helpers.test-helpers';
 import Agent, { AgentOptions } from '../agent';
-import { Operation } from '../ApolloServerPluginOperationRegistry';
+import type { Operation } from '../ApolloServerPluginOperationRegistry';
 import {
   fakeTestBaseUrl,
   getStoreKey,
   getOperationManifestUrl,
   urlOperationManifestBase,
 } from '../common';
-import { Logger } from 'apollo-server-types';
+import type { Logger } from 'apollo-server-types';
 
 // These get a bit verbose within the tests below, so we use this as a
 // sample store to pick and grab from.

--- a/packages/apollo-server-plugin-operation-registry/src/__tests__/helpers.test-helpers.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/__tests__/helpers.test-helpers.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { AgentOptions } from '../agent';
+import type { AgentOptions } from '../agent';
 import {
   getStorageSecretUrl,
   urlStorageSecretBase,
@@ -9,7 +9,7 @@ import {
 } from '../common';
 import nock from 'nock';
 import { InMemoryLRUCache } from 'apollo-server-caching';
-import {
+import type {
   Operation,
   OperationManifest,
 } from '../ApolloServerPluginOperationRegistry';

--- a/packages/apollo-server-plugin-operation-registry/src/agent.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/agent.ts
@@ -9,10 +9,10 @@ import loglevel from 'loglevel';
 import fetcher from 'make-fetch-happen';
 import { HttpRequestCache } from './cache';
 
-import { InMemoryLRUCache } from 'apollo-server-caching';
-import { OperationManifest } from './ApolloServerPluginOperationRegistry';
-import { Logger, ApolloConfig, WithRequired } from 'apollo-server-types';
-import { Response, RequestInit, fetch } from 'apollo-server-env';
+import type { InMemoryLRUCache } from 'apollo-server-caching';
+import type { OperationManifest } from './ApolloServerPluginOperationRegistry';
+import type { Logger, ApolloConfig, WithRequired } from 'apollo-server-types';
+import type { Response, RequestInit, fetch } from 'apollo-server-env';
 
 const DEFAULT_POLL_SECONDS: number = 30;
 const SYNC_WARN_TIME_SECONDS: number = 60;

--- a/packages/apollo-server-plugin-operation-registry/src/cache.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/cache.ts
@@ -1,4 +1,4 @@
-import { CacheManager } from 'make-fetch-happen';
+import type { CacheManager } from 'make-fetch-happen';
 import { Request, Response, Headers } from 'apollo-server-env';
 import { InMemoryLRUCache } from 'apollo-server-caching';
 

--- a/packages/apollo-server-plugin-operation-registry/src/schema.ts
+++ b/packages/apollo-server-plugin-operation-registry/src/schema.ts
@@ -3,7 +3,7 @@ import { parse } from 'graphql/language';
 import { execute, ExecutionResult } from 'graphql/execution';
 import { getIntrospectionQuery, IntrospectionSchema } from 'graphql/utilities';
 import stableStringify from 'fast-json-stable-stringify';
-import { GraphQLSchema } from 'graphql/type';
+import type { GraphQLSchema } from 'graphql/type';
 import { createHash } from 'crypto';
 
 export async function generateSchemaHash(

--- a/packages/apollo-server-plugin-response-cache/src/ApolloServerPluginResponseCache.ts
+++ b/packages/apollo-server-plugin-response-cache/src/ApolloServerPluginResponseCache.ts
@@ -1,8 +1,11 @@
-import {
+import type {
   ApolloServerPlugin,
   GraphQLRequestListener,
 } from 'apollo-server-plugin-base';
-import { GraphQLRequestContext, GraphQLResponse } from 'apollo-server-types';
+import type {
+  GraphQLRequestContext,
+  GraphQLResponse,
+} from 'apollo-server-types';
 import { KeyValueCache, PrefixingKeyValueCache } from 'apollo-server-caching';
 import type { CacheHint, ValueOrPromise } from 'apollo-server-types';
 import { CacheScope } from 'apollo-server-types';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "error",
     "lib": ["es2019", "esnext.asynciterable"],
     "types": ["node"],
     "baseUrl": ".",


### PR DESCRIPTION
This requires us to use `import type` if the symbols brought in by an
`import` aren't used at runtime.

Like the default value of remove, this gives the good performance of not
doing a runtime import for imports that are only used for typing. But by
enforcing the use of `import type`, you can easily tell with a glance if
a given import will be preserved for runtime or not.
