### PR TITLE
Remove path prefixes for server docs redirects

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,55 +1,55 @@
 # The v3 docs were beta for a while, and non-default, but now that they are
 # default, the v3 docs don't exist anymore.  So redirect them to the default!
-/docs/apollo-server/v3 /docs/apollo-server
-/docs/apollo-server/v3/* /docs/apollo-server/:splat
+/v3 /docs/apollo-server
+/v3/* /docs/apollo-server/:splat
 
 # Updating URLs for v3
-/docs/apollo-server/testing/graphql-playground/ /docs/apollo-server/testing/build-run-queries/#graphql-playground
-/docs/apollo-server/deployment /docs/apollo-server/deployment/heroku
+/testing/graphql-playground/ /docs/apollo-server/testing/build-run-queries/#graphql-playground
+/deployment /docs/apollo-server/deployment/heroku
 
 # Removing old hidden documentation
-/docs/apollo-server/features/schema-stitching/ /docs/apollo-server/
-/docs/apollo-server/features/schema-delegation/ /docs/apollo-server/
-/docs/apollo-server/features/remote-schemas/ /docs/apollo-server/
-/docs/apollo-server/features/schema-transforms/ /docs/apollo-server/
-/docs/apollo-server/why-apollo-server/ /docs/apollo-server/
+/features/schema-stitching/ /docs/apollo-server/
+/features/schema-delegation/ /docs/apollo-server/
+/features/remote-schemas/ /docs/apollo-server/
+/features/schema-transforms/ /docs/apollo-server/
+/why-apollo-server/ /docs/apollo-server/
 
-/docs/apollo-server/schema/scalars-enums/ /docs/apollo-server/schema/custom-scalars/
-/docs/apollo-server/data/data/ /docs/apollo-server/data/resolvers/
+/schema/scalars-enums/ /docs/apollo-server/schema/custom-scalars/
+/data/data/ /docs/apollo-server/data/resolvers/
 
-/docs/apollo-server/federation/implementing/ /docs/apollo-server/federation/implementing-services/
-/docs/apollo-server/federation/core-concepts/ /docs/apollo-server/federation/entities/
-/docs/apollo-server/federation/advanced-features/ /docs/apollo-server/federation/entities/
-/docs/apollo-server/federation/concerns/ /docs/apollo-server/federation/introduction/#separation-of-concerns
+/federation/implementing/ /docs/apollo-server/federation/implementing-services/
+/federation/core-concepts/ /docs/apollo-server/federation/entities/
+/federation/advanced-features/ /docs/apollo-server/federation/entities/
+/federation/concerns/ /docs/apollo-server/federation/introduction/#separation-of-concerns
 
-/docs/apollo-server/api/graphql-tools /docs/apollo-server/
+/api/graphql-tools /docs/apollo-server/
 
 # Redirects associated with revamp of Apollo Server information architecture
-/docs/apollo-server/whats-new https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md
-/docs/apollo-server/essentials/data/ /docs/apollo-server/data/data/
-/docs/apollo-server/essentials/schema/ /docs/apollo-server/schema/schema/
-/docs/apollo-server/essentials/server /docs/apollo-server/getting-started/
-/docs/apollo-server/features/apq/ /docs/apollo-server/performance/apq/
-/docs/apollo-server/features/authentication/ /docs/apollo-server/security/authentication/
-/docs/apollo-server/features/caching/ /docs/apollo-server/performance/caching/
-/docs/apollo-server/features/creating-directives/ /docs/apollo-server/schema/creating-directives/
-/docs/apollo-server/features/data-sources/ /docs/apollo-server/data/data-sources/
-/docs/apollo-server/features/data-sources.html /docs/apollo-server/data/data-sources/
-/docs/apollo-server/features/directives/ /docs/apollo-server/schema/directives/
-/docs/apollo-server/features/errors/ /docs/apollo-server/data/errors/
-/docs/apollo-server/features/file-uploads/ /docs/apollo-server/data/file-uploads/
-/docs/apollo-server/features/graphql-playground/ /docs/apollo-server/testing/graphql-playground/
-/docs/apollo-server/features/health-checks/ /docs/apollo-server/monitoring/health-checks/
-/docs/apollo-server/features/metrics/ /docs/apollo-server/monitoring/metrics/
-/docs/apollo-server/features/mocking/ /docs/apollo-server/testing/mocking/
-/docs/apollo-server/features/scalars-enums/ /docs/apollo-server/
-/docs/apollo-server/features/subscriptions/ /docs/apollo-server/data/subscriptions/
-/docs/apollo-server/features/testing/ /docs/apollo-server/testing/testing/
-/docs/apollo-server/features/unions-interfaces/ /docs/apollo-server/schema/unions-interfaces/
+/whats-new https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md
+/essentials/data/ /docs/apollo-server/data/data/
+/essentials/schema/ /docs/apollo-server/schema/schema/
+/essentials/server /docs/apollo-server/getting-started/
+/features/apq/ /docs/apollo-server/performance/apq/
+/features/authentication/ /docs/apollo-server/security/authentication/
+/features/caching/ /docs/apollo-server/performance/caching/
+/features/creating-directives/ /docs/apollo-server/schema/creating-directives/
+/features/data-sources/ /docs/apollo-server/data/data-sources/
+/features/data-sources.html /docs/apollo-server/data/data-sources/
+/features/directives/ /docs/apollo-server/schema/directives/
+/features/errors/ /docs/apollo-server/data/errors/
+/features/file-uploads/ /docs/apollo-server/data/file-uploads/
+/features/graphql-playground/ /docs/apollo-server/testing/graphql-playground/
+/features/health-checks/ /docs/apollo-server/monitoring/health-checks/
+/features/metrics/ /docs/apollo-server/monitoring/metrics/
+/features/mocking/ /docs/apollo-server/testing/mocking/
+/features/scalars-enums/ /docs/apollo-server/
+/features/subscriptions/ /docs/apollo-server/data/subscriptions/
+/features/testing/ /docs/apollo-server/testing/testing/
+/features/unions-interfaces/ /docs/apollo-server/schema/unions-interfaces/
 
 # Move federation docs into their own docset
-/docs/apollo-server/api/apollo-federation/ /docs/federation/api/apollo-federation/ 302!
-/docs/apollo-server/api/apollo-gateway/ /docs/federation/api/apollo-gateway/ 302!
-/docs/apollo-server/federation/managed-federation /docs/studio/managed-federation/overview/
-/docs/apollo-server/federation/introduction /docs/federation/ 302!
-/docs/apollo-server/federation/* /docs/federation/:splat 302!
+/api/apollo-federation/ /docs/federation/api/apollo-federation/ 302!
+/api/apollo-gateway/ /docs/federation/api/apollo-gateway/ 302!
+/federation/managed-federation /docs/studio/managed-federation/overview/
+/federation/introduction /docs/federation/ 302!
+/federation/* /docs/federation/:splat 302!


### PR DESCRIPTION
This branch updates our `_redirects` file to remove the `/docs/apollo-server` prefix from the `from` paths. This is necessary for our redirects to work since the change we made to the way docs sites are deployed in https://github.com/apollographql/apollo-server/pull/5632