### PR TITLE
Fix URL injection vulnerabilities in documentation

### DIFF
--- a/docs/source/data/data-sources.mdx
+++ b/docs/source/data/data-sources.mdx
@@ -179,7 +179,7 @@ class MoviesAPI extends RESTDataSource {
 
   async getMovie(id) {
     // Send a GET request to the specified endpoint
-    return this.get(`movies/${id}`);
+    return this.get(`movies/${encodeURIComponent(id)}`);
   }
 
   async getMostViewedMovies(limit = 10) {
@@ -211,7 +211,7 @@ class MoviesAPI extends RESTDataSource {
   // GET
   async getMovie(id) {
     return this.get(
-      `movies/${id}` // path
+      `movies/${encodeURIComponent(id)}` // path
     );
   }
 
@@ -242,7 +242,7 @@ class MoviesAPI extends RESTDataSource {
   // DELETE
   async deleteMovie(movie) {
     return this.delete(
-      `movies/${movie.id}`, // path
+      `movies/${encodeURIComponent(movie.id)}`, // path
     );
   }
 }

--- a/packages/apollo-datasource-rest/README.md
+++ b/packages/apollo-datasource-rest/README.md
@@ -28,7 +28,7 @@ class MoviesAPI extends RESTDataSource {
   }
 
   async getMovie(id) {
-    return this.get(`movies/${id}`);
+    return this.get(`movies/${encodeURIComponent(id)}`);
   }
 
   async getMostViewedMovies(limit = 10) {
@@ -79,7 +79,7 @@ class MoviesAPI extends RESTDataSource {
   // an example making an HTTP DELETE request
   async deleteMovie(movie) {
     return this.delete(
-      `movies/${movie.id}`, // path
+      `movies/${encodeURIComponent(movie.id)}`, // path
     );
   }
 }


### PR DESCRIPTION
The Apollo Server data source documentation has code samples that contain URL injection vulnerabilities. 

When user (e.g. query) input is concatenated into a URL without being encoded, an attacker can manipulate server-side requests to unintended targets. This type of vulnerability is sometimes referred to as Web Parameter Tampering (https://www.owasp.org/index.php/Web_Parameter_Tampering) and also can be thought of as a limited form of Server Side Request Forgery / SSRF (https://www.owasp.org/index.php/Server_Side_Request_Forgery).

In the samples, raw query input is used to concatenate URLs used to invoke backend REST APIs. If an attacker passes input that contains URL control characters they can modify the URL being accessed in a way the GraphQL Server does not expect, potentially gaining access to sensitive information or functionality.

For example, the documentation https://www.apollographql.com/docs/apollo-server/data/data-sources/ contains the following sample code:
``` 
async getMovie(id) {
    // Send a GET request to the specified endpoint
    return this.get(`movies/${id}`);
}
```

Assuming the `id` parameter allows any string input, an attacker could supply values such as `../newpath` or `5?overridden_parameter=true` to force the server-side URL to take unexpected forms (`/movies/../newpath`, `/movies/5?overriden_parameter=true`, etc). 

I've observed many developers copying and pasting the Apollo GraphQL sample documentation and introducing these types of vulnerabilities into their code. Thought it would be a wise idea to update the documentation so that developers are guided towards more secure options. 