### PR TITLE
Feat/async formatters [formatError, formatResponse]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20068,7 +20068,7 @@
       }
     },
     "packages/apollo-server": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "apollo-server-core": "file:../apollo-server-core",
@@ -20083,7 +20083,7 @@
       }
     },
     "packages/apollo-server-azure-functions": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@azure/functions": "1.2.3",
@@ -20137,7 +20137,7 @@
       }
     },
     "packages/apollo-server-cloud-functions": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "apollo-server-express": "file:../apollo-server-express",
@@ -20154,7 +20154,7 @@
       }
     },
     "packages/apollo-server-cloudflare": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "apollo-server-core": "file:../apollo-server-core",
@@ -20166,7 +20166,7 @@
       }
     },
     "packages/apollo-server-core": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@apollographql/apollo-tools": "^0.5.1",
@@ -20229,7 +20229,7 @@
       }
     },
     "packages/apollo-server-express": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/accepts": "^1.3.5",
@@ -20256,7 +20256,7 @@
       }
     },
     "packages/apollo-server-fastify": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "apollo-server-core": "file:../apollo-server-core",
@@ -20277,7 +20277,7 @@
       }
     },
     "packages/apollo-server-hapi": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@hapi/accept": "^5.0.2",
@@ -20297,7 +20297,7 @@
       }
     },
     "packages/apollo-server-integration-testsuite": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "apollo-server-core": "file:../apollo-server-core",
@@ -20308,7 +20308,7 @@
       }
     },
     "packages/apollo-server-koa": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@koa/cors": "^3.1.0",
@@ -20363,7 +20363,7 @@
       }
     },
     "packages/apollo-server-lambda": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.76",
@@ -20383,7 +20383,7 @@
       }
     },
     "packages/apollo-server-micro": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@hapi/accept": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20218,6 +20218,9 @@
     "packages/apollo-server-errors": {
       "version": "3.1.0",
       "license": "MIT",
+      "dependencies": {
+        "apollo-server-types": "file:../apollo-server-types"
+      },
       "engines": {
         "node": ">=12.0"
       },
@@ -25616,7 +25619,9 @@
     },
     "apollo-server-errors": {
       "version": "file:packages/apollo-server-errors",
-      "requires": {}
+      "requires": {
+        "apollo-server-types": "file:../apollo-server-types"
+      }
     },
     "apollo-server-express": {
       "version": "file:packages/apollo-server-express",

--- a/packages/apollo-datasource-rest/package.json
+++ b/packages/apollo-datasource-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-rest",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-datasource/package.json
+++ b/packages/apollo-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "3.3.0",
+	"version": "3.4.0",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-cache-memcached/package.json
+++ b/packages/apollo-server-cache-memcached/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cache-memcached",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-cache-redis/package.json
+++ b/packages/apollo-server-cache-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cache-redis",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-caching/package.json
+++ b/packages/apollo-server-caching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-caching",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/src/__tests__/errors.test.ts
+++ b/packages/apollo-server-core/src/__tests__/errors.test.ts
@@ -40,13 +40,13 @@ describe('Errors', () => {
     const code = 'CODE';
     const key = 'value';
 
-    const createFormattedError: CreateFormatError = (
+    const createFormattedError: CreateFormatError = async (
       options?: Record<string, any>,
       errors?: Error[],
     ) => {
       if (errors === undefined) {
         const error = new ApolloError(message, code, { key });
-        return formatApolloErrors(
+        return (await formatApolloErrors(
           [
             new GraphQLError(
               error.message,
@@ -58,14 +58,14 @@ describe('Errors', () => {
             ),
           ],
           options,
-        )[0];
+        ))[0];
       } else {
         return formatApolloErrors(errors, options);
       }
     };
 
-    it('exposes a stacktrace in debug mode', () => {
-      const error = createFormattedError({ debug: true });
+    it('exposes a stacktrace in debug mode', async () => {
+      const error = await createFormattedError({ debug: true });
       expect(error.message).toEqual(message);
       expect(error.extensions.key).toEqual(key);
       expect(error.extensions.exception.key).toBeUndefined();
@@ -73,10 +73,10 @@ describe('Errors', () => {
       // stacktrace should exist under exception
       expect(error.extensions.exception.stacktrace).toBeDefined();
     });
-    it('hides stacktrace by default', () => {
+    it('hides stacktrace by default', async () => {
       const thrown = new Error(message);
       (thrown as any).key = key;
-      const error = formatApolloErrors([
+      const error = (await formatApolloErrors([
         new GraphQLError(
           thrown.message,
           undefined,
@@ -85,7 +85,7 @@ describe('Errors', () => {
           undefined,
           thrown,
         ),
-      ])[0];
+      ]))[0];
       expect(error.message).toEqual(message);
       expect(error.extensions.code).toEqual('INTERNAL_SERVER_ERROR');
       expect(error.extensions.exception.key).toEqual(key);
@@ -99,10 +99,10 @@ describe('Errors', () => {
       expect(error.extensions.exception).toBeUndefined();
       expect(error.extensions.code).toEqual(code);
     });
-    it('calls formatter after exposing the code and stacktrace', () => {
+    it('calls formatter after exposing the code and stacktrace', async () => {
       const error = new ApolloError(message, code, { key });
       const formatter = jest.fn();
-      formatApolloErrors([error], {
+      await formatApolloErrors([error], {
         formatter,
         debug: true,
       });
@@ -113,9 +113,9 @@ describe('Errors', () => {
       expect(error instanceof ApolloError).toBe(true);
       expect(formatter).toHaveBeenCalledTimes(1);
     });
-    it('Formats native Errors in a JSON-compatible way', () => {
+    it('Formats native Errors in a JSON-compatible way', async () => {
       const error = new Error('Hello');
-      const [formattedError] = formatApolloErrors([error]);
+      const [formattedError] = await formatApolloErrors([error]);
       expect(JSON.parse(JSON.stringify(formattedError)).message).toBe('Hello');
     });
   });
@@ -164,7 +164,7 @@ describe('Errors', () => {
         name: 'ValidationError',
       });
     });
-    it('provides a user input error', () => {
+    it('provides a user input error', async () => {
       const error = new UserInputError(message, {
         field1: 'property1',
         field2: 'property2',
@@ -175,7 +175,7 @@ describe('Errors', () => {
         name: 'UserInputError',
       });
 
-      const formattedError = formatApolloErrors([
+      const formattedError = (await formatApolloErrors([
         new GraphQLError(
           error.message,
           undefined,
@@ -184,7 +184,7 @@ describe('Errors', () => {
           undefined,
           error,
         ),
-      ])[0];
+      ]))[0];
 
       expect(formattedError.extensions.field1).toEqual('property1');
       expect(formattedError.extensions.field2).toEqual('property2');

--- a/packages/apollo-server-core/src/__tests__/errors.test.ts
+++ b/packages/apollo-server-core/src/__tests__/errors.test.ts
@@ -34,8 +34,8 @@ describe('Errors', () => {
       | ((
           options: Record<string, any>,
           errors: Error[],
-        ) => Record<string, any>[])
-      | ((options?: Record<string, any>) => Record<string, any>);
+        ) => Promise<Record<string, any>[]>)
+      | ((options?: Record<string, any>) => Promise<Record<string, any>>);
     const message = 'message';
     const code = 'CODE';
     const key = 'value';
@@ -92,8 +92,8 @@ describe('Errors', () => {
       // stacktrace should exist under exception
       expect(error.extensions.exception.stacktrace).toBeUndefined();
     });
-    it('exposes fields on error under exception field and provides code', () => {
-      const error = createFormattedError();
+    it('exposes fields on error under exception field and provides code', async () => {
+      const error = await createFormattedError();
       expect(error.message).toEqual(message);
       expect(error.extensions.key).toEqual(key);
       expect(error.extensions.exception).toBeUndefined();

--- a/packages/apollo-server-core/src/__tests__/errors.test.ts
+++ b/packages/apollo-server-core/src/__tests__/errors.test.ts
@@ -46,19 +46,21 @@ describe('Errors', () => {
     ) => {
       if (errors === undefined) {
         const error = new ApolloError(message, code, { key });
-        return (await formatApolloErrors(
-          [
-            new GraphQLError(
-              error.message,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              error,
-            ),
-          ],
-          options,
-        ))[0];
+        return (
+          await formatApolloErrors(
+            [
+              new GraphQLError(
+                error.message,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                error,
+              ),
+            ],
+            options,
+          )
+        )[0];
       } else {
         return formatApolloErrors(errors, options);
       }
@@ -76,16 +78,18 @@ describe('Errors', () => {
     it('hides stacktrace by default', async () => {
       const thrown = new Error(message);
       (thrown as any).key = key;
-      const error = (await formatApolloErrors([
-        new GraphQLError(
-          thrown.message,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          thrown,
-        ),
-      ]))[0];
+      const error = (
+        await formatApolloErrors([
+          new GraphQLError(
+            thrown.message,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            thrown,
+          ),
+        ])
+      )[0];
       expect(error.message).toEqual(message);
       expect(error.extensions.code).toEqual('INTERNAL_SERVER_ERROR');
       expect(error.extensions.exception.key).toEqual(key);
@@ -175,16 +179,18 @@ describe('Errors', () => {
         name: 'UserInputError',
       });
 
-      const formattedError = (await formatApolloErrors([
-        new GraphQLError(
-          error.message,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          error,
-        ),
-      ]))[0];
+      const formattedError = (
+        await formatApolloErrors([
+          new GraphQLError(
+            error.message,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            error,
+          ),
+        ])
+      )[0];
 
       expect(formattedError.extensions.field1).toEqual('property1');
       expect(formattedError.extensions.field2).toEqual('property2');

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -41,7 +41,7 @@ export interface GraphQLServerOptions<
   schema: GraphQLSchema;
   schemaHash: SchemaHash;
   logger?: Logger;
-  formatError?: (error: GraphQLError) => GraphQLFormattedError;
+  formatError?: (error: GraphQLError) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
   rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -41,7 +41,10 @@ export interface GraphQLServerOptions<
   schema: GraphQLSchema;
   schemaHash: SchemaHash;
   logger?: Logger;
-  formatError?: (error: GraphQLError, requestContext?: GraphQLRequestContext<TContext>) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
+  formatError?: (
+    error: GraphQLError,
+    requestContext?: GraphQLRequestContext<TContext>,
+  ) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
   rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -49,7 +49,7 @@ export interface GraphQLServerOptions<
   formatResponse?: (
     response: GraphQLResponse,
     requestContext: GraphQLRequestContext<TContext>,
-  ) => GraphQLResponse | null;
+  ) => GraphQLResponse | null | Promise<GraphQLResponse | null>;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   debug?: boolean;
   dataSources?: () => DataSources<TContext>;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -41,7 +41,7 @@ export interface GraphQLServerOptions<
   schema: GraphQLSchema;
   schemaHash: SchemaHash;
   logger?: Logger;
-  formatError?: (error: GraphQLError) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
+  formatError?: (error: GraphQLError, requestContext?: GraphQLRequestContext<TContext>) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
   rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
   context?: TContext | (() => never);
   validationRules?: Array<(context: ValidationContext) => any>;

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -83,7 +83,10 @@ export interface GraphQLRequestPipelineConfig<TContext> {
 
   persistedQueries?: PersistedQueryOptions;
 
-  formatError?: (error: GraphQLError, requestContext?: GraphQLRequestContext<TContext>) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
+  formatError?: (
+    error: GraphQLError,
+    requestContext?: GraphQLRequestContext<TContext>,
+  ) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
   formatResponse?: (
     response: GraphQLResponse,
     requestContext: GraphQLRequestContext<TContext>,
@@ -437,10 +440,8 @@ export async function processGraphQLRequest<TContext>(
   }
 
   if (config.formatResponse) {
-    const formattedResponse: GraphQLResponse | null = await config.formatResponse(
-      response,
-      requestContext,
-    );
+    const formattedResponse: GraphQLResponse | null =
+      await config.formatResponse(response, requestContext);
     if (formattedResponse != null) {
       response = formattedResponse;
     }

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -83,7 +83,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
 
   persistedQueries?: PersistedQueryOptions;
 
-  formatError?: (error: GraphQLError) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
+  formatError?: (error: GraphQLError, requestContext?: GraphQLRequestContext<TContext>) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
   formatResponse?: (
     response: GraphQLResponse,
     requestContext: GraphQLRequestContext<TContext>,
@@ -587,6 +587,7 @@ export async function processGraphQLRequest<TContext>(
   ): Promise<ReadonlyArray<GraphQLFormattedError>> {
     return formatApolloErrors(errors, {
       formatter: config.formatError,
+      requestContext,
       debug: requestContext.debug,
     });
   }

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -87,7 +87,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   formatResponse?: (
     response: GraphQLResponse,
     requestContext: GraphQLRequestContext<TContext>,
-  ) => GraphQLResponse | null;
+  ) => GraphQLResponse | null | Promise<GraphQLResponse | null>;
 
   plugins?: ApolloServerPlugin[];
   documentStore?: InMemoryLRUCache<DocumentNode>;
@@ -437,7 +437,7 @@ export async function processGraphQLRequest<TContext>(
   }
 
   if (config.formatResponse) {
-    const formattedResponse: GraphQLResponse | null = config.formatResponse(
+    const formattedResponse: GraphQLResponse | null = await config.formatResponse(
       response,
       requestContext,
     );

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -371,6 +371,7 @@ export async function processHTTPRequest<TContext>(
     if (error instanceof HttpQueryError) {
       throw error;
     }
+    // @ts-ignore
     return throwHttpGraphQLError(500, [error as Error], options);
   }
 

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -73,13 +73,13 @@ export function isHttpQueryError(e: unknown): e is HttpQueryError {
 /**
  * If options is specified, then the errors array will be formatted
  */
-export function throwHttpGraphQLError<E extends Error>(
+export async function throwHttpGraphQLError<E extends Error>(
   statusCode: number,
   errors: Array<E>,
   options?: Pick<GraphQLOptions, 'debug' | 'formatError'>,
   extensions?: GraphQLExecutionResult['extensions'],
   headers?: Headers,
-): never {
+): Promise<never> {
   const allHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
   };
@@ -95,7 +95,7 @@ export function throwHttpGraphQLError<E extends Error>(
 
   const result: Result = {
     errors: options
-      ? formatApolloErrors(errors, {
+      ? await formatApolloErrors(errors, {
           debug: options.debug,
           formatter: options.formatError,
         })
@@ -321,7 +321,7 @@ export async function processHTTPRequest<TContext>(
             // A batch can contain another query that returns data,
             // so we don't error out the entire request with an HttpError
             return {
-              errors: formatApolloErrors([error as Error], options),
+              errors: await formatApolloErrors([error as Error], options),
             };
           }
         }),

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -79,7 +79,7 @@ export async function throwHttpGraphQLError<E extends Error>(
   options?: Pick<GraphQLOptions, 'debug' | 'formatError'>,
   extensions?: GraphQLExecutionResult['extensions'],
   headers?: Headers,
-  requestContext?: GraphQLRequestContext
+  requestContext?: GraphQLRequestContext,
 ): Promise<never> {
   const allHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -99,7 +99,7 @@ export async function throwHttpGraphQLError<E extends Error>(
       ? await formatApolloErrors(errors, {
           debug: options.debug,
           formatter: options.formatError,
-          requestContext
+          requestContext,
         })
       : errors,
   };
@@ -351,7 +351,7 @@ export async function processHTTPRequest<TContext>(
           undefined,
           response.extensions,
           response.http?.headers,
-          requestContext
+          requestContext,
         );
       }
 

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -17,6 +17,9 @@
   "engines": {
     "node": ">=12.0"
   },
+  "dependencies": {
+    "apollo-server-types": "file:../apollo-server-types"
+  },
   "peerDependencies": {
     "graphql": "^15.3.0"
   }

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-errors",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Apollo <opensource@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -5,7 +5,7 @@ import {
   Source,
   SourceLocation,
 } from 'graphql';
-import type { GraphQLRequestContext } from 'apollo-server-types'
+import type { GraphQLRequestContext } from 'apollo-server-types';
 
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
@@ -216,15 +216,14 @@ export class UserInputError extends ApolloError {
   }
 }
 
-
 export async function formatApolloErrors(
   errors: ReadonlyArray<Error>,
   options?: {
     formatter?: (
       error: GraphQLError,
-      requestContext?: GraphQLRequestContext<any>
+      requestContext?: GraphQLRequestContext<any>,
     ) => GraphQLFormattedError | Promise<GraphQLFormattedError>;
-    requestContext?: GraphQLRequestContext<any>
+    requestContext?: GraphQLRequestContext<any>;
     debug?: boolean;
   },
 ): Promise<Array<ApolloError>> {
@@ -275,7 +274,9 @@ export async function formatApolloErrors(
   return Promise.all(
     enrichedErrors.map(async (error) => {
       try {
-        return makePrintable(await formatter(error, requestContext as GraphQLRequestContext));
+        return makePrintable(
+          await formatter(error, requestContext as GraphQLRequestContext),
+        );
       } catch (err) {
         if (debug) {
           // XXX: This cast is pretty sketchy, as other error types can be thrown!

--- a/packages/apollo-server-errors/tsconfig.json
+++ b/packages/apollo-server-errors/tsconfig.json
@@ -5,5 +5,8 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/__tests__"]
+  "exclude": ["**/__tests__"],
+  "references": [
+    { "path": "../apollo-server-types" }
+  ]
 }

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Express",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/src/index.ts
+++ b/packages/apollo-server-integration-testsuite/src/index.ts
@@ -1085,7 +1085,7 @@ export default ({
         app = await createApp({
           graphqlOptions: {
             schema,
-            formatError: (error) => {
+            formatError: (error: GraphQLError) => {
               expect(error instanceof Error).toBe(true);
               return { message: expected };
             },
@@ -1105,7 +1105,7 @@ export default ({
         app = await createApp({
           graphqlOptions: {
             schema,
-            formatError: (error) => {
+            formatError: (error: GraphQLError) => {
               expect(error instanceof Error).toBe(true);
               expect(error instanceof GraphQLError).toBe(true);
               return { message: expected };
@@ -1125,7 +1125,7 @@ export default ({
         app = await createApp({
           graphqlOptions: {
             schema: TestSchema,
-            formatError(error) {
+            formatError(error: GraphQLError) {
               return { message: 'Custom error format: ' + error.message };
             },
           },
@@ -1150,7 +1150,7 @@ export default ({
         app = await createApp({
           graphqlOptions: {
             schema: TestSchema,
-            formatError(error) {
+            formatError(error: GraphQLError) {
               return {
                 message: error.message,
                 locations: error.locations,

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-base",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Apollo Server plugin base classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-operation-registry",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Apollo Server operation registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-response-cache",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Apollo Server full query response cache",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-types",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Apollo Server shared types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Production ready GraphQL Server",
   "author": "Apollo <opensource@apollographql.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
## Context
I want to use internationalization inside the formatError, because I don't want to pass the context to translate the message for all the resolvers when I could just pass once. But unfortunately the library I'm using to do that is based on promises and the formatError didn't support that. Also, the request context wasn't being passed to it, and information about the request can be really relevant when comes to format errors, for example I could use the request headers to get the accept language to translate the message according to the user browser.

## Changes
- Enabled promises to format error
- Enabled promises to format response
- Add request context to format error