### PR TITLE
Corrects errors in the documentation of unions and interfaces

### DIFF
--- a/docs/source/schema/unions-interfaces.md
+++ b/docs/source/schema/unions-interfaces.md
@@ -194,7 +194,7 @@ type Query {
 }
 ```
 
-In this schema, `Query.schoolBooks` returns a list that can include both `Textbook`s and `ColoringBook`s.
+In this schema, `Query.books` returns a list that can include both `Textbook`s and `ColoringBook`s.
 
 ### Querying an interface
 
@@ -287,7 +287,7 @@ const resolvers = {
     },
   },
   Query: {
-    schoolBooks: () => { ... }
+    books: () => { ... }
   },
 };
 ```


### PR DESCRIPTION
Hi Guys,

I think that in the last commit (https://github.com/apollographql/apollo-server/pull/5420/commits/5b50f2cab7d225c00bb0c90a963fcd9310d17e15) of the related file docs/source/schema/unions-interfaces.md, not all occurrences of "schoolBooks" were replaced.

Thanks