### PR TITLE
Lambda APQ - copy GET Query to Express.Request

### DIFF
--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -69,6 +69,14 @@ export class ApolloServer extends ApolloServerExpress<LambdaContextFunctionParam
     res: express.Response,
   ): Promise<GraphQLOptions> {
     const { event, context } = getCurrentInvoke();
+
+    //AWS API Gateway does not pass through APQ query in event structure
+    //https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+    //  For this reason, we need to copy over the APQ query if it exists ontp the express.Request
+    if(req.method == "GET" && event.query) {
+      req.query = event.query;
+    }
+
     const contextParams: LambdaContextFunctionParams = {
       event,
       context,

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -27,9 +27,20 @@ function defaultExpressAppFromMiddleware(
   middleware: express.RequestHandler,
 ): express.Application {
   const app = express();
+  const apqRouter = express.Router();
+
+  apqRouter.use('/', (req, res, next) => {
+    console.log(req);
+    console.log(res);
+    next();
+  });
+
+  app.use(apqRouter);
   app.use(middleware);
+
   return app;
 }
+
 export class ApolloServer extends ApolloServerExpress<LambdaContextFunctionParams> {
   protected override serverlessFramework(): boolean {
     return true;
@@ -69,12 +80,6 @@ export class ApolloServer extends ApolloServerExpress<LambdaContextFunctionParam
     res: express.Response,
   ): Promise<GraphQLOptions> {
     const { event, context } = getCurrentInvoke();
-    // AWS API Gateway does not pass through APQ query in event structure
-    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-    // For this reason, we need to copy over the APQ query if it exists ontp the express.Request
-    if (req.method == 'GET' && event.query) {
-      req.query = event.query;
-    }
     const contextParams: LambdaContextFunctionParams = {
       event,
       context,

--- a/packages/apollo-server-lambda/src/ApolloServer.ts
+++ b/packages/apollo-server-lambda/src/ApolloServer.ts
@@ -69,14 +69,12 @@ export class ApolloServer extends ApolloServerExpress<LambdaContextFunctionParam
     res: express.Response,
   ): Promise<GraphQLOptions> {
     const { event, context } = getCurrentInvoke();
-
-    //AWS API Gateway does not pass through APQ query in event structure
-    //https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-    //  For this reason, we need to copy over the APQ query if it exists ontp the express.Request
-    if(req.method == "GET" && event.query) {
+    // AWS API Gateway does not pass through APQ query in event structure
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+    // For this reason, we need to copy over the APQ query if it exists ontp the express.Request
+    if (req.method == 'GET' && event.query) {
       req.query = event.query;
     }
-
     const contextParams: LambdaContextFunctionParams = {
       event,
       context,


### PR DESCRIPTION
There currently is a gap in APQ support for AWS Lambda. The issue specifically arises from [this error](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/runHttpQuery.ts#L230). The AWS API Gateway payload comes in two expected formats, [v1.0 and v2.0](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html), neither support the `query` argument and this will be stripped out through the abstraction layers of `express` and `@vendia/serverless-express`. 

I was able to debug this down a bit futher and found that [`@vendia/serverless-express` sends the request information to the node server; the event.query is populated here](https://github.com/vendia/serverless-express/blob/mainline/src/configure.js#L71). The request is then [sent to the transport layer where it is structured into the `ServerlessRequest` which maps to the referenced API Gateway formats above](https://github.com/vendia/serverless-express/blob/mainline/src/transport.js#L77) (☝️).

It would seem the best place to handle this is in the Apollo Server Lambda middleware where we can copy the `event.query` into the `express.Request.query`. 

This PR will be a placeholder to test the associated changes.