### PR TITLE
Resolve Issue #5724: parse all content types ending with +json as json in rest data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-server-koa`: The peer dependency on `koa` (added in v3.0.0) should be a `^` range dependency rather than depending on exactly one version, and it should not be automatically increased when new versions of `koa` are released. [PR #5759](https://github.com/apollographql/apollo-server/pull/5759)
 - `apollo-server-fastify`: Export `ApolloServerFastifyConfig` and `FastifyContext` TypeScript types. [PR #5743](https://github.com/apollographql/apollo-server/pull/5743)
 - `apollo-server-core`: Only generate the schema hash once on startup rather than twice. [PR #5757](https://github.com/apollographql/apollo-server/pull/5757)
+- `apollo-datasource-rest@3.2.1`: When choosing whether or not to parse a response as JSON, treat any `content-type` ending in `+json` as JSON rather than just `application/hal+json` (in addition to `application/json`). [PR #5737](https://github.com/apollographql/apollo-server/pull/5737)
 
 ## v3.3.0
 

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -117,7 +117,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
       contentLength !== '0' &&
       contentType &&
       (contentType.startsWith('application/json') ||
-        contentType.startsWith('application/hal+json'))
+        contentType.endsWith('+json'))
     ) {
       return response.json();
     } else {

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -405,6 +405,27 @@ describe('RESTDataSource', () => {
       expect(data).toEqual({ foo: 'bar' });
     });
 
+    it('returns data as parsed JSON when Content-Type ends in +json', async () => {
+      const dataSource = new (class extends RESTDataSource {
+        override baseURL = 'https://api.example.com';
+
+        getFoo() {
+          return this.get('foo');
+        }
+      })();
+
+      dataSource.httpCache = httpCache;
+
+      fetch.mockJSONResponseOnce(
+        { foo: 'bar' },
+        { 'Content-Type': 'application/vnd.api+json' },
+      );
+
+      const data = await dataSource.getFoo();
+
+      expect(data).toEqual({ foo: 'bar' });
+    });
+
     it('returns data as a string when Content-Type is text/plain', async () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';


### PR DESCRIPTION

This commit addresses issue [5724](https://github.com/apollographql/apollo-server/issues/5724).  It is a simple change to treat all content types ending with +json similar to how all content types beginning with application/json are automatically parsed as JSON.  The helps cover some other common types of JSON types beyond the original hard coded exception.