### PR TITLE
feat: type Fastify context properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 ## vNEXT
 
 - `apollo-server-koa`: The peer dependency on `koa` (added in v3.0.0) should be a `^` range dependency rather than depending on exactly one version, and it should not be automatically increased when new versions of `koa` are released. [PR #5759](https://github.com/apollographql/apollo-server/pull/5759)
+- `apollo-server-fastify`: Export `ApolloServerFastifyConfig` and `FastifyContext` TypeScript types. [PR #5743](https://github.com/apollographql/apollo-server/pull/5743)
 
 ## v3.3.0
 

--- a/packages/apollo-server-fastify/src/index.ts
+++ b/packages/apollo-server-fastify/src/index.ts
@@ -13,4 +13,9 @@ export {
 } from 'apollo-server-core';
 
 // ApolloServer integration.
-export { ApolloServer, ServerRegistration } from './ApolloServer';
+export {
+  ApolloServer,
+  ApolloServerFastifyConfig,
+  FastifyContext,
+  ServerRegistration,
+} from './ApolloServer';


### PR DESCRIPTION
This way a `context` function provided to `new ApolloServer` is typed correctly.

I copied this approach from the Express plugin: https://github.com/apollographql/apollo-server/blob/48d3ab205afc682d5304c7c1cae349e0e2a1ffd5/packages/apollo-server-express/src/ApolloServer.ts#L37-L56