### PR TITLE
apollo-server-core: Stop computing schema-derived data twice for non-gateway modes of operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 - `apollo-server-koa`: The peer dependency on `koa` (added in v3.0.0) should be a `^` range dependency rather than depending on exactly one version, and it should not be automatically increased when new versions of `koa` are released. [PR #5759](https://github.com/apollographql/apollo-server/pull/5759)
 - `apollo-server-fastify`: Export `ApolloServerFastifyConfig` and `FastifyContext` TypeScript types. [PR #5743](https://github.com/apollographql/apollo-server/pull/5743)
+- `apollo-server-core`: Only generate the schema hash once on startup rather than twice. [PR #5757](https://github.com/apollographql/apollo-server/pull/5757)
 
 ## v3.3.0
 


### PR DESCRIPTION
Running the schema-derived data provider in `SchemaManager.ts` can be expensive. Currently, `SchemaManager` computes this twice for non-gateway modes of operation:
1. Once during `SchemaManager` construction (as the caller expects errors to be caught early here).
2. Once during `SchemaManager.start()` (as we naively call it within `SchemaManager.processSchemaLoadOrUpdateEvent()`).

This PR:
- Changes `SchemaManager.processSchemaLoadOrUpdateEvent()` to accept an optional `schemaDerivedData` argument, which (if provided) causes it to store that and skip calling the schema-derived data provider.
- Changes the constructor to store the results of calling the schema-derived-data provider in mode-specific state, so that it may be passed to `start()`.



Fixes #5729 .