### PR TITLE
docs: Update Import for ApolloServerPluginDrainHttpServer

### DIFF
--- a/docs/source/api/plugin/drain-http-server.md
+++ b/docs/source/api/plugin/drain-http-server.md
@@ -29,6 +29,7 @@ const express = require('express');
 const { ApolloServer } = require('apollo-server-express');
 const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
 const { typeDefs, resolvers } = require('./schema');
+const http = require('http');
 
 async function startApolloServer() {
   const app = express();


### PR DESCRIPTION
The `http` import in the example was missing, generating an error.
