### PR TITLE
Update tests and documentation for AWS API Gateway events

### DIFF
--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -6,7 +6,7 @@ description: How to deploy Apollo Server with AWS Lambda
 
 AWS Lambda is a service that allows users to run code without provisioning or managing servers. Cost is based on the compute time that is consumed, and there is no charge when code is not running.
 
-This guide explains how to setup Apollo Server 2 to run on AWS Lambda using Serverless Framework. To use CDK and SST instead, [follow this tutorial](https://serverless-stack.com/examples/how-to-create-an-apollo-graphql-api-with-serverless.html).
+This guide explains how to setup Apollo Server 3 to run on AWS Lambda using either AWS Application Serverless Model (SAM) or the Serverless Framework. To use CDK and SST instead, [follow this tutorial](https://serverless-stack.com/examples/how-to-create-an-apollo-graphql-api-with-serverless.html).
 
 ## Prerequisites
 
@@ -15,7 +15,8 @@ The following must be done before following this guide:
 - Setup an AWS account
 - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 - [Configure the AWS CLI with user credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
-- Install the serverless framework from NPM
+- If using SAM for deployment, [Install AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-linux.html)
+- If using the serverless framework for deployment, Install the serverless framework from NPM:
   - `npm install -g serverless`
 
 ---
@@ -58,6 +59,226 @@ exports.graphqlHandler = server.createHandler();
 
 Finally, **pay close attention to the last line**. This creates an export named `graphqlHandler` with a Lambda function handler.
 
+## Deploying with the AWS Serverless Application Model (SAM)
+
+The [AWS Serverless Application Model (AWS SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) is an open-source framework that you can use to build serverless applications on AWS.
+
+### Configuring your SAM template.yaml
+
+An AWS SAM template file closely follows the format of an AWS CloudFormation template file, which is described in [Template anatomy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html) in the AWS CloudFormation User Guide.
+
+For the sake of this example, the following file can just be copied and pasted into the root of your project.
+
+```
+# template.yaml
+
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  GraphQLFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: graphql/
+      Handler: app.graphqlHandler
+      Timeout: 5 #
+      MemorySize: 256
+      Runtime: nodejs14.x
+      Events:
+        AutomaticPersistedQueries:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+        GraphQL:
+          Type: Api
+          Properties:
+            Path: /
+            Method: post
+        ApolloSandbox:
+          Type: Api
+          Properties:
+            Path: /
+            Method: options
+```
+
+You will need to ensure `options` are exposed to use Apollo Explorer and Apollo Sandbox.
+
+*Note: The example above is using v1 of AWS API Gateway which is denoted by the `Type: Api`, but v2 (`Type: HttpApi`) is supported as well. The `apollo-server-lambda` [repository currently has tests that cover both v1 and v2 API Gateway events and ALB events](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts). More info about API Event Source can be found [here](https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#api)*
+
+### Invoking SAM locally
+
+To run your project locally with SAM, you will need to provide an event payload that "invokes" the AWS Lambda handler running locally in docker on your machine. [Invoking your lambda function](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-invoke.html) locally can be done with the SAM CLI:
+
+```
+sam local invoke "GraphQLFunction" -e event.json
+```
+
+For the `event.json`, you will need to provide the proper event depending on what is being used to provide the event to the AWS lambda. This will most commonly used will be an [AWS API Gateway, either v1 or v2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html).
+
+Below is an example of the minimum `event.json` needed for a standard GraphQL request when using AWS API Gateway v1:
+
+```
+{
+  "requestContext": {
+    "version": "1.0"
+  },
+  "path": "/graphql",
+  "httpMethod": "POST",
+  "body": "{ \"query\": \"{__typename}\" }",
+  "multiValueHeaders": {
+    "Accept": "*",
+    "origin": "",
+    "content-type": "application/json"
+  }
+}
+```
+
+Below is an example of the minimum `event.json` needed for a standard GraphQL request when using AWS API Gateway v2:
+
+```
+{
+  "version": "2.0",
+  "rawPath": "/graphql",
+  "requestContext": {
+    "http": {
+      "method: "POST",
+      "path": "/graphql",
+    }
+  },
+  "body": "{ \"query\": \"{__typename}\" }",
+  "headers": {
+    "Accept": "*",
+    "origin": "",
+    "content-type": "application/json"
+  }
+}
+```
+
+Below is an example of the minimum `event.json` needed to test an Automatic Persisted Queries (APQ) GraphQL request when using v1 API Gateway:
+
+```
+{
+  "requestContext": {
+    "version": "1.0"
+  },
+  "path": "/graphql",
+  "httpMethod": "GET",
+  "body": "",
+  "multiValueHeaders": {
+    "Accept": "*",
+    "origin": "",
+    "content-type": "application/json"
+  },
+  "multiValueQueryStringParameters": {
+    "query": ["{__typename}"],
+    "extensions": [
+      "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38\"}}"
+    ]
+  }
+}
+```
+
+Below is an example of the minimum `event.json` needed to test an Automatic Persisted Queries (APQ) GraphQL request when using v2 API Gateway:
+
+```
+{
+  "version": "2.0",
+  "rawPath": "/graphql",
+  "rawQueryString":"extensions={\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38\"}}",
+  "requestContext": {
+    "http": {
+      "method: "GET",
+      "path": "/graphql",
+    },
+  },
+  "body": "",
+  "headers": {
+    "Accept": "*",
+    "origin": "",
+    "content-type": "application/json"
+  }
+}
+```
+
+### Debugging SAM Template Locally with VS Code
+
+The AWS Sam CLI creates VS Code debugging configurations when initializing projects using the CLI. Below is an example of a VS Code Debug configuration:
+
+```
+{
+  "type": "aws-sam",
+  "request": "direct-invoke",
+  "name": "Debug Operation (POST)",
+  "invokeTarget": {
+    "target": "template",
+    "templatePath": "template.yaml",
+    "logicalId": "GraphQLFunction"
+  },
+  "lambda": {
+    "payload": {
+      "json": {
+        "requestContext": {
+          "version": "1.0"
+        },
+        "path": "/graphql",
+        "httpMethod": "POST",
+        "body": "{ \"query\": \"{__typename}\" }",
+        "multiValueHeaders": {
+          "Accept": "*",
+          "origin": "",
+          "content-type": "application/json"
+        }
+      }
+    }
+  }
+}
+```
+
+Below is an example of a VS Code Debug configuration for an Automatic Persisted Query (APQ):
+
+```
+{
+  "type": "aws-sam",
+  "request": "direct-invoke",
+  "name": "Debug APQ (GET)",
+  "invokeTarget": {
+    "target": "template",
+    "templatePath": "template.yaml",
+    "logicalId": "GraphQLFunction"
+  },
+  "lambda": {
+    "payload": {
+      "json": {
+        "requestContext": {
+          "version": "1.0"
+        },
+        "path": "/graphql",
+        "httpMethod": "GET",
+        "body": "",
+        "multiValueHeaders": {
+          "Accept": "*",
+          "origin": "",
+          "content-type": "application/json"
+        },
+        "multiValueQueryStringParameters": {
+          "query": ["{__typename}"],
+          "extensions": [
+            "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38\"}}"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Pushing to AWS with the SAM CLI
+
+After configuring and testing your project locally, all you have to do to deploy is run `sam deploy --guided`. Once you have finished the guided deploy, your lambda should be available in your [AWS console](https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions).
+
+If successful, `serverless` should output something similar to this example:
+
 ## Deploying with the Serverless Framework
 
 [Serverless](https://serverless.com) is a framework that makes deploying to services like AWS Lambda simpler.
@@ -87,6 +308,10 @@ functions:
     - http:
         path: /
         method: get
+        cors: true
+    - http:
+        path: /
+        method: options
         cors: true
 ```
 

--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -16,7 +16,7 @@ The following must be done before following this guide:
 - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 - [Configure the AWS CLI with user credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 - If using SAM for deployment, [Install AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-linux.html)
-- If using the serverless framework for deployment, Install the serverless framework from NPM:
+- If using the Serverless Framework for deployment, install it from NPM:
   - `npm install -g serverless`
 
 ---
@@ -85,17 +85,17 @@ Resources:
       MemorySize: 256
       Runtime: nodejs14.x
       Events:
-        AutomaticPersistedQueries:
+        GraphQLGET:
           Type: Api
           Properties:
             Path: /
             Method: get
-        GraphQL:
+        GraphQLPOST:
           Type: Api
           Properties:
             Path: /
             Method: post
-        ApolloSandbox:
+        GraphQLOPTIONS:
           Type: Api
           Properties:
             Path: /
@@ -104,7 +104,7 @@ Resources:
 
 You will need to ensure `options` are exposed to use Apollo Explorer and Apollo Sandbox.
 
-*Note: The example above is using v1 of AWS API Gateway which is denoted by the `Type: Api`, but v2 (`Type: HttpApi`) is supported as well. The `apollo-server-lambda` [repository currently has tests that cover both v1 and v2 API Gateway events and ALB events](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts). More info about API Event Source can be found [here](https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#api)*
+>The example above is using v1 of AWS API Gateway which is denoted by the `Type: Api`, but v2 (`Type: HttpApi`) is supported as well. The `apollo-server-lambda` [repository currently has tests that cover both v1 and v2 API Gateway events and ALB events](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts). More info about API Event Source can be found [here](https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#api)
 
 ### Invoking SAM locally
 
@@ -147,52 +147,6 @@ Below is an example of the minimum `event.json` needed for a standard GraphQL re
     }
   },
   "body": "{ \"query\": \"{__typename}\" }",
-  "headers": {
-    "Accept": "*",
-    "origin": "",
-    "content-type": "application/json"
-  }
-}
-```
-
-Below is an example of the minimum `event.json` needed to test an Automatic Persisted Queries (APQ) GraphQL request when using v1 API Gateway:
-
-```
-{
-  "requestContext": {
-    "version": "1.0"
-  },
-  "path": "/graphql",
-  "httpMethod": "GET",
-  "body": "",
-  "multiValueHeaders": {
-    "Accept": "*",
-    "origin": "",
-    "content-type": "application/json"
-  },
-  "multiValueQueryStringParameters": {
-    "query": ["{__typename}"],
-    "extensions": [
-      "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38\"}}"
-    ]
-  }
-}
-```
-
-Below is an example of the minimum `event.json` needed to test an Automatic Persisted Queries (APQ) GraphQL request when using v2 API Gateway:
-
-```
-{
-  "version": "2.0",
-  "rawPath": "/graphql",
-  "rawQueryString":"extensions={\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38\"}}",
-  "requestContext": {
-    "http": {
-      "method: "GET",
-      "path": "/graphql",
-    },
-  },
-  "body": "",
   "headers": {
     "Accept": "*",
     "origin": "",
@@ -308,10 +262,6 @@ functions:
     - http:
         path: /
         method: get
-        cors: true
-    - http:
-        path: /
-        method: options
         cors: true
 ```
 

--- a/packages/apollo-server-lambda/src/__tests__/ApolloServer.test.ts
+++ b/packages/apollo-server-lambda/src/__tests__/ApolloServer.test.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import request from 'supertest';
 import express from 'express';
-import { createMockServer } from './mockAPIGatewayServer';
+import { createAPIGatewayV2MockServer } from './mockAPIGatewayServer';
 import {
   ApolloServerPluginDrainHttpServer,
   Config,
@@ -57,7 +57,7 @@ describe('apollo-server-lambda', () => {
       const lambdaHandler = server.createHandler({
         expressGetMiddlewareOptions: { path: options?.graphqlPath },
       });
-      httpServer.on('request', createMockServer(lambdaHandler));
+      httpServer.on('request', createAPIGatewayV2MockServer(lambdaHandler));
       await new Promise<void>((resolve) => {
         httpServer.listen({ port: 0 }, () => resolve());
       });
@@ -83,7 +83,7 @@ describe('apollo-server-lambda', () => {
   ) => {
     const server = new ApolloServer(config);
     const handler = server.createHandler(createHandlerOptions);
-    return createMockServer(handler);
+    return createAPIGatewayV2MockServer(handler);
   };
 
   describe('context', () => {

--- a/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts
+++ b/packages/apollo-server-lambda/src/__tests__/lambdaApollo.test.ts
@@ -4,17 +4,26 @@ import testSuite, {
   CreateAppOptions,
 } from 'apollo-server-integration-testsuite';
 import type { Config } from 'apollo-server-core';
-import { createMockServer as createAPIGatewayMockServer } from './mockAPIGatewayServer';
+import {
+  createAPIGatewayV1MockServer,
+  createAPIGatewayV2MockServer,
+} from './mockAPIGatewayServer';
 import { createMockServer as createALBMockServer } from './mockALBServer';
 
-const createAPIGatewayLambda = async (options: CreateAppOptions = {}) => {
+const serverHandler = (options: CreateAppOptions = {}) => {
   const server = new ApolloServer(
     (options.graphqlOptions as Config) || { schema: Schema },
   );
 
-  const handler = server.createHandler();
+  return server.createHandler();
+};
 
-  return createAPIGatewayMockServer(handler);
+const createAPIGatewayV1Lambda = async (options: CreateAppOptions = {}) => {
+  return createAPIGatewayV1MockServer(serverHandler(options));
+};
+
+const createAPIGatewayV2Lambda = async (options: CreateAppOptions = {}) => {
+  return createAPIGatewayV2MockServer(serverHandler(options));
 };
 
 const createALBLambda = async (options: CreateAppOptions = {}) => {
@@ -27,8 +36,12 @@ const createALBLambda = async (options: CreateAppOptions = {}) => {
   return createALBMockServer(handler);
 };
 
-describe('integration:APIGateway:Lambda', () => {
-  testSuite({ createApp: createAPIGatewayLambda, serverlessFramework: true });
+describe('integration:APIGatewayV2:Lambda', () => {
+  testSuite({ createApp: createAPIGatewayV2Lambda, serverlessFramework: true });
+});
+
+describe('integration:APIGatewayV1:Lambda', () => {
+  testSuite({ createApp: createAPIGatewayV1Lambda, serverlessFramework: true });
 });
 
 describe('integration:ALB:Lambda', () => {


### PR DESCRIPTION
When using `apollo-server-lambda`, it can be confusing to understand what event payload should be used when testing your application locally. Most users getting started with AWS Lambda will be using AWS API Gateway, either v1 or v2. This PR adds a couple things:

- Introduce a new mock service for AWS API Gateway v1 that provides the proper event structure based on [AWS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)
- Add test suite for AWS API Gateway V1 
- Updated AWS deployment documentation to include AWS Serverless Application Model (SAM) deployment in addition to serverless framework.
- Document AWS API Gateway minimum event payloads to test `GET` and `POST` GraphQL requests

