### PR TITLE
npmignore: Don't include the source of tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 - `apollo-datasource-rest@3.2.1`: When choosing whether or not to parse a response as JSON, treat any `content-type` ending in `+json` as JSON rather than just `application/hal+json` (in addition to `application/json`). [PR #5737](https://github.com/apollographql/apollo-server/pull/5737)
 - `apollo-server`: You can now configure the health check URL path with the `healthCheckPath` constructor option, or disable serving health checks by passing `null` for this option. (This option is specific to the batteries-included `apollo-server` package; if you're using a framework integration package and want to serve a health check at a different path, just use your web framework directly.) [PR #5270](https://github.com/apollographql/apollo-server/pull/5270) [Issue #3577](https://github.com/apollographql/apollo-server/issues/3577)
 - `apollo-server-azure-functions`: This package now supports health checks like all of the other supported Apollo Server packages; they are on by default and can be customized with `disableHealthCheck` and `onHealthCheck`. [PR #5003](https:// github.com/apollographql/apollo-server/pull/5003) [Issue #4925](https://github.com/apollographql/apollo-server/issues/4925)
+- Tests are no longer distributed inside published npm modules. [PR #5799](https://github.com/apollographql/apollo-server/pull/5799) [Issue #5781](https://github.com/apollographql/apollo-server/issues/5781)
 
 ## v3.3.0
 

--- a/packages/apollo-datasource-rest/.npmignore
+++ b/packages/apollo-datasource-rest/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-datasource/.npmignore
+++ b/packages/apollo-datasource/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-reporting-protobuf/.npmignore
+++ b/packages/apollo-reporting-protobuf/.npmignore
@@ -1,6 +1,11 @@
+# Note that this npmignore file differs from the others because this package
+# puts its generated files in "generated" and checks them in to git rather than
+# unversioned in "dist".
+
 *
 !src/**/*
+src/**/__tests__/**
 !generated/**/*
-generated/**/*.test.*
+generated/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-azure-functions/.npmignore
+++ b/packages/apollo-server-azure-functions/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-cache-memcached/.npmignore
+++ b/packages/apollo-server-cache-memcached/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-cache-redis/.npmignore
+++ b/packages/apollo-server-cache-redis/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-caching/.npmignore
+++ b/packages/apollo-server-caching/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-cloud-functions/.npmignore
+++ b/packages/apollo-server-cloud-functions/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-core/.npmignore
+++ b/packages/apollo-server-core/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-env/.npmignore
+++ b/packages/apollo-server-env/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-errors/.npmignore
+++ b/packages/apollo-server-errors/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-express/.npmignore
+++ b/packages/apollo-server-express/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-fastify/.npmignore
+++ b/packages/apollo-server-fastify/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-hapi/.npmignore
+++ b/packages/apollo-server-hapi/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-integration-testsuite/.npmignore
+++ b/packages/apollo-server-integration-testsuite/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-koa/.npmignore
+++ b/packages/apollo-server-koa/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-lambda/.npmignore
+++ b/packages/apollo-server-lambda/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-micro/.npmignore
+++ b/packages/apollo-server-micro/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-plugin-base/.npmignore
+++ b/packages/apollo-server-plugin-base/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-plugin-response-cache/.npmignore
+++ b/packages/apollo-server-plugin-response-cache/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server-types/.npmignore
+++ b/packages/apollo-server-types/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md

--- a/packages/apollo-server/.npmignore
+++ b/packages/apollo-server/.npmignore
@@ -1,6 +1,7 @@
 *
 !src/**/*
+src/**/__tests__/**
 !dist/**/*
-dist/**/*.test.*
+dist/**/__tests__/**
 !package.json
 !README.md


### PR DESCRIPTION
We know of no reason that including the source of tests in built npm
packages would be helpful, and we've heard reports that including the
RSA private key fixture as we do in apollo-server-core can trigger
security scans.

Change how we drop tests from "dist" to drop the whole test directory in
case some other files sneak in there.

Fixes #5781.
