### PR TITLE
docs: provide TS versions of examples with `await new Promise`

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -4,6 +4,8 @@ sidebar_title: ApolloServer
 api_reference: true
 ---
 
+import { MultiCodeBlock } from 'gatsby-theme-apollo-docs';
+
 This API reference documents the `ApolloServer` class.
 
 There are [multiple implementations](../integrations/middleware/) of `ApolloServer` for different web frameworks with slightly different behavior.
@@ -269,6 +271,7 @@ Provide this function to transform the structure of GraphQL response objects bef
 ##### `apollo`
 
 `Object`
+</td>
 <td>
 
 An object containing configuration options for connecting Apollo Server to [Apollo Studio](https://www.apollographql.com/docs/studio/). Each field of this object can also be set with an environment variable, which is the recommended method of setting these parameters. All fields are optional. The fields are:
@@ -500,7 +503,7 @@ The `context` object passed between Apollo Server resolvers automatically includ
 | Azure Functions  | <code>{<br/>&nbsp;&nbsp;request: [`HttpRequest`](https://github.com/Azure/azure-functions-nodejs-worker/blob/ba8402bd3e86344e68cb06f65f9740b5d05a9700/types/public/Interfaces.d.ts#L73-L108),<br/>&nbsp;&nbsp;context: [`Context`](https://github.com/Azure/azure-functions-nodejs-worker/blob/ba8402bd3e86344e68cb06f65f9740b5d05a9700/types/public/Interfaces.d.ts#L18-L69)<br/>}</code> |
 | Cloudflare  | <code>{ req: [`Request`](https://github.com/apollographql/apollo-server/blob/04fe6aa1314ca84de26b4dc26e9b29dda16b81bc/packages/apollo-server-env/src/fetch.d.ts#L37-L45) }</code> |
 | Express (including `apollo-server`) | <code>{<br/>&nbsp;&nbsp;req: [`express.Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts),<br/>&nbsp;&nbsp;res: [`express.Response`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts#L490-L861)<br/>}</code> |
-| Fastify  | <code>{<br/>&nbsp;&nbsp;request: [`FastifyRequest`](https://github.com/fastify/fastify/blob/1d4dcf2bcde46256c72e96c2cafc843a461c721e/types/request.d.ts#L15),<br/>&nbsp;&nbsp;reply: [`FastifyReply`](https://github.com/fastify/fastify/blob/1d4dcf2bcde46256c72e96c2cafc843a461c721e/types/reply.d.ts#L10)</br>}</code> |
+| Fastify  | <code>{<br/>&nbsp;&nbsp;request: [`FastifyRequest`](https://github.com/fastify/fastify/blob/1d4dcf2bcde46256c72e96c2cafc843a461c721e/types/request.d.ts#L15),<br/>&nbsp;&nbsp;reply: [`FastifyReply`](https://github.com/fastify/fastify/blob/1d4dcf2bcde46256c72e96c2cafc843a461c721e/types/reply.d.ts#L10)<br/>}</code> |
 | Google Cloud Functions  | <code>{ req: [`Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts), res: [`Response`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/express-serve-static-core/index.d.ts#L490-L861) }</code> |
 | hapi  | <code>{<br/>&nbsp;&nbsp;request: [`hapi.Request`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05cbc5521f895344fb7dbf5c51902b6ff235aa69/types/hapi__hapi/index.d.ts#L406-L615),<br/>&nbsp;&nbsp;h: [`hapi.ResponseToolkit`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05cbc5521f895344fb7dbf5c51902b6ff235aa69/types/hapi__hapi/index.d.ts#L999-L1113)<br/>}</code> |
 | Koa | <code>{ ctx: [`Koa.Context`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/koa/index.d.ts#L724-L731) }</code> |
@@ -610,9 +613,11 @@ You call this method instead of [`listen`](#listen) if you're using a framework-
 
 These functions take an `options` object as a parameter. Some supported fields of this object are described below. **Not all packages support all options.** See [your package's description](../integrations/middleware/#basic-usage) to see what the name of the function is and which options are supported.
 
-### Example
+Here's an example of using `applyMiddleware` with `apollo-server-express`.
 
-```js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 const express = require('express');
 const { ApolloServer } = require('apollo-server-express');
 const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
@@ -626,6 +631,7 @@ async function startApolloServer() {
     resolvers,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
+
   await server.start();
 
   // Additional middleware can be mounted at this point to run before Apollo.
@@ -633,11 +639,13 @@ async function startApolloServer() {
 
   // Mount Apollo middleware here.
   server.applyMiddleware({ app, path: '/specialUrl' });
-  await new Promise(resolve => httpServer.listen({ port: 4000 }, resolve));
+  await new Promise<void>(resolve => httpServer.listen({ port: 4000 }, resolve));
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
   return { server, app };
 }
 ```
+
+</MultiCodeBlock>
 
 ### Options
 

--- a/docs/source/api/plugin/drain-http-server.mdx
+++ b/docs/source/api/plugin/drain-http-server.mdx
@@ -4,6 +4,8 @@ sidebar_title: Drain HTTP server
 api_reference: true
 ---
 
+import { MultiCodeBlock } from 'gatsby-theme-apollo-docs';
+
 ## Using the plugin
 
 This API reference documents the `ApolloServerPluginDrainHttpServer` plugin.
@@ -24,7 +26,9 @@ This plugin is exported from the `apollo-server-core` package. It is tested with
 
 Here's a basic example of how to use it with Express. See the [framework integrations docs](../../integrations/middleware/) for examples of how to use it with other frameworks.
 
-```js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 const express = require('express');
 const { ApolloServer } = require('apollo-server-express');
 const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
@@ -39,15 +43,18 @@ async function startApolloServer() {
     resolvers,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
+
   await server.start();
 
   // Mount Apollo middleware here.
   server.applyMiddleware({ app });
-  await new Promise(resolve => httpServer.listen({ port: 4000 }, resolve));
+  await new Promise<void>(resolve => httpServer.listen({ port: 4000 }, resolve));
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
   return { server, app };
 }
 ```
+
+</MultiCodeBlock>
 
 ## Options
 

--- a/docs/source/data/file-uploads.mdx
+++ b/docs/source/data/file-uploads.mdx
@@ -3,13 +3,17 @@ title: File uploads
 description: Enabling file uploads in Apollo Server
 ---
 
+import { MultiCodeBlock } from 'gatsby-theme-apollo-docs';
+
 You can add file upload support to Apollo Server via the third-party [`graphql-upload`](https://npm.im/graphql-upload) library. This package provides support for the `multipart/form-data` content-type.
 
 **New in Apollo Server 3:** Apollo Server 3 does not contain a built-in integration with `graphql-upload` like in Apollo Server 2. Instead, the instructions below show how to integrate it yourself. You cannot do this with the "batteries-included" `apollo-server` library; you must use a web framework integration such as `apollo-server-express` instead. This page shows out to integrate `graphql-upload` with Express and Fastify. To implement similar functionality with another Node.js HTTP framework (e.g., Koa), see the [`graphql-upload` documentation](https://github.com/jaydenseric/graphql-upload) for more information. Some integrations might need to use `graphql-upload`'s `processRequest` directly.
 
 ### Integrating with Express
 
-```js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 const express = require('express');
 const { ApolloServer, gql } = require('apollo-server-express');
 const {
@@ -81,13 +85,15 @@ async function startServer() {
 
   server.applyMiddleware({ app });
 
-  await new Promise(r => app.listen({ port: 4000 }, r));
+  await new Promise<void>(r => app.listen({ port: 4000 }, r));
 
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
 }
 
 startServer();
 ```
+
+</MultiCodeBlock>
 
 ### Integrating with Fastify
 

--- a/docs/source/integrations/middleware.mdx
+++ b/docs/source/integrations/middleware.mdx
@@ -4,6 +4,8 @@ sidebar_title: Choosing which package to use
 description: Use the right package for your project
 ---
 
+import { MultiCodeBlock } from 'gatsby-theme-apollo-docs';
+
 Apollo Server is distributed as a collection of different packages for different environments and web frameworks. You can choose which package to use based on your project.
 
 ## Which package should I use?
@@ -125,8 +127,10 @@ In this case, we recommend you swap out `apollo-server` for `apollo-server-expre
 
 Let's say our `apollo-server` implementation uses the following code:
 
-```javascript:title=index.js
-import { ApolloServer } from 'apollo-server';
+<MultiCodeBlock>
+
+```ts:title=index.ts
+import { ApolloServer } from "apollo-server";
 
 async function startApolloServer(typeDefs, resolvers) {
   const server = new ApolloServer({ typeDefs, resolvers });
@@ -134,6 +138,8 @@ async function startApolloServer(typeDefs, resolvers) {
   console.log(`🚀 Server ready at ${url}`);
 }
 ```
+
+</MultiCodeBlock>
 
 To swap this out for `apollo-server-express`, we first install the following required packages:
 
@@ -145,7 +151,9 @@ We can (and should) also _uninstall_ `apollo-server`.
 
 Next, we can modify our code to match the following:
 
-```javascript:title=index.js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-express';
 import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
 import express from 'express';
@@ -166,19 +174,21 @@ async function startApolloServer(typeDefs, resolvers) {
   // More required logic for integrating with Express
   await server.start();
   server.applyMiddleware({
-     app,
+    app,
 
-     // By default, apollo-server hosts its GraphQL endpoint at the
-     // server root. However, *other* Apollo Server packages host it at
-     // /graphql. Optionally provide this to match apollo-server.
-     path: '/'
+    // By default, apollo-server hosts its GraphQL endpoint at the
+    // server root. However, *other* Apollo Server packages host it at
+    // /graphql. Optionally provide this to match apollo-server.
+    path: '/'
   });
 
   // Modified server startup
-  await new Promise(resolve => httpServer.listen({ port: 4000 }, resolve));
+  await new Promise<void>(resolve => httpServer.listen({ port: 4000 }, resolve));
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
 }
 ```
+
+</MultiCodeBlock>
 
 
 
@@ -214,7 +224,9 @@ Each section also lists the options supported by each package's `applyMiddleware
 npm install apollo-server graphql
 ```
 
-```javascript:title=index.js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server';
 
 async function startApolloServer(typeDefs, resolvers) {
@@ -223,6 +235,8 @@ async function startApolloServer(typeDefs, resolvers) {
   console.log(`🚀 Server ready at ${url}`);
 }
 ```
+
+</MultiCodeBlock>
 
 Although `apollo-server` helps you get started quickly, you can't configure its behavior as much as you can other Apollo Server packages. For example, you can't serve other endpoints from the same HTTP server.
 
@@ -240,7 +254,9 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 npm install apollo-server-express apollo-server-core express graphql
 ```
 
-```javascript:title=index.js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-express';
 import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
 import express from 'express';
@@ -256,10 +272,12 @@ async function startApolloServer(typeDefs, resolvers) {
   });
   await server.start();
   server.applyMiddleware({ app });
-  await new Promise(resolve => httpServer.listen({ port: 4000 }, resolve));
+  await new Promise<void>(resolve => httpServer.listen({ port: 4000 }, resolve));
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
 }
 ```
+
+</MultiCodeBlock>
 
 You _must_ `await server.start()` before calling `server.applyMiddleware`. You can add other middleware to `app` before or after calling `applyMiddleware`.
 
@@ -283,10 +301,12 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-fastify apollo-server-core fastify graphql
 ```
 
-```javascript
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-fastify';
 import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
-import fastify from 'fastify';
+import fastify, { FastifyInstance } from 'fastify';
 
 function fastifyAppClosePlugin(app: FastifyInstance): ApolloServerPlugin {
   return {
@@ -310,12 +330,15 @@ async function startApolloServer(typeDefs, resolvers) {
       ApolloServerPluginDrainHttpServer({ httpServer: app.server }),
     ],
   });
+
   await server.start();
   app.register(server.createHandler());
   await app.listen(4000);
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
 }
 ```
+
+</MultiCodeBlock>
 
 You _must_ `await server.start()` before calling `server.createHandler`. You can call other functions on `app` before or after calling `createHandler`.
 
@@ -338,8 +361,13 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-hapi @hapi/hapi graphql
 ```
 
-```javascript
-import { ApolloServer, ApolloServerPluginStopHapiServer } from 'apollo-server-hapi';
+<MultiCodeBlock>
+
+```ts:title=index.ts
+import {
+  ApolloServer,
+  ApolloServerPluginStopHapiServer
+} from 'apollo-server-hapi';
 import Hapi from '@hapi/hapi';
 
 async function startApolloServer(typeDefs, resolvers) {
@@ -347,15 +375,16 @@ async function startApolloServer(typeDefs, resolvers) {
   const server = new ApolloServer({
     typeDefs,
     resolvers,
-    plugins: [
-      ApolloServerPluginStopHapiServer({ hapiServer: app }),
-    ],
+    plugins: [ApolloServerPluginStopHapiServer({ hapiServer: app })],
   });
+
   await server.start();
   await server.applyMiddleware({ app });
   await app.start();
 }
 ```
+
+</MultiCodeBlock>
 
 You _must_ `await server.start()` before calling `server.applyMiddleware`. You can call other functions on `app` before or after calling `applyMiddleware`.
 
@@ -378,7 +407,9 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-koa apollo-server-core koa graphql
 ```
 
-```javascript
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-koa';
 import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
 import Koa from 'koa';
@@ -391,15 +422,18 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
+
   await server.start();
   const app = new Koa();
   server.applyMiddleware({ app });
   httpServer.on('request', app.callback());
-  await new Promise(resolve => httpServer.listen({ port: 4000 }, resolve));
+  await new Promise<void>(resolve => httpServer.listen({ port: 4000 }, resolve));
   console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`);
   return { server, app };
 }
 ```
+
+</MultiCodeBlock>
 
 You _must_ `await server.start()` before calling `server.applyMiddleware`. You can call other functions on `app` before or after calling `applyMiddleware`.
 
@@ -424,13 +458,17 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-micro micro graphql
 ```
 
-```javascript:title=index.js
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-micro';
 
 const server = new ApolloServer({ typeDefs, resolvers });
 
 module.exports = server.start().then(() => server.createHandler());
 ```
+
+</MultiCodeBlock>
 
 Then run the web server with `npx micro`.
 
@@ -457,13 +495,17 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-lambda graphql
 ```
 
-```javascript
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-lambda';
 
 const server = new ApolloServer({ typeDefs, resolvers });
 
 exports.handler = server.createHandler();
 ```
+
+</MultiCodeBlock>
 
 For more details on using `apollo-server-lambda`, see the [documentation on deploying to Lambda](../deployment/lambda/).
 
@@ -479,13 +521,17 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-cloud-functions graphql
 ```
 
-```javascript
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-cloud-functions';
 
 const server = new ApolloServer({ typeDefs, resolvers });
 
 exports.handler = server.createHandler();
 ```
+
+</MultiCodeBlock>
 
 For more details on using `apollo-server-cloud-functions`, see the [documentation on deploying to Cloud Functions](../deployment/gcp-functions/).
 
@@ -500,13 +546,17 @@ The following example is roughly equivalent to the [`apollo-server` example](#ap
 $ npm install apollo-server-azure-functions graphql
 ```
 
-```javascript
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import { ApolloServer } from 'apollo-server-azure-functions';
 
 const server = new ApolloServer({ typeDefs, resolvers });
 
 exports.handler = server.createHandler();
 ```
+
+</MultiCodeBlock>
 
 `createHandler` accepts the following [common options](#common-options):
 

--- a/docs/source/security/terminating-ssl.mdx
+++ b/docs/source/security/terminating-ssl.mdx
@@ -2,6 +2,8 @@
 title: Terminating SSL
 ---
 
+import { MultiCodeBlock } from 'gatsby-theme-apollo-docs';
+
 Most production environments use a load balancer or HTTP proxy (such as nginx) to perform SSL termination on behalf of web applications in that environment.
 
 If you're using Apollo Server in an application that must perform its _own_ SSL termination, you can use the `https` module with the `apollo-server-express` [middleware
@@ -9,7 +11,9 @@ library](/integrations/middleware/).
 
 Here's an example that uses HTTPS in production and HTTP in development:
 
-```javascript
+<MultiCodeBlock>
+
+```ts:title=index.ts
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import typeDefs from './graphql/schema';
@@ -44,17 +48,26 @@ async function startApolloServer() {
         key: fs.readFileSync(`./ssl/${environment}/server.key`),
         cert: fs.readFileSync(`./ssl/${environment}/server.crt`)
       },
+
       app,
     );
   } else {
     httpServer = http.createServer(app);
   }
 
-  await new Promise(resolve => httpServer.listen({ port: config.port }, resolve));
+  await new Promise<void>(resolve =>
+    httpServer.listen({ port: config.port }, resolve)
+  );
+
   console.log(
     '🚀 Server ready at',
-    `http${config.ssl ? 's' : ''}://${config.hostname}:${config.port}${server.graphqlPath}`
+    `http${config.ssl ? 's' : ''}://${config.hostname}:${config.port}${
+      server.graphqlPath
+    }`
   );
+
   return { server, app };
 }
 ```
+
+</MultiCodeBlock>


### PR DESCRIPTION
TypeScript does not infer `Promise<void>` for `await new Promise(...)`
(see https://github.com/microsoft/TypeScript/issues/40162) which means
that this idiom requires us to write `await new Promise<void>(...)`. But
that's not valid JS.

Fortunately @trevorblades has gifted us with a magical MultiCodeBlock
component which lets us write TypeScript and make it available to users
as both TS and JS! It runs Babel and Prettier on it but doesn't do any
type checking.

I've found all the examples that use `await new Promise` in the docs
(and the other examples on the "which package" page for consistency) and
changed them to use MultiCodeBlock.

I made some minor formatting changes to minimize the diff between the TS
and JS versions. Note that I am leaving them in apollo-server's
preferred Prettier style (single quotes, trailing commas) even though
the component runs Prettier with default options; @trevorblades says we
can get the ability to override Prettier options soon, so that can be a
follow-up PR.

Fixes #5822.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
