### PR TITLE
Make tests compliant with stricter TS types on graphql@16

### DIFF
--- a/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
+++ b/packages/apollo-server-core/src/__tests__/ApolloServerBase.test.ts
@@ -202,8 +202,9 @@ describe('ApolloServerBase executeOperation', () => {
     const result = await server.executeOperation({ query: 'query { error }' });
 
     expect(result.errors).toHaveLength(1);
-    expect(result.errors?.[0].extensions?.code).toBe('INTERNAL_SERVER_ERROR');
-    expect(result.errors?.[0].extensions?.exception?.stacktrace).toBeDefined();
+    const extensions = result.errors?.[0].extensions;
+    expect(extensions).toHaveProperty('code', 'INTERNAL_SERVER_ERROR');
+    expect(extensions).toHaveProperty('exception.stacktrace');
   });
 
   it('works with string', async () => {

--- a/packages/apollo-server-core/src/__tests__/errors.test.ts
+++ b/packages/apollo-server-core/src/__tests__/errors.test.ts
@@ -88,9 +88,9 @@ describe('Errors', () => {
       ])[0];
       expect(error.message).toEqual(message);
       expect(error.extensions.code).toEqual('INTERNAL_SERVER_ERROR');
-      expect(error.extensions.exception.key).toEqual(key);
+      expect(error.extensions.exception).toHaveProperty('key', key);
       // stacktrace should exist under exception
-      expect(error.extensions.exception.stacktrace).toBeUndefined();
+      expect(error.extensions.exception).not.toHaveProperty('stacktrace');
     });
     it('exposes fields on error under exception field and provides code', () => {
       const error = createFormattedError();


### PR DESCRIPTION
I split out "safe" changes into smaller PRs, it's one of them.
