### PR TITLE
Switch tests to use 'IResolvers' instead of 'GraphQLResolverMap'

### DIFF
--- a/packages/apollo-server-express/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-express/src/__tests__/datasource.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'apollo-server-integration-testsuite';
 import { gql } from '../index';
 import type { AddressInfo } from 'net';
-import type { GraphQLResolverMap } from 'apollo-graphql';
+import type { IResolvers } from '@graphql-tools/utils';
 
 export class IdAPI extends RESTDataSource {
   // Set in subclass
@@ -35,7 +35,7 @@ const typeDefs = gql`
   }
 `;
 
-const resolvers: GraphQLResolverMap<{ dataSources: { id: IdAPI } }> = {
+const resolvers: IResolvers<any, any, { dataSources: { id: IdAPI } }> = {
   Query: {
     id: async (_source, _args, { dataSources }) => {
       return (await dataSources.id.getId('hi')).id;

--- a/packages/apollo-server-koa/src/__tests__/datasource.test.ts
+++ b/packages/apollo-server-koa/src/__tests__/datasource.test.ts
@@ -9,8 +9,8 @@ import {
 } from 'apollo-server-integration-testsuite';
 
 import { gql } from 'apollo-server-core';
-import type { GraphQLResolverMap } from 'apollo-graphql';
 import type { AddressInfo } from 'net';
+import type { IResolvers } from '@graphql-tools/utils';
 
 export class IdAPI extends RESTDataSource {
   // We will set this inside tests.
@@ -32,7 +32,7 @@ const typeDefs = gql`
   }
 `;
 
-const resolvers: GraphQLResolverMap<{ dataSources: { id: IdAPI } }> = {
+const resolvers: IResolvers<any, any, { dataSources: { id: IdAPI } }> = {
   Query: {
     id: async (_source, _args, { dataSources }) => {
       return (await dataSources.id.getId('hi')).id;


### PR DESCRIPTION
Both packages containing those tests doesn't have `apollo-graphql`
in their dependencies so it was causing errors with `npm i -f`.