### PR TITLE
Support for graphql@16

### DIFF
--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -35,6 +35,6 @@
 		"apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
 	},
 	"peerDependencies": {
-		"graphql": "^15.7.1"
+		"graphql": "^15.7.1 || ^16.0.0"
 	}
 }

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -35,6 +35,6 @@
 		"apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
 	},
 	"peerDependencies": {
-		"graphql": "^15.3.0"
+		"graphql": "^15.7.1"
 	}
 }

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -33,6 +33,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -33,6 +33,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -27,6 +27,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -27,6 +27,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -48,6 +48,6 @@
     "uuid": "^8.0.0"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -48,6 +48,6 @@
     "uuid": "^8.0.0"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -18,6 +18,6 @@
     "node": ">=12.0"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -18,6 +18,6 @@
     "node": ">=12.0"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "express": "^4.17.1",
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "express": "^4.17.1",
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -37,6 +37,6 @@
   },
   "peerDependencies": {
     "fastify": "^3.17.0",
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -37,6 +37,6 @@
   },
   "peerDependencies": {
     "fastify": "^3.17.0",
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -36,6 +36,6 @@
   },
   "peerDependencies": {
     "@hapi/hapi": "^20.1.2",
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -36,6 +36,6 @@
   },
   "peerDependencies": {
     "@hapi/hapi": "^20.1.2",
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -42,7 +42,7 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0",
+    "graphql": "^15.7.1",
     "koa": "^2.13.1"
   }
 }

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -42,7 +42,7 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1",
+    "graphql": "^15.7.1 || ^16.0.0",
     "koa": "^2.13.1"
   }
 }

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -36,6 +36,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -36,6 +36,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -14,6 +14,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -14,6 +14,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -26,6 +26,6 @@
     "make-fetch-happen": "^8.0.9"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -26,6 +26,6 @@
     "make-fetch-happen": "^8.0.9"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -25,6 +25,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -25,6 +25,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -16,6 +16,6 @@
     "apollo-server-env": "file:../apollo-server-env"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -16,6 +16,6 @@
     "apollo-server-env": "file:../apollo-server-env"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -30,6 +30,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.7.1"
+    "graphql": "^15.7.1 || ^16.0.0"
   }
 }

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -30,6 +30,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.7.1"
   }
 }


### PR DESCRIPTION
The only change required is in `apollo-server-errors`.
But in order to support both graphql@15 and graphql@16 we need to make `ApolloError` a subclass of `GraphQLError`.
The bad news is it requires `graphql@15.7.1` as a minimal supported version so I updated `peerDependencies` to that version.