### PR TITLE
Support for graphql@16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
-- Apollo Server can now be installed with `graphql@16` without causing peer dependency errors or warnings. [PR #5857](https://github.com/apollographql/apollo-server/pull/5857)
+- Apollo Server now supports `graphql@16`. (There is a very small backwards incompatibility: `ApolloError.originalError` can no longer be `null`, matching the type of `GraphQLError.originalError`. Use `undefined` instead. If this causes challenges, let us know and we can try to adapt.) [PR #5857](https://github.com/apollographql/apollo-server/pull/5857)
 - `apollo-server-core`: Fix build error when building with `@rollup/plugin-commonjs`. [PR #5797](https://github.com/apollographql/apollo-server/pull/5797)
 - `apollo-server-plugin-response-cache`: Add missing dependency on `apollo-server-types` (broken since v3.0.0). [Issue #5804](https://github.com/apollographql/apollo-server/issues/5804) [PR #5816](https://github.com/apollographql/apollo-server/pull/5816)
 - `apollo-server-core`: The default landing page plugins now take `document`, `variables`, and `headers` arguments which fill in default values if you click through to Explorer. [PR #5711](https://github.com/apollographql/apollo-server/pull/5711)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+- Apollo Server can now be installed with `graphql@16` without causing peer dependency errors or warnings. [PR #5857](https://github.com/apollographql/apollo-server/pull/5857)
 - `apollo-server-core`: Fix build error when building with `@rollup/plugin-commonjs`. [PR #5797](https://github.com/apollographql/apollo-server/pull/5797)
 - `apollo-server-plugin-response-cache`: Add missing dependency on `apollo-server-types` (broken since v3.0.0). [Issue #5804](https://github.com/apollographql/apollo-server/issues/5804) [PR #5816](https://github.com/apollographql/apollo-server/pull/5816)
 - `apollo-server-core`: The default landing page plugins now take `document`, `variables`, and `headers` arguments which fill in default values if you click through to Explorer. [PR #5711](https://github.com/apollographql/apollo-server/pull/5711)

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -35,6 +35,6 @@
 		"apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
 	},
 	"peerDependencies": {
-		"graphql": "^15.3.0"
+		"graphql": "^15.3.0 || ^16.0.0"
 	}
 }

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -33,6 +33,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -27,6 +27,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -48,6 +48,6 @@
     "uuid": "^8.0.0"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -18,6 +18,6 @@
     "node": ">=12.0"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-errors/src/__tests__/ApolloError.test.ts
+++ b/packages/apollo-server-errors/src/__tests__/ApolloError.test.ts
@@ -61,6 +61,14 @@ describe('ApolloError', () => {
       },
     });
   });
+
+  it('provides toString method', () => {
+    const error = new ApolloError('My original message', 'A_CODE', {
+      arbitrary: 'user_data',
+    });
+
+    expect(error.toString()).toEqual('My original message');
+  });
 });
 
 describe('ForbiddenError', () => {

--- a/packages/apollo-server-errors/src/__tests__/ApolloError.test.ts
+++ b/packages/apollo-server-errors/src/__tests__/ApolloError.test.ts
@@ -47,6 +47,20 @@ describe('ApolloError', () => {
         }),
     ).toThrow(/Pass extensions directly/);
   });
+
+  it('provides toJSON method', () => {
+    const error = new ApolloError('My original message', 'A_CODE', {
+      arbitrary: 'user_data',
+    });
+
+    expect(error.toJSON()).toEqual({
+      message: 'My original message',
+      extensions: {
+        code: 'A_CODE',
+        arbitrary: 'user_data',
+      },
+    });
+  });
 });
 
 describe('ForbiddenError', () => {

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -17,6 +17,8 @@ declare module 'graphql' {
   }
 }
 
+// Note: We'd like to switch to `extends GraphQLError` and look forward to doing so
+// as soon as we drop support for `graphql` bellow `v15.7.0`.
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
   override readonly name!: string;
@@ -165,7 +167,7 @@ export function fromGraphQLError(error: GraphQLError, options?: ErrorOptions) {
   // copy enumerable keys
   Object.entries(error).forEach(([key, value]) => {
     if (key === 'extensions') {
-      return; // extensions are handeled bellow
+      return; // extensions are handled bellow
     }
     copy[key] = value;
   });

--- a/packages/apollo-server-errors/src/index.ts
+++ b/packages/apollo-server-errors/src/index.ts
@@ -4,7 +4,18 @@ import {
   GraphQLFormattedError,
   Source,
   SourceLocation,
+  printError,
+  formatError,
 } from 'graphql';
+
+declare module 'graphql' {
+  export interface GraphQLErrorExtensions {
+    exception?: {
+      code?: string;
+      stacktrace?: ReadonlyArray<string>;
+    };
+  }
+}
 
 export class ApolloError extends Error implements GraphQLError {
   public extensions: Record<string, any>;
@@ -14,7 +25,7 @@ export class ApolloError extends Error implements GraphQLError {
   readonly source: Source | undefined;
   readonly positions: ReadonlyArray<number> | undefined;
   readonly nodes: ReadonlyArray<ASTNode> | undefined;
-  public originalError: Error | null | undefined;
+  public originalError: Error | undefined;
 
   [key: string]: any;
 
@@ -40,6 +51,30 @@ export class ApolloError extends Error implements GraphQLError {
 
     this.extensions = { ...extensions, code };
   }
+
+  toJSON(): GraphQLFormattedError {
+    return formatError(toGraphQLError(this));
+  }
+
+  override toString(): string {
+    return printError(toGraphQLError(this));
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.name;
+  }
+}
+
+function toGraphQLError(error: ApolloError): GraphQLError {
+  return new GraphQLError(
+    error.message,
+    error.nodes,
+    error.source,
+    error.positions,
+    error.path,
+    error.originalError,
+    error.extensions,
+  );
 }
 
 function enrichError(error: Partial<GraphQLError>, debug: boolean = false) {
@@ -129,10 +164,13 @@ export function fromGraphQLError(error: GraphQLError, options?: ErrorOptions) {
 
   // copy enumerable keys
   Object.entries(error).forEach(([key, value]) => {
+    if (key === 'extensions') {
+      return; // extensions are handeled bellow
+    }
     copy[key] = value;
   });
 
-  // extensions are non enumerable, so copy them directly
+  // merge extensions instead of just copying them
   copy.extensions = {
     ...copy.extensions,
     ...error.extensions,

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "express": "^4.17.1",
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -37,6 +37,6 @@
   },
   "peerDependencies": {
     "fastify": "^3.17.0",
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -36,6 +36,6 @@
   },
   "peerDependencies": {
     "@hapi/hapi": "^20.1.2",
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -42,7 +42,7 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0",
+    "graphql": "^15.3.0 || ^16.0.0",
     "koa": "^2.13.1"
   }
 }

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -36,6 +36,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -14,6 +14,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -26,6 +26,6 @@
     "make-fetch-happen": "^8.0.9"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -25,6 +25,6 @@
     "apollo-server-types": "file:../apollo-server-types"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -16,6 +16,6 @@
     "apollo-server-env": "file:../apollo-server-env"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -30,6 +30,6 @@
     "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
   },
   "peerDependencies": {
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }


### PR DESCRIPTION
The only change required is in `apollo-server-errors`.
Alternative to #5844
