### PR TITLE
Release 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+## v3.5.0
+
 - Apollo Server now supports `graphql@16`. (There is a very small backwards incompatibility: `ApolloError.originalError` can no longer be `null`, matching the type of `GraphQLError.originalError`. Use `undefined` instead. If this causes challenges, let us know and we can try to adapt.) [PR #5857](https://github.com/apollographql/apollo-server/pull/5857)
 - `apollo-server-core`: Fix build error when building with `@rollup/plugin-commonjs`. [PR #5797](https://github.com/apollographql/apollo-server/pull/5797)
 - `apollo-server-plugin-response-cache`: Add missing dependency on `apollo-server-types` (broken since v3.0.0). [Issue #5804](https://github.com/apollographql/apollo-server/issues/5804) [PR #5816](https://github.com/apollographql/apollo-server/pull/5816)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20152,7 +20152,7 @@
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-azure-functions": {
@@ -20171,7 +20171,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-cache-memcached": {
@@ -20223,7 +20223,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-cloudflare": {
@@ -20235,7 +20235,7 @@
         "apollo-server-types": "file:../apollo-server-types"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-core": {
@@ -20268,7 +20268,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-core/node_modules/uuid": {
@@ -20295,7 +20295,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-express": {
@@ -20322,7 +20322,7 @@
       },
       "peerDependencies": {
         "express": "^4.17.1",
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-fastify": {
@@ -20343,7 +20343,7 @@
       },
       "peerDependencies": {
         "fastify": "^3.17.0",
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-hapi": {
@@ -20363,7 +20363,7 @@
       },
       "peerDependencies": {
         "@hapi/hapi": "^20.1.2",
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-integration-testsuite": {
@@ -20400,7 +20400,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0",
+        "graphql": "^15.3.0 || ^16.0.0",
         "koa": "^2.13.1"
       }
     },
@@ -20449,7 +20449,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-micro": {
@@ -20478,7 +20478,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-plugin-operation-registry": {
@@ -20498,7 +20498,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-plugin-response-cache": {
@@ -20513,7 +20513,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-server-types": {
@@ -20528,7 +20528,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^15.3.0"
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     }
   },

--- a/packages/apollo-datasource-rest/package.json
+++ b/packages/apollo-datasource-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-rest",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-datasource/package.json
+++ b/packages/apollo-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-reporting-protobuf/package.json
+++ b/packages/apollo-reporting-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-reporting-protobuf",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Protobuf format for Apollo usage reporting",
   "main": "generated/index.js",
   "types": "generated/index.d.ts",

--- a/packages/apollo-server-azure-functions/package.json
+++ b/packages/apollo-server-azure-functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apollo-server-azure-functions",
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"description": "Production-ready Node.js GraphQL server for Azure Functions",
 	"keywords": [
 		"GraphQL",

--- a/packages/apollo-server-cache-memcached/package.json
+++ b/packages/apollo-server-cache-memcached/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cache-memcached",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-cache-redis/package.json
+++ b/packages/apollo-server-cache-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cache-redis",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-caching/package.json
+++ b/packages/apollo-server-caching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-caching",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-cloud-functions/package.json
+++ b/packages/apollo-server-cloud-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloud-functions",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Google Cloud Functions",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-cloudflare/package.json
+++ b/packages/apollo-server-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-cloudflare",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Cloudflare workers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-core",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Core engine for Apollo GraphQL server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-env/package.json
+++ b/packages/apollo-server-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-env",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-errors/package.json
+++ b/packages/apollo-server-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-errors",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-server-express/package.json
+++ b/packages/apollo-server-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-express",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Express",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-fastify",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Fastify",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-hapi/package.json
+++ b/packages/apollo-server-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-hapi",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Hapi",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-integration-testsuite/package.json
+++ b/packages/apollo-server-integration-testsuite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-server-integration-testsuite",
   "private": true,
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Apollo Server Integrations testsuite",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-koa/package.json
+++ b/packages/apollo-server-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-koa",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Koa",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-lambda/package.json
+++ b/packages/apollo-server-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-lambda",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for AWS Lambda",
   "keywords": [
     "GraphQL",

--- a/packages/apollo-server-micro/package.json
+++ b/packages/apollo-server-micro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-micro",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production-ready Node.js GraphQL server for Micro",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-base/package.json
+++ b/packages/apollo-server-plugin-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-base",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Apollo Server plugin base classes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-operation-registry/package.json
+++ b/packages/apollo-server-plugin-operation-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-operation-registry",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Apollo Server operation registry",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-plugin-response-cache/package.json
+++ b/packages/apollo-server-plugin-response-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-plugin-response-cache",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Apollo Server full query response cache",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server-types",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Apollo Server shared types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-server",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Production ready GraphQL Server",
   "author": "Apollo <packages@apollographql.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
As with [release PRs in the past](https://github.com/apollographql/apollo-server/issues?q=label%3A%22%F0%9F%8F%97+release%22+is%3Aclosed), this is a PR tracking a `release-x.y.z` branch for an upcoming release of Apollo Server. 🙌   The version in the title of this PR should correspond to the appropriate branch.

Check the appropriate milestone (to the right) for more details on what we hope to get into this release!

The intention of these release branches is to gather changes which are intended to land in a specific version (again, indicated by the subject of this PR).  Release branches allow additional clarity into what is being staged, provide a forum for comments from the community pertaining to the release's stability, and to facilitate the creation of pre-releases (e.g. `alpha`, `beta`, `rc`) without affecting the `main` branch.

PRs for new features might be opened against or re-targeted to this branch by the project maintainers.  The `main` branch may be periodically merged into this branch up until the point in time that this branch is being prepared for release.  Depending on the size of the release, this may be once it reaches RC (release candidate) stage with an `-rc.x` release suffix.  Some less substantial releases may be short-lived and may never have pre-release versions.

When this version is officially released onto the `latest` npm tag, this PR will be merged into `main`.