### PR TITLE
chore(types): add function to agent type

### DIFF
--- a/packages/apollo-server-env/src/fetch.d.ts
+++ b/packages/apollo-server-env/src/fetch.d.ts
@@ -1,5 +1,6 @@
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
+import type { URL } from './url';
 
 export declare function fetch(
   input: RequestInfo,
@@ -61,7 +62,7 @@ export interface RequestInit {
   timeout?: number;
   compress?: boolean;
   size?: number;
-  agent?: RequestAgent | false;
+  agent?: RequestAgent | ((parsedUrl: URL) => RequestAgent) | false;
 
   // Cloudflare Workers accept a `cf` property to control Cloudflare features
   // See https://developers.cloudflare.com/workers/reference/cloudflare-features/


### PR DESCRIPTION
Hi! I have a custom `RemoteGraphQLDataSource` and I am trying to override the  `agent` config field. I see in the typescript documentation you only accept a single `http` or `https` agent. 

```
type RequestAgent = HttpAgent | HttpsAgent;
agent?: RequestAgent | false;
```

However, the [node-fetch api accepts](https://github.com/node-fetch/node-fetch/blob/main/%40types/index.d.ts#L84) 

```
// Node-fetch extensions to the whatwg/fetch spec
agent?: Agent | ((parsedUrl: URL) => Agent);
```

Even more interesting, none of your call stack actually uses node-fetch that I can figure out, it actually uses `https://github.com/npm/make-fetch-happen`, which uses `https://github.com/npm/minipass-fetch`, [which does check for the existence of this as a function](https://github.com/npm/minipass-fetch/blob/main/lib/request.js#L197-L199), just like node-fetch does


my example `RemoteGraphQLDataSource`

```
import { GraphQLRequestContext } from 'apollo-server-types'
import { RemoteGraphQLDataSource } from '@apollo/gateway'
import { Context } from 'src/types/context'
import makeFetchHappen from 'make-fetch-happen'
import http from 'http'
import https from 'https'
import ShutdownCleanup, { SHUTDOWN_HANDLER } from '../utils/shutdownCleanup'
import { URL } from 'url'

const keepAlive = process.env.ENABLE_HTTP_KEEP_ALIVE === 'true'
console.log(`HTTP Connection pooling: ${keepAlive}`)

const httpAgent = new http.Agent({ keepAlive })
const httpsAgent = new https.Agent({ keepAlive })

const agent = (_parsedURL: URL) =>
  _parsedURL.protocol == 'http:' ? httpAgent : httpsAgent

// https://www.apollographql.com/docs/federation/api/apollo-gateway/#class-remotegraphqldatasource
export class SubgraphDataSource extends RemoteGraphQLDataSource<Context> {

  // bypasses the built in agent [`agentKeepAlive`](https://github.com/node-modules/agentkeepalive) used by `makeFetchHappen`.
  // @ts-expect-error - the apollo typescript types here are not correct
  fetcher = makeFetchHappen.defaults({ agent })

  willSendRequest({
    request,
    context
  }: Pick<GraphQLRequestContext<Context>, 'request' | 'context'>) {
    // pass through headers set in headersPlugin
    const headers = context.headers.entries()
    let header = headers.next()
    while (!header.done) {
      request.http?.headers.set(header.value[0], header.value[1])
      header = headers.next()
    }
  }
}


  const gateway = new ApolloGateway({
    // https://www.apollographql.com/docs/federation/api/apollo-gateway/#the-buildservice-function
    buildService({ url }) {
      return new SubgraphDataSource({ url })
    }
  })
```