### PR TITLE
usage reporting: remove client reference ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The version headers in this history reflect the versions of Apollo Server itself
 - [`@apollo/gateway`](https://github.com/apollographql/federation/blob/HEAD/gateway-js/CHANGELOG.md)
 - [`@apollo/federation`](https://github.com/apollographql/federation/blob/HEAD/federation-js/CHANGELOG.md)
 
-## vNEXT
+## vNEXT (minor!)
+
+- `apollo-server-core`: Usage reporting no longer sends a "client reference ID" to Apollo Studio (along with the client name and client version). This little-used feature has not been documented [since 2019](https://github.com/apollographql/apollo-server/pull/3180) and is currently entirely ignored by Apollo Studio. This is technically incompatible as the interface `ClientInfo` no longer has the field `clientReferenceId`; if you were one of the few users who explicitly set this field and you get a TypeScript compilation failure upon upgrading to v3.6.0, just stop using the field. [PR #5890](https://github.com/apollographql/apollo-server/pull/5890)
 
 ## v3.5.0
 

--- a/packages/apollo-reporting-protobuf/generated/protobuf.d.ts
+++ b/packages/apollo-reporting-protobuf/generated/protobuf.d.ts
@@ -35,9 +35,6 @@ export interface ITrace {
     /** Trace clientAddress */
     clientAddress?: (string|null);
 
-    /** Trace clientReferenceId */
-    clientReferenceId?: (string|null);
-
     /** Trace http */
     http?: (Trace.IHTTP|null);
 
@@ -104,9 +101,6 @@ export class Trace implements ITrace {
 
     /** Trace clientAddress. */
     public clientAddress: string;
-
-    /** Trace clientReferenceId. */
-    public clientReferenceId: string;
 
     /** Trace http. */
     public http?: (Trace.IHTTP|null);
@@ -1875,9 +1869,6 @@ export class QueryLatencyStats implements IQueryLatencyStats {
 /** Properties of a StatsContext. */
 export interface IStatsContext {
 
-    /** StatsContext clientReferenceId */
-    clientReferenceId?: (string|null);
-
     /** StatsContext clientName */
     clientName?: (string|null);
 
@@ -1893,9 +1884,6 @@ export class StatsContext implements IStatsContext {
      * @param [properties] Properties to set
      */
     constructor(properties?: IStatsContext);
-
-    /** StatsContext clientReferenceId. */
-    public clientReferenceId: string;
 
     /** StatsContext clientName. */
     public clientName: string;

--- a/packages/apollo-reporting-protobuf/generated/protobuf.js
+++ b/packages/apollo-reporting-protobuf/generated/protobuf.js
@@ -26,7 +26,6 @@ $root.Trace = (function() {
      * @property {string|null} [clientName] Trace clientName
      * @property {string|null} [clientVersion] Trace clientVersion
      * @property {string|null} [clientAddress] Trace clientAddress
-     * @property {string|null} [clientReferenceId] Trace clientReferenceId
      * @property {Trace.IHTTP|null} [http] Trace http
      * @property {Trace.ICachePolicy|null} [cachePolicy] Trace cachePolicy
      * @property {Trace.IQueryPlanNode|null} [queryPlan] Trace queryPlan
@@ -139,14 +138,6 @@ $root.Trace = (function() {
      * @instance
      */
     Trace.prototype.clientAddress = "";
-
-    /**
-     * Trace clientReferenceId.
-     * @member {string} clientReferenceId
-     * @memberof Trace
-     * @instance
-     */
-    Trace.prototype.clientReferenceId = "";
 
     /**
      * Trace http.
@@ -264,8 +255,6 @@ $root.Trace = (function() {
             writer.uint32(/* id 21, wireType 0 =*/168).bool(message.persistedQueryHit);
         if (message.persistedQueryRegister != null && Object.hasOwnProperty.call(message, "persistedQueryRegister"))
             writer.uint32(/* id 22, wireType 0 =*/176).bool(message.persistedQueryRegister);
-        if (message.clientReferenceId != null && Object.hasOwnProperty.call(message, "clientReferenceId"))
-            writer.uint32(/* id 23, wireType 2 =*/186).string(message.clientReferenceId);
         if (message.registeredOperation != null && Object.hasOwnProperty.call(message, "registeredOperation"))
             writer.uint32(/* id 24, wireType 0 =*/192).bool(message.registeredOperation);
         if (message.forbiddenOperation != null && Object.hasOwnProperty.call(message, "forbiddenOperation"))
@@ -342,9 +331,6 @@ $root.Trace = (function() {
                 break;
             case 9:
                 message.clientAddress = reader.string();
-                break;
-            case 23:
-                message.clientReferenceId = reader.string();
                 break;
             case 10:
                 message.http = $root.Trace.HTTP.decode(reader, reader.uint32());
@@ -446,9 +432,6 @@ $root.Trace = (function() {
         if (message.clientAddress != null && message.hasOwnProperty("clientAddress"))
             if (!$util.isString(message.clientAddress))
                 return "clientAddress: string expected";
-        if (message.clientReferenceId != null && message.hasOwnProperty("clientReferenceId"))
-            if (!$util.isString(message.clientReferenceId))
-                return "clientReferenceId: string expected";
         if (message.http != null && message.hasOwnProperty("http")) {
             var error = $root.Trace.HTTP.verify(message.http);
             if (error)
@@ -514,7 +497,6 @@ $root.Trace = (function() {
             object.fullQueryCacheHit = false;
             object.persistedQueryHit = false;
             object.persistedQueryRegister = false;
-            object.clientReferenceId = "";
             object.registeredOperation = false;
             object.forbiddenOperation = false;
             object.queryPlan = null;
@@ -552,8 +534,6 @@ $root.Trace = (function() {
             object.persistedQueryHit = message.persistedQueryHit;
         if (message.persistedQueryRegister != null && message.hasOwnProperty("persistedQueryRegister"))
             object.persistedQueryRegister = message.persistedQueryRegister;
-        if (message.clientReferenceId != null && message.hasOwnProperty("clientReferenceId"))
-            object.clientReferenceId = message.clientReferenceId;
         if (message.registeredOperation != null && message.hasOwnProperty("registeredOperation"))
             object.registeredOperation = message.registeredOperation;
         if (message.forbiddenOperation != null && message.hasOwnProperty("forbiddenOperation"))
@@ -4910,7 +4890,6 @@ $root.StatsContext = (function() {
      * Properties of a StatsContext.
      * @exports IStatsContext
      * @interface IStatsContext
-     * @property {string|null} [clientReferenceId] StatsContext clientReferenceId
      * @property {string|null} [clientName] StatsContext clientName
      * @property {string|null} [clientVersion] StatsContext clientVersion
      */
@@ -4929,14 +4908,6 @@ $root.StatsContext = (function() {
                 if (properties[keys[i]] != null)
                     this[keys[i]] = properties[keys[i]];
     }
-
-    /**
-     * StatsContext clientReferenceId.
-     * @member {string} clientReferenceId
-     * @memberof StatsContext
-     * @instance
-     */
-    StatsContext.prototype.clientReferenceId = "";
 
     /**
      * StatsContext clientName.
@@ -4978,8 +4949,6 @@ $root.StatsContext = (function() {
     StatsContext.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.clientReferenceId != null && Object.hasOwnProperty.call(message, "clientReferenceId"))
-            writer.uint32(/* id 1, wireType 2 =*/10).string(message.clientReferenceId);
         if (message.clientName != null && Object.hasOwnProperty.call(message, "clientName"))
             writer.uint32(/* id 2, wireType 2 =*/18).string(message.clientName);
         if (message.clientVersion != null && Object.hasOwnProperty.call(message, "clientVersion"))
@@ -5018,9 +4987,6 @@ $root.StatsContext = (function() {
         while (reader.pos < end) {
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.clientReferenceId = reader.string();
-                break;
             case 2:
                 message.clientName = reader.string();
                 break;
@@ -5062,9 +5028,6 @@ $root.StatsContext = (function() {
     StatsContext.verify = function verify(message) {
         if (typeof message !== "object" || message === null)
             return "object expected";
-        if (message.clientReferenceId != null && message.hasOwnProperty("clientReferenceId"))
-            if (!$util.isString(message.clientReferenceId))
-                return "clientReferenceId: string expected";
         if (message.clientName != null && message.hasOwnProperty("clientName"))
             if (!$util.isString(message.clientName))
                 return "clientName: string expected";
@@ -5088,12 +5051,9 @@ $root.StatsContext = (function() {
             options = {};
         var object = {};
         if (options.defaults) {
-            object.clientReferenceId = "";
             object.clientName = "";
             object.clientVersion = "";
         }
-        if (message.clientReferenceId != null && message.hasOwnProperty("clientReferenceId"))
-            object.clientReferenceId = message.clientReferenceId;
         if (message.clientName != null && message.hasOwnProperty("clientName"))
             object.clientName = message.clientName;
         if (message.clientVersion != null && message.hasOwnProperty("clientVersion"))

--- a/packages/apollo-reporting-protobuf/generated/reports.proto
+++ b/packages/apollo-reporting-protobuf/generated/reports.proto
@@ -207,7 +207,8 @@ message Trace {
   string client_name = 7;
   string client_version = 8;
   string client_address = 9;
-  string client_reference_id = 23;
+  // string client_reference_id = 23;
+  reserved 23;
 
   HTTP http = 10;
 
@@ -297,7 +298,8 @@ message QueryLatencyStats {
 }
 
 message StatsContext {
-  string client_reference_id = 1;
+  // string client_reference_id = 1;
+  reserved 1;
   string client_name = 2;
   string client_version = 3;
 }

--- a/packages/apollo-reporting-protobuf/src/reports.proto
+++ b/packages/apollo-reporting-protobuf/src/reports.proto
@@ -207,7 +207,8 @@ message Trace {
   string client_name = 7;
   string client_version = 8;
   string client_address = 9;
-  string client_reference_id = 23;
+  // string client_reference_id = 23;
+  reserved 23;
 
   HTTP http = 10;
 
@@ -297,7 +298,8 @@ message QueryLatencyStats {
 }
 
 message StatsContext {
-  string client_reference_id = 1;
+  // string client_reference_id = 1;
+  reserved 1;
   string client_name = 2;
   string client_version = 3;
 }

--- a/packages/apollo-server-core/src/plugin/schemaReporting/operations.d.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/operations.d.ts
@@ -25,7 +25,6 @@ export type Scalars = {
   Void: any;
 };
 
-
 export type Account = {
   __typename?: 'Account';
   auditLogExports?: Maybe<Array<AuditLogExport>>;
@@ -47,11 +46,11 @@ export type Account = {
    */
   avatarUrl?: Maybe<Scalars['String']>;
   billingInfo?: Maybe<BillingInfo>;
+  companyUrl?: Maybe<Scalars['String']>;
   currentBillingMonth?: Maybe<BillingMonth>;
   currentPlan: BillingPlan;
   currentSubscription?: Maybe<BillingSubscription>;
-  /** @deprecated Replaced with Account.inviteLink.role and Account.sso.defaultRole */
-  defaultPermission?: Maybe<UserPermission>;
+  experimentalFeatures: AccountExperimentalFeatures;
   expiredTrialSubscription?: Maybe<BillingSubscription>;
   graphIDAvailable: Scalars['Boolean'];
   hasBeenOnTrial: Scalars['Boolean'];
@@ -62,23 +61,15 @@ export type Account = {
    */
   internalID: Scalars['ID'];
   invitations?: Maybe<Array<AccountInvitation>>;
-  /**
-   * A reusable invitation link for the organization.
-   * @deprecated Replaced by Account.staticInvitations since Accounts can now have multiple static invitations.
-   */
-  inviteLink?: Maybe<OrganizationInviteLink>;
   invoices?: Maybe<Array<Invoice>>;
   isOnExpiredTrial: Scalars['Boolean'];
   isOnTrial: Scalars['Boolean'];
-  /**
-   * Token allowing to join the account using mutation{join(accountId:,token:)}}
-   * @deprecated Replaced with Account.inviteLink.joinToken
-   */
-  joinToken?: Maybe<Scalars['String']>;
   memberships?: Maybe<Array<AccountMembership>>;
   name: Scalars['String'];
   provisionedAt?: Maybe<Scalars['Timestamp']>;
   recurlyEmail?: Maybe<Scalars['String']>;
+  /** Returns a different registry related stats pertaining to this account. */
+  registryStatsWindow?: Maybe<RegistryStatsWindow>;
   requests?: Maybe<Scalars['Long']>;
   requestsInCurrentBillingPeriod?: Maybe<Scalars['Long']>;
   roles?: Maybe<AccountRoles>;
@@ -95,15 +86,14 @@ export type Account = {
   state?: Maybe<AccountState>;
   /** A list of reusable invitations for the organization. */
   staticInvitations?: Maybe<Array<OrganizationInviteLink>>;
+  /** @deprecated use Account.statsWindow instead */
   stats: AccountStatsWindow;
+  statsWindow?: Maybe<AccountStatsWindow>;
   subscriptions?: Maybe<Array<BillingSubscription>>;
-  /** @deprecated Replaced with Account.sso */
-  synchronized: Scalars['Boolean'];
+  /** Gets a ticket for this org, by id */
+  ticket?: Maybe<ZendeskTicket>;
   /** List of Zendesk tickets submitted for this org */
   tickets?: Maybe<Array<ZendeskTicket>>;
-  /** @deprecated Replaced with Account.memberships.user */
-  users: Array<User>;
-  experimentalFeatures: AccountExperimentalFeatures;
 };
 
 
@@ -122,6 +112,13 @@ export type AccountInvitationsArgs = {
 };
 
 
+export type AccountRegistryStatsWindowArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
 export type AccountRequestsArgs = {
   from: Scalars['Timestamp'];
   to: Scalars['Timestamp'];
@@ -137,6 +134,31 @@ export type AccountStatsArgs = {
   from: Scalars['Timestamp'];
   resolution?: Maybe<Resolution>;
   to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type AccountStatsWindowArgs = {
+  from: Scalars['Timestamp'];
+  resolution?: Maybe<Resolution>;
+  to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type AccountTicketArgs = {
+  id: Scalars['ID'];
+};
+
+export type AccountChecksStatsMetrics = {
+  __typename?: 'AccountChecksStatsMetrics';
+  totalFailedChecks: Scalars['Long'];
+  totalSuccessfulChecks: Scalars['Long'];
+};
+
+export type AccountChecksStatsRecord = {
+  __typename?: 'AccountChecksStatsRecord';
+  id: Scalars['ID'];
+  metrics: AccountChecksStatsMetrics;
+  timestamp: Scalars['Timestamp'];
 };
 
 /** Columns of AccountEdgeServerInfos. */
@@ -227,120 +249,9 @@ export type AccountEdgeServerInfosRecord = {
   timestamp: Scalars['Timestamp'];
 };
 
-/** Columns of AccountEnumStats. */
-export enum AccountEnumStatsColumn {
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  EnumType = 'ENUM_TYPE',
-  EnumValue = 'ENUM_VALUE',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
-  ResponseCount = 'RESPONSE_COUNT',
-  SchemaHash = 'SCHEMA_HASH',
-  SchemaTag = 'SCHEMA_TAG',
-  ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
-  Timestamp = 'TIMESTAMP'
-}
-
-export type AccountEnumStatsDimensions = {
-  __typename?: 'AccountEnumStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  enumType?: Maybe<Scalars['String']>;
-  enumValue?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in AccountEnumStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type AccountEnumStatsFilter = {
-  and?: Maybe<Array<AccountEnumStatsFilter>>;
-  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  /** Selects rows whose enumType dimension equals the given value if not null. To query for the null value, use {in: {enumType: [null]}} instead. */
-  enumType?: Maybe<Scalars['String']>;
-  /** Selects rows whose enumValue dimension equals the given value if not null. To query for the null value, use {in: {enumValue: [null]}} instead. */
-  enumValue?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountEnumStatsFilterIn>;
-  not?: Maybe<AccountEnumStatsFilter>;
-  or?: Maybe<Array<AccountEnumStatsFilter>>;
-  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in AccountEnumStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type AccountEnumStatsFilterIn = {
-  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose enumType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  enumType?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose enumValue dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  enumValue?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-export type AccountEnumStatsMetrics = {
-  __typename?: 'AccountEnumStatsMetrics';
-  requestCount: Scalars['Long'];
-  responseCount: Scalars['Long'];
-};
-
-export type AccountEnumStatsOrderBySpec = {
-  column: AccountEnumStatsColumn;
-  direction: Ordering;
-};
-
-export type AccountEnumStatsRecord = {
-  __typename?: 'AccountEnumStatsRecord';
-  /** Dimensions of AccountEnumStats that can be grouped by. */
-  groupBy: AccountEnumStatsDimensions;
-  /** Metrics of AccountEnumStats that can be aggregated over. */
-  metrics: AccountEnumStatsMetrics;
-  /** Starting segment timestamp. */
-  timestamp: Scalars['Timestamp'];
-};
-
 /** Columns of AccountErrorStats. */
 export enum AccountErrorStatsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   ErrorsCount = 'ERRORS_COUNT',
   Path = 'PATH',
@@ -350,14 +261,12 @@ export enum AccountErrorStatsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
 export type AccountErrorStatsDimensions = {
   __typename?: 'AccountErrorStatsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -365,7 +274,6 @@ export type AccountErrorStatsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -373,8 +281,6 @@ export type AccountErrorStatsFilter = {
   and?: Maybe<Array<AccountErrorStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   in?: Maybe<AccountErrorStatsFilterIn>;
@@ -392,16 +298,12 @@ export type AccountErrorStatsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountErrorStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -416,8 +318,6 @@ export type AccountErrorStatsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type AccountErrorStatsMetrics = {
@@ -443,172 +343,139 @@ export type AccountErrorStatsRecord = {
 
 export type AccountExperimentalFeatures = {
   __typename?: 'AccountExperimentalFeatures';
-  preRequestPreview: Scalars['Boolean'];
-  webhooksPreview: Scalars['Boolean'];
-  publicVariants: Scalars['Boolean'];
-  launchesPreview: Scalars['Boolean'];
   auditLogs: Scalars['Boolean'];
-  sandboxesSchemaCheck: Scalars['Boolean'];
+  championDashboard: Scalars['Boolean'];
+  contractsPreview: Scalars['Boolean'];
+  federation2Preview: Scalars['Boolean'];
+  preRequestPreview: Scalars['Boolean'];
+  publicVariants: Scalars['Boolean'];
+  variantHomepage: Scalars['Boolean'];
+  webhooksPreview: Scalars['Boolean'];
 };
 
-/** Columns of AccountFieldStats. */
-export enum AccountFieldStatsColumn {
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  ErrorsCount = 'ERRORS_COUNT',
+/** Columns of AccountFieldLatencies. */
+export enum AccountFieldLatenciesColumn {
   Field = 'FIELD',
   FieldHistogram = 'FIELD_HISTOGRAM',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
+  FieldName = 'FIELD_NAME',
+  ParentType = 'PARENT_TYPE',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
-export type AccountFieldStatsDimensions = {
-  __typename?: 'AccountFieldStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
+export type AccountFieldLatenciesDimensions = {
+  __typename?: 'AccountFieldLatenciesDimensions';
   field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
+  fieldName?: Maybe<Scalars['String']>;
+  parentType?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in AccountFieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type AccountFieldStatsFilter = {
-  and?: Maybe<Array<AccountFieldStatsFilter>>;
-  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+/** Filter for data in AccountFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountFieldLatenciesFilter = {
+  and?: Maybe<Array<AccountFieldLatenciesFilter>>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
   field?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountFieldStatsFilterIn>;
-  not?: Maybe<AccountFieldStatsFilter>;
-  or?: Maybe<Array<AccountFieldStatsFilter>>;
-  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
+  fieldName?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountFieldLatenciesFilterIn>;
+  not?: Maybe<AccountFieldLatenciesFilter>;
+  or?: Maybe<Array<AccountFieldLatenciesFilter>>;
+  /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
+  parentType?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in AccountFieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type AccountFieldStatsFilterIn = {
-  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+/** Filter for data in AccountFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountFieldLatenciesFilterIn = {
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
   field?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type AccountFieldStatsMetrics = {
-  __typename?: 'AccountFieldStatsMetrics';
-  errorsCount: Scalars['Long'];
+export type AccountFieldLatenciesMetrics = {
+  __typename?: 'AccountFieldLatenciesMetrics';
   fieldHistogram: DurationHistogram;
-  requestCount: Scalars['Long'];
 };
 
-export type AccountFieldStatsOrderBySpec = {
-  column: AccountFieldStatsColumn;
+export type AccountFieldLatenciesOrderBySpec = {
+  column: AccountFieldLatenciesColumn;
   direction: Ordering;
 };
 
-export type AccountFieldStatsRecord = {
-  __typename?: 'AccountFieldStatsRecord';
-  /** Dimensions of AccountFieldStats that can be grouped by. */
-  groupBy: AccountFieldStatsDimensions;
-  /** Metrics of AccountFieldStats that can be aggregated over. */
-  metrics: AccountFieldStatsMetrics;
+export type AccountFieldLatenciesRecord = {
+  __typename?: 'AccountFieldLatenciesRecord';
+  /** Dimensions of AccountFieldLatencies that can be grouped by. */
+  groupBy: AccountFieldLatenciesDimensions;
+  /** Metrics of AccountFieldLatencies that can be aggregated over. */
+  metrics: AccountFieldLatenciesMetrics;
   /** Starting segment timestamp. */
   timestamp: Scalars['Timestamp'];
 };
 
-/** Columns of AccountInputStats. */
-export enum AccountInputStatsColumn {
+/** Columns of AccountFieldUsage. */
+export enum AccountFieldUsageColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
+  ExecutionCount = 'EXECUTION_COUNT',
+  Field = 'FIELD',
   FieldName = 'FIELD_NAME',
-  FieldType = 'FIELD_TYPE',
   ParentType = 'PARENT_TYPE',
   QueryId = 'QUERY_ID',
   QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
-  RequestCountNull = 'REQUEST_COUNT_NULL',
-  RequestCountUndefined = 'REQUEST_COUNT_UNDEFINED',
+  ReferencingOperationCount = 'REFERENCING_OPERATION_COUNT',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
-export type AccountInputStatsDimensions = {
-  __typename?: 'AccountInputStatsDimensions';
+export type AccountFieldUsageDimensions = {
+  __typename?: 'AccountFieldUsageDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
   fieldName?: Maybe<Scalars['String']>;
-  fieldType?: Maybe<Scalars['String']>;
   parentType?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
   queryName?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in AccountInputStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type AccountInputStatsFilter = {
-  and?: Maybe<Array<AccountInputStatsFilter>>;
+/** Filter for data in AccountFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountFieldUsageFilter = {
+  and?: Maybe<Array<AccountFieldUsageFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
   /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
   fieldName?: Maybe<Scalars['String']>;
-  /** Selects rows whose fieldType dimension equals the given value if not null. To query for the null value, use {in: {fieldType: [null]}} instead. */
-  fieldType?: Maybe<Scalars['String']>;
-  in?: Maybe<AccountInputStatsFilterIn>;
-  not?: Maybe<AccountInputStatsFilter>;
-  or?: Maybe<Array<AccountInputStatsFilter>>;
+  in?: Maybe<AccountFieldUsageFilterIn>;
+  not?: Maybe<AccountFieldUsageFilter>;
+  or?: Maybe<Array<AccountFieldUsageFilter>>;
   /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
   parentType?: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
@@ -621,22 +488,18 @@ export type AccountInputStatsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in AccountInputStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type AccountInputStatsFilterIn = {
+/** Filter for data in AccountFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountFieldUsageFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose fieldType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fieldType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
   parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -649,28 +512,25 @@ export type AccountInputStatsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type AccountInputStatsMetrics = {
-  __typename?: 'AccountInputStatsMetrics';
-  requestCount: Scalars['Long'];
-  requestCountNull: Scalars['Long'];
-  requestCountUndefined: Scalars['Long'];
+export type AccountFieldUsageMetrics = {
+  __typename?: 'AccountFieldUsageMetrics';
+  executionCount: Scalars['Long'];
+  referencingOperationCount: Scalars['Long'];
 };
 
-export type AccountInputStatsOrderBySpec = {
-  column: AccountInputStatsColumn;
+export type AccountFieldUsageOrderBySpec = {
+  column: AccountFieldUsageColumn;
   direction: Ordering;
 };
 
-export type AccountInputStatsRecord = {
-  __typename?: 'AccountInputStatsRecord';
-  /** Dimensions of AccountInputStats that can be grouped by. */
-  groupBy: AccountInputStatsDimensions;
-  /** Metrics of AccountInputStats that can be aggregated over. */
-  metrics: AccountInputStatsMetrics;
+export type AccountFieldUsageRecord = {
+  __typename?: 'AccountFieldUsageRecord';
+  /** Dimensions of AccountFieldUsage that can be grouped by. */
+  groupBy: AccountFieldUsageDimensions;
+  /** Metrics of AccountFieldUsage that can be aggregated over. */
+  metrics: AccountFieldUsageMetrics;
   /** Starting segment timestamp. */
   timestamp: Scalars['Timestamp'];
 };
@@ -705,6 +565,7 @@ export type AccountMembership = {
 
 export type AccountMutation = {
   __typename?: 'AccountMutation';
+  auditExport?: Maybe<AuditLogExportMutation>;
   /** Cancel a pending change from an annual team subscription to a monthly team subscription when the current period expires. */
   cancelConvertAnnualTeamSubscriptionToMonthlyAtNextPeriod?: Maybe<Account>;
   /** Cancel account subscriptions, subscriptions will remain active until the end of the paid period */
@@ -728,11 +589,6 @@ export type AccountMutation = {
   reactivateCurrentSubscription?: Maybe<Account>;
   /** Refresh billing information from third-party billing service */
   refreshBilling?: Maybe<Scalars['Void']>;
-  /**
-   * Set the account-wide invitation token to a new random value
-   * @deprecated Accounts can now have multiple static invitations. Recreate individual static invitations instead.
-   */
-  regenerateJoinToken?: Maybe<Account>;
   /** Delete an invitation */
   removeInvitation?: Maybe<Scalars['Void']>;
   /** Remove a member of the account */
@@ -740,11 +596,6 @@ export type AccountMutation = {
   requestAuditExport?: Maybe<Account>;
   /** Send a new E-mail for an existing invitation */
   resendInvitation?: Maybe<AccountInvitation>;
-  /**
-   * Disable the account-wide join token
-   * @deprecated Accounts can now have multiple static invitations. Revoke individual static invitations instead.
-   */
-  revokeJoinToken?: Maybe<Account>;
   revokeStaticInvitation?: Maybe<OrganizationInviteLink>;
   /** Apollo admins only: set the billing plan to an arbitrary plan */
   setPlan?: Maybe<Scalars['Void']>;
@@ -760,15 +611,11 @@ export type AccountMutation = {
   updateBillingAddress?: Maybe<Account>;
   /** Update the billing information from a Recurly token */
   updateBillingInfo?: Maybe<Scalars['Void']>;
+  updateCompanyUrl?: Maybe<Account>;
   /** Set the E-mail address of the account, used notably for billing */
   updateEmail?: Maybe<Scalars['Void']>;
   /** Update the account ID */
   updateID?: Maybe<Account>;
-  /**
-   * Updates the role used by the org's invite link and regenerates the join token.
-   * @deprecated Accounts can now have multiple static invitations. Create a new static invitation instead.
-   */
-  updateInviteLinkRole?: Maybe<OrganizationInviteLink>;
   /** Update the company name */
   updateName?: Maybe<Scalars['Void']>;
   /** Apollo admins only: enable or disable an account for PingOne SSO login */
@@ -777,6 +624,11 @@ export type AccountMutation = {
   updateSSODefaultRole?: Maybe<OrganizationSso>;
   /** A (currently) internal to Apollo mutation to update a user's role within an organization */
   updateUserPermission?: Maybe<User>;
+};
+
+
+export type AccountMutationAuditExportArgs = {
+  id: Scalars['String'];
 };
 
 
@@ -849,6 +701,11 @@ export type AccountMutationUpdateBillingInfoArgs = {
 };
 
 
+export type AccountMutationUpdateCompanyUrlArgs = {
+  companyUrl?: Maybe<Scalars['String']>;
+};
+
+
 export type AccountMutationUpdateEmailArgs = {
   email: Scalars['String'];
 };
@@ -856,11 +713,6 @@ export type AccountMutationUpdateEmailArgs = {
 
 export type AccountMutationUpdateIdArgs = {
   id: Scalars['ID'];
-};
-
-
-export type AccountMutationUpdateInviteLinkRoleArgs = {
-  role: UserPermission;
 };
 
 
@@ -884,13 +736,98 @@ export type AccountMutationUpdateUserPermissionArgs = {
   userID: Scalars['ID'];
 };
 
+/** Columns of AccountOperationCheckStats. */
+export enum AccountOperationCheckStatsColumn {
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientVersion = 'CLIENT_VERSION',
+  QueryId = 'QUERY_ID',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type AccountOperationCheckStatsDimensions = {
+  __typename?: 'AccountOperationCheckStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type AccountOperationCheckStatsFilter = {
+  and?: Maybe<Array<AccountOperationCheckStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<AccountOperationCheckStatsFilterIn>;
+  not?: Maybe<AccountOperationCheckStatsFilter>;
+  or?: Maybe<Array<AccountOperationCheckStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in AccountOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type AccountOperationCheckStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type AccountOperationCheckStatsMetrics = {
+  __typename?: 'AccountOperationCheckStatsMetrics';
+  cachedRequestsCount: Scalars['Long'];
+  uncachedRequestsCount: Scalars['Long'];
+};
+
+export type AccountOperationCheckStatsOrderBySpec = {
+  column: AccountOperationCheckStatsColumn;
+  direction: Ordering;
+};
+
+export type AccountOperationCheckStatsRecord = {
+  __typename?: 'AccountOperationCheckStatsRecord';
+  /** Dimensions of AccountOperationCheckStats that can be grouped by. */
+  groupBy: AccountOperationCheckStatsDimensions;
+  /** Metrics of AccountOperationCheckStats that can be aggregated over. */
+  metrics: AccountOperationCheckStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+export type AccountPublishesStatsMetrics = {
+  __typename?: 'AccountPublishesStatsMetrics';
+  totalPublishes: Scalars['Long'];
+};
+
+export type AccountPublishesStatsRecord = {
+  __typename?: 'AccountPublishesStatsRecord';
+  id: Scalars['ID'];
+  metrics: AccountPublishesStatsMetrics;
+  timestamp: Scalars['Timestamp'];
+};
+
 /** Columns of AccountQueryStats. */
 export enum AccountQueryStatsColumn {
   CachedHistogram = 'CACHED_HISTOGRAM',
   CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
   CacheTtlHistogram = 'CACHE_TTL_HISTOGRAM',
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   ForbiddenOperationCount = 'FORBIDDEN_OPERATION_COUNT',
   FromEngineproxy = 'FROM_ENGINEPROXY',
@@ -901,7 +838,6 @@ export enum AccountQueryStatsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   UncachedHistogram = 'UNCACHED_HISTOGRAM',
   UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
@@ -910,7 +846,6 @@ export enum AccountQueryStatsColumn {
 export type AccountQueryStatsDimensions = {
   __typename?: 'AccountQueryStatsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   fromEngineproxy?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -919,7 +854,6 @@ export type AccountQueryStatsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -927,8 +861,6 @@ export type AccountQueryStatsFilter = {
   and?: Maybe<Array<AccountQueryStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
@@ -946,16 +878,12 @@ export type AccountQueryStatsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in AccountQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type AccountQueryStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -970,8 +898,6 @@ export type AccountQueryStatsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type AccountQueryStatsMetrics = {
@@ -1005,8 +931,6 @@ export type AccountQueryStatsRecord = {
 
 export type AccountRoles = {
   __typename?: 'AccountRoles';
-  /** @deprecated Use canManageMembers instead */
-  canAdminister: Scalars['Boolean'];
   canAudit: Scalars['Boolean'];
   canCreateDevGraph: Scalars['Boolean'];
   canCreateService: Scalars['Boolean'];
@@ -1014,24 +938,17 @@ export type AccountRoles = {
   /** @deprecated Use canQueryBillingInfo instead */
   canDownloadInvoice: Scalars['Boolean'];
   canManageMembers: Scalars['Boolean'];
-  /** @deprecated Use canQuery instead */
-  canModify: Scalars['Boolean'];
   canQuery: Scalars['Boolean'];
+  canQueryAudit: Scalars['Boolean'];
   canQueryBillingInfo: Scalars['Boolean'];
   /** @deprecated Use canQueryBillingInfo instead */
   canQueryInvoices: Scalars['Boolean'];
-  /** @deprecated Use canManageMembers instead */
-  canQueryJoinToken: Scalars['Boolean'];
   canQueryMembers: Scalars['Boolean'];
-  /** @deprecated Use canQueryBillingInfo instead */
-  canQueryRecurlyInfo: Scalars['Boolean'];
+  canQueryStats: Scalars['Boolean'];
+  canReadTickets: Scalars['Boolean'];
   canRemoveMembers: Scalars['Boolean'];
   canSetConstrainedPlan: Scalars['Boolean'];
-  /** @deprecated Use canUpdateMetadata instead */
-  canUpdateAvatar: Scalars['Boolean'];
   canUpdateBillingInfo: Scalars['Boolean'];
-  /** @deprecated Use canUpdateMetadata instead */
-  canUpdateID: Scalars['Boolean'];
   canUpdateMetadata: Scalars['Boolean'];
 };
 
@@ -1046,10 +963,10 @@ export enum AccountState {
 export type AccountStatsWindow = {
   __typename?: 'AccountStatsWindow';
   edgeServerInfos: Array<AccountEdgeServerInfosRecord>;
-  enumStats: Array<AccountEnumStatsRecord>;
   errorStats: Array<AccountErrorStatsRecord>;
-  fieldStats: Array<AccountFieldStatsRecord>;
-  inputStats: Array<AccountInputStatsRecord>;
+  fieldLatencies: Array<AccountFieldLatenciesRecord>;
+  fieldUsage: Array<AccountFieldUsageRecord>;
+  operationCheckStats: Array<AccountOperationCheckStatsRecord>;
   queryStats: Array<AccountQueryStatsRecord>;
   /** From field rounded down to the nearest resolution. */
   roundedDownFrom: Scalars['Timestamp'];
@@ -1069,14 +986,6 @@ export type AccountStatsWindowEdgeServerInfosArgs = {
 
 
 /** A time window with a specified granularity over a given account. */
-export type AccountStatsWindowEnumStatsArgs = {
-  filter?: Maybe<AccountEnumStatsFilter>;
-  limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountEnumStatsOrderBySpec>>;
-};
-
-
-/** A time window with a specified granularity over a given account. */
 export type AccountStatsWindowErrorStatsArgs = {
   filter?: Maybe<AccountErrorStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
@@ -1085,18 +994,26 @@ export type AccountStatsWindowErrorStatsArgs = {
 
 
 /** A time window with a specified granularity over a given account. */
-export type AccountStatsWindowFieldStatsArgs = {
-  filter?: Maybe<AccountFieldStatsFilter>;
+export type AccountStatsWindowFieldLatenciesArgs = {
+  filter?: Maybe<AccountFieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountFieldStatsOrderBySpec>>;
+  orderBy?: Maybe<Array<AccountFieldLatenciesOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given account. */
-export type AccountStatsWindowInputStatsArgs = {
-  filter?: Maybe<AccountInputStatsFilter>;
+export type AccountStatsWindowFieldUsageArgs = {
+  filter?: Maybe<AccountFieldUsageFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<AccountInputStatsOrderBySpec>>;
+  orderBy?: Maybe<Array<AccountFieldUsageOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given account. */
+export type AccountStatsWindowOperationCheckStatsArgs = {
+  filter?: Maybe<AccountOperationCheckStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<AccountOperationCheckStatsOrderBySpec>>;
 };
 
 
@@ -1126,7 +1043,6 @@ export type AccountStatsWindowTraceRefsArgs = {
 /** Columns of AccountTracePathErrorsRefs. */
 export enum AccountTracePathErrorsRefsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   DurationBucket = 'DURATION_BUCKET',
   ErrorsCountInPath = 'ERRORS_COUNT_IN_PATH',
@@ -1138,7 +1054,6 @@ export enum AccountTracePathErrorsRefsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   TraceHttpStatusCode = 'TRACE_HTTP_STATUS_CODE',
   TraceId = 'TRACE_ID',
@@ -1149,7 +1064,6 @@ export enum AccountTracePathErrorsRefsColumn {
 export type AccountTracePathErrorsRefsDimensions = {
   __typename?: 'AccountTracePathErrorsRefsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationBucket?: Maybe<Scalars['Int']>;
   errorMessage?: Maybe<Scalars['String']>;
@@ -1159,7 +1073,6 @@ export type AccountTracePathErrorsRefsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
   traceHttpStatusCode?: Maybe<Scalars['Int']>;
   traceId?: Maybe<Scalars['ID']>;
   traceStartsAt?: Maybe<Scalars['Timestamp']>;
@@ -1170,8 +1083,6 @@ export type AccountTracePathErrorsRefsFilter = {
   and?: Maybe<Array<AccountTracePathErrorsRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
@@ -1193,8 +1104,6 @@ export type AccountTracePathErrorsRefsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
   traceHttpStatusCode?: Maybe<Scalars['Int']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
@@ -1205,8 +1114,6 @@ export type AccountTracePathErrorsRefsFilter = {
 export type AccountTracePathErrorsRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -1225,8 +1132,6 @@ export type AccountTracePathErrorsRefsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
   traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -1258,7 +1163,6 @@ export type AccountTracePathErrorsRefsRecord = {
 /** Columns of AccountTraceRefs. */
 export enum AccountTraceRefsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   DurationBucket = 'DURATION_BUCKET',
   DurationNs = 'DURATION_NS',
@@ -1267,7 +1171,6 @@ export enum AccountTraceRefsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   TraceId = 'TRACE_ID',
   TraceSizeBytes = 'TRACE_SIZE_BYTES'
@@ -1276,7 +1179,6 @@ export enum AccountTraceRefsColumn {
 export type AccountTraceRefsDimensions = {
   __typename?: 'AccountTraceRefsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationBucket?: Maybe<Scalars['Int']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -1285,7 +1187,6 @@ export type AccountTraceRefsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
   traceId?: Maybe<Scalars['ID']>;
 };
 
@@ -1294,8 +1195,6 @@ export type AccountTraceRefsFilter = {
   and?: Maybe<Array<AccountTraceRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
@@ -1313,8 +1212,6 @@ export type AccountTraceRefsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
   traceId?: Maybe<Scalars['ID']>;
 };
@@ -1323,8 +1220,6 @@ export type AccountTraceRefsFilter = {
 export type AccountTraceRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -1339,8 +1234,6 @@ export type AccountTraceRefsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
@@ -1389,36 +1282,43 @@ export enum ActorType {
 
 export type AffectedClient = {
   __typename?: 'AffectedClient';
-  /** ID, often the name, of the client set by the user and reported alongside metrics */
+  /**
+   * ID, often the name, of the client set by the user and reported alongside metrics
+   * @deprecated Unsupported.
+   */
   clientReferenceId?: Maybe<Scalars['ID']>;
-  /** version of the client set by the user and reported alongside metrics */
+  /**
+   * version of the client set by the user and reported alongside metrics
+   * @deprecated Unsupported.
+   */
   clientVersion?: Maybe<Scalars['String']>;
 };
 
 export type AffectedQuery = {
   __typename?: 'AffectedQuery';
-  id: Scalars['ID'];
-  /** First 128 characters of query signature for display */
-  signature?: Maybe<Scalars['String']>;
-  /** Name to display to the user for the operation */
-  displayName?: Maybe<Scalars['String']>;
-  /** Name provided for the operation, which can be empty string if it is an anonymous operation */
-  name?: Maybe<Scalars['String']>;
-  /** Determines if this query validates against the proposed schema */
-  isValid?: Maybe<Scalars['Boolean']>;
-  /** List of changes affecting this query. Returns null if queried from SchemaDiff.changes.affectedQueries.changes */
-  changes?: Maybe<Array<ChangeOnOperation>>;
-  /** Whether this operation was ignored and its severity was downgraded for that reason */
-  markedAsIgnored?: Maybe<Scalars['Boolean']>;
-  /** Whether the changes were marked as safe and its severity was downgraded for that reason */
-  markedAsSafe?: Maybe<Scalars['Boolean']>;
   /** If the operation would be approved if the check ran again. Returns null if queried from SchemaDiff.changes.affectedQueries.alreadyApproved */
   alreadyApproved?: Maybe<Scalars['Boolean']>;
   /** If the operation would be ignored if the check ran again */
   alreadyIgnored?: Maybe<Scalars['Boolean']>;
+  /** List of changes affecting this query. Returns null if queried from SchemaDiff.changes.affectedQueries.changes */
+  changes?: Maybe<Array<ChangeOnOperation>>;
+  /** Name to display to the user for the operation */
+  displayName?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  /** Determines if this query validates against the proposed schema */
+  isValid?: Maybe<Scalars['Boolean']>;
+  /** Whether this operation was ignored and its severity was downgraded for that reason */
+  markedAsIgnored?: Maybe<Scalars['Boolean']>;
+  /** Whether the changes were marked as safe and its severity was downgraded for that reason */
+  markedAsSafe?: Maybe<Scalars['Boolean']>;
+  /** Name provided for the operation, which can be empty string if it is an anonymous operation */
+  name?: Maybe<Scalars['String']>;
+  /** First 128 characters of query signature for display */
+  signature?: Maybe<Scalars['String']>;
 };
 
 export type ApiKey = {
+  id: Scalars['ID'];
   keyName?: Maybe<Scalars['String']>;
   token: Scalars['String'];
 };
@@ -1444,7 +1344,14 @@ export type AuditLogExport = {
   to: Scalars['Timestamp'];
 };
 
+export type AuditLogExportMutation = {
+  __typename?: 'AuditLogExportMutation';
+  cancel?: Maybe<Account>;
+  delete?: Maybe<Account>;
+};
+
 export enum AuditStatus {
+  Cancelled = 'CANCELLED',
   Completed = 'COMPLETED',
   Expired = 'EXPIRED',
   Failed = 'FAILED',
@@ -1476,6 +1383,11 @@ export enum AvatarUploadErrorCode {
 
 export type AvatarUploadResult = AvatarUploadError | MediaUploadInfo;
 
+export type BillingAccount = {
+  __typename?: 'BillingAccount';
+  id: Scalars['ID'];
+};
+
 export type BillingAddress = {
   __typename?: 'BillingAddress';
   address1?: Maybe<Scalars['String']>;
@@ -1504,6 +1416,7 @@ export type BillingInfo = {
   lastFour?: Maybe<Scalars['Int']>;
   lastName?: Maybe<Scalars['String']>;
   month?: Maybe<Scalars['Int']>;
+  vatNumber?: Maybe<Scalars['String']>;
   year?: Maybe<Scalars['Int']>;
 };
 
@@ -1555,9 +1468,11 @@ export type BillingPlanAddon = {
 export type BillingPlanCapabilities = {
   __typename?: 'BillingPlanCapabilities';
   clients: Scalars['Boolean'];
+  contracts: Scalars['Boolean'];
   datadog: Scalars['Boolean'];
   errors: Scalars['Boolean'];
   federation: Scalars['Boolean'];
+  launches: Scalars['Boolean'];
   maxAuditInDays: Scalars['Int'];
   maxRangeInDays?: Maybe<Scalars['Int']>;
   maxRequestsPerMonth?: Maybe<Scalars['Long']>;
@@ -1623,7 +1538,6 @@ export type BillingSubscriptionAddon = {
   quantity: Scalars['Int'];
 };
 
-
 export type Build = {
   __typename?: 'Build';
   input: BuildInput;
@@ -1660,29 +1574,29 @@ export enum CacheScope {
 
 export type Change = {
   __typename?: 'Change';
-  /**
-   * Indication of the success of the overall change, either failure, warning, or notice.
-   * @deprecated use severity instead
-   */
-  type: ChangeType;
-  /** Indication of the success of the overall change, either failure, warning, or notice. */
-  severity: ChangeSeverity;
-  /** Indication of the kind of target and action of the change, e.g. 'TYPE_REMOVED'. */
-  code: Scalars['String'];
+  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  /** Target arg of change made. */
+  argNode?: Maybe<NamedIntrospectionArg>;
   /** Indication of the category of the change (e.g. addition, removal, edit). */
   category: ChangeCategory;
-  /** Explanation of both the target of the change and how it was changed. */
-  description: Scalars['String'];
-  affectedQueries?: Maybe<Array<AffectedQuery>>;
-  /** Top level node affected by the change */
-  parentNode?: Maybe<NamedIntrospectionType>;
   /**
    * Node related to the top level node that was changed, such as a field in an object,
    * a value in an enum or the object of an interface
    */
   childNode?: Maybe<NamedIntrospectionValue>;
-  /** Target arg of change made. */
-  argNode?: Maybe<NamedIntrospectionArg>;
+  /** Indication of the kind of target and action of the change, e.g. 'TYPE_REMOVED'. */
+  code: Scalars['String'];
+  /** Explanation of both the target of the change and how it was changed. */
+  description: Scalars['String'];
+  /** Top level node affected by the change */
+  parentNode?: Maybe<NamedIntrospectionType>;
+  /** Indication of the success of the overall change, either failure, warning, or notice. */
+  severity: ChangeSeverity;
+  /**
+   * Indication of the success of the overall change, either failure, warning, or notice.
+   * @deprecated use severity instead
+   */
+  type: ChangeType;
 };
 
 /**
@@ -1691,9 +1605,9 @@ export type Change = {
  */
 export enum ChangeCategory {
   Addition = 'ADDITION',
+  Deprecation = 'DEPRECATION',
   Edit = 'EDIT',
-  Removal = 'REMOVAL',
-  Deprecation = 'DEPRECATION'
+  Removal = 'REMOVAL'
 }
 
 /**
@@ -1701,83 +1615,83 @@ export enum ChangeCategory {
  * occur during the schema diff algorithm.
  */
 export enum ChangeCode {
-  /** Field was removed from the type. */
-  FieldRemoved = 'FIELD_REMOVED',
-  /** Type (object or scalar) was removed from the schema. */
-  TypeRemoved = 'TYPE_REMOVED',
+  /** Type of the argument was changed. */
+  ArgChangedType = 'ARG_CHANGED_TYPE',
+  /** Argument was changed from nullable to non-nullable. */
+  ArgChangedTypeOptionalToRequired = 'ARG_CHANGED_TYPE_OPTIONAL_TO_REQUIRED',
+  /** Default value added or changed for the argument. */
+  ArgDefaultValueChange = 'ARG_DEFAULT_VALUE_CHANGE',
+  /** Description was added, removed, or updated for argument. */
+  ArgDescriptionChange = 'ARG_DESCRIPTION_CHANGE',
   /** Argument to a field was removed. */
   ArgRemoved = 'ARG_REMOVED',
-  /** Type is no longer included in the union. */
-  TypeRemovedFromUnion = 'TYPE_REMOVED_FROM_UNION',
-  /** Field was removed from the input object. */
-  FieldRemovedFromInputObject = 'FIELD_REMOVED_FROM_INPUT_OBJECT',
-  /** Value was removed from the enum. */
-  ValueRemovedFromEnum = 'VALUE_REMOVED_FROM_ENUM',
-  /** Type no longer implements the interface. */
-  TypeRemovedFromInterface = 'TYPE_REMOVED_FROM_INTERFACE',
-  /** Non-nullable argument was added to the field. */
-  RequiredArgAdded = 'REQUIRED_ARG_ADDED',
-  /** Non-nullable field was added to the input object. */
-  NonNullableFieldAddedToInputObject = 'NON_NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT',
+  /** Argument to the directive was removed. */
+  DirectiveArgRemoved = 'DIRECTIVE_ARG_REMOVED',
+  /** Location of the directive was removed. */
+  DirectiveLocationRemoved = 'DIRECTIVE_LOCATION_REMOVED',
+  /** Directive was removed. */
+  DirectiveRemoved = 'DIRECTIVE_REMOVED',
+  /** Repeatable flag was removed for directive. */
+  DirectiveRepeatableRemoved = 'DIRECTIVE_REPEATABLE_REMOVED',
+  /** Enum was deprecated. */
+  EnumDeprecated = 'ENUM_DEPRECATED',
+  /** Reason for enum deprecation changed. */
+  EnumDeprecatedReasonChange = 'ENUM_DEPRECATED_REASON_CHANGE',
+  /** Enum deprecation was removed. */
+  EnumDeprecationRemoved = 'ENUM_DEPRECATION_REMOVED',
+  /** Description was added, removed, or updated for enum value. */
+  EnumValueDescriptionChange = 'ENUM_VALUE_DESCRIPTION_CHANGE',
+  /** Field was added to the type. */
+  FieldAdded = 'FIELD_ADDED',
   /** Return type for the field was changed. */
   FieldChangedType = 'FIELD_CHANGED_TYPE',
+  /** Field was deprecated. */
+  FieldDeprecated = 'FIELD_DEPRECATED',
+  /** Reason for field deprecation changed. */
+  FieldDeprecatedReasonChange = 'FIELD_DEPRECATED_REASON_CHANGE',
+  /** Field deprecation removed. */
+  FieldDeprecationRemoved = 'FIELD_DEPRECATION_REMOVED',
+  /** Description was added, removed, or updated for field. */
+  FieldDescriptionChange = 'FIELD_DESCRIPTION_CHANGE',
   /** Type of the field in the input object was changed. */
   FieldOnInputObjectChangedType = 'FIELD_ON_INPUT_OBJECT_CHANGED_TYPE',
+  /** Field was removed from the type. */
+  FieldRemoved = 'FIELD_REMOVED',
+  /** Field was removed from the input object. */
+  FieldRemovedFromInputObject = 'FIELD_REMOVED_FROM_INPUT_OBJECT',
+  /** Non-nullable field was added to the input object. */
+  NonNullableFieldAddedToInputObject = 'NON_NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT',
+  /** Nullable field was added to the input type. */
+  NullableFieldAddedToInputObject = 'NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT',
+  /** Nullable argument was added to the field. */
+  OptionalArgAdded = 'OPTIONAL_ARG_ADDED',
+  /** Non-nullable argument was added to the field. */
+  RequiredArgAdded = 'REQUIRED_ARG_ADDED',
+  /** Non-nullable argument added to directive. */
+  RequiredDirectiveArgAdded = 'REQUIRED_DIRECTIVE_ARG_ADDED',
+  /** Type was added to the schema. */
+  TypeAdded = 'TYPE_ADDED',
+  /** Type now implements the interface. */
+  TypeAddedToInterface = 'TYPE_ADDED_TO_INTERFACE',
+  /** A new value was added to the enum. */
+  TypeAddedToUnion = 'TYPE_ADDED_TO_UNION',
   /**
    * Type was changed from one kind to another.
    * Ex: scalar to object or enum to union.
    */
   TypeChangedKind = 'TYPE_CHANGED_KIND',
-  /** Type of the argument was changed. */
-  ArgChangedType = 'ARG_CHANGED_TYPE',
-  /** Argument was changed from nullable to non-nullable. */
-  ArgChangedTypeOptionalToRequired = 'ARG_CHANGED_TYPE_OPTIONAL_TO_REQUIRED',
-  /** A new value was added to the enum. */
-  ValueAddedToEnum = 'VALUE_ADDED_TO_ENUM',
-  /** A new value was added to the enum. */
-  TypeAddedToUnion = 'TYPE_ADDED_TO_UNION',
-  /** Type now implements the interface. */
-  TypeAddedToInterface = 'TYPE_ADDED_TO_INTERFACE',
-  /** Default value added or changed for the argument. */
-  ArgDefaultValueChange = 'ARG_DEFAULT_VALUE_CHANGE',
-  /** Nullable argument was added to the field. */
-  OptionalArgAdded = 'OPTIONAL_ARG_ADDED',
-  /** Nullable field was added to the input type. */
-  NullableFieldAddedToInputObject = 'NULLABLE_FIELD_ADDED_TO_INPUT_OBJECT',
-  /** Field was added to the type. */
-  FieldAdded = 'FIELD_ADDED',
-  /** Type was added to the schema. */
-  TypeAdded = 'TYPE_ADDED',
-  /** Enum was deprecated. */
-  EnumDeprecated = 'ENUM_DEPRECATED',
-  /** Enum deprecation was removed. */
-  EnumDeprecationRemoved = 'ENUM_DEPRECATION_REMOVED',
-  /** Reason for enum deprecation changed. */
-  EnumDeprecatedReasonChange = 'ENUM_DEPRECATED_REASON_CHANGE',
-  /** Field was deprecated. */
-  FieldDeprecated = 'FIELD_DEPRECATED',
-  /** Field deprecation removed. */
-  FieldDeprecationRemoved = 'FIELD_DEPRECATION_REMOVED',
-  /** Reason for field deprecation changed. */
-  FieldDeprecatedReasonChange = 'FIELD_DEPRECATED_REASON_CHANGE',
   /** Description was added, removed, or updated for type. */
   TypeDescriptionChange = 'TYPE_DESCRIPTION_CHANGE',
-  /** Description was added, removed, or updated for field. */
-  FieldDescriptionChange = 'FIELD_DESCRIPTION_CHANGE',
-  /** Description was added, removed, or updated for enum value. */
-  EnumValueDescriptionChange = 'ENUM_VALUE_DESCRIPTION_CHANGE',
-  /** Description was added, removed, or updated for argument. */
-  ArgDescriptionChange = 'ARG_DESCRIPTION_CHANGE',
-  /** Directive was removed. */
-  DirectiveRemoved = 'DIRECTIVE_REMOVED',
-  /** Argument to the directive was removed. */
-  DirectiveArgRemoved = 'DIRECTIVE_ARG_REMOVED',
-  /** Location of the directive was removed. */
-  DirectiveLocationRemoved = 'DIRECTIVE_LOCATION_REMOVED',
-  /** Repeatable flag was removed for directive. */
-  DirectiveRepeatableRemoved = 'DIRECTIVE_REPEATABLE_REMOVED',
-  /** Non-nullable argument added to directive. */
-  RequiredDirectiveArgAdded = 'REQUIRED_DIRECTIVE_ARG_ADDED'
+  /** Type (object or scalar) was removed from the schema. */
+  TypeRemoved = 'TYPE_REMOVED',
+  /** Type no longer implements the interface. */
+  TypeRemovedFromInterface = 'TYPE_REMOVED_FROM_INTERFACE',
+  /** Type is no longer included in the union. */
+  TypeRemovedFromUnion = 'TYPE_REMOVED_FROM_UNION',
+  /** A new value was added to the enum. */
+  ValueAddedToEnum = 'VALUE_ADDED_TO_ENUM',
+  /** Value was removed from the enum. */
+  ValueRemovedFromEnum = 'VALUE_REMOVED_FROM_ENUM'
 }
 
 /**
@@ -1786,18 +1700,18 @@ export enum ChangeCode {
  */
 export type ChangeDefinition = {
   __typename?: 'ChangeDefinition';
+  category: ChangeCategory;
   code: ChangeCode;
   defaultSeverity: ChangeSeverity;
-  category: ChangeCategory;
 };
 
 /** Info about a change in the context of an operation it affects */
 export type ChangeOnOperation = {
   __typename?: 'ChangeOnOperation';
-  /** The semantic info about this change, i.e. info about the change that doesn't depend on the operation */
-  semanticChange: SemanticChange;
   /** Human-readable explanation of the impact of this change on the operation */
   impact?: Maybe<Scalars['String']>;
+  /** The semantic info about this change, i.e. info about the change that doesn't depend on the operation */
+  semanticChange: SemanticChange;
 };
 
 export enum ChangeSeverity {
@@ -1818,15 +1732,15 @@ export enum ChangeSeverity {
  */
 export type ChangeSummary = {
   __typename?: 'ChangeSummary';
+  /** Counts for changes to fields of objects, input objects, and interfaces. */
+  field: FieldChangeSummaryCounts;
+  /** Counts for all changes. */
+  total: TotalChangeSummaryCounts;
   /**
    * Counts for changes to non-field aspects of objects, input objects, and interfaces,
    * and all aspects of enums, unions, and scalars.
    */
   type: TypeChangeSummaryCounts;
-  /** Counts for changes to fields of objects, input objects, and interfaces. */
-  field: FieldChangeSummaryCounts;
-  /** Counts for all changes. */
-  total: TotalChangeSummaryCounts;
 };
 
 export enum ChangeType {
@@ -1856,27 +1770,20 @@ export type ChannelSubscription = {
 
 export type CheckConfiguration = {
   __typename?: 'CheckConfiguration';
-  /** ID of the check configuration */
-  id: Scalars['ID'];
-  /** Graph that this check configuration belongs to */
-  graphID: Scalars['ID'];
-  /** Operations to ignore during validation */
-  excludedOperations: Array<ExcludedOperation>;
-  /** Clients to ignore during validation */
-  excludedClients: Array<ClientFilter>;
-  /** Variant overrides for validation */
-  includedVariants: Array<Scalars['String']>;
   /** Time when check configuration was created */
   createdAt: Scalars['Timestamp'];
-  /** Time when check configuration was last updated */
-  updatedAt: Scalars['Timestamp'];
-  /** Identity of the last user to update the check configuration */
-  updatedBy?: Maybe<Identity>;
-  /**
-   * Only check operations from the last <timeRangeSeconds> seconds.
-   * The default is 7 days (604,800 seconds).
-   */
-  timeRangeSeconds: Scalars['Long'];
+  /** Clients to ignore during validation */
+  excludedClients: Array<ClientFilter>;
+  /** Operations to ignore during validation */
+  excludedOperations: Array<ExcludedOperation>;
+  /** Graph that this check configuration belongs to */
+  graphID: Scalars['ID'];
+  /** ID of the check configuration */
+  id: Scalars['ID'];
+  /** Default configuration to include operations on the base variant. */
+  includeBaseVariant: Scalars['Boolean'];
+  /** Variant overrides for validation */
+  includedVariants: Array<Scalars['String']>;
   /** Minimum number of requests within the window for an operation to be considered. */
   operationCountThreshold: Scalars['Int'];
   /**
@@ -1885,41 +1792,48 @@ export type CheckConfiguration = {
    * total request volume)
    */
   operationCountThresholdPercentage: Scalars['Float'];
-  /** Default configuration to include operations on the base variant. */
-  includeBaseVariant: Scalars['Boolean'];
+  /**
+   * Only check operations from the last <timeRangeSeconds> seconds.
+   * The default is 7 days (604,800 seconds).
+   */
+  timeRangeSeconds: Scalars['Long'];
+  /** Time when check configuration was last updated */
+  updatedAt: Scalars['Timestamp'];
+  /** Identity of the last user to update the check configuration */
+  updatedBy?: Maybe<Identity>;
 };
 
 /** Filter options available when listing checks. */
 export type CheckFilterInput = {
   authors?: Maybe<Array<Scalars['String']>>;
   branches?: Maybe<Array<Scalars['String']>>;
-  subgraphs?: Maybe<Array<Scalars['String']>>;
   status?: Maybe<CheckFilterInputStatusOption>;
+  subgraphs?: Maybe<Array<Scalars['String']>>;
 };
 
 /** Options for filtering CheckWorkflows by status */
 export enum CheckFilterInputStatusOption {
   Failed = 'FAILED',
-  Pending = 'PENDING',
-  Passed = 'PASSED'
+  Passed = 'PASSED',
+  Pending = 'PENDING'
 }
 
 export type CheckPartialSchemaResult = {
   __typename?: 'CheckPartialSchemaResult';
-  /** Result of composition validation run before the schema check. */
-  compositionValidationResult: CompositionValidationResult;
   /** Result of traffic validation. This will be null if composition validation was unsuccessful. */
   checkSchemaResult?: Maybe<CheckSchemaResult>;
+  /** Result of composition validation run before the schema check. */
+  compositionValidationResult: CompositionValidationResult;
   /** Workflow associated with the composition validation. */
   workflow?: Maybe<CheckWorkflow>;
 };
 
 export type CheckSchemaResult = {
   __typename?: 'CheckSchemaResult';
-  /** ID of the operations check that was created */
-  operationsCheckID: Scalars['ID'];
   /** Schema diff and affected operations generated by the schema check */
   diffToPrevious: SchemaDiff;
+  /** ID of the operations check that was created */
+  operationsCheckID: Scalars['ID'];
   /** Generated url to view schema diff in Engine */
   targetUrl?: Maybe<Scalars['String']>;
   /** Workflow associated with this check result */
@@ -1928,29 +1842,29 @@ export type CheckSchemaResult = {
 
 export type CheckWorkflow = {
   __typename?: 'CheckWorkflow';
-  id: Scalars['ID'];
   /**
    * The variant provided as a base to check against.  Only the differences from the
    * base schema will be tested in operations checks.
    */
   baseVariant?: Maybe<GraphVariant>;
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
   /** Contextual parameters supplied by the runtime environment where the check was run. */
   gitContext?: Maybe<GitContext>;
+  id: Scalars['ID'];
   /** The name of the implementing service that was responsible for triggering the validation. */
   implementingServiceName?: Maybe<Scalars['String']>;
-  /** Configuration of validation at the time the check was run. */
-  validationConfig?: Maybe<SchemaDiffValidationConfig>;
-  /** The set of check tasks associated with this workflow, e.g. OperationsCheck, GraphComposition, etc. */
-  tasks: Array<CheckWorkflowTask>;
-  /** Overall status of the workflow, based on the underlying task statuses. */
-  status: CheckWorkflowStatus;
   /** If this check was created by rerunning, the original check that was rerun. */
   rerunOf?: Maybe<CheckWorkflow>;
   /** Checks created by re-running this check, most recent first. */
   reruns?: Maybe<Array<CheckWorkflow>>;
-  createdAt: Scalars['Timestamp'];
   startedAt?: Maybe<Scalars['Timestamp']>;
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  /** Overall status of the workflow, based on the underlying task statuses. */
+  status: CheckWorkflowStatus;
+  /** The set of check tasks associated with this workflow, e.g. OperationsCheck, GraphComposition, etc. */
+  tasks: Array<CheckWorkflowTask>;
+  /** Configuration of validation at the time the check was run. */
+  validationConfig?: Maybe<SchemaDiffValidationConfig>;
 };
 
 
@@ -1966,43 +1880,41 @@ export type CheckWorkflowMutation = {
 
 export type CheckWorkflowRerunResult = {
   __typename?: 'CheckWorkflowRerunResult';
-  /** Check workflow that was rerun. */
-  source?: Maybe<CheckWorkflow>;
   /** Check workflow created by re-running. */
   result?: Maybe<CheckWorkflow>;
+  /** Check workflow that was rerun. */
+  source?: Maybe<CheckWorkflow>;
 };
 
 export enum CheckWorkflowStatus {
-  Pending = 'PENDING',
+  Failed = 'FAILED',
   Passed = 'PASSED',
-  Failed = 'FAILED'
+  Pending = 'PENDING'
 }
 
 export type CheckWorkflowTask = {
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
+  status: CheckWorkflowTaskStatus;
   /** The workflow that this task belongs to. */
   workflow: CheckWorkflow;
-  status: CheckWorkflowTaskStatus;
-  createdAt: Scalars['Timestamp'];
-  completedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export enum CheckWorkflowTaskStatus {
-  Pending = 'PENDING',
-  Passed = 'PASSED',
+  Blocked = 'BLOCKED',
   Failed = 'FAILED',
-  Blocked = 'BLOCKED'
+  Passed = 'PASSED',
+  Pending = 'PENDING'
 }
 
 /** Client filter configuration for a graph. */
 export type ClientFilter = {
   __typename?: 'ClientFilter';
-  /** ID, often the name, of the client set by the user and reported alongside metrics */
-  referenceID?: Maybe<Scalars['ID']>;
-  /** version of the client set by the user and reported alongside metrics */
-  version?: Maybe<Scalars['String']>;
   /** name of the client set by the user and reported alongside metrics */
   name?: Maybe<Scalars['String']>;
+  /** version of the client set by the user and reported alongside metrics */
+  version?: Maybe<Scalars['String']>;
 };
 
 /**
@@ -2010,25 +1922,23 @@ export type ClientFilter = {
  * If passing client version, make sure to either provide a client reference ID or client name.
  */
 export type ClientFilterInput = {
-  /** ID, often the name, of the client set by the user and reported alongside metrics */
-  referenceID?: Maybe<Scalars['ID']>;
-  /** version of the client set by the user and reported alongside metrics */
-  version?: Maybe<Scalars['String']>;
   /** name of the client set by the user and reported alongside metrics */
   name?: Maybe<Scalars['String']>;
+  /** version of the client set by the user and reported alongside metrics */
+  version?: Maybe<Scalars['String']>;
 };
 
 /** Filter options to exclude by client reference ID, client name, and client version. */
 export type ClientInfoFilter = {
-  referenceID?: Maybe<Scalars['ID']>;
   name?: Maybe<Scalars['String']>;
+  /** Ignored */
+  referenceID?: Maybe<Scalars['ID']>;
   version?: Maybe<Scalars['String']>;
 };
 
 /** Filter options to exclude clients. Used as an output type for SchemaDiffValidationConfig. */
 export type ClientInfoFilterOutput = {
   __typename?: 'ClientInfoFilterOutput';
-  referenceID?: Maybe<Scalars['ID']>;
   name?: Maybe<Scalars['String']>;
   version?: Maybe<Scalars['String']>;
 };
@@ -2048,20 +1958,20 @@ export type CompositionAndRemoveResult = {
   __typename?: 'CompositionAndRemoveResult';
   /** The produced composition config. Will be null if there are any errors */
   compositionConfig?: Maybe<CompositionConfig>;
+  /** Whether the removed implementing service existed. */
+  didExist: Scalars['Boolean'];
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
    * published to the implementing service if there were any errors encountered.
    */
   errors: Array<Maybe<SchemaCompositionError>>;
-  /** Whether the gateway link was updated, or would have been for dry runs. */
-  updatedGateway: Scalars['Boolean'];
-  /** Whether the removed implementing service existed. */
-  didExist: Scalars['Boolean'];
   /** ID that points to the results of composition. */
   graphCompositionID: Scalars['String'];
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
+  /** Whether the gateway link was updated, or would have been for dry runs. */
+  updatedGateway: Scalars['Boolean'];
 };
 
 /** Metadata about the result of composition run in the cloud, combined with implementing service upsert */
@@ -2075,39 +1985,40 @@ export type CompositionAndUpsertResult = {
    * published to the implementing service if there were any errors encountered
    */
   errors: Array<Maybe<SchemaCompositionError>>;
+  /** ID that points to the results of composition. */
+  graphCompositionID: Scalars['String'];
+  /** List of subgraphs that are included in this composition. */
+  subgraphConfigs: Array<SubgraphConfig>;
   /** Whether the gateway link was updated. */
   updatedGateway: Scalars['Boolean'];
   /** Whether an implementingService was created as part of this mutation */
   wasCreated: Scalars['Boolean'];
-  /** ID that points to the results of composition. */
-  graphCompositionID: Scalars['String'];
   /** Whether an implementingService was updated as part of this mutation */
   wasUpdated: Scalars['Boolean'];
-  /** List of subgraphs that are included in this composition. */
-  subgraphConfigs: Array<SubgraphConfig>;
 };
 
 export type CompositionBuildInput = {
   __typename?: 'CompositionBuildInput';
   subgraphs: Array<Subgraph>;
+  version?: Maybe<Scalars['String']>;
 };
 
 export type CompositionCheckTask = CheckWorkflowTask & {
   __typename?: 'CompositionCheckTask';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
-  workflow: CheckWorkflow;
-  status: CheckWorkflowTaskStatus;
   /** The result of the composition. */
   result?: Maybe<CompositionResult>;
-  createdAt: Scalars['Timestamp'];
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  status: CheckWorkflowTaskStatus;
+  workflow: CheckWorkflow;
 };
 
 /** The composition config exposed to the gateway */
 export type CompositionConfig = {
   __typename?: 'CompositionConfig';
   /**
-   * List of GCS links for implementing services that comprise a composed graph
+   * List of GCS links for implementing services that comprise a composed graph. Is empty if tag/inaccessible is enabled.
    * @deprecated Soon we will stop writing to GCS locations
    */
   implementingServiceLocations: Array<ImplementingServiceLocation>;
@@ -2118,49 +2029,49 @@ export type CompositionConfig = {
 /** Metadata about the result of composition run in the cloud */
 export type CompositionPublishResult = CompositionResult & {
   __typename?: 'CompositionPublishResult';
-  /** ID that points to the results of this composition. */
-  graphCompositionID: Scalars['ID'];
   /** The produced composition config. Will be null if there are any errors */
   compositionConfig?: Maybe<CompositionConfig>;
+  /**
+   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
+   * @deprecated Use supergraphSdl instead
+   */
+  csdl?: Maybe<Scalars['GraphQLDocument']>;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
    * published to the implementing service if there were any errors encountered
    */
   errors: Array<SchemaCompositionError>;
-  /** Whether the gateway link was updated. */
-  updatedGateway: Scalars['Boolean'];
-  /**
-   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
-   * @deprecated Use supergraphSdl instead
-   */
-  csdl?: Maybe<Scalars['GraphQLDocument']>;
-  /** Supergraph SDL generated by composition. */
-  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  /** ID that points to the results of this composition. */
+  graphCompositionID: Scalars['ID'];
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
+  /** Supergraph SDL generated by composition. */
+  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  /** Whether the gateway link was updated. */
+  updatedGateway: Scalars['Boolean'];
   webhookNotificationBody?: Maybe<Scalars['String']>;
 };
 
 /** Result of a composition, either as the result of a composition validation or a publish. */
 export type CompositionResult = {
-  /** ID that points to the results of this composition. */
-  graphCompositionID: Scalars['ID'];
+  /**
+   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
+   * @deprecated Use supergraphSdl instead
+   */
+  csdl?: Maybe<Scalars['GraphQLDocument']>;
   /**
    * List of errors during composition. Errors mean that Apollo was unable to compose the
    * graph's implementing services into a GraphQL schema. This partial schema should not be
    * published to the implementing service if there were any errors encountered
    */
   errors: Array<SchemaCompositionError>;
-  /**
-   * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
-   * @deprecated Use supergraphSdl instead
-   */
-  csdl?: Maybe<Scalars['GraphQLDocument']>;
-  /** Supergraph SDL generated by composition. */
-  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  /** ID that points to the results of this composition. */
+  graphCompositionID: Scalars['ID'];
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
+  /** Supergraph SDL generated by composition. */
+  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
 };
 
 export type CompositionStatusSubscription = ChannelSubscription & {
@@ -2185,41 +2096,45 @@ export type CompositionValidationDetails = {
 /** Metadata about the result of compositions validation run in the cloud */
 export type CompositionValidationResult = CompositionResult & {
   __typename?: 'CompositionValidationResult';
-  /** ID that points to the results of this composition. */
-  graphCompositionID: Scalars['ID'];
-  /**
-   * List of errors during composition. Errors mean that Apollo was unable to compose the
-   * graph's implementing services into a GraphQL schema. This partial schema should not be
-   * published to the implementing service if there were any errors encountered
-   */
-  errors: Array<SchemaCompositionError>;
+  /** Describes whether composition succeeded. */
+  compositionSuccess: Scalars['Boolean'];
   /**
    * Akin to a composition config, represents the partial schemas and implementing services that were used
    * in running composition. Will be null if any errors are encountered. Also may contain a schema hash if
    * one could be computed, which can be used for schema validation.
    */
   compositionValidationDetails?: Maybe<CompositionValidationDetails>;
-  /** The implementing service that was responsible for triggering the validation */
-  proposedImplementingService: FederatedImplementingServicePartialSchema;
-  /** Describes whether composition succeeded. */
-  compositionSuccess: Scalars['Boolean'];
   /**
    * Supergraph SDL generated by composition (this is not the CSDL, that is a deprecated format).
    * @deprecated Use supergraphSdl instead
    */
   csdl?: Maybe<Scalars['GraphQLDocument']>;
-  /** Supergraph SDL generated by composition. */
-  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
+  /**
+   * List of errors during composition. Errors mean that Apollo was unable to compose the
+   * graph's implementing services into a GraphQL schema. This partial schema should not be
+   * published to the implementing service if there were any errors encountered
+   */
+  errors: Array<SchemaCompositionError>;
+  /** ID that points to the results of this composition. */
+  graphCompositionID: Scalars['ID'];
+  /** The implementing service that was responsible for triggering the validation */
+  proposedImplementingService: FederatedImplementingServicePartialSchema;
   /** List of subgraphs that are included in this composition. */
   subgraphConfigs: Array<SubgraphConfig>;
+  /** Supergraph SDL generated by composition. */
+  supergraphSdl?: Maybe<Scalars['GraphQLDocument']>;
   /** If created as part of a check workflow, the associated workflow task. */
   workflowTask?: Maybe<CompositionCheckTask>;
 };
 
 export enum ContractVariantFailedStep {
+  DirectiveDefinitionLocationAugmenting = 'DIRECTIVE_DEFINITION_LOCATION_AUGMENTING',
   EmptyObjectAndInterfaceMasking = 'EMPTY_OBJECT_AND_INTERFACE_MASKING',
   EmptyUnionMasking = 'EMPTY_UNION_MASKING',
+  EnsureQueryTypeAccessible = 'ENSURE_QUERY_TYPE_ACCESSIBLE',
+  InputValidation = 'INPUT_VALIDATION',
   Parsing = 'PARSING',
+  ParsingTagDirectives = 'PARSING_TAG_DIRECTIVES',
   PartialInterfaceMasking = 'PARTIAL_INTERFACE_MASKING',
   SchemaRetrieval = 'SCHEMA_RETRIEVAL',
   TagMatching = 'TAG_MATCHING',
@@ -2315,10 +2230,10 @@ export enum DeletionTargetType {
 /** Support for a single directive on a graph variant */
 export type DirectiveSupportStatus = {
   __typename?: 'DirectiveSupportStatus';
-  /** name of the directive */
-  name: Scalars['String'];
   /** whether the directive is supported on the current graph variant */
   enabled: Scalars['Boolean'];
+  /** name of the directive */
+  name: Scalars['String'];
 };
 
 export type DurationHistogram = {
@@ -2463,122 +2378,6 @@ export type EmailPreferences = {
   unsubscribedFromAll: Scalars['Boolean'];
 };
 
-/** Columns of EnumStats. */
-export enum EnumStatsColumn {
-  AccountId = 'ACCOUNT_ID',
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  EnumType = 'ENUM_TYPE',
-  EnumValue = 'ENUM_VALUE',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
-  ResponseCount = 'RESPONSE_COUNT',
-  SchemaHash = 'SCHEMA_HASH',
-  SchemaTag = 'SCHEMA_TAG',
-  ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
-  Timestamp = 'TIMESTAMP'
-}
-
-export type EnumStatsDimensions = {
-  __typename?: 'EnumStatsDimensions';
-  accountId?: Maybe<Scalars['ID']>;
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  enumType?: Maybe<Scalars['String']>;
-  enumValue?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in EnumStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type EnumStatsFilter = {
-  /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
-  accountId?: Maybe<Scalars['ID']>;
-  and?: Maybe<Array<EnumStatsFilter>>;
-  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  /** Selects rows whose enumType dimension equals the given value if not null. To query for the null value, use {in: {enumType: [null]}} instead. */
-  enumType?: Maybe<Scalars['String']>;
-  /** Selects rows whose enumValue dimension equals the given value if not null. To query for the null value, use {in: {enumValue: [null]}} instead. */
-  enumValue?: Maybe<Scalars['String']>;
-  in?: Maybe<EnumStatsFilterIn>;
-  not?: Maybe<EnumStatsFilter>;
-  or?: Maybe<Array<EnumStatsFilter>>;
-  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in EnumStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type EnumStatsFilterIn = {
-  /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose enumType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  enumType?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose enumValue dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  enumValue?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-export type EnumStatsMetrics = {
-  __typename?: 'EnumStatsMetrics';
-  requestCount: Scalars['Long'];
-  responseCount: Scalars['Long'];
-};
-
-export type EnumStatsOrderBySpec = {
-  column: EnumStatsColumn;
-  direction: Ordering;
-};
-
-export type EnumStatsRecord = {
-  __typename?: 'EnumStatsRecord';
-  /** Dimensions of EnumStats that can be grouped by. */
-  groupBy: EnumStatsDimensions;
-  /** Metrics of EnumStats that can be aggregated over. */
-  metrics: EnumStatsMetrics;
-  /** Starting segment timestamp. */
-  timestamp: Scalars['Timestamp'];
-};
-
 export type Error = {
   message: Scalars['String'];
 };
@@ -2587,7 +2386,6 @@ export type Error = {
 export enum ErrorStatsColumn {
   AccountId = 'ACCOUNT_ID',
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   ErrorsCount = 'ERRORS_COUNT',
   Path = 'PATH',
@@ -2597,7 +2395,6 @@ export enum ErrorStatsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
@@ -2605,7 +2402,6 @@ export type ErrorStatsDimensions = {
   __typename?: 'ErrorStatsDimensions';
   accountId?: Maybe<Scalars['ID']>;
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -2613,7 +2409,6 @@ export type ErrorStatsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -2623,8 +2418,6 @@ export type ErrorStatsFilter = {
   and?: Maybe<Array<ErrorStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   in?: Maybe<ErrorStatsFilterIn>;
@@ -2642,8 +2435,6 @@ export type ErrorStatsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
@@ -2652,8 +2443,6 @@ export type ErrorStatsFilterIn = {
   accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -2668,8 +2457,6 @@ export type ErrorStatsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ErrorStatsMetrics = {
@@ -2729,15 +2516,13 @@ export type FeatureIntrosInput = {
 
 export type FederatedImplementingService = {
   __typename?: 'FederatedImplementingService';
-  /** Name of the implementing service */
-  name: Scalars['String'];
-  /** URL of the graphql endpoint of the implementing service */
-  url?: Maybe<Scalars['String']>;
   /**
-   * A way to capture some customer-specific way of tracking which version / edition
-   * of the ImplementingService this is. Typically a Git SHA or docker image ID.
+   * An implementing service could have multiple inactive partial schemas that were previously uploaded
+   * activePartialSchema returns the one that is designated to be used for composition for a given graph-variant
    */
-  revision: Scalars['String'];
+  activePartialSchema: PartialSchema;
+  /** Timestamp of when this implementing service was created */
+  createdAt: Scalars['Timestamp'];
   /**
    * Identifies which graph this implementing service belongs to.
    * Formerly known as "service_id"
@@ -2748,15 +2533,17 @@ export type FederatedImplementingService = {
    * Formerly known as "tag"
    */
   graphVariant: Scalars['String'];
+  /** Name of the implementing service */
+  name: Scalars['String'];
   /**
-   * An implementing service could have multiple inactive partial schemas that were previously uploaded
-   * activePartialSchema returns the one that is designated to be used for composition for a given graph-variant
+   * A way to capture some customer-specific way of tracking which version / edition
+   * of the ImplementingService this is. Typically a Git SHA or docker image ID.
    */
-  activePartialSchema: PartialSchema;
-  /** Timestamp of when this implementing service was created */
-  createdAt: Scalars['Timestamp'];
+  revision: Scalars['String'];
   /** Timestamp for when this implementing service was updated */
   updatedAt: Scalars['Timestamp'];
+  /** URL of the graphql endpoint of the implementing service */
+  url?: Maybe<Scalars['String']>;
 };
 
 /** A minimal representation of a federated implementing service, using only a name and partial schema SDL */
@@ -2778,66 +2565,141 @@ export type FieldChangeSummaryCounts = {
   __typename?: 'FieldChangeSummaryCounts';
   /** Number of changes that are additions of fields to object and interface types. */
   additions: Scalars['Int'];
-  /** Number of changes that are removals of fields from object and interface types. */
-  removals: Scalars['Int'];
   /**
    * Number of changes that are field edits. This includes fields changing type and any field
    * deprecation and description changes, but also includes any argument changes and any input object
    * field changes.
    */
   edits: Scalars['Int'];
+  /** Number of changes that are removals of fields from object and interface types. */
+  removals: Scalars['Int'];
 };
 
-/** Columns of FieldStats. */
-export enum FieldStatsColumn {
-  AccountId = 'ACCOUNT_ID',
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  ErrorsCount = 'ERRORS_COUNT',
+/** Columns of FieldLatencies. */
+export enum FieldLatenciesColumn {
   Field = 'FIELD',
   FieldHistogram = 'FIELD_HISTOGRAM',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
+  FieldName = 'FIELD_NAME',
+  ParentType = 'PARENT_TYPE',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
-export type FieldStatsDimensions = {
-  __typename?: 'FieldStatsDimensions';
-  accountId?: Maybe<Scalars['ID']>;
+export type FieldLatenciesDimensions = {
+  __typename?: 'FieldLatenciesDimensions';
+  field?: Maybe<Scalars['String']>;
+  fieldName?: Maybe<Scalars['String']>;
+  parentType?: Maybe<Scalars['String']>;
+  schemaHash?: Maybe<Scalars['String']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in FieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type FieldLatenciesFilter = {
+  and?: Maybe<Array<FieldLatenciesFilter>>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
+  /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
+  fieldName?: Maybe<Scalars['String']>;
+  in?: Maybe<FieldLatenciesFilterIn>;
+  not?: Maybe<FieldLatenciesFilter>;
+  or?: Maybe<Array<FieldLatenciesFilter>>;
+  /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
+  parentType?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
+  schemaHash?: Maybe<Scalars['String']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in FieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type FieldLatenciesFilterIn = {
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type FieldLatenciesMetrics = {
+  __typename?: 'FieldLatenciesMetrics';
+  fieldHistogram: DurationHistogram;
+};
+
+export type FieldLatenciesOrderBySpec = {
+  column: FieldLatenciesColumn;
+  direction: Ordering;
+};
+
+export type FieldLatenciesRecord = {
+  __typename?: 'FieldLatenciesRecord';
+  /** Dimensions of FieldLatencies that can be grouped by. */
+  groupBy: FieldLatenciesDimensions;
+  /** Metrics of FieldLatencies that can be aggregated over. */
+  metrics: FieldLatenciesMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
+};
+
+/** Columns of FieldUsage. */
+export enum FieldUsageColumn {
+  ClientName = 'CLIENT_NAME',
+  ClientVersion = 'CLIENT_VERSION',
+  ExecutionCount = 'EXECUTION_COUNT',
+  Field = 'FIELD',
+  FieldName = 'FIELD_NAME',
+  ParentType = 'PARENT_TYPE',
+  QueryId = 'QUERY_ID',
+  QueryName = 'QUERY_NAME',
+  ReferencingOperationCount = 'REFERENCING_OPERATION_COUNT',
+  SchemaHash = 'SCHEMA_HASH',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP'
+}
+
+export type FieldUsageDimensions = {
+  __typename?: 'FieldUsageDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   field?: Maybe<Scalars['String']>;
+  fieldName?: Maybe<Scalars['String']>;
+  parentType?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
   queryName?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in FieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type FieldStatsFilter = {
-  /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
-  accountId?: Maybe<Scalars['ID']>;
-  and?: Maybe<Array<FieldStatsFilter>>;
+/** Filter for data in FieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type FieldUsageFilter = {
+  and?: Maybe<Array<FieldUsageFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
   field?: Maybe<Scalars['String']>;
-  in?: Maybe<FieldStatsFilterIn>;
-  not?: Maybe<FieldStatsFilter>;
-  or?: Maybe<Array<FieldStatsFilter>>;
+  /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
+  fieldName?: Maybe<Scalars['String']>;
+  in?: Maybe<FieldUsageFilterIn>;
+  not?: Maybe<FieldUsageFilter>;
+  or?: Maybe<Array<FieldUsageFilter>>;
+  /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
+  parentType?: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
   queryId?: Maybe<Scalars['ID']>;
   /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
@@ -2848,22 +2710,20 @@ export type FieldStatsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in FieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type FieldStatsFilterIn = {
-  /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+/** Filter for data in FieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type FieldUsageFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
   field?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -2874,28 +2734,25 @@ export type FieldStatsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type FieldStatsMetrics = {
-  __typename?: 'FieldStatsMetrics';
-  errorsCount: Scalars['Long'];
-  fieldHistogram: DurationHistogram;
-  requestCount: Scalars['Long'];
+export type FieldUsageMetrics = {
+  __typename?: 'FieldUsageMetrics';
+  executionCount: Scalars['Long'];
+  referencingOperationCount: Scalars['Long'];
 };
 
-export type FieldStatsOrderBySpec = {
-  column: FieldStatsColumn;
+export type FieldUsageOrderBySpec = {
+  column: FieldUsageColumn;
   direction: Ordering;
 };
 
-export type FieldStatsRecord = {
-  __typename?: 'FieldStatsRecord';
-  /** Dimensions of FieldStats that can be grouped by. */
-  groupBy: FieldStatsDimensions;
-  /** Metrics of FieldStats that can be aggregated over. */
-  metrics: FieldStatsMetrics;
+export type FieldUsageRecord = {
+  __typename?: 'FieldUsageRecord';
+  /** Dimensions of FieldUsage that can be grouped by. */
+  groupBy: FieldUsageDimensions;
+  /** Metrics of FieldUsage that can be aggregated over. */
+  metrics: FieldUsageMetrics;
   /** Starting segment timestamp. */
   timestamp: Scalars['Timestamp'];
 };
@@ -2919,34 +2776,37 @@ export type FilterConfigInput = {
 
 export type GitContext = {
   __typename?: 'GitContext';
-  remoteUrl?: Maybe<Scalars['String']>;
-  remoteHost?: Maybe<GitRemoteHost>;
+  branch?: Maybe<Scalars['String']>;
   commit?: Maybe<Scalars['ID']>;
   commitUrl?: Maybe<Scalars['String']>;
   committer?: Maybe<Scalars['String']>;
   message?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
+  remoteHost?: Maybe<GitRemoteHost>;
+  remoteUrl?: Maybe<Scalars['String']>;
 };
 
 /** This is stored with a schema when it is uploaded */
 export type GitContextInput = {
-  remoteUrl?: Maybe<Scalars['String']>;
+  branch?: Maybe<Scalars['String']>;
   commit?: Maybe<Scalars['ID']>;
   committer?: Maybe<Scalars['String']>;
   message?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
+  remoteUrl?: Maybe<Scalars['String']>;
 };
 
 export enum GitRemoteHost {
+  Bitbucket = 'BITBUCKET',
   Github = 'GITHUB',
-  Gitlab = 'GITLAB',
-  Bitbucket = 'BITBUCKET'
+  Gitlab = 'GITLAB'
 }
 
 export type GlobalExperimentalFeatures = {
   __typename?: 'GlobalExperimentalFeatures';
-  sandboxesPreview: Scalars['Boolean'];
+  operationsCollections: Scalars['Boolean'];
   sandboxesFullRelease: Scalars['Boolean'];
+  sandboxesPreview: Scalars['Boolean'];
+  sandboxesSchemaChecksPage: Scalars['Boolean'];
+  sandboxesSchemaDiffPage: Scalars['Boolean'];
 };
 
 export type GraphApiKey = ApiKey & {
@@ -2960,49 +2820,59 @@ export type GraphApiKey = ApiKey & {
 };
 
 /** A union of all combinations that can comprise the implementingServices for a Service */
-export type GraphImplementors = NonFederatedImplementingService | FederatedImplementingServices;
-
+export type GraphImplementors = FederatedImplementingServices | NonFederatedImplementingService;
 
 /** A variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariant = {
   __typename?: 'GraphVariant';
-  /** Global identifier for the graph variant, in the form `graph@variant`. */
-  id: Scalars['ID'];
-  /** Graph ID of the variant. Prefer using graph { id } when feasible. */
-  graphId: Scalars['String'];
-  /** Graph the variant belongs to */
-  graph: Service;
-  /** Name of the variant, like `variant`. */
-  name: Scalars['String'];
-  /** URL where the graph can be queried. */
-  url?: Maybe<Scalars['String']>;
-  /** If the graphql endpoint is set up to accept cookies */
-  sendCookies?: Maybe<Scalars['Boolean']>;
-  /** URL where the graph subscription can be queried. */
-  subscriptionUrl?: Maybe<Scalars['String']>;
-  /** Explorer setting for preflight script to run before the actual GraphQL operations is run. */
-  preflightScript?: Maybe<Scalars['String']>;
-  /** Explorer setting for default headers for a graph */
-  defaultHeaders?: Maybe<Scalars['String']>;
   /** As new schema tags keep getting published, activeSchemaPublish refers to the latest. */
   activeSchemaPublish?: Maybe<SchemaTag>;
-  /** If the variant is protected */
-  isProtected: Scalars['Boolean'];
-  /** A list of supported directives */
-  supportedDirectives?: Maybe<Array<DirectiveSupportStatus>>;
+  /** The version of composition currently in use */
+  compositionVersion: Scalars['String'];
+  /** Filter configuration used to create the contract schema */
+  contractFilterConfig?: Maybe<FilterConfig>;
+  /** Explorer setting for default headers for a graph */
+  defaultHeaders?: Maybe<Scalars['String']>;
   derivedVariantCount: Scalars['Int'];
+  /** Graph the variant belongs to */
+  graph: Service;
+  /** Graph ID of the variant. Prefer using graph { id } when feasible. */
+  graphId: Scalars['String'];
+  /** Global identifier for the graph variant, in the form `graph@variant`. */
+  id: Scalars['ID'];
+  /** Represents whether this variant is a Contract. */
+  isContract: Scalars['Boolean'];
   /** Is this variant one of the current user's favorite variants? */
   isFavoriteOfCurrentUser: Scalars['Boolean'];
+  /** If the variant is protected */
+  isProtected: Scalars['Boolean'];
   isPublic: Scalars['Boolean'];
+  /** Represents whether this variant should be listed in the public variants directory. This can only be true if the variant is also public. */
+  isPubliclyListed: Scalars['Boolean'];
+  /** Represents whether Apollo has verified the authenticity of this public variant. This can only be true if the variant is also public. */
+  isVerified: Scalars['Boolean'];
   latestLaunch?: Maybe<Launch>;
   launch?: Maybe<Launch>;
   launchHistory: Array<Launch>;
+  links?: Maybe<Array<LinkInfo>>;
+  /** Name of the variant, like `variant`. */
+  name: Scalars['String'];
   /** Which permissions the current user has for interacting with this variant */
   permissions: GraphVariantPermissions;
-  readme?: Maybe<Scalars['String']>;
+  /** Explorer setting for preflight script to run before the actual GraphQL operations is run. */
+  preflightScript?: Maybe<Scalars['String']>;
+  readme?: Maybe<Readme>;
   /** The total number of requests for this variant in the last 24 hours */
   requestsInLastDay?: Maybe<Scalars['Long']>;
+  /** If the graphql endpoint is set up to accept cookies */
+  sendCookies?: Maybe<Scalars['Boolean']>;
   sourceVariant?: Maybe<GraphVariant>;
+  /** URL where the graph subscription can be queried. */
+  subscriptionUrl?: Maybe<Scalars['String']>;
+  /** A list of supported directives */
+  supportedDirectives?: Maybe<Array<DirectiveSupportStatus>>;
+  /** URL where the graph can be queried. */
+  url?: Maybe<Scalars['String']>;
   /** The last instant that usage information (e.g. operation stat, client stats) was reported for this variant */
   usageLastReportedAt?: Maybe<Scalars['Timestamp']>;
 };
@@ -3024,40 +2894,68 @@ export type GraphVariantLookup = GraphVariant | InvalidRefFormat;
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutation = {
   __typename?: 'GraphVariantMutation';
-  /** Global identifier for the graph variant, in the form `graph@variant`. */
-  id: Scalars['ID'];
+  addLinkToVariant: GraphVariant;
+  configureComposition?: Maybe<GraphVariant>;
+  /** @deprecated Use configureComposition instead */
+  enableTagAndInaccessible?: Maybe<GraphVariant>;
   /** Graph ID of the variant */
   graphId: Scalars['String'];
+  /** Global identifier for the graph variant, in the form `graph@variant`. */
+  id: Scalars['ID'];
   /** Name of the variant, like `variant`. */
   name: Scalars['String'];
-  updateURL?: Maybe<GraphVariant>;
-  updateSubscriptionURL?: Maybe<GraphVariant>;
-  updateSendCookies?: Maybe<GraphVariant>;
+  relaunch: RelaunchResult;
+  removeLinkFromVariant: GraphVariant;
+  setIsFavoriteOfCurrentUser: GraphVariant;
+  updateDefaultHeaders?: Maybe<GraphVariant>;
   updateIsProtected?: Maybe<GraphVariant>;
   updatePreflightScript?: Maybe<GraphVariant>;
-  updateDefaultHeaders?: Maybe<GraphVariant>;
-  enableTagAndInaccessible?: Maybe<GraphVariant>;
-  setIsFavoriteOfCurrentUser: GraphVariant;
+  updateSendCookies?: Maybe<GraphVariant>;
+  updateSubscriptionURL?: Maybe<GraphVariant>;
+  updateURL?: Maybe<GraphVariant>;
   updateVariantIsPublic?: Maybe<GraphVariant>;
+  updateVariantIsPubliclyListed?: Maybe<GraphVariant>;
+  updateVariantIsVerified?: Maybe<GraphVariant>;
   updateVariantReadme?: Maybe<GraphVariant>;
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
-export type GraphVariantMutationUpdateUrlArgs = {
-  url?: Maybe<Scalars['String']>;
+export type GraphVariantMutationAddLinkToVariantArgs = {
+  title?: Maybe<Scalars['String']>;
+  type: LinkInfoType;
+  url: Scalars['String'];
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
-export type GraphVariantMutationUpdateSubscriptionUrlArgs = {
-  subscriptionUrl?: Maybe<Scalars['String']>;
+export type GraphVariantMutationConfigureCompositionArgs = {
+  enableTagAndInaccessible?: Maybe<Scalars['Boolean']>;
+  version?: Maybe<Scalars['String']>;
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
-export type GraphVariantMutationUpdateSendCookiesArgs = {
-  sendCookies: Scalars['Boolean'];
+export type GraphVariantMutationEnableTagAndInaccessibleArgs = {
+  enabled: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationRemoveLinkFromVariantArgs = {
+  linkInfoId: Scalars['ID'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationSetIsFavoriteOfCurrentUserArgs = {
+  favorite: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateDefaultHeadersArgs = {
+  defaultHeaders?: Maybe<Scalars['String']>;
 };
 
 
@@ -3074,26 +2972,38 @@ export type GraphVariantMutationUpdatePreflightScriptArgs = {
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
-export type GraphVariantMutationUpdateDefaultHeadersArgs = {
-  defaultHeaders?: Maybe<Scalars['String']>;
+export type GraphVariantMutationUpdateSendCookiesArgs = {
+  sendCookies: Scalars['Boolean'];
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
-export type GraphVariantMutationEnableTagAndInaccessibleArgs = {
-  enabled: Scalars['Boolean'];
+export type GraphVariantMutationUpdateSubscriptionUrlArgs = {
+  subscriptionUrl?: Maybe<Scalars['String']>;
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
-export type GraphVariantMutationSetIsFavoriteOfCurrentUserArgs = {
-  favorite: Scalars['Boolean'];
+export type GraphVariantMutationUpdateUrlArgs = {
+  url?: Maybe<Scalars['String']>;
 };
 
 
 /** Modifies a variant of a graph, also called a schema tag in parts of our product. */
 export type GraphVariantMutationUpdateVariantIsPublicArgs = {
   isPublic: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateVariantIsPubliclyListedArgs = {
+  isPubliclyListed: Scalars['Boolean'];
+};
+
+
+/** Modifies a variant of a graph, also called a schema tag in parts of our product. */
+export type GraphVariantMutationUpdateVariantIsVerifiedArgs = {
+  isVerified: Scalars['Boolean'];
 };
 
 
@@ -3105,14 +3015,18 @@ export type GraphVariantMutationUpdateVariantReadmeArgs = {
 /** A map from permission String to boolean that the current user is allowed for the root graph variant */
 export type GraphVariantPermissions = {
   __typename?: 'GraphVariantPermissions';
+  canManageBuildConfig: Scalars['Boolean'];
   canManageExplorerSettings: Scalars['Boolean'];
   canPushSchemas: Scalars['Boolean'];
+  canQueryBuildConfig: Scalars['Boolean'];
   /**
    * Whether the current user can access the schema for this variant. This will be anded with
    * the ServiceRoles.canQuerySchemas, this will be true when the service schema permission is
    * false for Services with public variants
    */
   canQuerySchemas: Scalars['Boolean'];
+  canUpdateVariantLinkInfo: Scalars['Boolean'];
+  canUpdateVariantReadme: Scalars['Boolean'];
 };
 
 export enum HttpMethod {
@@ -3130,20 +3044,11 @@ export enum HttpMethod {
 }
 
 export type HistoricQueryParameters = {
-  from?: Maybe<Scalars['Timestamp']>;
-  to?: Maybe<Scalars['Timestamp']>;
-  /** Minimum number of requests within the window for a query to be considered. */
-  queryCountThreshold?: Maybe<Scalars['Int']>;
-  /**
-   * Number of requests within the window for a query to be considered, relative to
-   * total request count. Expected values are between 0 and 0.05 (minimum 5% of total
-   * request volume)
-   */
-  queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
-  /** A list of operation IDs to filter out during validation. */
-  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
   /** A list of clients to filter out during validation. */
   excludedClients?: Maybe<Array<ClientInfoFilter>>;
+  from?: Maybe<Scalars['Timestamp']>;
+  /** A list of operation IDs to filter out during validation. */
+  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
   /**
    * A list of variants to include in the validation. If no variants are provided
    * then this defaults to the "current" variant along with the base variant. The
@@ -3153,6 +3058,15 @@ export type HistoricQueryParameters = {
    * supports users who have not tagged their metrics or schema.
    */
   includedVariants?: Maybe<Array<Scalars['String']>>;
+  /** Minimum number of requests within the window for a query to be considered. */
+  queryCountThreshold?: Maybe<Scalars['Int']>;
+  /**
+   * Number of requests within the window for a query to be considered, relative to
+   * total request count. Expected values are between 0 and 0.05 (minimum 5% of total
+   * request volume)
+   */
+  queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
+  to?: Maybe<Scalars['Timestamp']>;
 };
 
 export type Identity = {
@@ -3164,12 +3078,12 @@ export type Identity = {
 /** An actor's identity and info about the client they used to perform the action */
 export type IdentityAndClientInfo = {
   __typename?: 'IdentityAndClientInfo';
-  /** Identity info about the actor */
-  identity?: Maybe<Identity>;
   /** The clientName given to Apollo Cloud when the actor performed the action */
   clientName?: Maybe<Scalars['String']>;
   /** The clientVersion given to Apollo Cloud when the actor performed the action */
   clientVersion?: Maybe<Scalars['String']>;
+  /** Identity info about the actor */
+  identity?: Maybe<Identity>;
 };
 
 export type IdentityMutation = ServiceMutation | UserMutation;
@@ -3186,130 +3100,6 @@ export type ImplementingServiceLocation = {
   name: Scalars['String'];
   /** The path in storage to access the implementing service config file */
   path: Scalars['String'];
-};
-
-/** Columns of InputStats. */
-export enum InputStatsColumn {
-  AccountId = 'ACCOUNT_ID',
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  FieldName = 'FIELD_NAME',
-  FieldType = 'FIELD_TYPE',
-  ParentType = 'PARENT_TYPE',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
-  RequestCountNull = 'REQUEST_COUNT_NULL',
-  RequestCountUndefined = 'REQUEST_COUNT_UNDEFINED',
-  SchemaHash = 'SCHEMA_HASH',
-  SchemaTag = 'SCHEMA_TAG',
-  ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
-  Timestamp = 'TIMESTAMP'
-}
-
-export type InputStatsDimensions = {
-  __typename?: 'InputStatsDimensions';
-  accountId?: Maybe<Scalars['ID']>;
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  fieldName?: Maybe<Scalars['String']>;
-  fieldType?: Maybe<Scalars['String']>;
-  parentType?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in InputStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type InputStatsFilter = {
-  /** Selects rows whose accountId dimension equals the given value if not null. To query for the null value, use {in: {accountId: [null]}} instead. */
-  accountId?: Maybe<Scalars['ID']>;
-  and?: Maybe<Array<InputStatsFilter>>;
-  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
-  fieldName?: Maybe<Scalars['String']>;
-  /** Selects rows whose fieldType dimension equals the given value if not null. To query for the null value, use {in: {fieldType: [null]}} instead. */
-  fieldType?: Maybe<Scalars['String']>;
-  in?: Maybe<InputStatsFilterIn>;
-  not?: Maybe<InputStatsFilter>;
-  or?: Maybe<Array<InputStatsFilter>>;
-  /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
-  parentType?: Maybe<Scalars['String']>;
-  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
-  serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in InputStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type InputStatsFilterIn = {
-  /** Selects rows whose accountId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose fieldType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fieldType?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-export type InputStatsMetrics = {
-  __typename?: 'InputStatsMetrics';
-  requestCount: Scalars['Long'];
-  requestCountNull: Scalars['Long'];
-  requestCountUndefined: Scalars['Long'];
-};
-
-export type InputStatsOrderBySpec = {
-  column: InputStatsColumn;
-  direction: Ordering;
-};
-
-export type InputStatsRecord = {
-  __typename?: 'InputStatsRecord';
-  /** Dimensions of InputStats that can be grouped by. */
-  groupBy: InputStatsDimensions;
-  /** Metrics of InputStats that can be aggregated over. */
-  metrics: InputStatsMetrics;
-  /** Starting segment timestamp. */
-  timestamp: Scalars['Timestamp'];
 };
 
 export type InternalAdminUser = {
@@ -3336,128 +3126,128 @@ export enum InternalMdgAdminRole {
 
 export type IntrospectionDirective = {
   __typename?: 'IntrospectionDirective';
-  name: Scalars['String'];
+  args: Array<IntrospectionInputValue>;
   description?: Maybe<Scalars['String']>;
   locations: Array<IntrospectionDirectiveLocation>;
-  args: Array<IntrospectionInputValue>;
+  name: Scalars['String'];
 };
 
 export type IntrospectionDirectiveInput = {
-  name: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  locations: Array<IntrospectionDirectiveLocation>;
   args: Array<IntrospectionInputValueInput>;
+  description?: Maybe<Scalars['String']>;
   isRepeatable?: Maybe<Scalars['Boolean']>;
+  locations: Array<IntrospectionDirectiveLocation>;
+  name: Scalars['String'];
 };
 
 /** __DirectiveLocation introspection type */
 export enum IntrospectionDirectiveLocation {
-  /** Location adjacent to a query operation. */
-  Query = 'QUERY',
-  /** Location adjacent to a mutation operation. */
-  Mutation = 'MUTATION',
-  /** Location adjacent to a subscription operation. */
-  Subscription = 'SUBSCRIPTION',
+  /** Location adjacent to an argument definition. */
+  ArgumentDefinition = 'ARGUMENT_DEFINITION',
+  /** Location adjacent to an enum definition. */
+  Enum = 'ENUM',
+  /** Location adjacent to an enum value definition. */
+  EnumValue = 'ENUM_VALUE',
   /** Location adjacent to a field. */
   Field = 'FIELD',
+  /** Location adjacent to a field definition. */
+  FieldDefinition = 'FIELD_DEFINITION',
   /** Location adjacent to a fragment definition. */
   FragmentDefinition = 'FRAGMENT_DEFINITION',
   /** Location adjacent to a fragment spread. */
   FragmentSpread = 'FRAGMENT_SPREAD',
   /** Location adjacent to an inline fragment. */
   InlineFragment = 'INLINE_FRAGMENT',
-  /** Location adjacent to a variable definition. */
-  VariableDefinition = 'VARIABLE_DEFINITION',
-  /** Location adjacent to a schema definition. */
-  Schema = 'SCHEMA',
-  /** Location adjacent to a scalar definition. */
-  Scalar = 'SCALAR',
-  /** Location adjacent to an object type definition. */
-  Object = 'OBJECT',
-  /** Location adjacent to a field definition. */
-  FieldDefinition = 'FIELD_DEFINITION',
-  /** Location adjacent to an argument definition. */
-  ArgumentDefinition = 'ARGUMENT_DEFINITION',
-  /** Location adjacent to an interface definition. */
-  Interface = 'INTERFACE',
-  /** Location adjacent to a union definition. */
-  Union = 'UNION',
-  /** Location adjacent to an enum definition. */
-  Enum = 'ENUM',
-  /** Location adjacent to an enum value definition. */
-  EnumValue = 'ENUM_VALUE',
+  /** Location adjacent to an input object field definition. */
+  InputFieldDefinition = 'INPUT_FIELD_DEFINITION',
   /** Location adjacent to an input object type definition. */
   InputObject = 'INPUT_OBJECT',
-  /** Location adjacent to an input object field definition. */
-  InputFieldDefinition = 'INPUT_FIELD_DEFINITION'
+  /** Location adjacent to an interface definition. */
+  Interface = 'INTERFACE',
+  /** Location adjacent to a mutation operation. */
+  Mutation = 'MUTATION',
+  /** Location adjacent to an object type definition. */
+  Object = 'OBJECT',
+  /** Location adjacent to a query operation. */
+  Query = 'QUERY',
+  /** Location adjacent to a scalar definition. */
+  Scalar = 'SCALAR',
+  /** Location adjacent to a schema definition. */
+  Schema = 'SCHEMA',
+  /** Location adjacent to a subscription operation. */
+  Subscription = 'SUBSCRIPTION',
+  /** Location adjacent to a union definition. */
+  Union = 'UNION',
+  /** Location adjacent to a variable definition. */
+  VariableDefinition = 'VARIABLE_DEFINITION'
 }
 
 /** Values associated with introspection result for an enum value */
 export type IntrospectionEnumValue = {
   __typename?: 'IntrospectionEnumValue';
-  name: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  isDeprecated: Scalars['Boolean'];
   /** @deprecated Use deprecationReason instead */
   depreactionReason?: Maybe<Scalars['String']>;
   deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
 };
 
 /** __EnumValue introspection type */
 export type IntrospectionEnumValueInput = {
-  name: Scalars['String'];
+  deprecationReason?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   isDeprecated: Scalars['Boolean'];
-  deprecationReason?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
 };
 
 /** Values associated with introspection result for field */
 export type IntrospectionField = {
   __typename?: 'IntrospectionField';
-  name: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
   args: Array<IntrospectionInputValue>;
-  type: IntrospectionType;
-  isDeprecated: Scalars['Boolean'];
   deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
+  type: IntrospectionType;
 };
 
 /** __Field introspection type */
 export type IntrospectionFieldInput = {
-  name: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
   args: Array<IntrospectionInputValueInput>;
-  type: IntrospectionTypeInput;
-  isDeprecated: Scalars['Boolean'];
   deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated: Scalars['Boolean'];
+  name: Scalars['String'];
+  type: IntrospectionTypeInput;
 };
 
 /** Values associated with introspection result for an input field */
 export type IntrospectionInputValue = {
   __typename?: 'IntrospectionInputValue';
-  name: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  type: IntrospectionType;
   defaultValue?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  type: IntrospectionType;
 };
 
 /** __Value introspection type */
 export type IntrospectionInputValueInput = {
-  name: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  type: IntrospectionTypeInput;
   defaultValue?: Maybe<Scalars['String']>;
-  isDeprecated?: Maybe<Scalars['Boolean']>;
   deprecationReason?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  isDeprecated?: Maybe<Scalars['Boolean']>;
+  name: Scalars['String'];
+  type: IntrospectionTypeInput;
 };
 
 export type IntrospectionSchema = {
   __typename?: 'IntrospectionSchema';
-  types: Array<IntrospectionType>;
-  queryType: IntrospectionType;
-  mutationType?: Maybe<IntrospectionType>;
-  subscriptionType?: Maybe<IntrospectionType>;
   directives: Array<IntrospectionDirective>;
+  mutationType?: Maybe<IntrospectionType>;
+  queryType: IntrospectionType;
+  subscriptionType?: Maybe<IntrospectionType>;
+  types: Array<IntrospectionType>;
 };
 
 
@@ -3467,30 +3257,30 @@ export type IntrospectionSchemaTypesArgs = {
 
 /** __Schema introspection type */
 export type IntrospectionSchemaInput = {
-  types?: Maybe<Array<IntrospectionTypeInput>>;
-  queryType: IntrospectionTypeRefInput;
-  mutationType?: Maybe<IntrospectionTypeRefInput>;
-  subscriptionType?: Maybe<IntrospectionTypeRefInput>;
-  directives: Array<IntrospectionDirectiveInput>;
   description?: Maybe<Scalars['String']>;
+  directives: Array<IntrospectionDirectiveInput>;
+  mutationType?: Maybe<IntrospectionTypeRefInput>;
+  queryType: IntrospectionTypeRefInput;
+  subscriptionType?: Maybe<IntrospectionTypeRefInput>;
+  types?: Maybe<Array<IntrospectionTypeInput>>;
 };
 
 /** Object containing all possible values for an introspectionType */
 export type IntrospectionType = {
   __typename?: 'IntrospectionType';
-  kind?: Maybe<IntrospectionTypeKind>;
-  name?: Maybe<Scalars['String']>;
-  /** printed representation of type, including nested nullability and list ofTypes */
-  printed: Scalars['String'];
   /** the base kind of the type this references, ignoring lists and nullability */
   baseKind?: Maybe<IntrospectionTypeKind>;
   description?: Maybe<Scalars['String']>;
-  fields?: Maybe<Array<IntrospectionField>>;
-  interfaces?: Maybe<Array<IntrospectionType>>;
-  possibleTypes?: Maybe<Array<IntrospectionType>>;
   enumValues?: Maybe<Array<IntrospectionEnumValue>>;
+  fields?: Maybe<Array<IntrospectionField>>;
   inputFields?: Maybe<Array<IntrospectionInputValue>>;
+  interfaces?: Maybe<Array<IntrospectionType>>;
+  kind?: Maybe<IntrospectionTypeKind>;
+  name?: Maybe<Scalars['String']>;
   ofType?: Maybe<IntrospectionType>;
+  possibleTypes?: Maybe<Array<IntrospectionType>>;
+  /** printed representation of type, including nested nullability and list ofTypes */
+  printed: Scalars['String'];
 };
 
 
@@ -3501,50 +3291,50 @@ export type IntrospectionTypeEnumValuesArgs = {
 
 /** __Type introspection type */
 export type IntrospectionTypeInput = {
+  description?: Maybe<Scalars['String']>;
+  enumValues?: Maybe<Array<IntrospectionEnumValueInput>>;
+  fields?: Maybe<Array<IntrospectionFieldInput>>;
+  inputFields?: Maybe<Array<IntrospectionInputValueInput>>;
+  interfaces?: Maybe<Array<IntrospectionTypeInput>>;
   kind: IntrospectionTypeKind;
   name?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  specifiedByUrl?: Maybe<Scalars['String']>;
-  fields?: Maybe<Array<IntrospectionFieldInput>>;
-  interfaces?: Maybe<Array<IntrospectionTypeInput>>;
-  possibleTypes?: Maybe<Array<IntrospectionTypeInput>>;
-  enumValues?: Maybe<Array<IntrospectionEnumValueInput>>;
-  inputFields?: Maybe<Array<IntrospectionInputValueInput>>;
   ofType?: Maybe<IntrospectionTypeInput>;
+  possibleTypes?: Maybe<Array<IntrospectionTypeInput>>;
+  specifiedByUrl?: Maybe<Scalars['String']>;
 };
 
 export enum IntrospectionTypeKind {
-  /** Indicates this type is a scalar. */
-  Scalar = 'SCALAR',
-  /** Indicates this type is an object. 'fields' and 'interfaces' are valid fields. */
-  Object = 'OBJECT',
+  /** Indicates this type is an enum. 'enumValues' is a valid field. */
+  Enum = 'ENUM',
+  /** Indicates this type is an input object. 'inputFields' is a valid field. */
+  InputObject = 'INPUT_OBJECT',
   /**
    * Indicates this type is an interface. 'fields' and 'possibleTypes' are valid
    * fields
    */
   Interface = 'INTERFACE',
-  /** Indicates this type is a union. 'possibleTypes' is a valid field. */
-  Union = 'UNION',
-  /** Indicates this type is an enum. 'enumValues' is a valid field. */
-  Enum = 'ENUM',
-  /** Indicates this type is an input object. 'inputFields' is a valid field. */
-  InputObject = 'INPUT_OBJECT',
   /** Indicates this type is a list. 'ofType' is a valid field. */
   List = 'LIST',
   /** Indicates this type is a non-null. 'ofType' is a valid field. */
-  NonNull = 'NON_NULL'
+  NonNull = 'NON_NULL',
+  /** Indicates this type is an object. 'fields' and 'interfaces' are valid fields. */
+  Object = 'OBJECT',
+  /** Indicates this type is a scalar. */
+  Scalar = 'SCALAR',
+  /** Indicates this type is a union. 'possibleTypes' is a valid field. */
+  Union = 'UNION'
 }
 
 /** Shallow __Type introspection type */
 export type IntrospectionTypeRefInput = {
-  name: Scalars['String'];
   kind?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
 };
 
 export type InvalidOperation = {
   __typename?: 'InvalidOperation';
-  signature: Scalars['ID'];
   errors?: Maybe<Array<OperationValidationError>>;
+  signature: Scalars['ID'];
 };
 
 export type InvalidRefFormat = Error & {
@@ -3589,7 +3379,9 @@ export type Launch = {
   results: Array<LaunchResult>;
   schemaTag?: Maybe<SchemaTag>;
   sequence: Array<LaunchSequenceStep>;
+  shortenedID: Scalars['String'];
   status: LaunchStatus;
+  subgraphChanges?: Maybe<Array<SubgraphChange>>;
   supersededAt?: Maybe<Scalars['Timestamp']>;
   supersededBy?: Maybe<Launch>;
 };
@@ -3638,17 +3430,31 @@ export enum LaunchStatus {
   LaunchInitiated = 'LAUNCH_INITIATED'
 }
 
+export type LinkInfo = {
+  __typename?: 'LinkInfo';
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
+  title?: Maybe<Scalars['String']>;
+  type: LinkInfoType;
+  url: Scalars['String'];
+};
+
+export enum LinkInfoType {
+  DeveloperPortal = 'DEVELOPER_PORTAL',
+  Other = 'OTHER',
+  Repository = 'REPOSITORY'
+}
 
 export type MarkChangesForOperationAsSafeResult = {
   __typename?: 'MarkChangesForOperationAsSafeResult';
-  success: Scalars['Boolean'];
-  message: Scalars['String'];
   /**
    * Nice to have for the frontend since the Apollo cache is already watching for AffectedQuery to update.
    * This might return null if no behavior changes were found for the affected operation ID.
    * This is a weird situation that should never happen.
    */
   affectedOperation?: Maybe<AffectedQuery>;
+  message: Scalars['String'];
+  success: Scalars['Boolean'];
 };
 
 export type MediaUploadInfo = {
@@ -3713,6 +3519,7 @@ export type MutationJoinAccountArgs = {
 
 
 export type MutationNewAccountArgs = {
+  companyUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
 };
 
@@ -3807,8 +3614,8 @@ export type MutationUserArgs = {
 
 export type NamedIntrospectionArg = {
   __typename?: 'NamedIntrospectionArg';
-  name?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
 };
 
 export type NamedIntrospectionArgNoDescription = {
@@ -3827,9 +3634,9 @@ export type NamedIntrospectionArgNoDescription = {
  */
 export type NamedIntrospectionType = {
   __typename?: 'NamedIntrospectionType';
+  description?: Maybe<Scalars['String']>;
   kind?: Maybe<IntrospectionTypeKind>;
   name?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
 };
 
 export type NamedIntrospectionTypeNoDescription = {
@@ -3845,8 +3652,8 @@ export type NamedIntrospectionTypeNoDescription = {
  */
 export type NamedIntrospectionValue = {
   __typename?: 'NamedIntrospectionValue';
-  name?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
   printedType?: Maybe<Scalars['String']>;
 };
 
@@ -3873,30 +3680,29 @@ export type NonFederatedImplementingService = {
   graphVariant: Scalars['String'];
 };
 
-
 export type OdysseyCourse = {
   __typename?: 'OdysseyCourse';
-  id: Scalars['ID'];
-  enrolledAt?: Maybe<Scalars['Timestamp']>;
   completedAt?: Maybe<Scalars['Timestamp']>;
+  enrolledAt?: Maybe<Scalars['Timestamp']>;
+  id: Scalars['ID'];
 };
 
 export type OdysseyCourseInput = {
-  courseId: Scalars['String'];
   completedAt?: Maybe<Scalars['Timestamp']>;
+  courseId: Scalars['String'];
 };
 
 export type OdysseyTask = {
   __typename?: 'OdysseyTask';
+  completedAt?: Maybe<Scalars['Timestamp']>;
   id: Scalars['ID'];
   value?: Maybe<Scalars['String']>;
-  completedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export type OdysseyTaskInput = {
+  completedAt?: Maybe<Scalars['Timestamp']>;
   taskId: Scalars['String'];
   value?: Maybe<Scalars['String']>;
-  completedAt?: Maybe<Scalars['Timestamp']>;
 };
 
 export type Operation = {
@@ -3909,13 +3715,87 @@ export type Operation = {
 
 export type OperationAcceptedChange = {
   __typename?: 'OperationAcceptedChange';
-  id: Scalars['ID'];
-  graphID: Scalars['ID'];
-  checkID: Scalars['ID'];
-  operationID: Scalars['String'];
-  change: StoredApprovedChange;
   acceptedAt: Scalars['Timestamp'];
   acceptedBy: Identity;
+  change: StoredApprovedChange;
+  checkID: Scalars['ID'];
+  graphID: Scalars['ID'];
+  id: Scalars['ID'];
+  operationID: Scalars['String'];
+};
+
+/** Columns of OperationCheckStats. */
+export enum OperationCheckStatsColumn {
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientVersion = 'CLIENT_VERSION',
+  QueryId = 'QUERY_ID',
+  SchemaTag = 'SCHEMA_TAG',
+  ServiceId = 'SERVICE_ID',
+  Timestamp = 'TIMESTAMP',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
+
+export type OperationCheckStatsDimensions = {
+  __typename?: 'OperationCheckStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  schemaTag?: Maybe<Scalars['String']>;
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in OperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type OperationCheckStatsFilter = {
+  and?: Maybe<Array<OperationCheckStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<OperationCheckStatsFilterIn>;
+  not?: Maybe<OperationCheckStatsFilter>;
+  or?: Maybe<Array<OperationCheckStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
+  /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
+  serviceId?: Maybe<Scalars['ID']>;
+};
+
+/** Filter for data in OperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type OperationCheckStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+};
+
+export type OperationCheckStatsMetrics = {
+  __typename?: 'OperationCheckStatsMetrics';
+  cachedRequestsCount: Scalars['Long'];
+  uncachedRequestsCount: Scalars['Long'];
+};
+
+export type OperationCheckStatsOrderBySpec = {
+  column: OperationCheckStatsColumn;
+  direction: Ordering;
+};
+
+export type OperationCheckStatsRecord = {
+  __typename?: 'OperationCheckStatsRecord';
+  /** Dimensions of OperationCheckStats that can be grouped by. */
+  groupBy: OperationCheckStatsDimensions;
+  /** Metrics of OperationCheckStats that can be aggregated over. */
+  metrics: OperationCheckStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
 };
 
 export type OperationDocument = {
@@ -3940,34 +3820,39 @@ export type OperationValidationError = {
 
 export type OperationsCheckResult = {
   __typename?: 'OperationsCheckResult';
-  id: Scalars['ID'];
-  /** The variant that was used as a base to check against */
-  checkedVariant: GraphVariant;
-  /** Indication of the success of the change, either failure, warning, or notice. */
-  checkSeverity: ChangeSeverity;
-  /** Number of operations that were validated during schema diff */
-  numberOfCheckedOperations: Scalars['Int'];
-  /** List of schema changes with associated affected clients and operations */
-  changes: Array<Change>;
-  /** Summary/counts for all changes in diff */
-  changeSummary: ChangeSummary;
   /** Operations affected by all changes in diff */
   affectedQueries?: Maybe<Array<AffectedQuery>>;
+  /** Summary/counts for all changes in diff */
+  changeSummary: ChangeSummary;
+  /** List of schema changes with associated affected clients and operations */
+  changes: Array<Change>;
+  /** Indication of the success of the change, either failure, warning, or notice. */
+  checkSeverity: ChangeSeverity;
+  /** The variant that was used as a base to check against */
+  checkedVariant: GraphVariant;
+  createdAt: Scalars['Timestamp'];
+  id: Scalars['ID'];
   /** Number of affected query operations that are neither marked as SAFE or IGNORED */
   numberOfAffectedOperations: Scalars['Int'];
+  /** Number of operations that were validated during schema diff */
+  numberOfCheckedOperations: Scalars['Int'];
   workflowTask: OperationsCheckTask;
-  createdAt: Scalars['Timestamp'];
 };
 
 export type OperationsCheckTask = CheckWorkflowTask & {
   __typename?: 'OperationsCheckTask';
+  completedAt?: Maybe<Scalars['Timestamp']>;
+  createdAt: Scalars['Timestamp'];
   id: Scalars['ID'];
-  workflow: CheckWorkflow;
-  status: CheckWorkflowTaskStatus;
   /** The result of the check. */
   result?: Maybe<OperationsCheckResult>;
-  createdAt: Scalars['Timestamp'];
-  completedAt?: Maybe<Scalars['Timestamp']>;
+  status: CheckWorkflowTaskStatus;
+  workflow: CheckWorkflow;
+};
+
+export type OperationsCollection = {
+  __typename?: 'OperationsCollection';
+  id: Scalars['ID'];
 };
 
 export enum Ordering {
@@ -4014,14 +3899,14 @@ export type PagerDutyChannelInput = {
 /** Schema for an implementing service with associated metadata */
 export type PartialSchema = {
   __typename?: 'PartialSchema';
-  /** The enriched sdl of a partial schema */
-  sdl: Scalars['String'];
-  /** The path of deep storage to find the raw enriched partial schema file */
-  sdlPath: Scalars['String'];
   /** Timestamp for when the partial schema was created */
   createdAt: Scalars['Timestamp'];
   /** If this sdl is currently actively composed in the gateway, this is true */
   isLive: Scalars['Boolean'];
+  /** The enriched sdl of a partial schema */
+  sdl: Scalars['String'];
+  /** The path of deep storage to find the raw enriched partial schema file */
+  sdlPath: Scalars['String'];
 };
 
 /**
@@ -4037,15 +3922,15 @@ export type PartialSchema = {
  */
 export type PartialSchemaInput = {
   /**
-   * Contents of the partial schema in SDL syntax, but may reference types
-   * that aren't defined in this document
-   */
-  sdl?: Maybe<Scalars['String']>;
-  /**
    * Hash of the partial schema to associate; error is thrown if only the hash is
    * specified and the hash has not been seen before
    */
   hash?: Maybe<Scalars['String']>;
+  /**
+   * Contents of the partial schema in SDL syntax, but may reference types
+   * that aren't defined in this document
+   */
+  sdl?: Maybe<Scalars['String']>;
 };
 
 export type PromoteSchemaError = {
@@ -4065,11 +3950,11 @@ export type PromoteSchemaResponse = {
 };
 
 export enum PromoteSchemaResponseCode {
-  PromotionSuccess = 'PROMOTION_SUCCESS',
-  NoChangesDetected = 'NO_CHANGES_DETECTED'
+  NoChangesDetected = 'NO_CHANGES_DETECTED',
+  PromotionSuccess = 'PROMOTION_SUCCESS'
 }
 
-export type PromoteSchemaResponseOrError = PromoteSchemaResponse | PromoteSchemaError;
+export type PromoteSchemaResponseOrError = PromoteSchemaError | PromoteSchemaResponse;
 
 export type Protobuf = {
   __typename?: 'Protobuf';
@@ -4081,7 +3966,6 @@ export type Protobuf = {
 
 export type Query = {
   __typename?: 'Query';
-  diffSchemas: Array<Change>;
   _odysseyFakeField?: Maybe<Scalars['Boolean']>;
   /** Account by ID */
   account?: Maybe<Account>;
@@ -4099,9 +3983,13 @@ export type Query = {
   allUsers?: Maybe<Array<User>>;
   /** If this is true, the user is an Apollo administrator who can ignore restrictions based purely on billing plan. */
   canBypassPlanRestrictions: Scalars['Boolean'];
+  diffSchemas: Array<Change>;
   /** Get the unsubscribe settings for a given email. */
   emailPreferences?: Maybe<EmailPreferences>;
+  experimentalFeatures: GlobalExperimentalFeatures;
   frontendUrlRoot: Scalars['String'];
+  helloWorldBilling?: Maybe<Scalars['String']>;
+  helloWorldOperationsCollections?: Maybe<Scalars['String']>;
   internalActiveCronJobs: Array<CronJob>;
   internalAdminUsers?: Maybe<Array<InternalAdminUser>>;
   internalUnresolvedCronExecutionFailures: Array<CronExecution>;
@@ -4109,6 +3997,8 @@ export type Query = {
   me?: Maybe<Identity>;
   /** Look up a plan by ID */
   plan?: Maybe<BillingPlan>;
+  /** A list of public variants that have been selected to be shown on our Graph Directory. */
+  publiclyListedVariants?: Maybe<Array<GraphVariant>>;
   /** Service by ID */
   service?: Maybe<Service>;
   /** Query statistics across all services. For admins only; normal users must go through AccountsStatsWindow or ServiceStatsWindow. */
@@ -4127,13 +4017,6 @@ export type Query = {
    * Note that we can return more types implementing Error in the future.
    */
   variant?: Maybe<GraphVariantLookup>;
-  experimentalFeatures: GlobalExperimentalFeatures;
-};
-
-
-export type QueryDiffSchemasArgs = {
-  baseSchema: Scalars['String'];
-  nextSchema: Scalars['String'];
 };
 
 
@@ -4160,6 +4043,12 @@ export type QueryAllServicesArgs = {
 
 export type QueryAllUsersArgs = {
   search?: Maybe<Scalars['String']>;
+};
+
+
+export type QueryDiffSchemasArgs = {
+  baseSchema: Scalars['String'];
+  nextSchema: Scalars['String'];
 };
 
 
@@ -4212,7 +4101,6 @@ export enum QueryStatsColumn {
   CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
   CacheTtlHistogram = 'CACHE_TTL_HISTOGRAM',
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   ForbiddenOperationCount = 'FORBIDDEN_OPERATION_COUNT',
   FromEngineproxy = 'FROM_ENGINEPROXY',
@@ -4223,7 +4111,6 @@ export enum QueryStatsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   UncachedHistogram = 'UNCACHED_HISTOGRAM',
   UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
@@ -4233,7 +4120,6 @@ export type QueryStatsDimensions = {
   __typename?: 'QueryStatsDimensions';
   accountId?: Maybe<Scalars['ID']>;
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   fromEngineproxy?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -4242,7 +4128,6 @@ export type QueryStatsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in QueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -4252,8 +4137,6 @@ export type QueryStatsFilter = {
   and?: Maybe<Array<QueryStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
@@ -4271,8 +4154,6 @@ export type QueryStatsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in QueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
@@ -4281,8 +4162,6 @@ export type QueryStatsFilterIn = {
   accountId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -4297,8 +4176,6 @@ export type QueryStatsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type QueryStatsMetrics = {
@@ -4405,11 +4282,19 @@ export enum QueryTriggerWindow {
   Unrecognized = 'UNRECOGNIZED'
 }
 
+export type Readme = {
+  __typename?: 'Readme';
+  content: Scalars['String'];
+  id: Scalars['ID'];
+  lastUpdatedAt: Scalars['Timestamp'];
+  lastUpdatedBy?: Maybe<Identity>;
+};
+
 export type RegisterOperationsMutationResponse = {
   __typename?: 'RegisterOperationsMutationResponse';
-  registrationSuccess: Scalars['Boolean'];
-  newOperations?: Maybe<Array<RegisteredOperation>>;
   invalidOperations?: Maybe<Array<InvalidOperation>>;
+  newOperations?: Maybe<Array<RegisteredOperation>>;
+  registrationSuccess: Scalars['Boolean'];
 };
 
 export type RegisteredClientIdentityInput = {
@@ -4424,9 +4309,9 @@ export type RegisteredOperation = {
 };
 
 export type RegisteredOperationInput = {
-  signature: Scalars['ID'];
   document?: Maybe<Scalars['String']>;
   metadata?: Maybe<RegisteredOperationMetadataInput>;
+  signature: Scalars['ID'];
 };
 
 export type RegisteredOperationMetadataInput = {
@@ -4438,6 +4323,12 @@ export type RegistryApiKey = {
   __typename?: 'RegistryApiKey';
   keyName?: Maybe<Scalars['String']>;
   token: Scalars['String'];
+};
+
+export type RegistryStatsWindow = {
+  __typename?: 'RegistryStatsWindow';
+  schemaCheckStats: Array<AccountChecksStatsRecord>;
+  schemaPublishStats: Array<AccountPublishesStatsRecord>;
 };
 
 export type RegistrySubscription = ChannelSubscription & {
@@ -4452,6 +4343,19 @@ export type RegistrySubscription = ChannelSubscription & {
   options: SubscriptionOptions;
   variant?: Maybe<Scalars['String']>;
 };
+
+export type RelaunchComplete = {
+  __typename?: 'RelaunchComplete';
+  latestLaunch: Launch;
+  updated: Scalars['Boolean'];
+};
+
+export type RelaunchError = {
+  __typename?: 'RelaunchError';
+  message: Scalars['String'];
+};
+
+export type RelaunchResult = RelaunchComplete | RelaunchError;
 
 export type ReportSchemaError = ReportSchemaResult & {
   __typename?: 'ReportSchemaError';
@@ -4514,12 +4418,12 @@ export type ReportServerInfoResult = {
 };
 
 export enum Resolution {
-  R15M = 'R15M',
   R1D = 'R1D',
   R1H = 'R1H',
   R1M = 'R1M',
   R5M = 'R5M',
-  R6H = 'R6H'
+  R6H = 'R6H',
+  R15M = 'R15M'
 }
 
 export enum ResponseHints {
@@ -4538,7 +4442,6 @@ export type RoleOverride = {
   user: User;
 };
 
-
 export type ScheduledSummary = ChannelSubscription & {
   __typename?: 'ScheduledSummary';
   /** @deprecated Use channels list instead */
@@ -4552,16 +4455,16 @@ export type ScheduledSummary = ChannelSubscription & {
 
 export type Schema = {
   __typename?: 'Schema';
-  hash: Scalars['ID'];
+  createTemporaryURL?: Maybe<TemporaryUrl>;
   createdAt: Scalars['Timestamp'];
-  introspection: IntrospectionSchema;
-  gitContext?: Maybe<GitContext>;
+  document: Scalars['GraphQLDocument'];
   /** The number of fields; this includes user defined fields only, excluding built-in types and fields */
   fieldCount: Scalars['Int'];
+  gitContext?: Maybe<GitContext>;
+  hash: Scalars['ID'];
+  introspection: IntrospectionSchema;
   /** The number of types; this includes user defined types only, excluding built-in types */
   typeCount: Scalars['Int'];
-  document: Scalars['GraphQLDocument'];
-  createTemporaryURL?: Maybe<TemporaryUrl>;
 };
 
 
@@ -4572,40 +4475,42 @@ export type SchemaCreateTemporaryUrlArgs = {
 /** Represents an error from running schema composition on a list of service definitions. */
 export type SchemaCompositionError = {
   __typename?: 'SchemaCompositionError';
-  message: Scalars['String'];
-  locations: Array<Maybe<SourceLocation>>;
   code?: Maybe<Scalars['String']>;
+  locations: Array<Maybe<SourceLocation>>;
+  message: Scalars['String'];
 };
 
 export type SchemaDiff = {
   __typename?: 'SchemaDiff';
-  /** @deprecated use severity instead */
-  type: ChangeType;
-  /** Indication of the success of the change, either failure, warning, or notice. */
-  severity: ChangeSeverity;
-  /** List of schema changes with associated affected clients and operations */
-  changes: Array<Change>;
-  /** Summary/counts for all changes in diff */
-  changeSummary: ChangeSummary;
-  /** Operations affected by all changes in diff */
-  affectedQueries?: Maybe<Array<AffectedQuery>>;
   /**
    * Clients affected by all changes in diff
    * @deprecated Unsupported.
    */
   affectedClients?: Maybe<Array<AffectedClient>>;
-  /** Number of operations that were validated during schema diff */
-  numberOfCheckedOperations?: Maybe<Scalars['Int']>;
+  /** Operations affected by all changes in diff */
+  affectedQueries?: Maybe<Array<AffectedQuery>>;
+  /** Summary/counts for all changes in diff */
+  changeSummary: ChangeSummary;
+  /** List of schema changes with associated affected clients and operations */
+  changes: Array<Change>;
   /** Number of affected query operations that are neither marked as SAFE or IGNORED */
   numberOfAffectedOperations: Scalars['Int'];
-  /** Configuration of validation */
-  validationConfig?: Maybe<SchemaDiffValidationConfig>;
+  /** Number of operations that were validated during schema diff */
+  numberOfCheckedOperations?: Maybe<Scalars['Int']>;
+  /** Indication of the success of the change, either failure, warning, or notice. */
+  severity: ChangeSeverity;
   /** The tag against which this diff was created */
   tag?: Maybe<Scalars['String']>;
+  /** @deprecated use severity instead */
+  type: ChangeType;
+  /** Configuration of validation */
+  validationConfig?: Maybe<SchemaDiffValidationConfig>;
 };
 
 export type SchemaDiffValidationConfig = {
   __typename?: 'SchemaDiffValidationConfig';
+  /** Clients to ignore during validation. */
+  excludedClients?: Maybe<Array<ClientInfoFilterOutput>>;
   /**
    * delta in seconds from current time that determines the start of the window
    * for reported metrics included in a schema diff. A day window from the present
@@ -4613,14 +4518,10 @@ export type SchemaDiffValidationConfig = {
    * timestamp if the user passed one in on diff creation
    */
   from?: Maybe<Scalars['Timestamp']>;
-  /**
-   * delta in seconds from current time that determines the end of the
-   * window for reported metrics included in a schema diff. A day window
-   * from the present day would have a `to` value of -0. In rare
-   * cases, this could be an ISO timestamp if the user passed one in on diff
-   * creation
-   */
-  to?: Maybe<Scalars['Timestamp']>;
+  /** Operation IDs to ignore during validation. */
+  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
+  /** Variants to include during validation. */
+  includedVariants?: Maybe<Array<Scalars['String']>>;
   /** Minimum number of requests within the window for a query to be considered. */
   queryCountThreshold?: Maybe<Scalars['Int']>;
   /**
@@ -4629,12 +4530,14 @@ export type SchemaDiffValidationConfig = {
    * total request volume)
    */
   queryCountThresholdPercentage?: Maybe<Scalars['Float']>;
-  /** Clients to ignore during validation. */
-  excludedClients?: Maybe<Array<ClientInfoFilterOutput>>;
-  /** Operation IDs to ignore during validation. */
-  ignoredOperations?: Maybe<Array<Scalars['ID']>>;
-  /** Variants to include during validation. */
-  includedVariants?: Maybe<Array<Scalars['String']>>;
+  /**
+   * delta in seconds from current time that determines the end of the
+   * window for reported metrics included in a schema diff. A day window
+   * from the present day would have a `to` value of -0. In rare
+   * cases, this could be an ISO timestamp if the user passed one in on diff
+   * creation
+   */
+  to?: Maybe<Scalars['Timestamp']>;
 };
 
 export type SchemaPublishSubscription = ChannelSubscription & {
@@ -4668,40 +4571,11 @@ export type SchemaReport = {
 
 export type SchemaTag = {
   __typename?: 'SchemaTag';
-  /**
-   * The identifier for this particular schema tag, which may be either a particular
-   * run of a check or a specific publish. This ID can be used alongside `schemaTagByID`
-   * in order to look up a particular entry.
-   */
-  id: Scalars['ID'];
-  /** The graph variant this schema tag belongs to. */
-  variant: GraphVariant;
-  /** @deprecated Please use variant { name } instead */
-  tag: Scalars['String'];
-  schema: Schema;
   /** The composition result that corresponds to this schema repo tag, if it exists. */
   compositionResult?: Maybe<CompositionResult>;
-  /**
-   * Indicates the schemaTag of the schema's original upload, null if this is the
-   * first upload of the schema.
-   */
-  reversionFrom?: Maybe<SchemaTag>;
   createdAt: Scalars['Timestamp'];
-  /**
-   * Indicates this schema is "published" meaning that our users correspond this schema
-   * with a long-running or permanent initiative. Published schemas appear in the UI
-   * when exploring a service's schemas, and typically refer to either active environments
-   * with metrics (e.g. "staging") or git branches that are constantly used as a base
-   * (e.g. "main"). If this field is not found, the schema is "private" to Engine
-   * and is uploaded but not promoted to published yet. The other benefit is this makes
-   * for nice UX around publishing events
-   */
-  publishedAt: Scalars['Timestamp'];
-  /**
-   * The Identity that published this schema and their client info, or null if this isn't
-   * a publish. Sub-fields may be null if they weren't recorded.
-   */
-  publishedBy?: Maybe<IdentityAndClientInfo>;
+  diffToPrevious?: Maybe<SchemaDiff>;
+  gitContext?: Maybe<GitContext>;
   /**
    * List of previously uploaded SchemaTags under the same tag name, starting with
    * the selected published schema record. Sorted in reverse chronological order
@@ -4720,14 +4594,44 @@ export type SchemaTag = {
    * in the tag history.
    */
   historyOrder: Scalars['Int'];
-  diffToPrevious?: Maybe<SchemaDiff>;
-  gitContext?: Maybe<GitContext>;
+  /**
+   * The identifier for this particular schema tag, which may be either a particular
+   * run of a check or a specific publish. This ID can be used alongside `schemaTagByID`
+   * in order to look up a particular entry.
+   */
+  id: Scalars['ID'];
+  /**
+   * Indicates this schema is "published" meaning that our users correspond this schema
+   * with a long-running or permanent initiative. Published schemas appear in the UI
+   * when exploring a service's schemas, and typically refer to either active environments
+   * with metrics (e.g. "staging") or git branches that are constantly used as a base
+   * (e.g. "main"). If this field is not found, the schema is "private" to Engine
+   * and is uploaded but not promoted to published yet. The other benefit is this makes
+   * for nice UX around publishing events
+   */
+  publishedAt: Scalars['Timestamp'];
+  /**
+   * The Identity that published this schema and their client info, or null if this isn't
+   * a publish. Sub-fields may be null if they weren't recorded.
+   */
+  publishedBy?: Maybe<IdentityAndClientInfo>;
+  /**
+   * Indicates the schemaTag of the schema's original upload, null if this is the
+   * first upload of the schema.
+   */
+  reversionFrom?: Maybe<SchemaTag>;
+  schema: Schema;
   slackNotificationBody?: Maybe<Scalars['String']>;
+  /** @deprecated Please use variant { name } instead */
+  tag: Scalars['String'];
+  /** The graph variant this schema tag belongs to. */
+  variant: GraphVariant;
   webhookNotificationBody: Scalars['String'];
 };
 
 
 export type SchemaTagHistoryArgs = {
+  includeUnchanged?: Scalars['Boolean'];
   limit?: Scalars['Int'];
   offset?: Maybe<Scalars['Int']>;
 };
@@ -4748,17 +4652,17 @@ export type Seats = {
 
 export type SemanticChange = {
   __typename?: 'SemanticChange';
-  /** Semantic metadata about the type of change */
-  definition: ChangeDefinition;
-  /** Top level node affected by the change */
-  parentNode?: Maybe<NamedIntrospectionType>;
+  /** Target arg of change made. */
+  argNode?: Maybe<NamedIntrospectionArg>;
   /**
    * Node related to the top level node that was changed, such as a field in an object,
    * a value in an enum or the object of an interface
    */
   childNode?: Maybe<NamedIntrospectionValue>;
-  /** Target arg of change made. */
-  argNode?: Maybe<NamedIntrospectionArg>;
+  /** Semantic metadata about the type of change */
+  definition: ChangeDefinition;
+  /** Top level node affected by the change */
+  parentNode?: Maybe<NamedIntrospectionType>;
 };
 
 export type Service = Identity & {
@@ -4784,85 +4688,12 @@ export type Service = Identity & {
   avatarUrl?: Maybe<Scalars['String']>;
   /** Get available notification endpoints */
   channels?: Maybe<Array<Channel>>;
-  createdAt: Scalars['Timestamp'];
-  createdBy?: Maybe<Identity>;
-  datadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
-  deletedAt?: Maybe<Scalars['Timestamp']>;
-  description?: Maybe<Scalars['String']>;
-  devGraphOwner?: Maybe<User>;
-  firstReportedAt?: Maybe<Scalars['Timestamp']>;
-  /**
-   * When this is true, this graph will be hidden from non-admin members of the org who haven't been explicitly assigned a
-   * role on this graph.
-   */
-  hiddenFromUninvitedNonAdminAccountMembers: Scalars['Boolean'];
-  id: Scalars['ID'];
-  lastReportedAt?: Maybe<Scalars['Timestamp']>;
-  /** Current identity, null if not authenticated. */
-  me?: Maybe<Identity>;
-  myRole?: Maybe<UserPermission>;
-  /** @deprecated Use Service.title */
-  name: Scalars['String'];
-  /** Get query triggers for a given variant. If variant is null all the triggers for this service will be gotten. */
-  queryTriggers?: Maybe<Array<QueryTrigger>>;
-  readme?: Maybe<Scalars['String']>;
-  /**
-   * Whether registry subscriptions (with any options) are enabled. If variant is not passed, returns true if configuration is present for any variant
-   * @deprecated This field will be removed
-   */
-  registrySubscriptionsEnabled: Scalars['Boolean'];
-  reportingEnabled: Scalars['Boolean'];
-  /** The list of members that can access this graph, accounting for graph role overrides */
-  roleOverrides?: Maybe<Array<RoleOverride>>;
-  /** Which permissions the current user has for interacting with this service */
-  roles?: Maybe<ServiceRoles>;
-  scheduledSummaries: Array<ScheduledSummary>;
-  /** @deprecated use Service.statsWindow instead */
-  stats: ServiceStatsWindow;
-  statsWindow?: Maybe<ServiceStatsWindow>;
-  title: Scalars['String'];
-  trace?: Maybe<Trace>;
-  traceStorageEnabled: Scalars['Boolean'];
-  /** A particular variant (sometimes called "tag") of the graph, often representing a live traffic environment (such as "prod"). Each variant can represent a specific URL or destination to query at, analytics, and its own schema history. */
-  variant?: Maybe<GraphVariant>;
-  /** The list of variants that exist for this graph */
-  variants: Array<GraphVariant>;
-  operation?: Maybe<Operation>;
-  /** Get a schema by hash OR current tag */
-  schema?: Maybe<Schema>;
-  /**
-   * Get schema tags, with optional filtering to a set of tags. Always sorted by creation
-   * date in reverse chronological order.
-   */
-  schemaTags?: Maybe<Array<SchemaTag>>;
-  /** Get the schema tag */
-  schemaTag?: Maybe<SchemaTag>;
-  schemaTagById?: Maybe<SchemaTag>;
-  /**
-   * List of implementing services that comprise a graph. A non-federated graph should have a single implementing service.
-   * Set includeDeleted to see deleted implementing services.
-   */
-  implementingServices?: Maybe<GraphImplementors>;
-  /**
-   * This returns the composition result that was most recently published to the graph.
-   * Only identities that canQuerySchemas and canQueryImplementingServices have access
-   * to this field
-   */
-  mostRecentCompositionPublish?: Maybe<CompositionPublishResult>;
-  /** Given a graphCompositionID, return the results of composition. This can represent either a validation or a publish. */
-  compositionResultById?: Maybe<CompositionResult>;
   /** Get check configuration for this graph. */
   checkConfiguration?: Maybe<CheckConfiguration>;
-  /** Gets the operations and their approved changes for this graph, checkID, and operationID. */
-  operationsAcceptedChanges: Array<OperationAcceptedChange>;
   /** Get a check workflow for this graph by its ID */
   checkWorkflow?: Maybe<CheckWorkflow>;
   /** Get check workflows for this graph ordered by creation time, most recent first. */
   checkWorkflows: Array<CheckWorkflow>;
-  /** Get an operations check result for a specific check ID */
-  operationsCheck?: Maybe<OperationsCheckResult>;
-  /** Generate a test schema publish notification body */
-  testSchemaPublishBody: Scalars['String'];
   /**
    * List of options available for filtering checks for this graph by author.
    * If a filter is passed, constrains results to match the filter.
@@ -4878,6 +4709,80 @@ export type Service = Identity & {
    * If a filter is passed, constrains results to match the filter.
    */
   checksSubgraphOptions: Array<Scalars['String']>;
+  /** Given a graphCompositionID, return the results of composition. This can represent either a validation or a publish. */
+  compositionResultById?: Maybe<CompositionResult>;
+  createdAt: Scalars['Timestamp'];
+  createdBy?: Maybe<Identity>;
+  datadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
+  deletedAt?: Maybe<Scalars['Timestamp']>;
+  description?: Maybe<Scalars['String']>;
+  devGraphOwner?: Maybe<User>;
+  /** Get a graphql by hash */
+  document?: Maybe<Scalars['String']>;
+  /**
+   * When this is true, this graph will be hidden from non-admin members of the org who haven't been explicitly assigned a
+   * role on this graph.
+   */
+  hiddenFromUninvitedNonAdminAccountMembers: Scalars['Boolean'];
+  id: Scalars['ID'];
+  /**
+   * List of implementing services that comprise a graph. A non-federated graph should have a single implementing service.
+   * Set includeDeleted to see deleted implementing services.
+   */
+  implementingServices?: Maybe<GraphImplementors>;
+  lastReportedAt?: Maybe<Scalars['Timestamp']>;
+  /** Current identity, null if not authenticated. */
+  me?: Maybe<Identity>;
+  /**
+   * This returns the composition result that was most recently published to the graph.
+   * Only identities that canQuerySchemas and canQueryImplementingServices have access
+   * to this field
+   */
+  mostRecentCompositionPublish?: Maybe<CompositionPublishResult>;
+  myRole?: Maybe<UserPermission>;
+  /** @deprecated Use Service.title */
+  name: Scalars['String'];
+  operation?: Maybe<Operation>;
+  /** Gets the operations and their approved changes for this graph, checkID, and operationID. */
+  operationsAcceptedChanges: Array<OperationAcceptedChange>;
+  /** Get an operations check result for a specific check ID */
+  operationsCheck?: Maybe<OperationsCheckResult>;
+  /** Get query triggers for a given variant. If variant is null all the triggers for this service will be gotten. */
+  queryTriggers?: Maybe<Array<QueryTrigger>>;
+  readme?: Maybe<Readme>;
+  /**
+   * Whether registry subscriptions (with any options) are enabled. If variant is not passed, returns true if configuration is present for any variant
+   * @deprecated This field will be removed
+   */
+  registrySubscriptionsEnabled: Scalars['Boolean'];
+  reportingEnabled: Scalars['Boolean'];
+  /** The list of members that can access this graph, accounting for graph role overrides */
+  roleOverrides?: Maybe<Array<RoleOverride>>;
+  /** Which permissions the current user has for interacting with this service */
+  roles?: Maybe<ServiceRoles>;
+  scheduledSummaries: Array<ScheduledSummary>;
+  /** Get a schema by hash OR current tag */
+  schema?: Maybe<Schema>;
+  /** Get the schema tag */
+  schemaTag?: Maybe<SchemaTag>;
+  schemaTagById?: Maybe<SchemaTag>;
+  /**
+   * Get schema tags, with optional filtering to a set of tags. Always sorted by creation
+   * date in reverse chronological order.
+   */
+  schemaTags?: Maybe<Array<SchemaTag>>;
+  /** @deprecated use Service.statsWindow instead */
+  stats: ServiceStatsWindow;
+  statsWindow?: Maybe<ServiceStatsWindow>;
+  /** Generate a test schema publish notification body */
+  testSchemaPublishBody: Scalars['String'];
+  title: Scalars['String'];
+  trace?: Maybe<Trace>;
+  traceStorageEnabled: Scalars['Boolean'];
+  /** A particular variant (sometimes called "tag") of the graph, often representing a live traffic environment (such as "prod"). Each variant can represent a specific URL or destination to query at, analytics, and its own schema history. */
+  variant?: Maybe<GraphVariant>;
+  /** The list of variants that exist for this graph */
+  variants: Array<GraphVariant>;
 };
 
 
@@ -4891,8 +4796,71 @@ export type ServiceChannelsArgs = {
 };
 
 
+export type ServiceCheckWorkflowArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceCheckWorkflowsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+  limit?: Scalars['Int'];
+};
+
+
+export type ServiceChecksAuthorOptionsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+};
+
+
+export type ServiceChecksBranchOptionsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+};
+
+
+export type ServiceChecksSubgraphOptionsArgs = {
+  filter?: Maybe<CheckFilterInput>;
+};
+
+
+export type ServiceCompositionResultByIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceDocumentArgs = {
+  hash?: Maybe<Scalars['SHA256']>;
+};
+
+
+export type ServiceImplementingServicesArgs = {
+  graphVariant: Scalars['String'];
+  includeDeleted?: Maybe<Scalars['Boolean']>;
+};
+
+
 export type ServiceLastReportedAtArgs = {
   graphVariant?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceMostRecentCompositionPublishArgs = {
+  graphVariant: Scalars['String'];
+};
+
+
+export type ServiceOperationArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceOperationsAcceptedChangesArgs = {
+  checkID: Scalars['ID'];
+  operationID: Scalars['String'];
+};
+
+
+export type ServiceOperationsCheckArgs = {
+  checkID: Scalars['ID'];
 };
 
 
@@ -4904,6 +4872,27 @@ export type ServiceQueryTriggersArgs = {
 
 export type ServiceRegistrySubscriptionsEnabledArgs = {
   graphVariant?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceSchemaArgs = {
+  hash?: Maybe<Scalars['ID']>;
+  tag?: Maybe<Scalars['String']>;
+};
+
+
+export type ServiceSchemaTagArgs = {
+  tag: Scalars['String'];
+};
+
+
+export type ServiceSchemaTagByIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type ServiceSchemaTagsArgs = {
+  tags?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -4921,6 +4910,11 @@ export type ServiceStatsWindowArgs = {
 };
 
 
+export type ServiceTestSchemaPublishBodyArgs = {
+  variant: Scalars['String'];
+};
+
+
 export type ServiceTraceArgs = {
   id: Scalars['ID'];
 };
@@ -4928,90 +4922,6 @@ export type ServiceTraceArgs = {
 
 export type ServiceVariantArgs = {
   name: Scalars['String'];
-};
-
-
-export type ServiceOperationArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type ServiceSchemaArgs = {
-  hash?: Maybe<Scalars['ID']>;
-  tag?: Maybe<Scalars['String']>;
-};
-
-
-export type ServiceSchemaTagsArgs = {
-  tags?: Maybe<Array<Scalars['String']>>;
-};
-
-
-export type ServiceSchemaTagArgs = {
-  tag: Scalars['String'];
-};
-
-
-export type ServiceSchemaTagByIdArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type ServiceImplementingServicesArgs = {
-  graphVariant: Scalars['String'];
-  includeDeleted?: Maybe<Scalars['Boolean']>;
-};
-
-
-export type ServiceMostRecentCompositionPublishArgs = {
-  graphVariant: Scalars['String'];
-};
-
-
-export type ServiceCompositionResultByIdArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type ServiceOperationsAcceptedChangesArgs = {
-  checkID: Scalars['ID'];
-  operationID: Scalars['String'];
-};
-
-
-export type ServiceCheckWorkflowArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type ServiceCheckWorkflowsArgs = {
-  limit?: Scalars['Int'];
-  filter?: Maybe<CheckFilterInput>;
-};
-
-
-export type ServiceOperationsCheckArgs = {
-  checkID: Scalars['ID'];
-};
-
-
-export type ServiceTestSchemaPublishBodyArgs = {
-  variant: Scalars['String'];
-};
-
-
-export type ServiceChecksAuthorOptionsArgs = {
-  filter?: Maybe<CheckFilterInput>;
-};
-
-
-export type ServiceChecksBranchOptionsArgs = {
-  filter?: Maybe<CheckFilterInput>;
-};
-
-
-export type ServiceChecksSubgraphOptionsArgs = {
-  filter?: Maybe<CheckFilterInput>;
 };
 
 /** Columns of ServiceEdgeServerInfos. */
@@ -5096,114 +5006,9 @@ export type ServiceEdgeServerInfosRecord = {
   timestamp: Scalars['Timestamp'];
 };
 
-/** Columns of ServiceEnumStats. */
-export enum ServiceEnumStatsColumn {
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  EnumType = 'ENUM_TYPE',
-  EnumValue = 'ENUM_VALUE',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
-  ResponseCount = 'RESPONSE_COUNT',
-  SchemaHash = 'SCHEMA_HASH',
-  SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
-  Timestamp = 'TIMESTAMP'
-}
-
-export type ServiceEnumStatsDimensions = {
-  __typename?: 'ServiceEnumStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
-  enumType?: Maybe<Scalars['String']>;
-  enumValue?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
-  schemaHash?: Maybe<Scalars['String']>;
-  schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in ServiceEnumStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type ServiceEnumStatsFilter = {
-  and?: Maybe<Array<ServiceEnumStatsFilter>>;
-  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
-  /** Selects rows whose enumType dimension equals the given value if not null. To query for the null value, use {in: {enumType: [null]}} instead. */
-  enumType?: Maybe<Scalars['String']>;
-  /** Selects rows whose enumValue dimension equals the given value if not null. To query for the null value, use {in: {enumValue: [null]}} instead. */
-  enumValue?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceEnumStatsFilterIn>;
-  not?: Maybe<ServiceEnumStatsFilter>;
-  or?: Maybe<Array<ServiceEnumStatsFilter>>;
-  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
-  schemaHash?: Maybe<Scalars['String']>;
-  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
-  schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
-};
-
-/** Filter for data in ServiceEnumStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type ServiceEnumStatsFilterIn = {
-  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose enumType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  enumType?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose enumValue dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  enumValue?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-export type ServiceEnumStatsMetrics = {
-  __typename?: 'ServiceEnumStatsMetrics';
-  requestCount: Scalars['Long'];
-  responseCount: Scalars['Long'];
-};
-
-export type ServiceEnumStatsOrderBySpec = {
-  column: ServiceEnumStatsColumn;
-  direction: Ordering;
-};
-
-export type ServiceEnumStatsRecord = {
-  __typename?: 'ServiceEnumStatsRecord';
-  /** Dimensions of ServiceEnumStats that can be grouped by. */
-  groupBy: ServiceEnumStatsDimensions;
-  /** Metrics of ServiceEnumStats that can be aggregated over. */
-  metrics: ServiceEnumStatsMetrics;
-  /** Starting segment timestamp. */
-  timestamp: Scalars['Timestamp'];
-};
-
 /** Columns of ServiceErrorStats. */
 export enum ServiceErrorStatsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   ErrorsCount = 'ERRORS_COUNT',
   Path = 'PATH',
@@ -5212,21 +5017,18 @@ export enum ServiceErrorStatsColumn {
   RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
 export type ServiceErrorStatsDimensions = {
   __typename?: 'ServiceErrorStatsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
   queryName?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceErrorStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -5234,8 +5036,6 @@ export type ServiceErrorStatsFilter = {
   and?: Maybe<Array<ServiceErrorStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   in?: Maybe<ServiceErrorStatsFilterIn>;
@@ -5251,16 +5051,12 @@ export type ServiceErrorStatsFilter = {
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceErrorStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceErrorStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose path dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -5273,8 +5069,6 @@ export type ServiceErrorStatsFilterIn = {
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceErrorStatsMetrics = {
@@ -5298,156 +5092,121 @@ export type ServiceErrorStatsRecord = {
   timestamp: Scalars['Timestamp'];
 };
 
-/** Columns of ServiceFieldStats. */
-export enum ServiceFieldStatsColumn {
-  ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
-  ClientVersion = 'CLIENT_VERSION',
-  ErrorsCount = 'ERRORS_COUNT',
+/** Columns of ServiceFieldLatencies. */
+export enum ServiceFieldLatenciesColumn {
   Field = 'FIELD',
   FieldHistogram = 'FIELD_HISTOGRAM',
-  QueryId = 'QUERY_ID',
-  QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
+  FieldName = 'FIELD_NAME',
+  ParentType = 'PARENT_TYPE',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
-export type ServiceFieldStatsDimensions = {
-  __typename?: 'ServiceFieldStatsDimensions';
-  clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  clientVersion?: Maybe<Scalars['String']>;
+export type ServiceFieldLatenciesDimensions = {
+  __typename?: 'ServiceFieldLatenciesDimensions';
   field?: Maybe<Scalars['String']>;
-  queryId?: Maybe<Scalars['ID']>;
-  queryName?: Maybe<Scalars['String']>;
+  fieldName?: Maybe<Scalars['String']>;
+  parentType?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in ServiceFieldStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type ServiceFieldStatsFilter = {
-  and?: Maybe<Array<ServiceFieldStatsFilter>>;
-  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
-  clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
-  clientVersion?: Maybe<Scalars['String']>;
+/** Filter for data in ServiceFieldLatencies. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceFieldLatenciesFilter = {
+  and?: Maybe<Array<ServiceFieldLatenciesFilter>>;
   /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
   field?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceFieldStatsFilterIn>;
-  not?: Maybe<ServiceFieldStatsFilter>;
-  or?: Maybe<Array<ServiceFieldStatsFilter>>;
-  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
-  queryId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose queryName dimension equals the given value if not null. To query for the null value, use {in: {queryName: [null]}} instead. */
-  queryName?: Maybe<Scalars['String']>;
+  /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
+  fieldName?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceFieldLatenciesFilterIn>;
+  not?: Maybe<ServiceFieldLatenciesFilter>;
+  or?: Maybe<Array<ServiceFieldLatenciesFilter>>;
+  /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
+  parentType?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaHash dimension equals the given value if not null. To query for the null value, use {in: {schemaHash: [null]}} instead. */
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in ServiceFieldStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type ServiceFieldStatsFilterIn = {
-  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+/** Filter for data in ServiceFieldLatencies. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceFieldLatenciesFilterIn = {
   /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
   field?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose queryName dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  queryName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaHash dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type ServiceFieldStatsMetrics = {
-  __typename?: 'ServiceFieldStatsMetrics';
-  errorsCount: Scalars['Long'];
+export type ServiceFieldLatenciesMetrics = {
+  __typename?: 'ServiceFieldLatenciesMetrics';
   fieldHistogram: DurationHistogram;
-  requestCount: Scalars['Long'];
 };
 
-export type ServiceFieldStatsOrderBySpec = {
-  column: ServiceFieldStatsColumn;
+export type ServiceFieldLatenciesOrderBySpec = {
+  column: ServiceFieldLatenciesColumn;
   direction: Ordering;
 };
 
-export type ServiceFieldStatsRecord = {
-  __typename?: 'ServiceFieldStatsRecord';
-  /** Dimensions of ServiceFieldStats that can be grouped by. */
-  groupBy: ServiceFieldStatsDimensions;
-  /** Metrics of ServiceFieldStats that can be aggregated over. */
-  metrics: ServiceFieldStatsMetrics;
+export type ServiceFieldLatenciesRecord = {
+  __typename?: 'ServiceFieldLatenciesRecord';
+  /** Dimensions of ServiceFieldLatencies that can be grouped by. */
+  groupBy: ServiceFieldLatenciesDimensions;
+  /** Metrics of ServiceFieldLatencies that can be aggregated over. */
+  metrics: ServiceFieldLatenciesMetrics;
   /** Starting segment timestamp. */
   timestamp: Scalars['Timestamp'];
 };
 
-/** Columns of ServiceInputStats. */
-export enum ServiceInputStatsColumn {
+/** Columns of ServiceFieldUsage. */
+export enum ServiceFieldUsageColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
+  ExecutionCount = 'EXECUTION_COUNT',
+  Field = 'FIELD',
   FieldName = 'FIELD_NAME',
-  FieldType = 'FIELD_TYPE',
   ParentType = 'PARENT_TYPE',
   QueryId = 'QUERY_ID',
   QueryName = 'QUERY_NAME',
-  RequestCount = 'REQUEST_COUNT',
-  RequestCountNull = 'REQUEST_COUNT_NULL',
-  RequestCountUndefined = 'REQUEST_COUNT_UNDEFINED',
+  ReferencingOperationCount = 'REFERENCING_OPERATION_COUNT',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP'
 }
 
-export type ServiceInputStatsDimensions = {
-  __typename?: 'ServiceInputStatsDimensions';
+export type ServiceFieldUsageDimensions = {
+  __typename?: 'ServiceFieldUsageDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
+  field?: Maybe<Scalars['String']>;
   fieldName?: Maybe<Scalars['String']>;
-  fieldType?: Maybe<Scalars['String']>;
   parentType?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
   queryName?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in ServiceInputStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
-export type ServiceInputStatsFilter = {
-  and?: Maybe<Array<ServiceInputStatsFilter>>;
+/** Filter for data in ServiceFieldUsage. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceFieldUsageFilter = {
+  and?: Maybe<Array<ServiceFieldUsageFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
+  /** Selects rows whose field dimension equals the given value if not null. To query for the null value, use {in: {field: [null]}} instead. */
+  field?: Maybe<Scalars['String']>;
   /** Selects rows whose fieldName dimension equals the given value if not null. To query for the null value, use {in: {fieldName: [null]}} instead. */
   fieldName?: Maybe<Scalars['String']>;
-  /** Selects rows whose fieldType dimension equals the given value if not null. To query for the null value, use {in: {fieldType: [null]}} instead. */
-  fieldType?: Maybe<Scalars['String']>;
-  in?: Maybe<ServiceInputStatsFilterIn>;
-  not?: Maybe<ServiceInputStatsFilter>;
-  or?: Maybe<Array<ServiceInputStatsFilter>>;
+  in?: Maybe<ServiceFieldUsageFilterIn>;
+  not?: Maybe<ServiceFieldUsageFilter>;
+  or?: Maybe<Array<ServiceFieldUsageFilter>>;
   /** Selects rows whose parentType dimension equals the given value if not null. To query for the null value, use {in: {parentType: [null]}} instead. */
   parentType?: Maybe<Scalars['String']>;
   /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
@@ -5458,22 +5217,18 @@ export type ServiceInputStatsFilter = {
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
-/** Filter for data in ServiceInputStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
-export type ServiceInputStatsFilterIn = {
+/** Filter for data in ServiceFieldUsage. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceFieldUsageFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose field dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  field?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fieldName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   fieldName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose fieldType dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  fieldType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose parentType dimension is in the given list. A null value in the list means a row with null for that dimension. */
   parentType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -5484,34 +5239,49 @@ export type ServiceInputStatsFilterIn = {
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type ServiceInputStatsMetrics = {
-  __typename?: 'ServiceInputStatsMetrics';
-  requestCount: Scalars['Long'];
-  requestCountNull: Scalars['Long'];
-  requestCountUndefined: Scalars['Long'];
+export type ServiceFieldUsageMetrics = {
+  __typename?: 'ServiceFieldUsageMetrics';
+  executionCount: Scalars['Long'];
+  referencingOperationCount: Scalars['Long'];
 };
 
-export type ServiceInputStatsOrderBySpec = {
-  column: ServiceInputStatsColumn;
+export type ServiceFieldUsageOrderBySpec = {
+  column: ServiceFieldUsageColumn;
   direction: Ordering;
 };
 
-export type ServiceInputStatsRecord = {
-  __typename?: 'ServiceInputStatsRecord';
-  /** Dimensions of ServiceInputStats that can be grouped by. */
-  groupBy: ServiceInputStatsDimensions;
-  /** Metrics of ServiceInputStats that can be aggregated over. */
-  metrics: ServiceInputStatsMetrics;
+export type ServiceFieldUsageRecord = {
+  __typename?: 'ServiceFieldUsageRecord';
+  /** Dimensions of ServiceFieldUsage that can be grouped by. */
+  groupBy: ServiceFieldUsageDimensions;
+  /** Metrics of ServiceFieldUsage that can be aggregated over. */
+  metrics: ServiceFieldUsageMetrics;
   /** Starting segment timestamp. */
   timestamp: Scalars['Timestamp'];
 };
 
 export type ServiceMutation = {
   __typename?: 'ServiceMutation';
+  /**
+   * Compose an implementing service's partial schema, diff the composed schema, validate traffic against that schema,
+   * and store the result so the details can be viewed by users in the UI.
+   * This mutation will not mark the schema as "published".
+   */
+  checkPartialSchema: CheckPartialSchemaResult;
+  /**
+   * Checks a proposed schema against the schema that has been published to
+   * a particular tag, using metrics that have been published to the base tag.
+   * Callers can set the historicParameters directly, which will be used if
+   * provided. If useMaximumRetention is provided, but historicParameters is not,
+   * then validation will use the maximum retention the graph has access to.
+   * If neither historicParameters nor useMaximumRetention is provided, the
+   * default time range of one week (7 days) will be used.
+   */
+  checkSchema: CheckSchemaResult;
+  /** Make changes to a check workflow. */
+  checkWorkflow?: Maybe<CheckWorkflowMutation>;
   createCompositionStatusSubscription: SchemaPublishSubscription;
   createSchemaPublishSubscription: SchemaPublishSubscription;
   /** Soft delete a graph. Data associated with the graph is not permanently deleted; Apollo support can undo. */
@@ -5530,6 +5300,7 @@ export type ServiceMutation = {
    */
   deleteRegistrySubscriptions: Array<Scalars['ID']>;
   deleteScheduledSummary: Scalars['Boolean'];
+  deleteSchemaTag: DeleteSchemaTagResult;
   /** Given a UTC timestamp, delete all traces associated with this Service, on that corresponding day. If a timestamp to is provided, deletes all days inclusive. */
   deleteTraces?: Maybe<Scalars['Void']>;
   disableDatadogForwardingLegacyMetricNames?: Maybe<Service>;
@@ -5537,89 +5308,6 @@ export type ServiceMutation = {
   hardDelete?: Maybe<Scalars['Void']>;
   /** @deprecated Use service.id */
   id: Scalars['ID'];
-  newKey: GraphApiKey;
-  /** Adds an override to the given users permission for this graph */
-  overrideUserPermission?: Maybe<Service>;
-  /** Returns a preview of the Core and API schema contracts derived from a source variant and a set of filter configurations */
-  previewContractVariant: ContractVariantPreviewResult;
-  removeKey?: Maybe<Scalars['Void']>;
-  renameKey?: Maybe<GraphApiKey>;
-  /** @deprecated use Mutation.reportSchema instead */
-  reportServerInfo?: Maybe<ReportServerInfoResult>;
-  service: Service;
-  /** Test Slack notification channel */
-  testSlackChannel?: Maybe<Scalars['Void']>;
-  testSubscriptionForChannel: Scalars['String'];
-  transfer?: Maybe<Service>;
-  undelete?: Maybe<Service>;
-  updateDatadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
-  updateDescription?: Maybe<Service>;
-  /** Update hiddenFromUninvitedNonAdminAccountMembers */
-  updateHiddenFromUninvitedNonAdminAccountMembers?: Maybe<Service>;
-  updateReadme?: Maybe<Service>;
-  updateTitle?: Maybe<Service>;
-  upsertChannel?: Maybe<Channel>;
-  /** Creates a contract schema from a source variant and a set of filter configurations */
-  upsertContractVariant: ContractVariantUpsertResult;
-  /** Create/update PagerDuty notification channel */
-  upsertPagerDutyChannel?: Maybe<PagerDutyChannel>;
-  upsertQueryTrigger?: Maybe<QueryTrigger>;
-  /** Create or update a subscription for a service. */
-  upsertRegistrySubscription: RegistrySubscription;
-  upsertScheduledSummary?: Maybe<ScheduledSummary>;
-  /** Create/update Slack notification channel */
-  upsertSlackChannel?: Maybe<SlackChannel>;
-  upsertWebhookChannel?: Maybe<WebhookChannel>;
-  /** Make changes to a graph variant. */
-  variant?: Maybe<GraphVariantMutation>;
-  validateOperations: ValidateOperationsResult;
-  registerOperationsWithResponse?: Maybe<RegisterOperationsMutationResponse>;
-  uploadSchema?: Maybe<UploadSchemaMutationResponse>;
-  /**
-   * Store a given schema document. This schema will be attached to the graph but
-   * not be associated with any variant. On success, returns the schema hash.
-   */
-  storeSchemaDocument: StoreSchemaResponseOrError;
-  /** Promote the schema with the given SHA-256 hash to active for the given variant/tag. */
-  promoteSchema: PromoteSchemaResponseOrError;
-  /**
-   * Checks a proposed schema against the schema that has been published to
-   * a particular tag, using metrics that have been published to the base tag.
-   * Callers can set the historicParameters directly, which will be used if
-   * provided. If useMaximumRetention is provided, but historicParameters is not,
-   * then validation will use the maximum retention the graph has access to.
-   * If neither historicParameters nor useMaximumRetention is provided, the
-   * default time range of one week (7 days) will be used.
-   */
-  checkSchema: CheckSchemaResult;
-  /** Make changes to a check workflow. */
-  checkWorkflow?: Maybe<CheckWorkflowMutation>;
-  deleteSchemaTag: DeleteSchemaTagResult;
-  upsertImplementingServiceAndTriggerComposition?: Maybe<CompositionAndUpsertResult>;
-  /**
-   * This mutation will not result in any changes to the implementing service
-   * Run composition with the Implementing Service's partial schema replaced with the one provided
-   * in the mutation's input. Store the composed schema, return the hash of the composed schema,
-   * and any warnings and errors pertaining to composition.
-   * This mutation will not run validation against operations.
-   */
-  validatePartialSchemaOfImplementingServiceAgainstGraph: CompositionValidationResult;
-  removeImplementingServiceAndTriggerComposition: CompositionAndRemoveResult;
-  /**
-   * Compose an implementing service's partial schema, diff the composed schema, validate traffic against that schema,
-   * and store the result so the details can be viewed by users in the UI.
-   * This mutation will not mark the schema as "published".
-   */
-  checkPartialSchema: CheckPartialSchemaResult;
-  /** Update schema check configuration for a graph. */
-  updateCheckConfiguration: CheckConfiguration;
-  /**
-   * Mark the changeset that affects an operation in a given check instance as safe.
-   * Note that only operations marked as behavior changes are allowed to be marked as safe.
-   */
-  markChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
-  /** Unmark changes for an operation as safe. */
-  unmarkChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
   /**
    * Ignore an operation in future checks;
    * changes affecting it will be tracked,
@@ -5629,11 +5317,104 @@ export type ServiceMutation = {
    */
   ignoreOperationsInChecks?: Maybe<IgnoreOperationsInChecksResult>;
   /**
+   * Mark the changeset that affects an operation in a given check instance as safe.
+   * Note that only operations marked as behavior changes are allowed to be marked as safe.
+   */
+  markChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
+  newKey: GraphApiKey;
+  /** Adds an override to the given users permission for this graph */
+  overrideUserPermission?: Maybe<Service>;
+  /** Returns a preview of the Core and API schema contracts derived from a source variant and a set of filter configurations */
+  previewContractVariant: ContractVariantPreviewResult;
+  /** Promote the schema with the given SHA-256 hash to active for the given variant/tag. */
+  promoteSchema: PromoteSchemaResponseOrError;
+  registerOperationsWithResponse?: Maybe<RegisterOperationsMutationResponse>;
+  removeImplementingServiceAndTriggerComposition: CompositionAndRemoveResult;
+  removeKey?: Maybe<Scalars['Void']>;
+  renameKey?: Maybe<GraphApiKey>;
+  /** @deprecated use Mutation.reportSchema instead */
+  reportServerInfo?: Maybe<ReportServerInfoResult>;
+  service: Service;
+  /**
+   * Store a given schema document. This schema will be attached to the graph but
+   * not be associated with any variant. On success, returns the schema hash.
+   */
+  storeSchemaDocument: StoreSchemaResponseOrError;
+  /** Test Slack notification channel */
+  testSlackChannel?: Maybe<Scalars['Void']>;
+  testSubscriptionForChannel: Scalars['String'];
+  transfer?: Maybe<Service>;
+  triggerRepublish?: Maybe<Scalars['Void']>;
+  undelete?: Maybe<Service>;
+  /**
    * Revert the effects of ignoreOperation.
    * Returns true if the operation is no longer ignored,
    * false if it wasn't.
    */
   unignoreOperationsInChecks?: Maybe<UnignoreOperationsInChecksResult>;
+  /** Unmark changes for an operation as safe. */
+  unmarkChangesForOperationAsSafe: MarkChangesForOperationAsSafeResult;
+  /** Update schema check configuration for a graph. */
+  updateCheckConfiguration: CheckConfiguration;
+  updateDatadogMetricsConfig?: Maybe<DatadogMetricsConfig>;
+  updateDescription?: Maybe<Service>;
+  /** Update hiddenFromUninvitedNonAdminAccountMembers */
+  updateHiddenFromUninvitedNonAdminAccountMembers?: Maybe<Service>;
+  updateReadme?: Maybe<Service>;
+  updateTitle?: Maybe<Service>;
+  uploadSchema?: Maybe<UploadSchemaMutationResponse>;
+  upsertChannel?: Maybe<Channel>;
+  /** Creates a contract schema from a source variant and a set of filter configurations */
+  upsertContractVariant: ContractVariantUpsertResult;
+  upsertImplementingServiceAndTriggerComposition?: Maybe<CompositionAndUpsertResult>;
+  /** Create/update PagerDuty notification channel */
+  upsertPagerDutyChannel?: Maybe<PagerDutyChannel>;
+  upsertQueryTrigger?: Maybe<QueryTrigger>;
+  /** Create or update a subscription for a service. */
+  upsertRegistrySubscription: RegistrySubscription;
+  upsertScheduledSummary?: Maybe<ScheduledSummary>;
+  /** Create/update Slack notification channel */
+  upsertSlackChannel?: Maybe<SlackChannel>;
+  upsertWebhookChannel?: Maybe<WebhookChannel>;
+  validateOperations: ValidateOperationsResult;
+  /**
+   * This mutation will not result in any changes to the implementing service
+   * Run composition with the Implementing Service's partial schema replaced with the one provided
+   * in the mutation's input. Store the composed schema, return the hash of the composed schema,
+   * and any warnings and errors pertaining to composition.
+   * This mutation will not run validation against operations.
+   */
+  validatePartialSchemaOfImplementingServiceAgainstGraph: CompositionValidationResult;
+  /** Make changes to a graph variant. */
+  variant?: Maybe<GraphVariantMutation>;
+};
+
+
+export type ServiceMutationCheckPartialSchemaArgs = {
+  frontend?: Maybe<Scalars['String']>;
+  gitContext?: Maybe<GitContextInput>;
+  graphVariant: Scalars['String'];
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  implementingServiceName: Scalars['String'];
+  partialSchema: PartialSchemaInput;
+  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ServiceMutationCheckSchemaArgs = {
+  baseSchemaTag?: Maybe<Scalars['String']>;
+  frontend?: Maybe<Scalars['String']>;
+  gitContext?: Maybe<GitContextInput>;
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  proposedSchema?: Maybe<IntrospectionSchemaInput>;
+  proposedSchemaDocument?: Maybe<Scalars['String']>;
+  proposedSchemaHash?: Maybe<Scalars['String']>;
+  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ServiceMutationCheckWorkflowArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -5674,9 +5455,25 @@ export type ServiceMutationDeleteScheduledSummaryArgs = {
 };
 
 
+export type ServiceMutationDeleteSchemaTagArgs = {
+  tag: Scalars['String'];
+};
+
+
 export type ServiceMutationDeleteTracesArgs = {
   from: Scalars['Timestamp'];
   to?: Maybe<Scalars['Timestamp']>;
+};
+
+
+export type ServiceMutationIgnoreOperationsInChecksArgs = {
+  ids: Array<Scalars['ID']>;
+};
+
+
+export type ServiceMutationMarkChangesForOperationAsSafeArgs = {
+  checkID: Scalars['ID'];
+  operationID: Scalars['ID'];
 };
 
 
@@ -5698,22 +5495,49 @@ export type ServiceMutationPreviewContractVariantArgs = {
 };
 
 
+export type ServiceMutationPromoteSchemaArgs = {
+  graphVariant: Scalars['String'];
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  overrideComposedSchema?: Scalars['Boolean'];
+  sha256: Scalars['SHA256'];
+};
+
+
+export type ServiceMutationRegisterOperationsWithResponseArgs = {
+  clientIdentity?: Maybe<RegisteredClientIdentityInput>;
+  gitContext?: Maybe<GitContextInput>;
+  graphVariant?: Scalars['String'];
+  manifestVersion?: Maybe<Scalars['Int']>;
+  operations: Array<RegisteredOperationInput>;
+};
+
+
+export type ServiceMutationRemoveImplementingServiceAndTriggerCompositionArgs = {
+  dryRun?: Scalars['Boolean'];
+  graphVariant: Scalars['String'];
+  name: Scalars['String'];
+};
+
+
 export type ServiceMutationRemoveKeyArgs = {
-  key?: Maybe<Scalars['String']>;
-  token?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
 };
 
 
 export type ServiceMutationRenameKeyArgs = {
-  key?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
   newKeyName?: Maybe<Scalars['String']>;
-  token?: Maybe<Scalars['String']>;
 };
 
 
 export type ServiceMutationReportServerInfoArgs = {
   executableSchema?: Maybe<Scalars['String']>;
   info: EdgeServerInfo;
+};
+
+
+export type ServiceMutationStoreSchemaDocumentArgs = {
+  schemaDocument: Scalars['String'];
 };
 
 
@@ -5731,6 +5555,33 @@ export type ServiceMutationTestSubscriptionForChannelArgs = {
 
 export type ServiceMutationTransferArgs = {
   to: Scalars['String'];
+};
+
+
+export type ServiceMutationTriggerRepublishArgs = {
+  graphVariant: Scalars['String'];
+};
+
+
+export type ServiceMutationUnignoreOperationsInChecksArgs = {
+  ids: Array<Scalars['ID']>;
+};
+
+
+export type ServiceMutationUnmarkChangesForOperationAsSafeArgs = {
+  checkID: Scalars['ID'];
+  operationID: Scalars['ID'];
+};
+
+
+export type ServiceMutationUpdateCheckConfigurationArgs = {
+  excludedClients?: Maybe<Array<ClientFilterInput>>;
+  excludedOperations?: Maybe<Array<ExcludedOperationInput>>;
+  includeBaseVariant?: Maybe<Scalars['Boolean']>;
+  includedVariants?: Maybe<Array<Scalars['String']>>;
+  operationCountThreshold?: Maybe<Scalars['Int']>;
+  operationCountThresholdPercentage?: Maybe<Scalars['Float']>;
+  timeRangeSeconds?: Maybe<Scalars['Long']>;
 };
 
 
@@ -5761,6 +5612,17 @@ export type ServiceMutationUpdateTitleArgs = {
 };
 
 
+export type ServiceMutationUploadSchemaArgs = {
+  errorOnBadRequest?: Scalars['Boolean'];
+  gitContext?: Maybe<GitContextInput>;
+  historicParameters?: Maybe<HistoricQueryParameters>;
+  overrideComposedSchema?: Scalars['Boolean'];
+  schema?: Maybe<IntrospectionSchemaInput>;
+  schemaDocument?: Maybe<Scalars['String']>;
+  tag: Scalars['String'];
+};
+
+
 export type ServiceMutationUpsertChannelArgs = {
   id?: Maybe<Scalars['ID']>;
   pagerDutyChannel?: Maybe<PagerDutyChannelInput>;
@@ -5772,7 +5634,18 @@ export type ServiceMutationUpsertChannelArgs = {
 export type ServiceMutationUpsertContractVariantArgs = {
   contractVariantName: Scalars['String'];
   filterConfig: FilterConfigInput;
+  initiateLaunch?: Scalars['Boolean'];
   sourceVariant: Scalars['String'];
+};
+
+
+export type ServiceMutationUpsertImplementingServiceAndTriggerCompositionArgs = {
+  activePartialSchema: PartialSchemaInput;
+  gitContext?: Maybe<GitContextInput>;
+  graphVariant: Scalars['String'];
+  name: Scalars['String'];
+  revision: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
 };
 
 
@@ -5820,80 +5693,10 @@ export type ServiceMutationUpsertWebhookChannelArgs = {
 };
 
 
-export type ServiceMutationVariantArgs = {
-  name: Scalars['String'];
-};
-
-
 export type ServiceMutationValidateOperationsArgs = {
+  gitContext?: Maybe<GitContextInput>;
   operations: Array<OperationDocumentInput>;
   tag?: Maybe<Scalars['String']>;
-  gitContext?: Maybe<GitContextInput>;
-};
-
-
-export type ServiceMutationRegisterOperationsWithResponseArgs = {
-  clientIdentity?: Maybe<RegisteredClientIdentityInput>;
-  gitContext?: Maybe<GitContextInput>;
-  operations: Array<RegisteredOperationInput>;
-  manifestVersion?: Maybe<Scalars['Int']>;
-  graphVariant?: Scalars['String'];
-};
-
-
-export type ServiceMutationUploadSchemaArgs = {
-  schema?: Maybe<IntrospectionSchemaInput>;
-  tag: Scalars['String'];
-  gitContext?: Maybe<GitContextInput>;
-  historicParameters?: Maybe<HistoricQueryParameters>;
-  overrideComposedSchema?: Scalars['Boolean'];
-  schemaDocument?: Maybe<Scalars['String']>;
-  errorOnBadRequest?: Scalars['Boolean'];
-};
-
-
-export type ServiceMutationStoreSchemaDocumentArgs = {
-  schemaDocument: Scalars['String'];
-};
-
-
-export type ServiceMutationPromoteSchemaArgs = {
-  sha256: Scalars['SHA256'];
-  graphVariant: Scalars['String'];
-  historicParameters?: Maybe<HistoricQueryParameters>;
-  overrideComposedSchema?: Scalars['Boolean'];
-};
-
-
-export type ServiceMutationCheckSchemaArgs = {
-  proposedSchema?: Maybe<IntrospectionSchemaInput>;
-  proposedSchemaDocument?: Maybe<Scalars['String']>;
-  proposedSchemaHash?: Maybe<Scalars['String']>;
-  baseSchemaTag?: Maybe<Scalars['String']>;
-  gitContext?: Maybe<GitContextInput>;
-  historicParameters?: Maybe<HistoricQueryParameters>;
-  useMaximumRetention?: Maybe<Scalars['Boolean']>;
-  frontend?: Maybe<Scalars['String']>;
-};
-
-
-export type ServiceMutationCheckWorkflowArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type ServiceMutationDeleteSchemaTagArgs = {
-  tag: Scalars['String'];
-};
-
-
-export type ServiceMutationUpsertImplementingServiceAndTriggerCompositionArgs = {
-  graphVariant: Scalars['String'];
-  name: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
-  revision: Scalars['String'];
-  activePartialSchema: PartialSchemaInput;
-  gitContext?: Maybe<GitContextInput>;
 };
 
 
@@ -5904,54 +5707,76 @@ export type ServiceMutationValidatePartialSchemaOfImplementingServiceAgainstGrap
 };
 
 
-export type ServiceMutationRemoveImplementingServiceAndTriggerCompositionArgs = {
-  graphVariant: Scalars['String'];
+export type ServiceMutationVariantArgs = {
   name: Scalars['String'];
-  dryRun?: Scalars['Boolean'];
 };
 
+/** Columns of ServiceOperationCheckStats. */
+export enum ServiceOperationCheckStatsColumn {
+  CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
+  ClientName = 'CLIENT_NAME',
+  ClientVersion = 'CLIENT_VERSION',
+  QueryId = 'QUERY_ID',
+  SchemaTag = 'SCHEMA_TAG',
+  Timestamp = 'TIMESTAMP',
+  UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
+}
 
-export type ServiceMutationCheckPartialSchemaArgs = {
-  graphVariant: Scalars['String'];
-  implementingServiceName: Scalars['String'];
-  partialSchema: PartialSchemaInput;
-  gitContext?: Maybe<GitContextInput>;
-  historicParameters?: Maybe<HistoricQueryParameters>;
-  frontend?: Maybe<Scalars['String']>;
-  useMaximumRetention?: Maybe<Scalars['Boolean']>;
+export type ServiceOperationCheckStatsDimensions = {
+  __typename?: 'ServiceOperationCheckStatsDimensions';
+  clientName?: Maybe<Scalars['String']>;
+  clientVersion?: Maybe<Scalars['String']>;
+  queryId?: Maybe<Scalars['ID']>;
+  schemaTag?: Maybe<Scalars['String']>;
 };
 
-
-export type ServiceMutationUpdateCheckConfigurationArgs = {
-  excludedOperations?: Maybe<Array<ExcludedOperationInput>>;
-  excludedClients?: Maybe<Array<ClientFilterInput>>;
-  includedVariants?: Maybe<Array<Scalars['String']>>;
-  timeRangeSeconds?: Maybe<Scalars['Long']>;
-  operationCountThreshold?: Maybe<Scalars['Int']>;
-  operationCountThresholdPercentage?: Maybe<Scalars['Float']>;
-  includeBaseVariant?: Maybe<Scalars['Boolean']>;
+/** Filter for data in ServiceOperationCheckStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
+export type ServiceOperationCheckStatsFilter = {
+  and?: Maybe<Array<ServiceOperationCheckStatsFilter>>;
+  /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
+  clientName?: Maybe<Scalars['String']>;
+  /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
+  clientVersion?: Maybe<Scalars['String']>;
+  in?: Maybe<ServiceOperationCheckStatsFilterIn>;
+  not?: Maybe<ServiceOperationCheckStatsFilter>;
+  or?: Maybe<Array<ServiceOperationCheckStatsFilter>>;
+  /** Selects rows whose queryId dimension equals the given value if not null. To query for the null value, use {in: {queryId: [null]}} instead. */
+  queryId?: Maybe<Scalars['ID']>;
+  /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
+  schemaTag?: Maybe<Scalars['String']>;
 };
 
-
-export type ServiceMutationMarkChangesForOperationAsSafeArgs = {
-  checkID: Scalars['ID'];
-  operationID: Scalars['ID'];
+/** Filter for data in ServiceOperationCheckStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
+export type ServiceOperationCheckStatsFilterIn = {
+  /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
+  /** Selects rows whose queryId dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  queryId?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
+  schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-
-export type ServiceMutationUnmarkChangesForOperationAsSafeArgs = {
-  checkID: Scalars['ID'];
-  operationID: Scalars['ID'];
+export type ServiceOperationCheckStatsMetrics = {
+  __typename?: 'ServiceOperationCheckStatsMetrics';
+  cachedRequestsCount: Scalars['Long'];
+  uncachedRequestsCount: Scalars['Long'];
 };
 
-
-export type ServiceMutationIgnoreOperationsInChecksArgs = {
-  ids: Array<Scalars['ID']>;
+export type ServiceOperationCheckStatsOrderBySpec = {
+  column: ServiceOperationCheckStatsColumn;
+  direction: Ordering;
 };
 
-
-export type ServiceMutationUnignoreOperationsInChecksArgs = {
-  ids: Array<Scalars['ID']>;
+export type ServiceOperationCheckStatsRecord = {
+  __typename?: 'ServiceOperationCheckStatsRecord';
+  /** Dimensions of ServiceOperationCheckStats that can be grouped by. */
+  groupBy: ServiceOperationCheckStatsDimensions;
+  /** Metrics of ServiceOperationCheckStats that can be aggregated over. */
+  metrics: ServiceOperationCheckStatsMetrics;
+  /** Starting segment timestamp. */
+  timestamp: Scalars['Timestamp'];
 };
 
 /** Columns of ServiceQueryStats. */
@@ -5960,7 +5785,6 @@ export enum ServiceQueryStatsColumn {
   CachedRequestsCount = 'CACHED_REQUESTS_COUNT',
   CacheTtlHistogram = 'CACHE_TTL_HISTOGRAM',
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   ForbiddenOperationCount = 'FORBIDDEN_OPERATION_COUNT',
   FromEngineproxy = 'FROM_ENGINEPROXY',
@@ -5970,7 +5794,6 @@ export enum ServiceQueryStatsColumn {
   RequestsWithErrorsCount = 'REQUESTS_WITH_ERRORS_COUNT',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   UncachedHistogram = 'UNCACHED_HISTOGRAM',
   UncachedRequestsCount = 'UNCACHED_REQUESTS_COUNT'
@@ -5979,7 +5802,6 @@ export enum ServiceQueryStatsColumn {
 export type ServiceQueryStatsDimensions = {
   __typename?: 'ServiceQueryStatsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   fromEngineproxy?: Maybe<Scalars['String']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -5987,7 +5809,6 @@ export type ServiceQueryStatsDimensions = {
   querySignature?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceQueryStats. Fields with dimension names represent equality checks. All fields are implicitly ANDed together. */
@@ -5995,8 +5816,6 @@ export type ServiceQueryStatsFilter = {
   and?: Maybe<Array<ServiceQueryStatsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose fromEngineproxy dimension equals the given value if not null. To query for the null value, use {in: {fromEngineproxy: [null]}} instead. */
@@ -6012,16 +5831,12 @@ export type ServiceQueryStatsFilter = {
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
 };
 
 /** Filter for data in ServiceQueryStats. Fields match if the corresponding dimension's value is in the given list. All fields are implicitly ANDed together. */
 export type ServiceQueryStatsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose fromEngineproxy dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6034,8 +5849,6 @@ export type ServiceQueryStatsFilterIn = {
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type ServiceQueryStatsMetrics = {
@@ -6078,12 +5891,14 @@ export type ServiceRoles = {
   canManageIntegrations: Scalars['Boolean'];
   canManageKeys: Scalars['Boolean'];
   canManageVariants: Scalars['Boolean'];
+  canQueryBuildConfig: Scalars['Boolean'];
   canQueryCheckConfiguration: Scalars['Boolean'];
   canQueryDeletedImplementingServices: Scalars['Boolean'];
   canQueryImplementingServices: Scalars['Boolean'];
   canQueryIntegrations: Scalars['Boolean'];
   canQueryPrivateInfo: Scalars['Boolean'];
   canQueryPublicInfo: Scalars['Boolean'];
+  canQueryReadmeAuthor: Scalars['Boolean'];
   canQueryRoleOverrides: Scalars['Boolean'];
   canQuerySchemas: Scalars['Boolean'];
   canQueryStats: Scalars['Boolean'];
@@ -6106,10 +5921,11 @@ export type ServiceRoles = {
 export type ServiceStatsWindow = {
   __typename?: 'ServiceStatsWindow';
   edgeServerInfos: Array<ServiceEdgeServerInfosRecord>;
-  enumStats: Array<ServiceEnumStatsRecord>;
   errorStats: Array<ServiceErrorStatsRecord>;
-  fieldStats: Array<ServiceFieldStatsRecord>;
-  inputStats: Array<ServiceInputStatsRecord>;
+  fieldLatencies: Array<ServiceFieldLatenciesRecord>;
+  fieldStats: Array<ServiceFieldLatenciesRecord>;
+  fieldUsage: Array<ServiceFieldUsageRecord>;
+  operationCheckStats: Array<ServiceOperationCheckStatsRecord>;
   queryStats: Array<ServiceQueryStatsRecord>;
   /** From field rounded down to the nearest resolution. */
   roundedDownFrom: Scalars['Timestamp'];
@@ -6129,14 +5945,6 @@ export type ServiceStatsWindowEdgeServerInfosArgs = {
 
 
 /** A time window with a specified granularity over a given service. */
-export type ServiceStatsWindowEnumStatsArgs = {
-  filter?: Maybe<ServiceEnumStatsFilter>;
-  limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceEnumStatsOrderBySpec>>;
-};
-
-
-/** A time window with a specified granularity over a given service. */
 export type ServiceStatsWindowErrorStatsArgs = {
   filter?: Maybe<ServiceErrorStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
@@ -6145,18 +5953,34 @@ export type ServiceStatsWindowErrorStatsArgs = {
 
 
 /** A time window with a specified granularity over a given service. */
-export type ServiceStatsWindowFieldStatsArgs = {
-  filter?: Maybe<ServiceFieldStatsFilter>;
+export type ServiceStatsWindowFieldLatenciesArgs = {
+  filter?: Maybe<ServiceFieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceFieldStatsOrderBySpec>>;
+  orderBy?: Maybe<Array<ServiceFieldLatenciesOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity over a given service. */
-export type ServiceStatsWindowInputStatsArgs = {
-  filter?: Maybe<ServiceInputStatsFilter>;
+export type ServiceStatsWindowFieldStatsArgs = {
+  filter?: Maybe<ServiceFieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<ServiceInputStatsOrderBySpec>>;
+  orderBy?: Maybe<Array<ServiceFieldLatenciesOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowFieldUsageArgs = {
+  filter?: Maybe<ServiceFieldUsageFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceFieldUsageOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity over a given service. */
+export type ServiceStatsWindowOperationCheckStatsArgs = {
+  filter?: Maybe<ServiceOperationCheckStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<ServiceOperationCheckStatsOrderBySpec>>;
 };
 
 
@@ -6186,7 +6010,6 @@ export type ServiceStatsWindowTraceRefsArgs = {
 /** Columns of ServiceTracePathErrorsRefs. */
 export enum ServiceTracePathErrorsRefsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   DurationBucket = 'DURATION_BUCKET',
   ErrorsCountInPath = 'ERRORS_COUNT_IN_PATH',
@@ -6197,7 +6020,6 @@ export enum ServiceTracePathErrorsRefsColumn {
   QueryName = 'QUERY_NAME',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   TraceHttpStatusCode = 'TRACE_HTTP_STATUS_CODE',
   TraceId = 'TRACE_ID',
@@ -6208,7 +6030,6 @@ export enum ServiceTracePathErrorsRefsColumn {
 export type ServiceTracePathErrorsRefsDimensions = {
   __typename?: 'ServiceTracePathErrorsRefsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationBucket?: Maybe<Scalars['Int']>;
   errorMessage?: Maybe<Scalars['String']>;
@@ -6217,7 +6038,6 @@ export type ServiceTracePathErrorsRefsDimensions = {
   queryName?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
   traceHttpStatusCode?: Maybe<Scalars['Int']>;
   traceId?: Maybe<Scalars['ID']>;
   traceStartsAt?: Maybe<Scalars['Timestamp']>;
@@ -6228,8 +6048,6 @@ export type ServiceTracePathErrorsRefsFilter = {
   and?: Maybe<Array<ServiceTracePathErrorsRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
@@ -6249,8 +6067,6 @@ export type ServiceTracePathErrorsRefsFilter = {
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
   traceHttpStatusCode?: Maybe<Scalars['Int']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
@@ -6261,8 +6077,6 @@ export type ServiceTracePathErrorsRefsFilter = {
 export type ServiceTracePathErrorsRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6279,8 +6093,6 @@ export type ServiceTracePathErrorsRefsFilterIn = {
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
   traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6312,7 +6124,6 @@ export type ServiceTracePathErrorsRefsRecord = {
 /** Columns of ServiceTraceRefs. */
 export enum ServiceTraceRefsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   DurationBucket = 'DURATION_BUCKET',
   DurationNs = 'DURATION_NS',
@@ -6320,7 +6131,6 @@ export enum ServiceTraceRefsColumn {
   QueryName = 'QUERY_NAME',
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   TraceId = 'TRACE_ID',
   TraceSizeBytes = 'TRACE_SIZE_BYTES'
@@ -6329,7 +6139,6 @@ export enum ServiceTraceRefsColumn {
 export type ServiceTraceRefsDimensions = {
   __typename?: 'ServiceTraceRefsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationBucket?: Maybe<Scalars['Int']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -6337,7 +6146,6 @@ export type ServiceTraceRefsDimensions = {
   querySignature?: Maybe<Scalars['String']>;
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
-  serviceVersion?: Maybe<Scalars['String']>;
   traceId?: Maybe<Scalars['ID']>;
 };
 
@@ -6346,8 +6154,6 @@ export type ServiceTraceRefsFilter = {
   and?: Maybe<Array<ServiceTraceRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
@@ -6363,8 +6169,6 @@ export type ServiceTraceRefsFilter = {
   schemaHash?: Maybe<Scalars['String']>;
   /** Selects rows whose schemaTag dimension equals the given value if not null. To query for the null value, use {in: {schemaTag: [null]}} instead. */
   schemaTag?: Maybe<Scalars['String']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
   traceId?: Maybe<Scalars['ID']>;
 };
@@ -6373,8 +6177,6 @@ export type ServiceTraceRefsFilter = {
 export type ServiceTraceRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6387,8 +6189,6 @@ export type ServiceTraceRefsFilterIn = {
   schemaHash?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose schemaTag dimension is in the given list. A null value in the list means a row with null for that dimension. */
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
@@ -6457,10 +6257,10 @@ export type SourceLocation = {
 export type StatsWindow = {
   __typename?: 'StatsWindow';
   edgeServerInfos: Array<EdgeServerInfosRecord>;
-  enumStats: Array<EnumStatsRecord>;
   errorStats: Array<ErrorStatsRecord>;
-  fieldStats: Array<FieldStatsRecord>;
-  inputStats: Array<InputStatsRecord>;
+  fieldLatencies: Array<FieldLatenciesRecord>;
+  fieldUsage: Array<FieldUsageRecord>;
+  operationCheckStats: Array<OperationCheckStatsRecord>;
   queryStats: Array<QueryStatsRecord>;
   /** From field rounded down to the nearest resolution. */
   roundedDownFrom: Scalars['Timestamp'];
@@ -6480,14 +6280,6 @@ export type StatsWindowEdgeServerInfosArgs = {
 
 
 /** A time window with a specified granularity. */
-export type StatsWindowEnumStatsArgs = {
-  filter?: Maybe<EnumStatsFilter>;
-  limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<EnumStatsOrderBySpec>>;
-};
-
-
-/** A time window with a specified granularity. */
 export type StatsWindowErrorStatsArgs = {
   filter?: Maybe<ErrorStatsFilter>;
   limit?: Maybe<Scalars['Int']>;
@@ -6496,18 +6288,26 @@ export type StatsWindowErrorStatsArgs = {
 
 
 /** A time window with a specified granularity. */
-export type StatsWindowFieldStatsArgs = {
-  filter?: Maybe<FieldStatsFilter>;
+export type StatsWindowFieldLatenciesArgs = {
+  filter?: Maybe<FieldLatenciesFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<FieldStatsOrderBySpec>>;
+  orderBy?: Maybe<Array<FieldLatenciesOrderBySpec>>;
 };
 
 
 /** A time window with a specified granularity. */
-export type StatsWindowInputStatsArgs = {
-  filter?: Maybe<InputStatsFilter>;
+export type StatsWindowFieldUsageArgs = {
+  filter?: Maybe<FieldUsageFilter>;
   limit?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Array<InputStatsOrderBySpec>>;
+  orderBy?: Maybe<Array<FieldUsageOrderBySpec>>;
+};
+
+
+/** A time window with a specified granularity. */
+export type StatsWindowOperationCheckStatsArgs = {
+  filter?: Maybe<OperationCheckStatsFilter>;
+  limit?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<Array<OperationCheckStatsOrderBySpec>>;
 };
 
 
@@ -6550,16 +6350,15 @@ export type StoreSchemaResponse = {
   sha256: Scalars['SHA256'];
 };
 
-export type StoreSchemaResponseOrError = StoreSchemaResponse | StoreSchemaError;
+export type StoreSchemaResponseOrError = StoreSchemaError | StoreSchemaResponse;
 
 export type StoredApprovedChange = {
   __typename?: 'StoredApprovedChange';
+  argNode?: Maybe<NamedIntrospectionArgNoDescription>;
+  childNode?: Maybe<NamedIntrospectionValueNoDescription>;
   code: ChangeCode;
   parentNode?: Maybe<NamedIntrospectionTypeNoDescription>;
-  childNode?: Maybe<NamedIntrospectionValueNoDescription>;
-  argNode?: Maybe<NamedIntrospectionArgNoDescription>;
 };
-
 
 export type StringToString = {
   __typename?: 'StringToString';
@@ -6579,12 +6378,24 @@ export type Subgraph = {
   routingURL: Scalars['String'];
 };
 
+export type SubgraphChange = {
+  __typename?: 'SubgraphChange';
+  name: Scalars['ID'];
+  type: SubgraphChangeType;
+};
+
+export enum SubgraphChangeType {
+  Addition = 'ADDITION',
+  Deletion = 'DELETION',
+  Modification = 'MODIFICATION'
+}
+
 export type SubgraphConfig = {
   __typename?: 'SubgraphConfig';
+  id: Scalars['ID'];
+  name: Scalars['String'];
   schemaHash: Scalars['String'];
   sdl: Scalars['String'];
-  name: Scalars['String'];
-  id: Scalars['ID'];
   url: Scalars['String'];
 };
 
@@ -6636,7 +6447,6 @@ export enum TicketStatus {
   Solved = 'SOLVED'
 }
 
-
 export type TimezoneOffset = {
   __typename?: 'TimezoneOffset';
   minutesOffsetFromUTC: Scalars['Int'];
@@ -6651,20 +6461,20 @@ export type TotalChangeSummaryCounts = {
    * adding arguments.
    */
   additions: Scalars['Int'];
-  /**
-   * Number of changes that are removals. This includes removing types, removing fields from object,
-   * input object, and interface types, removing values from enums, removing members from interfaces
-   * and unions, and removing arguments. This also includes removing @deprecated usages.
-   */
-  removals: Scalars['Int'];
+  /** Number of changes that are new usages of the @deprecated directive. */
+  deprecations: Scalars['Int'];
   /**
    * Number of changes that are edits. This includes types changing kind, fields and arguments
    * changing type, arguments changing default value, and any description changes. This also includes
    * edits to @deprecated reason strings.
    */
   edits: Scalars['Int'];
-  /** Number of changes that are new usages of the @deprecated directive. */
-  deprecations: Scalars['Int'];
+  /**
+   * Number of changes that are removals. This includes removing types, removing fields from object,
+   * input object, and interface types, removing values from enums, removing members from interfaces
+   * and unions, and removing arguments. This also includes removing @deprecated usages.
+   */
+  removals: Scalars['Int'];
 };
 
 export type Trace = {
@@ -6672,7 +6482,6 @@ export type Trace = {
   cacheMaxAgeMs?: Maybe<Scalars['Float']>;
   cacheScope?: Maybe<CacheScope>;
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationMs: Scalars['Float'];
   endTime: Scalars['Timestamp'];
@@ -6730,7 +6539,6 @@ export type TraceNode = {
 /** Columns of TracePathErrorsRefs. */
 export enum TracePathErrorsRefsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   DurationBucket = 'DURATION_BUCKET',
   ErrorsCountInPath = 'ERRORS_COUNT_IN_PATH',
@@ -6742,7 +6550,6 @@ export enum TracePathErrorsRefsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   TraceHttpStatusCode = 'TRACE_HTTP_STATUS_CODE',
   TraceId = 'TRACE_ID',
@@ -6753,7 +6560,6 @@ export enum TracePathErrorsRefsColumn {
 export type TracePathErrorsRefsDimensions = {
   __typename?: 'TracePathErrorsRefsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationBucket?: Maybe<Scalars['Int']>;
   errorMessage?: Maybe<Scalars['String']>;
@@ -6764,7 +6570,6 @@ export type TracePathErrorsRefsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
   traceHttpStatusCode?: Maybe<Scalars['Int']>;
   traceId?: Maybe<Scalars['ID']>;
   traceStartsAt?: Maybe<Scalars['Timestamp']>;
@@ -6775,8 +6580,6 @@ export type TracePathErrorsRefsFilter = {
   and?: Maybe<Array<TracePathErrorsRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
@@ -6798,8 +6601,6 @@ export type TracePathErrorsRefsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose traceHttpStatusCode dimension equals the given value if not null. To query for the null value, use {in: {traceHttpStatusCode: [null]}} instead. */
   traceHttpStatusCode?: Maybe<Scalars['Int']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
@@ -6810,8 +6611,6 @@ export type TracePathErrorsRefsFilter = {
 export type TracePathErrorsRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6830,8 +6629,6 @@ export type TracePathErrorsRefsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceHttpStatusCode dimension is in the given list. A null value in the list means a row with null for that dimension. */
   traceHttpStatusCode?: Maybe<Array<Maybe<Scalars['Int']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6863,7 +6660,6 @@ export type TracePathErrorsRefsRecord = {
 /** Columns of TraceRefs. */
 export enum TraceRefsColumn {
   ClientName = 'CLIENT_NAME',
-  ClientReferenceId = 'CLIENT_REFERENCE_ID',
   ClientVersion = 'CLIENT_VERSION',
   DurationBucket = 'DURATION_BUCKET',
   DurationNs = 'DURATION_NS',
@@ -6872,7 +6668,6 @@ export enum TraceRefsColumn {
   SchemaHash = 'SCHEMA_HASH',
   SchemaTag = 'SCHEMA_TAG',
   ServiceId = 'SERVICE_ID',
-  ServiceVersion = 'SERVICE_VERSION',
   Timestamp = 'TIMESTAMP',
   TraceId = 'TRACE_ID',
   TraceSizeBytes = 'TRACE_SIZE_BYTES'
@@ -6881,7 +6676,6 @@ export enum TraceRefsColumn {
 export type TraceRefsDimensions = {
   __typename?: 'TraceRefsDimensions';
   clientName?: Maybe<Scalars['String']>;
-  clientReferenceId?: Maybe<Scalars['ID']>;
   clientVersion?: Maybe<Scalars['String']>;
   durationBucket?: Maybe<Scalars['Int']>;
   queryId?: Maybe<Scalars['ID']>;
@@ -6890,7 +6684,6 @@ export type TraceRefsDimensions = {
   schemaHash?: Maybe<Scalars['String']>;
   schemaTag?: Maybe<Scalars['String']>;
   serviceId?: Maybe<Scalars['ID']>;
-  serviceVersion?: Maybe<Scalars['String']>;
   traceId?: Maybe<Scalars['ID']>;
 };
 
@@ -6899,8 +6692,6 @@ export type TraceRefsFilter = {
   and?: Maybe<Array<TraceRefsFilter>>;
   /** Selects rows whose clientName dimension equals the given value if not null. To query for the null value, use {in: {clientName: [null]}} instead. */
   clientName?: Maybe<Scalars['String']>;
-  /** Selects rows whose clientReferenceId dimension equals the given value if not null. To query for the null value, use {in: {clientReferenceId: [null]}} instead. */
-  clientReferenceId?: Maybe<Scalars['ID']>;
   /** Selects rows whose clientVersion dimension equals the given value if not null. To query for the null value, use {in: {clientVersion: [null]}} instead. */
   clientVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose durationBucket dimension equals the given value if not null. To query for the null value, use {in: {durationBucket: [null]}} instead. */
@@ -6918,8 +6709,6 @@ export type TraceRefsFilter = {
   schemaTag?: Maybe<Scalars['String']>;
   /** Selects rows whose serviceId dimension equals the given value if not null. To query for the null value, use {in: {serviceId: [null]}} instead. */
   serviceId?: Maybe<Scalars['ID']>;
-  /** Selects rows whose serviceVersion dimension equals the given value if not null. To query for the null value, use {in: {serviceVersion: [null]}} instead. */
-  serviceVersion?: Maybe<Scalars['String']>;
   /** Selects rows whose traceId dimension equals the given value if not null. To query for the null value, use {in: {traceId: [null]}} instead. */
   traceId?: Maybe<Scalars['ID']>;
 };
@@ -6928,8 +6717,6 @@ export type TraceRefsFilter = {
 export type TraceRefsFilterIn = {
   /** Selects rows whose clientName dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientName?: Maybe<Array<Maybe<Scalars['String']>>>;
-  /** Selects rows whose clientReferenceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  clientReferenceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
   /** Selects rows whose clientVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
   clientVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose durationBucket dimension is in the given list. A null value in the list means a row with null for that dimension. */
@@ -6944,8 +6731,6 @@ export type TraceRefsFilterIn = {
   schemaTag?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose serviceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   serviceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  /** Selects rows whose serviceVersion dimension is in the given list. A null value in the list means a row with null for that dimension. */
-  serviceVersion?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Selects rows whose traceId dimension is in the given list. A null value in the list means a row with null for that dimension. */
   traceId?: Maybe<Array<Maybe<Scalars['ID']>>>;
 };
@@ -6981,14 +6766,14 @@ export type TypeChangeSummaryCounts = {
   __typename?: 'TypeChangeSummaryCounts';
   /** Number of changes that are additions of types. */
   additions: Scalars['Int'];
-  /** Number of changes that are removals of types. */
-  removals: Scalars['Int'];
   /**
    * Number of changes that are edits. This includes types changing kind and any type description
    * changes, but also includes adding/removing values from enums, adding/removing members from
    * interfaces and unions, and any enum value deprecation and description changes.
    */
   edits: Scalars['Int'];
+  /** Number of changes that are removals of types. */
+  removals: Scalars['Int'];
 };
 
 /**
@@ -7022,8 +6807,8 @@ export type UnignoreOperationsInChecksResult = {
 export type UploadSchemaMutationResponse = {
   __typename?: 'UploadSchemaMutationResponse';
   code: Scalars['String'];
-  success: Scalars['Boolean'];
   message: Scalars['String'];
+  success: Scalars['Boolean'];
   tag?: Maybe<SchemaTag>;
 };
 
@@ -7057,6 +6842,7 @@ export type User = Identity & {
   email?: Maybe<Scalars['String']>;
   emailModifiedAt?: Maybe<Scalars['Timestamp']>;
   emailVerified: Scalars['Boolean'];
+  experimentalFeatures: UserExperimentalFeatures;
   featureIntros?: Maybe<FeatureIntros>;
   fullName: Scalars['String'];
   /** The user's GitHub username, if they log in via GitHub. May be null even for GitHub users in some edge cases. */
@@ -7072,13 +6858,12 @@ export type User = Identity & {
   logoutAfterIdleMs?: Maybe<Scalars['Int']>;
   memberships: Array<UserMembership>;
   name: Scalars['String'];
+  odysseyCourses: Array<OdysseyCourse>;
+  odysseyTasks: Array<OdysseyTask>;
   synchronized: Scalars['Boolean'];
   /** List of Zendesk tickets this user has submitted */
   tickets?: Maybe<Array<ZendeskTicket>>;
   type: UserType;
-  odysseyTasks: Array<OdysseyTask>;
-  odysseyCourses: Array<OdysseyCourse>;
-  experimentalFeatures: UserExperimentalFeatures;
 };
 
 
@@ -7093,6 +6878,7 @@ export type UserAvatarUrlArgs = {
 
 export type UserApiKey = ApiKey & {
   __typename?: 'UserApiKey';
+  id: Scalars['ID'];
   keyName?: Maybe<Scalars['String']>;
   token: Scalars['String'];
 };
@@ -7115,6 +6901,8 @@ export type UserMutation = {
   acceptPrivacyPolicy?: Maybe<Scalars['Void']>;
   /** Change the user's password */
   changePassword?: Maybe<Scalars['Void']>;
+  createOdysseyCourses?: Maybe<Array<OdysseyCourse>>;
+  createOdysseyTasks?: Maybe<Array<OdysseyTask>>;
   /** Delete the user's avatar. Requires User.canUpdateAvatar to be true. */
   deleteAvatar?: Maybe<AvatarDeleteError>;
   /** Hard deletes the associated user. Throws an error otherwise with reason included. */
@@ -7131,8 +6919,10 @@ export type UserMutation = {
   /** Removes the given key from this user. Can be used to remove either a web cookie or a user API key. */
   removeKey?: Maybe<Scalars['Void']>;
   /** Renames the given key to the new key name. */
-  renameKey: UserApiKey;
+  renameKey?: Maybe<UserApiKey>;
   resendVerificationEmail?: Maybe<Scalars['Void']>;
+  setOdysseyCourse?: Maybe<OdysseyCourse>;
+  setOdysseyTask?: Maybe<OdysseyTask>;
   /** Submit a zendesk ticket for this user */
   submitZendeskTicket?: Maybe<ZendeskTicket>;
   /** Update information about a user; all arguments are optional */
@@ -7150,16 +6940,22 @@ export type UserMutation = {
   updateRole?: Maybe<User>;
   user: User;
   verifyEmail?: Maybe<User>;
-  setOdysseyTask?: Maybe<OdysseyTask>;
-  createOdysseyTasks?: Maybe<Array<OdysseyTask>>;
-  setOdysseyCourse?: Maybe<OdysseyCourse>;
-  createOdysseyCourses?: Maybe<Array<OdysseyCourse>>;
 };
 
 
 export type UserMutationChangePasswordArgs = {
   newPassword: Scalars['String'];
   previousPassword: Scalars['String'];
+};
+
+
+export type UserMutationCreateOdysseyCoursesArgs = {
+  courses: Array<OdysseyCourseInput>;
+};
+
+
+export type UserMutationCreateOdysseyTasksArgs = {
+  tasks: Array<OdysseyTaskInput>;
 };
 
 
@@ -7174,13 +6970,23 @@ export type UserMutationProvisionKeyArgs = {
 
 
 export type UserMutationRemoveKeyArgs = {
-  key: Scalars['String'];
+  id: Scalars['ID'];
 };
 
 
 export type UserMutationRenameKeyArgs = {
-  key: Scalars['String'];
-  newKeyName: Scalars['String'];
+  id: Scalars['ID'];
+  newKeyName?: Maybe<Scalars['String']>;
+};
+
+
+export type UserMutationSetOdysseyCourseArgs = {
+  course: OdysseyCourseInput;
+};
+
+
+export type UserMutationSetOdysseyTaskArgs = {
+  task: OdysseyTaskInput;
 };
 
 
@@ -7221,26 +7027,6 @@ export type UserMutationUpdateRoleArgs = {
 
 export type UserMutationVerifyEmailArgs = {
   token: Scalars['String'];
-};
-
-
-export type UserMutationSetOdysseyTaskArgs = {
-  task: OdysseyTaskInput;
-};
-
-
-export type UserMutationCreateOdysseyTasksArgs = {
-  tasks: Array<OdysseyTaskInput>;
-};
-
-
-export type UserMutationSetOdysseyCourseArgs = {
-  course: OdysseyCourseInput;
-};
-
-
-export type UserMutationCreateOdysseyCoursesArgs = {
-  courses: Array<OdysseyCourseInput>;
 };
 
 export enum UserPermission {
@@ -7297,15 +7083,15 @@ export type ValidateOperationsResult = {
 };
 
 export enum ValidationErrorCode {
-  NonParseableDocument = 'NON_PARSEABLE_DOCUMENT',
+  DeprecatedField = 'DEPRECATED_FIELD',
   InvalidOperation = 'INVALID_OPERATION',
-  DeprecatedField = 'DEPRECATED_FIELD'
+  NonParseableDocument = 'NON_PARSEABLE_DOCUMENT'
 }
 
 export enum ValidationErrorType {
   Failure = 'FAILURE',
-  Warning = 'WARNING',
-  Invalid = 'INVALID'
+  Invalid = 'INVALID',
+  Warning = 'WARNING'
 }
 
 /**
@@ -7314,16 +7100,15 @@ export enum ValidationErrorType {
  */
 export type ValidationResult = {
   __typename?: 'ValidationResult';
-  /** The type of validation error thrown - warning, failure, or invalid. */
-  type: ValidationErrorType;
   /** The validation result's error code */
   code: ValidationErrorCode;
   /** Description of the validation error */
   description: Scalars['String'];
   /** The operation related to this validation result */
   operation: OperationDocument;
+  /** The type of validation error thrown - warning, failure, or invalid. */
+  type: ValidationErrorType;
 };
-
 
 /** Webhook notification channel */
 export type WebhookChannel = Channel & {
@@ -7370,4 +7155,4 @@ export type SchemaReportMutationVariables = Exact<{
 }>;
 
 
-export type SchemaReportMutation = { __typename?: 'Mutation', reportSchema?: Maybe<{ __typename: 'ReportSchemaError', message: string, code: ReportSchemaErrorCode } | { __typename: 'ReportSchemaResponse', inSeconds: number, withCoreSchema: boolean }> };
+export type SchemaReportMutation = { __typename?: 'Mutation', reportSchema?: { __typename: 'ReportSchemaError', message: string, code: ReportSchemaErrorCode } | { __typename: 'ReportSchemaResponse', inSeconds: number, withCoreSchema: boolean } | null | undefined };

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/__snapshots__/stats.test.ts.snap
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/__snapshots__/stats.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`Check query latency stats when adding a forbidden trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -339,7 +338,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a fully cached trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -675,7 +673,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a persisted hit trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -1011,7 +1008,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a persisted miss trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -1347,7 +1343,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a private cached trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -1683,7 +1678,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a public cached trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -2019,7 +2013,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a registered trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -2355,7 +2348,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding a single trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -2691,7 +2683,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when adding an errored trace  1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -3033,7 +3024,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when merging errored traces 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -3392,7 +3382,6 @@ OurContextualizedStats {
 exports[`Check query latency stats when merging non-errored traces 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {},
@@ -3728,7 +3717,6 @@ OurContextualizedStats {
 exports[`Check type stats add multiple errored traces trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {
@@ -4337,7 +4325,6 @@ OurContextualizedStats {
 exports[`Check type stats add multiple federated trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {
@@ -4934,7 +4921,6 @@ OurContextualizedStats {
 exports[`Check type stats add multiple non-federated trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {
@@ -5531,7 +5517,6 @@ OurContextualizedStats {
 exports[`Check type stats add single non-federated trace 1`] = `
 OurContextualizedStats {
   "context": Object {
-    "clientReferenceId": "reference",
     "clientVersion": "version",
   },
   "perTypeStat": Object {

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/stats.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/stats.test.ts
@@ -4,7 +4,6 @@ import { OurContextualizedStats, SizeEstimator } from '../stats';
 import { DurationHistogram } from '../durationHistogram';
 
 const statsContext = {
-  clientReferenceId: 'reference',
   clientVersion: 'version',
 };
 

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -248,7 +248,6 @@ export type VariableValueOptions =
 export interface ClientInfo {
   clientName?: string;
   clientVersion?: string;
-  clientReferenceId?: string;
 }
 export type GenerateClientInfo<TContext> = (
   requestContext: GraphQLRequestContext<TContext>,

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -456,12 +456,8 @@ export function ApolloServerPluginUsageReporting<TContext>(
             if (clientInfo) {
               // While there is a clientAddress protobuf field, the backend
               // doesn't pay attention to it yet, so we'll ignore it for now.
-              const { clientName, clientVersion, clientReferenceId } =
-                clientInfo;
-              // the backend makes the choice of mapping clientName => clientReferenceId if
-              // no custom reference id is provided
+              const { clientName, clientVersion } = clientInfo;
               treeBuilder.trace.clientVersion = clientVersion || '';
-              treeBuilder.trace.clientReferenceId = clientReferenceId || '';
               treeBuilder.trace.clientName = clientName || '';
             }
           },
@@ -708,7 +704,6 @@ export function makeHTTPRequestHeaders(
 
 function defaultGenerateClientInfo({ request }: GraphQLRequestContext) {
   const clientNameHeaderKey = 'apollographql-client-name';
-  const clientReferenceIdHeaderKey = 'apollographql-client-reference-id';
   const clientVersionHeaderKey = 'apollographql-client-version';
 
   // Default to using the `apollo-client-x` header fields if present.
@@ -718,13 +713,11 @@ function defaultGenerateClientInfo({ request }: GraphQLRequestContext) {
   // set is the empty String for all fields (as per protobuf defaults)
   if (
     request.http?.headers?.get(clientNameHeaderKey) ||
-    request.http?.headers?.get(clientVersionHeaderKey) ||
-    request.http?.headers?.get(clientReferenceIdHeaderKey)
+    request.http?.headers?.get(clientVersionHeaderKey)
   ) {
     return {
       clientName: request.http?.headers?.get(clientNameHeaderKey),
       clientVersion: request.http?.headers?.get(clientVersionHeaderKey),
-      clientReferenceId: request.http?.headers?.get(clientReferenceIdHeaderKey),
     };
   } else if (request.extensions?.clientInfo) {
     return request.extensions.clientInfo;

--- a/packages/apollo-server-core/src/plugin/usageReporting/stats.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/stats.ts
@@ -121,7 +121,6 @@ class StatsByContext {
     const statsContext: IStatsContext = {
       clientName: trace.clientName,
       clientVersion: trace.clientVersion,
-      clientReferenceId: trace.clientReferenceId,
     };
     const statsContextKey = JSON.stringify(statsContext);
 
@@ -135,8 +134,7 @@ class StatsByContext {
     sizeEstimator.bytes +=
       20 +
       estimatedBytesForString(trace.clientName) +
-      estimatedBytesForString(trace.clientVersion) +
-      estimatedBytesForString(trace.clientReferenceId);
+      estimatedBytesForString(trace.clientVersion);
     const contextualizedStats = new OurContextualizedStats(statsContext);
     this.map[statsContextKey] = contextualizedStats;
     return contextualizedStats;


### PR DESCRIPTION
See CHANGELOG for more details.

Also rerun GraphQL codegen (to reduce the number of instances of
"clientReferenceId" in the repo).
