### PR TITLE
Fix a corner case for Fastify with both path and prefix defined for the app

### DIFF
--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -158,7 +158,7 @@ export class ApolloServer<
           });
         },
         {
-          prefix: this.graphqlPath,
+          prefix: this.graphqlPath === '/' ? undefined : this.graphqlPath,
         },
       );
     };


### PR DESCRIPTION
`apollo-server-fastify` currently uses `path` property of `server.createHandler()` options as a prefix for registering a Fastify route.
So the problem occurs if one uses `/` as the `path` and uses a prefix in addition.
Let's say the server is registered like this:
```
const app = fastify();
const server = new ApolloServer({ ... });
app.register(server.createHandler({path: '/'}), { prefix: '/prefix' });
```

Then only requests with a **trailing slash** in the URL would work (e.g. `https://host.com/prefix/`), but `https://host.com/prefix` would not.

I stumbled upon this issue while solving a real-world production use case.
We needed to serve GLQ both from the root (`/`) and prefixed paths (`/my-prefix`).

So we tried to just register the handler with a prefix:
```
const handler = server.createHandler({ path: '/' });
app.register(handler);
app.register(handler, { prefix: '/my-prefix' });
```

Surprisingly, the second route didn't work without the trailing slash.

Of course, there are other ways of solving this (reverse proxy redirects, Fasify's URL rewrites, separate apps or instances, etc) - but this way also seemed legit and the behaviour felt wrong, thus this PR :)

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
