### PR TITLE
docs: clarify wording around playground

### DIFF
--- a/docs/source/testing/build-run-queries.mdx
+++ b/docs/source/testing/build-run-queries.mdx
@@ -63,7 +63,7 @@ For all available configuration options for these plugins, [see the API referenc
 
 ### GraphQL Playground
 
-> **Note:** The GraphQL Playground project is [retired](https://github.com/graphql/graphql-playground/issues/1143) in favor of GraphiQL. This functionality is provided to help developers migrating from Apollo Server 2.
+> **Note:** The GraphQL Playground project has been [retired](https://github.com/graphql/graphql-playground/issues/1143). Apollo Server provides an integration with GraphQL Playground to help developers migrate from Apollo Server 2 with as few changes as possible, but we do not recommend long-term use of this unmaintained project.
 
  The previous version of Apollo Server (v2) serves GraphQL Playground from its base URL:
 


### PR DESCRIPTION
See https://github.com/apollographql/apollo-server/issues/5341#issuecomment-973148345 — the previous wording could imply that we were actively recommending migration to GraphiQL (which isn't simple as we do not know of a landing page plugin for GraphiQL yet).
