### PR TITLE
CI: Test against NodeJS 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,12 @@ jobs:
     steps:
       - common_test_steps
 
+  NodeJS 17:
+    docker:
+    - image: cimg/node:17.2.0
+    steps:
+      - common_test_steps
+
   Prettier:
     docker:
     - image: cimg/node:16.10.0
@@ -127,6 +133,8 @@ workflows:
           <<: *common_non_publish_filters
       - NodeJS 16:
           <<: *common_non_publish_filters
+      - NodeJS 17:
+          <<: *common_non_publish_filters
       - "Check for FIXM\x45"
       - Prettier
       - oss/lerna_tarballs:
@@ -136,6 +144,7 @@ workflows:
             - NodeJS 12
             - NodeJS 14
             - NodeJS 16
+            - NodeJS 17
             - Prettier
       - oss/dry_run:
           name: Dry-run
@@ -144,6 +153,7 @@ workflows:
             - NodeJS 12
             - NodeJS 14
             - NodeJS 16
+            - NodeJS 17
             - Prettier
       - oss/confirmation:
           name: Confirmation


### PR DESCRIPTION
Node 17 has been the "Current" (though not LTS) release for a couple of
months. CI appears to pass against it, so let's keep it that way!
