### PR TITLE
apollo-server-core: copy signature tests left out of #5955

### DIFF
--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/__snapshots__/defaultUsageReportingSignature.test.ts.snap
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/__snapshots__/defaultUsageReportingSignature.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`defaultUsageReportingSignature basic test 1`] = `"{user{name}}"`;
+
+exports[`defaultUsageReportingSignature basic test with query 1`] = `"{user{name}}"`;
+
+exports[`defaultUsageReportingSignature basic with operation name 1`] = `"query OpName{user{name}}"`;
+
+exports[`defaultUsageReportingSignature fragment 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+
+exports[`defaultUsageReportingSignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+
+exports[`defaultUsageReportingSignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){name tz...Bar...on User{bee hello}}}"`;
+
+exports[`defaultUsageReportingSignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
+
+exports[`defaultUsageReportingSignature with various inline types 1`] = `"query OpName{user{name(apple:[],bag:{},cat:ENUM_VALUE)}}"`;

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/defaultUsageReportingSignature.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/defaultUsageReportingSignature.test.ts
@@ -1,0 +1,144 @@
+import { default as gql, disableFragmentWarnings } from 'graphql-tag';
+import { defaultUsageReportingSignature } from '../defaultUsageReportingSignature';
+
+// The gql duplicate fragment warning feature really is just warnings; nothing
+// breaks if you turn it off in tests.
+disableFragmentWarnings();
+
+describe('defaultUsageReportingSignature', () => {
+  const cases = [
+    // Test cases borrowed from optics-agent-js.
+    {
+      name: 'basic test',
+      operationName: '',
+      input: gql`
+        {
+          user {
+            name
+          }
+        }
+      `,
+    },
+    {
+      name: 'basic test with query',
+      operationName: '',
+      input: gql`
+        query {
+          user {
+            name
+          }
+        }
+      `,
+    },
+    {
+      name: 'basic with operation name',
+      operationName: 'OpName',
+      input: gql`
+        query OpName {
+          user {
+            name
+          }
+        }
+      `,
+    },
+    {
+      name: 'with various inline types',
+      operationName: 'OpName',
+      input: gql`
+        query OpName {
+          user {
+            name(apple: [[10]], cat: ENUM_VALUE, bag: { input: "value" })
+          }
+        }
+      `,
+    },
+    {
+      name: 'with various argument types',
+      operationName: 'OpName',
+      input: gql`
+        query OpName($c: Int!, $a: [[Boolean!]!], $b: EnumType) {
+          user {
+            name(apple: $a, cat: $c, bag: $b)
+          }
+        }
+      `,
+    },
+    {
+      name: 'fragment',
+      operationName: '',
+      input: gql`
+        {
+          user {
+            name
+            ...Bar
+          }
+        }
+
+        fragment Bar on User {
+          asd
+        }
+
+        fragment Baz on User {
+          jkl
+        }
+      `,
+    },
+    {
+      name: 'fragments in various order',
+      operationName: '',
+      input: gql`
+        fragment Bar on User {
+          asd
+        }
+
+        {
+          user {
+            name
+            ...Bar
+          }
+        }
+
+        fragment Baz on User {
+          jkl
+        }
+      `,
+    },
+    {
+      name: 'full test',
+      operationName: 'Foo',
+      input: gql`
+        query Foo($b: Int, $a: Boolean) {
+          user(name: "hello", age: 5) {
+            ...Bar
+            ... on User {
+              hello
+              bee
+            }
+            tz
+            aliased: name
+          }
+        }
+
+        fragment Baz on User {
+          asd
+        }
+
+        fragment Bar on User {
+          age @skip(if: $a)
+          ...Nested
+        }
+
+        fragment Nested on User {
+          blah
+        }
+      `,
+    },
+  ];
+  cases.forEach(({ name, operationName, input }) => {
+    test(name, () => {
+      expect(
+        defaultUsageReportingSignature(input, operationName),
+      ).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
In #5955 we inlined defaultUsageReportingSignature into
apollo-server-core from apollo-graphql but left its tests behind. This
brings the tests over too. The tests themselves including snapshots are
verbatim from apollo-graphql.
