### PR TITLE
Fix grammar error

### DIFF
--- a/docs/source/security/authentication.md
+++ b/docs/source/security/authentication.md
@@ -126,9 +126,9 @@ For example, a model file for `User` would include all the logic for operating o
 
 ```js
 export const User = {
- getAll: () => { /* fetching/transform logic for all users */ },
- getById: (id) => { /* fetching/transform logic for a single user */ },
- getByGroupId: (id) => { /* fetching/transform logic for a group of users */ },
+ getAll: () => { /* fetching/transformation logic for all users */ },
+ getById: (id) => { /* fetching/transformation logic for a single user */ },
+ getByGroupId: (id) => { /* fetching/transformation logic for a group of users */ },
 };
 ```
 


### PR DESCRIPTION
I changed the verb "transform" to the noun "transformation" in the comments of [the data model authorization example](https://www.apollographql.com/docs/apollo-server/security/authentication/#in-data-models) as the noun is grammatically correct here.