### PR TITLE
apollo-server-core(usageReporting): remove reference to apollo-graphql

### DIFF
--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -1,7 +1,6 @@
 import os from 'os';
 import { gzip } from 'zlib';
 import retry from 'async-retry';
-import { defaultUsageReportingSignature } from 'apollo-graphql';
 import { Report, ReportHeader, Trace } from 'apollo-reporting-protobuf';
 import { Response, fetch, Headers } from 'apollo-server-env';
 import type {
@@ -20,6 +19,7 @@ import {
   OperationDerivedData,
   operationDerivedDataCacheKey,
 } from './operationDerivedDataCache';
+import { defaultUsageReportingSignature } from './defaultUsageReportingSignature';
 import type {
   ApolloServerPluginUsageReportingOptions,
   SendValuesBaseOptions,


### PR DESCRIPTION
Fixes #5980

Remove reference to now removed dependency `apollo-graphql` from usageReporting plugin, use inlined `defaultUsageReportingSignature` instead.