### PR TITLE
apollo-server-fastify: drop dependency on `fast-json-stringify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The version headers in this history reflect the versions of Apollo Server itself
 - [`@apollo/gateway`](https://github.com/apollographql/federation/blob/HEAD/gateway-js/CHANGELOG.md)
 - [`@apollo/federation`](https://github.com/apollographql/federation/blob/HEAD/federation-js/CHANGELOG.md)
 
+## vNEXT
+
+- `apollo-server-fastify`: Drop dependency on `fast-json-stringify`. [PR #5988](https://github.com/apollographql/apollo-server/pull/5988)
+
 ## v3.6.1
 
 - Correctly remove dependency on `apollo-graphql` as intended in v3.6.0. [Issue #5981](https://github.com/apollographql/apollo-server/issues/5981) [PR #5981](https://github.com/apollographql/apollo-server/pull/5981)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20983,7 +20983,6 @@
       "dependencies": {
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-types": "file:../apollo-server-types",
-        "fast-json-stringify": "^2.7.6",
         "fastify-accepts": "^2.0.1",
         "fastify-cors": "^6.0.0"
       },
@@ -26474,7 +26473,6 @@
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
         "apollo-server-types": "file:../apollo-server-types",
-        "fast-json-stringify": "^2.7.6",
         "fastify-accepts": "^2.0.1",
         "fastify-cors": "^6.0.0"
       }

--- a/packages/apollo-server-fastify/package.json
+++ b/packages/apollo-server-fastify/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-types": "file:../apollo-server-types",
-    "fast-json-stringify": "^2.7.6",
     "fastify-accepts": "^2.0.1",
     "fastify-cors": "^6.0.0"
   },

--- a/packages/apollo-server-fastify/src/ApolloServer.ts
+++ b/packages/apollo-server-fastify/src/ApolloServer.ts
@@ -9,7 +9,6 @@ import {
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import accepts from 'fastify-accepts';
 import fastifyCors from 'fastify-cors';
-import fastJson from 'fast-json-stringify';
 
 export interface ServerRegistration {
   path?: string;
@@ -24,15 +23,6 @@ export interface FastifyContext {
 }
 
 export type ApolloServerFastifyConfig = Config<FastifyContext>;
-
-const stringifyHealthCheck = fastJson({
-  type: 'object',
-  properties: {
-    status: {
-      type: 'string',
-    },
-  },
-});
 
 export class ApolloServer<
   ContextFunctionParams = FastifyContext,
@@ -66,12 +56,12 @@ export class ApolloServer<
           if (onHealthCheck) {
             try {
               await onHealthCheck(request);
-              reply.send(stringifyHealthCheck({ status: 'pass' }));
+              reply.send('{"status":"pass"}');
             } catch (e) {
-              reply.status(503).send(stringifyHealthCheck({ status: 'fail' }));
+              reply.status(503).send('{"status":"fail"}');
             }
           } else {
-            reply.send(stringifyHealthCheck({ status: 'pass' }));
+            reply.send('{"status":"pass"}');
           }
         });
       }


### PR DESCRIPTION
This package was being used only to stringify two small constant
objects. It has a major version update available and rather than
evaluate the CHANGELOG, we might as well just not use it.

(Honestly I think it would be fine to just use JSON.stringify here; I
don't see any justification in #1971 for why this particular use case
requires a faster stringification than all the other JSON
stringification we do in Apollo Server. But just in case this matters to
anybody, I went with the fastest possible way of converting a constant
object to string.)

This should replace #5985.
