### PR TITLE
docs: update migration advice around schemaDirectives

### DIFF
--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -347,11 +347,13 @@ Note that if you are using Studio, make sure to [set your graph ref or graph ID]
 
 ### `schemaDirectives`
 
-In Apollo Server 2, you can pass `schemaDirectives` to `new ApolloServer` alongside `typeDefs` and `resolvers`. These arguments are all passed through to the [`makeExecutableSchema` function](https://www.graphql-tools.com/docs/generate-schema/#makeexecutableschemaoptions)  from the `graphql-tools` package. `graphql-tools` now considers `schemaDirectives` to be a [legacy feature](https://www.graphql-tools.com/docs/legacy-schema-directives/).
+In Apollo Server 2, you can pass `schemaDirectives` to `new ApolloServer` alongside `typeDefs` and `resolvers`. These arguments are all passed through to the [`makeExecutableSchema` function](https://www.graphql-tools.com/docs/generate-schema/#makeexecutableschemaoptions)  from the `graphql-tools` package.
+
+The `graphql-tools` project deprecated the  [`schemaDirectives` feature](https://github.com/ardatan/graphql-tools/blob/%40graphql-tools/schema%407.1.5/website/docs/legacy-schema-directives.md) and removed it in v8 of `@graphql-tools/schema`.
 
 In Apollo Server 3, the `ApolloServer` constructor now only passes `typeDefs`, `resolvers`, and `parseOptions` through to `makeExecutableSchema`.
 
-To provide other arguments to `makeExecutableSchema` (such as `schemaDirectives` or its replacement `schemaTransforms`), you can call `makeExecutableSchema` yourself and pass its returned schema as the `schema` constructor option.
+If you would like to still use `schemaDirectives`, you can install an older version of `@graphql-tools/schema` yourself with `npm install @graphql-tools/schema@7` and call `makeExecutableSchema` yourself and pass its returned schema as the `schema` constructor option.
 
 That is, you can replace:
 
@@ -366,6 +368,7 @@ new ApolloServer({
 with:
 
 ```javascript
+// Make sure you are using v7, not anything newer!
 import { makeExecutableSchema } from '@graphql-tools/schema';
 
 new ApolloServer({
@@ -376,6 +379,8 @@ new ApolloServer({
   }),
 });
 ```
+
+This can help you with the initial migration to Apollo Server 3. As `schemaDirectives` is no longer part of the actively maintained version of `@graphql-tools/schema`, we recommend that once you've successfully migrated to Apollo Server 3, you then port your schema directive to the [newer schema directives API](https://www.graphql-tools.com/docs/schema-directives) which uses the `mapSchema` function in `@graphql-tools/utils`.
 
 > In Apollo Server 2, there are subtle differences between providing a schema with `schema` versus providing it with `typeDefs` and `resolvers`. For example, the automatic definition of the `@cacheControl` directive is added only in the latter case. These differences are removed in Apollo Server 3 (for example, the definition of the `@cacheControl` directive is _never_ automatically added).
 


### PR DESCRIPTION
We told folks who didn't want to update their schemaDirectives to use
graphql-tools directly, but graphql-tools has removed that old feature.
So now we should tell people to either pin an old version of
graphql-tools or rewrite to the new mapSchema API.

Fixes #5996.
