### PR TITLE
usage reporting: switch to stripIgnoredCharacters

### DIFF
--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/__snapshots__/defaultUsageReportingSignature.test.ts.snap
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/__snapshots__/defaultUsageReportingSignature.test.ts.snap
@@ -6,12 +6,14 @@ exports[`defaultUsageReportingSignature basic test with query 1`] = `"{user{name
 
 exports[`defaultUsageReportingSignature basic with operation name 1`] = `"query OpName{user{name}}"`;
 
-exports[`defaultUsageReportingSignature fragment 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+exports[`defaultUsageReportingSignature block strings convert to normal (empty) strings 1`] = `"{foo(str:\\"\\")}"`;
 
-exports[`defaultUsageReportingSignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name...Bar}}"`;
+exports[`defaultUsageReportingSignature fragment 1`] = `"fragment Bar on User{asd}{user{name ...Bar}}"`;
 
-exports[`defaultUsageReportingSignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean,$b:Int){user(age:0,name:\\"\\"){name tz...Bar...on User{bee hello}}}"`;
+exports[`defaultUsageReportingSignature fragments in various order 1`] = `"fragment Bar on User{asd}{user{name ...Bar}}"`;
 
-exports[`defaultUsageReportingSignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!],$b:EnumType,$c:Int!){user{name(apple:$a,bag:$b,cat:$c)}}"`;
+exports[`defaultUsageReportingSignature full test 1`] = `"fragment Bar on User{age@skip(if:$a)...Nested}fragment Nested on User{blah}query Foo($a:Boolean$b:Int){user(age:0 name:\\"\\"){name tz ...Bar ...on User{bee hello}}}"`;
 
-exports[`defaultUsageReportingSignature with various inline types 1`] = `"query OpName{user{name(apple:[],bag:{},cat:ENUM_VALUE)}}"`;
+exports[`defaultUsageReportingSignature with various argument types 1`] = `"query OpName($a:[[Boolean!]!]$b:EnumType$c:Int!){user{name(apple:$a bag:$b cat:$c)}}"`;
+
+exports[`defaultUsageReportingSignature with various inline types 1`] = `"query OpName{user{name(apple:[]bag:{}cat:ENUM_VALUE)}}"`;

--- a/packages/apollo-server-core/src/plugin/usageReporting/__tests__/defaultUsageReportingSignature.test.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/__tests__/defaultUsageReportingSignature.test.ts
@@ -1,3 +1,4 @@
+import type { DocumentNode } from 'graphql';
 import { default as gql, disableFragmentWarnings } from 'graphql-tag';
 import { defaultUsageReportingSignature } from '../defaultUsageReportingSignature';
 
@@ -5,8 +6,10 @@ import { defaultUsageReportingSignature } from '../defaultUsageReportingSignatur
 // breaks if you turn it off in tests.
 disableFragmentWarnings();
 
+type TestCase = { name: string; operationName: string; input: DocumentNode };
+
 describe('defaultUsageReportingSignature', () => {
-  const cases = [
+  const cases: TestCase[] = [
     // Test cases borrowed from optics-agent-js.
     {
       name: 'basic test',
@@ -130,6 +133,22 @@ describe('defaultUsageReportingSignature', () => {
 
         fragment Nested on User {
           blah
+        }
+      `,
+    },
+    {
+      name: 'block strings convert to normal (empty) strings',
+      operationName: '',
+      input: gql`
+        query {
+          foo(
+            str: """
+            hello
+            world
+
+            hooray
+            """
+          )
         }
       `,
     },


### PR DESCRIPTION
The usage reporting signature algorithm wants to throw away whitespace
and other ignored characters. It currently does this via a hacky set of
regexp replacements.

This PR changes it to use stripIgnoredCharacters which has been in
graphql-js since v14.3.0.  stripIgnoredCharacters has straightforward spec-based
semantics; it consists of running the graphql-js lexer and outputting
non-ignored tokens with a few minor tweaks.

This does have slightly different output. Notably,
stripIgnoredCharacters strips commas, and it includes spaces before
`...` if the previous character is not punctuation. (That's because
otherwise the sequence of tokens `1 ...Foo` would turn into `1...Foo`
which is not valid for the lexer; while this sequence cannot exist in a
legally parsable document, it makes sense that stripIgnoredCharacters
would want to not break the lexer.)

The impact will be that when you upgrade to a version of Apollo Server
with this change, it will appear in Apollo Studio as if all of your
operations have changed even though there is no textual difference.
(Note that Studio already pretty-prints your signature before displaying
it to you which will add back commas where appropriate.)
