### PR TITLE
Testing Article Edit and Add Examples

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -599,6 +599,69 @@ The `start` method triggers the following actions:
 1. If your server is a [federated gateway](https://www.apollographql.com/docs/federation/managed-federation/overview/), it attempts to fetch its schema. If the fetch fails, `start` throws an error.
 2. Your server calls all of the [`serverWillStart` handlers](../integrations/plugins-event-reference/#serverwillstart) of your installed plugins. If any of these handlers throw an error, `start` throws an error.
 
+
+## `executeOperation`
+
+The async `executeOperation` method is used primarily for [testing GraphQL operations](../testing/#testing-using-executeoperation) through the server's request pipeline without going through a full HTTP operation.
+
+The `executeOperation` method takes two arguments: 
+* The first argument is a configuration options object
+* The second argument will be passed in to the current `ApolloServer` instance's `context` function
+
+Below are the available configuration options for the first argument of `executeOperation`:
+
+<table class="field-table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+
+<tbody>
+<tr class="required">
+<td>
+
+##### `query`
+
+`String` or `<DocumentNode>`
+</td>
+
+<td>
+
+The GraphQL operation to be run. Note you must use the `query` key even if the operation is a mutation. 
+</td>
+</tr>
+
+<tr>
+<td>
+
+##### `variables`
+
+`Object`
+</td>
+<td>
+
+You can optionally provide variables to be passed in as arguments to the `query`. 
+</td>
+</tr>
+
+<tr>
+<td>
+
+##### `operationName`
+
+`String`
+</td>
+<td>
+
+Optional, but if included the `operationName` must be present in the provided `query`.
+</td>
+</tr>
+
+</tbody>
+</table>
+
 ## `stop`
 
 `ApolloServer.stop()` is an async method that tells all of Apollo Server's background tasks to complete. Specifically, it:

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -600,68 +600,6 @@ The `start` method triggers the following actions:
 2. Your server calls all of the [`serverWillStart` handlers](../integrations/plugins-event-reference/#serverwillstart) of your installed plugins. If any of these handlers throw an error, `start` throws an error.
 
 
-## `executeOperation`
-
-The async `executeOperation` method is used primarily for [testing GraphQL operations](../testing/testing/#testing-using-executeoperation) through the server's request pipeline without going through a full HTTP operation.
-
-The `executeOperation` method takes two arguments:
-* The first argument is a configuration options object
-* The second argument will be passed in to the current `ApolloServer` instance's `context` function
-
-Below are the available configuration options for the first argument of `executeOperation`:
-
-<table class="field-table">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-
-<tbody>
-<tr class="required">
-<td>
-
-##### `query`
-
-`String` or `<DocumentNode>`
-</td>
-
-<td>
-
-The GraphQL operation to be run. Note you must use the `query` key even if the operation is a mutation.
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `variables`
-
-`Object`
-</td>
-<td>
-
-You can optionally provide variables to be passed in as arguments to the `query`.
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `operationName`
-
-`String`
-</td>
-<td>
-
-Optional, but if included the `operationName` must be present in the provided `query`.
-</td>
-</tr>
-
-</tbody>
-</table>
-
 ## `stop`
 
 `ApolloServer.stop()` is an async method that tells all of Apollo Server's background tasks to complete. Specifically, it:
@@ -680,6 +618,78 @@ Optional, but if included the `operationName` must be present in the provided `q
 This method takes no arguments. You should only call it after [`start()`](#start) returns successfully (or [`listen()`](#listen) if you're using the batteries-included `apollo-server` package).
 
 In some circumstances, Apollo Server calls `stop` automatically when the process receives a `SIGINT` or `SIGTERM` signal. See the [`stopOnTerminationSignals` constructor option](#stoponterminationsignals) for details.
+
+
+## `executeOperation`
+
+The async `executeOperation` method is used primarily for [testing GraphQL operations](../testing/testing/#testing-using-executeoperation) through Apollo Server's request pipeline _without_ sending an HTTP request.
+
+```js
+const result = await server.executeOperation({
+  query: 'query SayHelloWorld($name: String) { hello(name: $name) }',
+  variables: { name: 'world' },
+});
+```
+
+The `executeOperation` method takes two arguments:
+* The first argument is a configuration options object.
+  * Supported options are listed in the table below.
+* The second argument is passed to `ApolloServer`'s `context` function.
+  * This is helpful when [testing](../testing/testing/) that your server's `context` is correctly gathering the values needed from a request.
+
+Below are the available configuration options for the first argument of `executeOperation`:
+
+### Options
+<table class="field-table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+
+<tbody>
+<tr class="required">
+<td>
+
+##### `query`
+
+`string` or `DocumentNode`
+</td>
+
+<td>
+
+**Required**. The GraphQL operation to run. Note that you must use the `query` option even if the operation is a mutation.
+</td>
+</tr>
+
+<tr>
+<td>
+
+##### `variables`
+
+`object`
+</td>
+<td>
+An object containing any GraphQL variables to use as argument values for the executed operation.
+</td>
+</tr>
+
+<tr>
+<td>
+
+##### `operationName`
+
+`string`
+</td>
+<td>
+
+If `query` contains more than one operation definition, you must provide this option to indicate which operation to execute.
+</td>
+</tr>
+
+</tbody>
+</table>
 
 ## Framework-specific middleware function
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -602,9 +602,9 @@ The `start` method triggers the following actions:
 
 ## `executeOperation`
 
-The async `executeOperation` method is used primarily for [testing GraphQL operations](../testing/#testing-using-executeoperation) through the server's request pipeline without going through a full HTTP operation.
+The async `executeOperation` method is used primarily for [testing GraphQL operations](../testing/testing/#testing-using-executeoperation) through the server's request pipeline without going through a full HTTP operation.
 
-The `executeOperation` method takes two arguments: 
+The `executeOperation` method takes two arguments:
 * The first argument is a configuration options object
 * The second argument will be passed in to the current `ApolloServer` instance's `context` function
 
@@ -629,7 +629,7 @@ Below are the available configuration options for the first argument of `execute
 
 <td>
 
-The GraphQL operation to be run. Note you must use the `query` key even if the operation is a mutation. 
+The GraphQL operation to be run. Note you must use the `query` key even if the operation is a mutation.
 </td>
 </tr>
 
@@ -642,7 +642,7 @@ The GraphQL operation to be run. Note you must use the `query` key even if the o
 </td>
 <td>
 
-You can optionally provide variables to be passed in as arguments to the `query`. 
+You can optionally provide variables to be passed in as arguments to the `query`.
 </td>
 </tr>
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -632,7 +632,7 @@ const result = await server.executeOperation({
 ```
 
 The `executeOperation` method takes two arguments:
-* The first argument is an options object describing the GraphQL operation to be performed.
+* The first argument is an object describing the GraphQL operation to be executed.
   * Supported options are listed in the table below.
 * The second optional argument is passed to `ApolloServer`'s `context` function.
   * This is helpful when [testing](../testing/testing/) that your server's `context` is correctly gathering the values needed from a request.

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -632,9 +632,9 @@ const result = await server.executeOperation({
 ```
 
 The `executeOperation` method takes two arguments:
-* The first argument is a configuration options object.
+* The first argument is a configuration options object describing the GraphQL operation to be performed.
   * Supported options are listed in the table below.
-* The second argument is passed to `ApolloServer`'s `context` function.
+* The second optional argument is passed to `ApolloServer`'s `context` function.
   * This is helpful when [testing](../testing/testing/) that your server's `context` is correctly gathering the values needed from a request.
 
 Below are the available configuration options for the first argument of `executeOperation`:

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -659,7 +659,7 @@ Below are the available fields for the first argument of `executeOperation`:
 
 <td>
 
-**Required**. The GraphQL operation to run. Note that you must use the `query` option even if the operation is a mutation.
+**Required**. The GraphQL operation to run. Note that you must use the `query` field even if the operation is a mutation.
 </td>
 </tr>
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -632,12 +632,12 @@ const result = await server.executeOperation({
 ```
 
 The `executeOperation` method takes two arguments:
-* The first argument is a configuration options object describing the GraphQL operation to be performed.
+* The first argument is an options object describing the GraphQL operation to be performed.
   * Supported options are listed in the table below.
 * The second optional argument is passed to `ApolloServer`'s `context` function.
   * This is helpful when [testing](../testing/testing/) that your server's `context` is correctly gathering the values needed from a request.
 
-Below are the available configuration options for the first argument of `executeOperation`:
+Below are the available options for the first argument of `executeOperation`:
 
 ### Options
 <table class="field-table">

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -633,13 +633,13 @@ const result = await server.executeOperation({
 
 The `executeOperation` method takes two arguments:
 * The first argument is an object describing the GraphQL operation to be executed.
-  * Supported options are listed in the table below.
+  * Supported fields are listed in the table below.
 * The second optional argument is passed to `ApolloServer`'s `context` function.
   * This is helpful when [testing](../testing/testing/) that your server's `context` is correctly gathering the values needed from a request.
 
-Below are the available options for the first argument of `executeOperation`:
+Below are the available fields for the first argument of `executeOperation`:
 
-### Options
+### Fields
 <table class="field-table">
   <thead>
     <tr>

--- a/docs/source/testing/testing.md
+++ b/docs/source/testing/testing.md
@@ -3,15 +3,15 @@ title: Integration testing
 description: Utilities for testing Apollo Server
 ---
 
-Integration testing a GraphQL server means testing the combination of many interlocking parts at once. One way to test your server setup is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
+Integration testing a GraphQL server means testing the combination of many interlocking parts at once. One way to test your server setup is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP request.
 
 ## Testing using `executeOperation`
 
-The `apollo-server` library has a request pipeline that can support many plugins which can each affect the way an operation is executed. The `executeOperation` method is available to run operations through the request pipeline, enabling the most thorough tests possible without starting up an HTTP server. 
+The `apollo-server` library has a request pipeline that can support many plugins which can each affect the way an operation is executed. The `executeOperation` method is available to run operations through the request pipeline, enabling the most thorough tests possible without starting up an HTTP server.
 
-The [`executeOperation` method](../api/apollo-server/#executeoperation) can accept the following arguments: 
-* An object containing configuration options which must include a `query` key specifying the GraphQL operation to be run. 
-  * You can use `executeOperation` to execute both queries and mutations, but both use the `query` key. 
+The [`executeOperation` method](../api/apollo-server/#executeoperation) accepts the following arguments:
+* An object containing configuration options, which must include a `query` option that specifies the GraphQL operation to run.
+  * You can use `executeOperation` to execute both queries and mutations, but both use the `query` option.
 * An argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 
 Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/):
@@ -45,11 +45,11 @@ it('returns hello with the provided name', async () => {
   expect(result.data?.hello).toBe('Hello world!');
 });
 ```
-Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result rather than thrown (just like a normal GraphQL response).
+Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result. As with a normal GraphQL response, these errors are not _thrown_.
 
-Unlike with a normal instance of `ApolloServer`,  you don't need to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance will call `start` automatically for you if it has not been called, and any startup errors will be thrown.
+Unlike with a normal instance of `ApolloServer`,  you don't need to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance calls `start` automatically for you if it hasn't been called already, and any startup errors are thrown.
 
-To expand on the example above, here is a full integration test being run against a test instance of `ApolloServer`. This test imports all of the important pieces to test (`typeDefs`, `resolvers`, `dataSources`) and creates a new instance of `ApolloServer`.
+To expand on the example above, here's a full integration test being run against a test instance of `ApolloServer`. This test imports all of the important pieces to test (`typeDefs`, `resolvers`, `dataSources`) and creates a new instance of `ApolloServer`.
 
 ```js:title=integration.test.js
 it('fetches single launch', async () => {
@@ -78,17 +78,17 @@ it('fetches single launch', async () => {
 });
 ```
 
-The example above includes a test-specific [`context` function](../data/resolvers/#the-context-argument) which provides data directly to the `ApolloServer` instance, instead of calculating it from the request's context. 
+The example above includes a test-specific [`context` function](../data/resolvers/#the-context-argument), which provides data directly to the `ApolloServer` instance instead of calculating it from the request's context.
 
-If you'd like to use your server's real `context` function, you can pass a second argument into `executeOperation` which is then passed to your server's `context` function. Note that in order to use your server's `context` function you need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
+To use your server's defined `context` function, you can pass a second argument to `executeOperation`, which is then passed to your server's `context` function. Note that to use your server's `context` function you need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
 
 For examples of both integration and end-to-end testing we recommend checking out the [tests included in the Apollo fullstack tutorial](https://github.com/apollographql/fullstack-tutorial/tree/master/final/server/src/__tests__).
 ## End-to-end testing
 
 
-Instead of bypassing the HTTP layer, you may want to fully run your server and test it with a real HTTP client. Apollo Server doesn't have any built-in support for this at this time. 
+Instead of bypassing the HTTP layer, you might want to fully run your server and test it with a real HTTP client. Apollo Server doesn't have any built-in support for this at this time.
 
-You can run operations against your server using a combination of any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) . There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing) which uses mocked Express request and response objects. 
+You can run operations against your server using a combination of any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) . There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing), which uses mocked Express request and response objects.
 
 Below is an example of writing an end-to-end test using the [`apollo-server-express` package](../integrations/middleware/#apollo-server-express) and `supertest`:
 

--- a/docs/source/testing/testing.md
+++ b/docs/source/testing/testing.md
@@ -3,23 +3,21 @@ title: Integration testing
 description: Utilities for testing Apollo Server
 ---
 
-Integration testing a GraphQL server means testing the combination of many interlocking parts at once. One  way to test your setup of `apollo-server` is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
+Integration testing a GraphQL server means testing the combination of many interlocking parts at once. One way to test your server setup is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
 
 ## Testing using `executeOperation`
 
-The `apollo-server` library has a request pipeline that can support many plugins which can each affect the way an operation is executed. The `executeOperation` method is available to run operations through the request pipeline enabling the most thorough tests possible without starting up an HTTP server. 
+The `apollo-server` library has a request pipeline that can support many plugins which can each affect the way an operation is executed. The `executeOperation` method is available to run operations through the request pipeline, enabling the most thorough tests possible without starting up an HTTP server. 
 
-The `executeOperation` method can accept multiple arguments: 
-* The first is an object containing configuration options which must include a `query` key specifying the GraphQL operation to be run. 
-  * You can optionally include additional keys for `variables`,  `operationName`, `extensions`, and `http`, much like with [HTTP requests](../requests).
-* An argument that will be passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument)
+The [`executeOperation` method](../api/apollo-server/#executeoperation) can accept the following arguments: 
+* An object containing configuration options which must include a `query` key specifying the GraphQL operation to be run. 
+  * You can use `executeOperation` to execute both queries and mutations, but both will use the `query` key. 
+* An argument that will be passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 
-You can use `executeOperation` to execute both queries and mutations. Because the interface matches the GraphQL HTTP protocol, you must specify the operation text under the `query` key even if the operation is a mutation. You can specify `query` either as a string or as a `DocumentNode` (an AST created by using the `gql` tag).
-
-Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/). You are, of course, free to use whichever testing library you like best.
+Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/):
 ```js:title=index.test.js
-// For clarity in this example we included our typeDefs and resolvers above our test, but in a real world situation
-// you'd be importing these from other files in your application
+// For clarity in this example we included our typeDefs and resolvers above our test,
+// but in a real world situation you'd be importing these in
 const typeDefs = gql`
   type Query {
     hello(name: String): String!
@@ -32,7 +30,7 @@ const resolvers = {
   },
 };
 
-test('returns hello with the provided name', async () => {
+it('returns hello with the provided name', async () => {
   const mockServer = new ApolloServer({
     typeDefs,
     resolvers
@@ -47,10 +45,9 @@ test('returns hello with the provided name', async () => {
   expect(result.data?.hello).toBe('Hello world!');
 });
 ```
+Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result rather than thrown (just like a normal GraphQL response).
 
-Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result (just like with a normal GraphQL response) rather than thrown.
-
-Unlike with a normal instance of `ApolloServer`,  don't have to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance will call it automatically for you if it has not been called, and any startup errors will be thrown.
+Unlike with a normal instance of `ApolloServer`,  you don't have to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance will call `start` automatically for you if it has not been called, and any startup errors will be thrown.
 
 To expand on the example above, here is a full integration test being run against a test instance of `ApolloServer`. This test imports all of the important pieces to test (`typeDefs`, `resolvers`, `dataSources`) and creates a new instance of `ApolloServer`.
 
@@ -85,8 +82,66 @@ The example above includes a test-specific [`context` function](../data/resolver
 
 If you'd like to use your server's real `context` function, you can pass a second argument into `executeOperation` which is then passed to your server's `context` function. Note that in order to use your server's `context` function you will need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
 
+For examples of both integration and end-to-end testing we recommend checking out the [tests included in the Apollo fullstack tutorial](https://github.com/apollographql/fullstack-tutorial/tree/master/final/server/src/__tests__).
 ## End-to-end testing
 
-Instead of bypassing the HTTP layer, you may want to fully run your server and test it with a real HTTP client.
 
-Apollo Server doesn't have any built-in support for this at this time. You can combine any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) to run operations against your server. There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing) which uses mocked Express request and response objects.
+Instead of bypassing the HTTP layer, you may want to fully run your server and test it with a real HTTP client. Apollo Server doesn't have any built-in support for this at this time. 
+
+You can run operations against your server using a combination of any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) . There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing) which uses mocked Express request and response objects. 
+
+Below is an example of writing an end-to-end test using the [`apollo-server-express` package](../integrations/middleware/#apollo-server-express) and `supertest`:
+
+```js:title=e2e.test.js
+// we import our server instance
+const { server } = require('./server.js');
+const express = require('express');
+const { createServer } = require('http');
+
+// we will use supertest to test our server
+const request = require('supertest');
+
+// this is the query we use for our test
+const queryData = {
+  query: `query sayHello($name: String) {
+    hello(name: $name)
+  }`,
+  variables: { name: 'world' },
+};
+
+// create a new http server for testing
+const createTestServer = async () => {
+  const app = express();
+
+  await server.applyMiddleware({
+    app,
+    path: '/graphql',
+  });
+
+  const httpServer = createServer(app);
+  const port = process.env.PORT || 3000;
+  httpServer.listen({ port });
+
+  return { httpServer, expressApp: app };
+};
+
+describe('e2e demo', () => {
+  let httpServer;
+
+  // before the tests we will create our http server
+  beforeAll(async () => {
+    const testServer = await createTestServer();
+    expressApp = testServer.expressApp;
+    httpServer = testServer.httpServer;
+  });
+
+  // after the tests we will stop our server
+  afterAll(async () => await httpServer?.close());
+
+  it('says hello', async () => {
+    const response = await request(expressApp).post('/graphql').send(queryData);
+    expect(response.errors).toBeUndefined();
+    expect(response.body.data?.hello).toBe('Hello world!');
+  });
+});
+```

--- a/docs/source/testing/testing.md
+++ b/docs/source/testing/testing.md
@@ -11,8 +11,8 @@ The `apollo-server` library has a request pipeline that can support many plugins
 
 The [`executeOperation` method](../api/apollo-server/#executeoperation) can accept the following arguments: 
 * An object containing configuration options which must include a `query` key specifying the GraphQL operation to be run. 
-  * You can use `executeOperation` to execute both queries and mutations, but both will use the `query` key. 
-* An argument that will be passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
+  * You can use `executeOperation` to execute both queries and mutations, but both use the `query` key. 
+* An argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 
 Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/):
 ```js:title=index.test.js
@@ -47,7 +47,7 @@ it('returns hello with the provided name', async () => {
 ```
 Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result rather than thrown (just like a normal GraphQL response).
 
-Unlike with a normal instance of `ApolloServer`,  you don't have to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance will call `start` automatically for you if it has not been called, and any startup errors will be thrown.
+Unlike with a normal instance of `ApolloServer`,  you don't need to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance will call `start` automatically for you if it has not been called, and any startup errors will be thrown.
 
 To expand on the example above, here is a full integration test being run against a test instance of `ApolloServer`. This test imports all of the important pieces to test (`typeDefs`, `resolvers`, `dataSources`) and creates a new instance of `ApolloServer`.
 
@@ -80,7 +80,7 @@ it('fetches single launch', async () => {
 
 The example above includes a test-specific [`context` function](../data/resolvers/#the-context-argument) which provides data directly to the `ApolloServer` instance, instead of calculating it from the request's context. 
 
-If you'd like to use your server's real `context` function, you can pass a second argument into `executeOperation` which is then passed to your server's `context` function. Note that in order to use your server's `context` function you will need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
+If you'd like to use your server's real `context` function, you can pass a second argument into `executeOperation` which is then passed to your server's `context` function. Note that in order to use your server's `context` function you need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
 
 For examples of both integration and end-to-end testing we recommend checking out the [tests included in the Apollo fullstack tutorial](https://github.com/apollographql/fullstack-tutorial/tree/master/final/server/src/__tests__).
 ## End-to-end testing

--- a/docs/source/testing/testing.md
+++ b/docs/source/testing/testing.md
@@ -3,7 +3,7 @@ title: Integration testing
 description: Utilities for testing Apollo Server
 ---
 
-Integration testing a GraphQL server means testing the combination of many interlocking parts at once. Testing your setup of `apollo-server` can be done in a variety of ways. One simple way is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
+Integration testing a GraphQL server means testing the combination of many interlocking parts at once. One  way to test your setup of `apollo-server` is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
 
 ## Testing using `executeOperation`
 

--- a/docs/source/testing/testing.md
+++ b/docs/source/testing/testing.md
@@ -3,26 +3,58 @@ title: Integration testing
 description: Utilities for testing Apollo Server
 ---
 
-Testing `apollo-server` can be done in many ways. One simple way is to use ApolloServer's `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
+Integration testing a GraphQL server means testing the combination of many interlocking parts at once. Testing your setup of `apollo-server` can be done in a variety of ways. One simple way is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP operation.
 
-## `executeOperation`
+## Testing using `executeOperation`
 
-Integration testing a GraphQL server means testing many things. `apollo-server` has a request pipeline that can support many plugins that can affect the way an operation is executed. The `executeOperation` method provides a single hook to run operations through the request pipeline, enabling the most thorough tests possible without starting up an HTTP server.
+The `apollo-server` library has a request pipeline that can support many plugins which can each affect the way an operation is executed. The `executeOperation` method is available to run operations through the request pipeline enabling the most thorough tests possible without starting up an HTTP server. 
 
-```javascript
-const server = new ApolloServer(config);
+The `executeOperation` method can accept multiple arguments: 
+* The first is an object containing configuration options which must include a `query` key specifying the GraphQL operation to be run. 
+  * You can optionally include additional keys for `variables`,  `operationName`, `extensions`, and `http`, much like with [HTTP requests](../requests).
+* An argument that will be passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument)
 
-const result = await server.executeOperation({
-  query: GET_USER,
-  variables: { id: 1 }
+You can use `executeOperation` to execute both queries and mutations. Because the interface matches the GraphQL HTTP protocol, you must specify the operation text under the `query` key even if the operation is a mutation. You can specify `query` either as a string or as a `DocumentNode` (an AST created by using the `gql` tag).
+
+Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/). You are, of course, free to use whichever testing library you like best.
+```js:title=index.test.js
+// For clarity in this example we included our typeDefs and resolvers above our test, but in a real world situation
+// you'd be importing these from other files in your application
+const typeDefs = gql`
+  type Query {
+    hello(name: String): String!
+  }
+`;
+
+const resolvers = {
+  Query: {
+    hello: (_, { name }) => `Hello ${name}!`,
+  },
+};
+
+test('returns hello with the provided name', async () => {
+  const mockServer = new ApolloServer({
+    typeDefs,
+    resolvers
+  });
+
+  const result = await mockServer.executeOperation({
+    query: 'query SayHelloWorld($name: String) { hello(name: $name) }',
+    variables: { name: 'world' },
+  });
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data?.hello).toBe('Hello world!');
 });
-expect(result.errors).toBeUndefined();
-expect(result.data?.user.name).toBe('Ida');
 ```
 
-For example, you can set up a full server with your schema and resolvers and run an operation against it.
+Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result (just like with a normal GraphQL response) rather than thrown.
 
-```javascript
+Unlike with a normal instance of `ApolloServer`,  don't have to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance will call it automatically for you if it has not been called, and any startup errors will be thrown.
+
+To expand on the example above, here is a full integration test being run against a test instance of `ApolloServer`. This test imports all of the important pieces to test (`typeDefs`, `resolvers`, `dataSources`) and creates a new instance of `ApolloServer`.
+
+```js:title=integration.test.js
 it('fetches single launch', async () => {
   const userAPI = new UserAPI({ store });
   const launchAPI = new LaunchAPI();
@@ -43,27 +75,18 @@ it('fetches single launch', async () => {
     { dataValues: { launchId: 1 } },
   ]);
 
-  // run query against the server and snapshot the output
+  // run the query against the server and snapshot the output
   const res = await server.executeOperation({ query: GET_LAUNCH, variables: { id: 1 } });
   expect(res).toMatchSnapshot();
 });
 ```
 
-This is an example of a full integration test being run against a test instance of `apollo-server`. This test imports the important pieces to test (`typeDefs`, `resolvers`, `dataSources`) and creates a new instance of `apollo-server`.
+The example above includes a test-specific [`context` function](../data/resolvers/#the-context-argument) which provides data directly to the `ApolloServer` instance, instead of calculating it from the request's context. 
 
-The example above shows writing a test-specific [`context` function](../data/resolvers/#the-context-argument) which provides data directly instead of calculating it from the request context. If you'd like to use your server's real `context` function, you can pass a second argument to `executeOperation` which will be passed to your `context` function as its argument. You will need to put together an object with the [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) yourself.
-
-You can use `executeOperation` to execute queries and mutations. Because the interface matches the GraphQL HTTP protocol, you specify the operation text under the `query` key even if the operation is a mutation. You can specify `query` either as a string or as a `DocumentNode` (an AST created by the `gql` tag).
-
-In addition to `query`, the first argument to `executeOperation` can take `operationName`, `variables`, `extensions`, and `http` keys.
-
-Note that errors in parsing, validating, and executing your operation are returned in the `errors` field of the result (just like in a GraphQL response) rather than thrown.
-
-You don't have to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`; it will be called automatically for you if it has not been called, and any startup errors will be thrown.
-
+If you'd like to use your server's real `context` function, you can pass a second argument into `executeOperation` which is then passed to your server's `context` function. Note that in order to use your server's `context` function you will need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
 
 ## End-to-end testing
 
-Instead of bypassing the HTTP layer, you may just want to fully run your server and test it with a real HTTP client.
+Instead of bypassing the HTTP layer, you may want to fully run your server and test it with a real HTTP client.
 
-Apollo Server doesn't have any built-in support for this. You can combine any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) to run operations against your server. There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing) which uses mocked Express request and response objects.
+Apollo Server doesn't have any built-in support for this at this time. You can combine any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) to run operations against your server. There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing) which uses mocked Express request and response objects.

--- a/docs/source/testing/testing.mdx
+++ b/docs/source/testing/testing.mdx
@@ -95,8 +95,8 @@ The example above includes a test-specific [`context` function](../data/resolver
 To use your server's defined `context` function, you can pass a second argument to `executeOperation`, which is then passed to your server's `context` function. Note that to use your server's `context` function you need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
 
 >For examples of both integration and end-to-end testing we recommend checking out the [tests included in the Apollo fullstack tutorial](https://github.com/apollographql/fullstack-tutorial/tree/master/final/server/src/__tests__).
-## End-to-end testing
 
+## End-to-end testing
 
 Instead of bypassing the HTTP layer, you might want to fully run your server and test it with a real HTTP client. Apollo Server doesn't provide built-in support for this at this time.
 

--- a/docs/source/testing/testing.mdx
+++ b/docs/source/testing/testing.mdx
@@ -16,7 +16,7 @@ There are two main options for integration testing with Apollo Server:
 Apollo Server's `executeOperation` method enables you to run operations through the request pipeline _without_ sending an HTTP request.
 
 The [`executeOperation` method](../api/apollo-server/#executeoperation) accepts the following arguments:
-* An object containing configuration options describing the GraphQL operation to preform.
+* An object containing the options describing the GraphQL operation to perform.
   * This object must include a `query` option specifying the GraphQL operation to run. You can use `executeOperation` to execute both queries and mutations, but both use the `query` option.
 * An optional argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 

--- a/docs/source/testing/testing.mdx
+++ b/docs/source/testing/testing.mdx
@@ -17,7 +17,7 @@ Apollo Server's `executeOperation` method enables you to run operations through 
 
 The [`executeOperation` method](../api/apollo-server/#executeoperation) accepts the following arguments:
 * An object that describes the GraphQL operation to execute.
-  * This object must include a `query` option specifying the GraphQL operation to run. You can use `executeOperation` to execute both queries and mutations, but both use the `query` option.
+  * This object must include a `query` field specifying the GraphQL operation to run. You can use `executeOperation` to execute both queries and mutations, but both use the `query` field.
 * An optional argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 
 Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/):

--- a/docs/source/testing/testing.mdx
+++ b/docs/source/testing/testing.mdx
@@ -3,21 +3,30 @@ title: Integration testing
 description: Utilities for testing Apollo Server
 ---
 
-Integration testing a GraphQL server means testing the combination of many interlocking parts at once. One way to test your server setup is to use `ApolloServer`'s `executeOperation` method to directly execute a GraphQL operation without going through a full HTTP request.
+import { MultiCodeBlock } from 'gatsby-theme-apollo-docs';
+
+Apollo Server uses a [multi-step request pipeline](../integrations/plugins/#request-lifecycle-event-flow) to validate and execute incoming GraphQL operations. This pipeline supports integration with custom plugins at each step, which can affect an operation's execution. Because of this, it's important to perform **integration tests** with a variety of operations to ensure your request pipeline works as expected.
+
+There are two main options for integration testing with Apollo Server:
+* Using `ApolloServer`'s `executeOperation` method.
+* Setting up an HTTP client to query your server.
 
 ## Testing using `executeOperation`
 
-The `apollo-server` library has a request pipeline that can support many plugins which can each affect the way an operation is executed. The `executeOperation` method is available to run operations through the request pipeline, enabling the most thorough tests possible without starting up an HTTP server.
+Apollo Server's `executeOperation` method enables you to run operations through the request pipeline _without_ sending an HTTP request.
 
 The [`executeOperation` method](../api/apollo-server/#executeoperation) accepts the following arguments:
-* An object containing configuration options, which must include a `query` option that specifies the GraphQL operation to run.
-  * You can use `executeOperation` to execute both queries and mutations, but both use the `query` option.
-* An argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
+* An object containing configuration options describing the GraphQL operation to preform.
+  * This object must include a `query` option specifying the GraphQL operation to run. You can use `executeOperation` to execute both queries and mutations, but both use the `query` option.
+* An optional argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 
 Below is a simplified example of setting up a test using the JavaScript testing library [Jest](https://jestjs.io/):
-```js:title=index.test.js
+
+<MultiCodeBlock>
+
+```ts:title=index.test.ts
 // For clarity in this example we included our typeDefs and resolvers above our test,
-// but in a real world situation you'd be importing these in
+// but in a real world situation you'd be importing these in from different files
 const typeDefs = gql`
   type Query {
     hello(name: String): String!
@@ -31,12 +40,12 @@ const resolvers = {
 };
 
 it('returns hello with the provided name', async () => {
-  const mockServer = new ApolloServer({
+  const testServer = new ApolloServer({
     typeDefs,
     resolvers
   });
 
-  const result = await mockServer.executeOperation({
+  const result = await testServer.executeOperation({
     query: 'query SayHelloWorld($name: String) { hello(name: $name) }',
     variables: { name: 'world' },
   });
@@ -45,7 +54,10 @@ it('returns hello with the provided name', async () => {
   expect(result.data?.hello).toBe('Hello world!');
 });
 ```
-Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the result. As with a normal GraphQL response, these errors are not _thrown_.
+
+</MultiCodeBlock>
+
+Note that when testing, any errors in parsing, validating, and executing your GraphQL operation are returned in the `errors` field of the operation result. As with any GraphQL response, these errors are not _thrown_.
 
 Unlike with a normal instance of `ApolloServer`,  you don't need to call [`start`](../../api/apollo-server/#start) before calling `executeOperation`. The server instance calls `start` automatically for you if it hasn't been called already, and any startup errors are thrown.
 
@@ -82,24 +94,24 @@ The example above includes a test-specific [`context` function](../data/resolver
 
 To use your server's defined `context` function, you can pass a second argument to `executeOperation`, which is then passed to your server's `context` function. Note that to use your server's `context` function you need to put together an object with the correct [middleware-specific context fields](../api/apollo-server/#middleware-specific-context-fields) for your implementation.
 
-For examples of both integration and end-to-end testing we recommend checking out the [tests included in the Apollo fullstack tutorial](https://github.com/apollographql/fullstack-tutorial/tree/master/final/server/src/__tests__).
+>For examples of both integration and end-to-end testing we recommend checking out the [tests included in the Apollo fullstack tutorial](https://github.com/apollographql/fullstack-tutorial/tree/master/final/server/src/__tests__).
 ## End-to-end testing
 
 
-Instead of bypassing the HTTP layer, you might want to fully run your server and test it with a real HTTP client. Apollo Server doesn't have any built-in support for this at this time.
+Instead of bypassing the HTTP layer, you might want to fully run your server and test it with a real HTTP client. Apollo Server doesn't provide built-in support for this at this time.
 
 You can run operations against your server using a combination of any HTTP or GraphQL client such as [`supertest`](https://www.npmjs.com/package/supertest) or [Apollo Client's HTTP Link](https://www.apollographql.com/docs/react/api/link/apollo-link-http/) . There are also community packages available such as [`apollo-server-integration-testing`](https://www.npmjs.com/package/apollo-server-integration-testing), which uses mocked Express request and response objects.
 
-Below is an example of writing an end-to-end test using the [`apollo-server-express` package](../integrations/middleware/#apollo-server-express) and `supertest`:
+Below is an example of writing an end-to-end test using the `apollo-server` package and `supertest`:
 
-```js:title=e2e.test.js
-// we import our server instance
-const { server } = require('./server.js');
-const express = require('express');
-const { createServer } = require('http');
+<MultiCodeBlock>
+
+```ts:title=server.test.ts
+/// we import a function that we wrote to create a new instance of Apollo Server
+import { createApolloServer } from '../server';
 
 // we will use supertest to test our server
-const request = require('supertest');
+import request from 'supertest';
 
 // this is the query we use for our test
 const queryData = {
@@ -109,39 +121,34 @@ const queryData = {
   variables: { name: 'world' },
 };
 
-// create a new http server for testing
-const createTestServer = async () => {
-  const app = express();
-
-  await server.applyMiddleware({
-    app,
-    path: '/graphql',
-  });
-
-  const httpServer = createServer(app);
-  const port = process.env.PORT || 3000;
-  httpServer.listen({ port });
-
-  return { httpServer, expressApp: app };
-};
-
 describe('e2e demo', () => {
-  let httpServer;
+  let server, url;
 
-  // before the tests we will create our http server
+  // before the tests we will spin up a new Apollo Server
   beforeAll(async () => {
-    const testServer = await createTestServer();
-    expressApp = testServer.expressApp;
-    httpServer = testServer.httpServer;
+    // Note we must wrap our object destructuring in parentheses because we already declared these variables
+    // We pass in the port as 0 to let the server pick its own ephemeral port for testing
+    ({ server, url } = await createApolloServer({ port: 0 }));
   });
 
   // after the tests we will stop our server
-  afterAll(async () => await httpServer?.close());
+  afterAll(async () => {
+    await server?.close();
+  });
 
   it('says hello', async () => {
-    const response = await request(expressApp).post('/graphql').send(queryData);
+    // send our request to the url of the test server
+    const response = await request(url).post('/').send(queryData);
     expect(response.errors).toBeUndefined();
     expect(response.body.data?.hello).toBe('Hello world!');
   });
 });
 ```
+
+</MultiCodeBlock>
+
+You can also view and fork this complete example on CodeSandbox:
+
+<a href="https://codesandbox.io/s/github/apollographql/docs-examples/tree/main/apollo-server/v3/integration-testing?fontsize=14&hidenavigation=1&theme=dark">
+  <img alt="Edit integration-testing" src="https://codesandbox.io/static/img/play-codesandbox.svg" />
+</a>

--- a/docs/source/testing/testing.mdx
+++ b/docs/source/testing/testing.mdx
@@ -16,7 +16,7 @@ There are two main options for integration testing with Apollo Server:
 Apollo Server's `executeOperation` method enables you to run operations through the request pipeline _without_ sending an HTTP request.
 
 The [`executeOperation` method](../api/apollo-server/#executeoperation) accepts the following arguments:
-* An object containing the options describing the GraphQL operation to perform.
+* An object that describes the GraphQL operation to execute.
   * This object must include a `query` option specifying the GraphQL operation to run. You can use `executeOperation` to execute both queries and mutations, but both use the `query` option.
 * An optional argument that is passed in to the `ApolloServer` instance's [`context` function](../data/resolvers/#the-context-argument).
 


### PR DESCRIPTION
Did a first pass at editing the testing page!

I added:
1.  two new code examples to try and simplify the core ideas of testing
2. the `executeOperation` method to the main ApolloServer API Reference page 

Thank you for any and all feedback! ⭐ 