### PR TITLE
Update renovate.json5 for docs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,18 +17,6 @@
   //   old branch point. GH auto-merge doesn't have that property so it's a bit more likely that
   //   a deps update could break the build if there are recent related changes.
   platformAutomerge: false,
-  // We've run into some weird problems where Renovate will notice that a
-  // package has the same version in the root and in docs/ and make sure that a
-  // package is only installed in the root node_modules and not
-  // docs/node_modules. Unfortunately our Netlify doc build system only runs
-  // `npm i` under docs so this breaks. Rather than spend much effort figuring
-  // out how to make Netlify install more things or make Renovate not do this,
-  // let's just stop doing Renovate on the docs subdirectory. The docs team is
-  // currently working on a big overhaul that will remove docs/package.json
-  // entirely anyway. (Note that if you want to revert this change, you'll want
-  // to add back a bunch of docs-specific config that was removed when this line
-  // was added.)
-  ignorePaths: ["**/docs/**"],
   "packageRules": [
     // Bunch up all non-major dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster
@@ -65,6 +53,51 @@
     {
       "matchPackageNames": ["node-fetch", "@types/node-fetch"],
       "allowedVersions": "2.x"
+    },
+    /*
+      Docs-related Renovate rules
+      These ensure that the `docs/` folder, which is its own application with
+      its own dependencies which lives inside this repository, plays by its
+      own Renovate rules.  Those rules are defined within the external (npm)
+      package called `renovate-config-apollo-docs` (defined here only by
+      the `apollo-docs` suffix).
+    */
+    {
+      "matchPaths": [
+        "docs/package.json"
+      ],
+      "extends": [
+        "apollo-docs"
+      ],
+      // We need to tell Renovate to check the branches for each major version
+      // of Apollo Server.  "Past" major versions should be added here!
+      "baseBranches": [
+        "main",
+        "version-2"
+      ],
+    },
+    // The current Apollo Gatsby theme does not support a version of Gatsby
+    // that supports React 17.
+    {
+      "matchPaths": [
+        "docs/package.json"
+      ],
+      "matchPackageNames": ["react", "react-dom"],
+      "allowedVersions": "16.x",
+    },
+    // The current Apollo Gatsby theme does not support Gatsby v4
+    {
+      "matchPaths": [
+        "docs/package.json"
+      ],
+      "matchPackageNames": ["gatsby"],
+      "allowedVersions": "3.x",
+    },
+    {
+      matchPackagePatterns: [""],
+      // Override this value set in apollo-open-source and apollo-docs back to the default.
+      // It's nice to be able to see PRs for everything in the Dependency Dashboard.
+      prCreation: "immediate",
     },
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,18 @@
   //   old branch point. GH auto-merge doesn't have that property so it's a bit more likely that
   //   a deps update could break the build if there are recent related changes.
   platformAutomerge: false,
+  // We've run into some weird problems where Renovate will notice that a
+  // package has the same version in the root and in docs/ and make sure that a
+  // package is only installed in the root node_modules and not
+  // docs/node_modules. Unfortunately our Netlify doc build system only runs
+  // `npm i` under docs so this breaks. Rather than spend much effort figuring
+  // out how to make Netlify install more things or make Renovate not do this,
+  // let's just stop doing Renovate on the docs subdirectory. The docs team is
+  // currently working on a big overhaul that will remove docs/package.json
+  // entirely anyway. (Note that if you want to revert this change, you'll want
+  // to add back a bunch of docs-specific config that was removed when this line
+  // was added.)
+  ignorePaths: ["**/docs/**"],
   "packageRules": [
     // Bunch up all non-major dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster


### PR DESCRIPTION
This PR updates Renovate to allow for updates to the docs again, back to the [previous docs config](https://github.com/apollographql/apollo-server/blob/77441b7f6c707741ebe4bd71322116d9e2b5e7b9/renovate.json5#L58-#L95) + allowing for updates for `gatsby` within v3.