### PR TITLE
jest: only include projects with jest.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   },
   "jest": {
     "projects": [
-      "<rootDir>/packages/*"
+      "<rootDir>/packages/*/jest.config.js"
     ]
   }
 }


### PR DESCRIPTION
Previously, if you had an empty-ish directory under `packages` (which
could easily happen when switching branches) between major versions,
`jest` would treat that empty-ish directory as a project without a config
file and throw an error.
