### PR TITLE
No longer error in schema and usage reports for misconfigured environments

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -813,7 +813,7 @@ export class ApolloServerBase<
           const options: ApolloServerPluginSchemaReportingOptions = {};
           this.plugins.push(ApolloServerPluginSchemaReporting(options));
         } else {
-          throw new Error(
+          this.logger.error(
             "You've enabled schema reporting by setting the APOLLO_SCHEMA_REPORTING " +
               'environment variable to true, but you also need to provide your ' +
               'Apollo API key, via the APOLLO_KEY environment ' +

--- a/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
+++ b/packages/apollo-server-core/src/plugin/schemaReporting/index.ts
@@ -73,19 +73,21 @@ export function ApolloServerPluginSchemaReporting(
     async serverWillStart({ apollo, schema, logger }) {
       const { key, graphRef } = apollo;
       if (!key) {
-        throw Error(
+        logger.error(
           'To use ApolloServerPluginSchemaReporting, you must provide an Apollo API ' +
             'key, via the APOLLO_KEY environment variable or via `new ApolloServer({apollo: {key})`',
         );
+        return;
       }
       if (!graphRef) {
         // This error is a bit imprecise as you can also specify ID and variant separately,
         // or rely on API-key parsing (before AS3), but this is "best practices".
-        throw Error(
+        logger.error(
           'To use ApolloServerPluginSchemaReporting, you must provide your graph ref (eg, ' +
             "'my-graph-id@my-graph-variant'). Try setting the APOLLO_GRAPH_REF environment " +
             'variable or passing `new ApolloServer({apollo: {graphRef}})`.',
         );
+        return;
       }
 
       // Ensure a provided override schema can be parsed and validated

--- a/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts
@@ -114,12 +114,13 @@ export function ApolloServerPluginUsageReporting<TContext>(
       const logger = options.logger ?? serverLogger;
       const { key, graphRef } = apollo;
       if (!(key && graphRef)) {
-        throw new Error(
+        logger.error(
           "You've enabled usage reporting via ApolloServerPluginUsageReporting, " +
             'but you also need to provide your Apollo API key and graph ref, via ' +
             'the APOLLO_KEY/APOLLO_GRAPH_REF environment ' +
             'variables or via `new ApolloServer({apollo: {key, graphRef})`.',
         );
+        return {};
       }
 
       logger.info(


### PR DESCRIPTION
No longer errors out on the schema and usage reporting plugins. This change applies to the plugins themselves, as well as when Apollo attempts to automatically add them.

My reasons:
- There are other places in the project where the logger will `warn` on similar misconfigurations, so there is somewhat of a precedent for it.
- Usage reporting and schema reporting are not mission critical. It is absolutely helpful to see these detailed error messages, but not at the expense of uptime. For federated schemas, the schema reporting becomes much more important, but this mechanism is disabled for federated schemas anyways. 
- Logging instead of warning can help make the transition to the latest setups easier, particularly when upgrading Apollo. For example, switching from the `APOLLO_GRAPH_ID` and `APOLLO_GRAPH_VARIANT` combination to `APOLLO_GRAPH_REF`, or migrating from the `apollo` property to env vars, or migrating to plugins. Eliminating the risk of crashing a server makes this a lot less risky. Considering that Apollo 4 is on the horizon, perhaps similar migration steps will need to be required, and reducing friction there is valuable.
- Throwing Errors here are not easy to recover from, particularly in Kubernetes environments. A misconfiguration would prevent new pods from starting up. And since new pods would spin up in response to scaling demands, I bet you can imagine that it's not the most pleasant time to discover these errors 😉 .
- Expanding on the above, this makes it more difficult to coordinate deployments due to chicken-egg conflicts. If you populate the environment first, you can run into issues; likewise, if you deploy code changes (without the environment), you can run into issues. For rolling deployments, having some grace here helps a lot.
- This one is admittedly opinionated, but considering that plugins can be added automatically, it's a bit distressing to see my server blowing up for things that I don't necessarily have control over, and that are hard to predict ahead of time. For example, injecting a `APOLLO_SCHEMA_REPORTING` var into an environment could be handled by another team, and the impact of that isn't obvious. In this case, you could argue it shouldn't try to add the plugin unless _all_ configuration requirements are met.

I can't help but feel my solution is a bit crude, but my thought process:
- I opted for `error` even though other places use `warn` because it was thematically similar to throwing an error. It's also possible that `warn`ings won't propagate to error logs in production environments, and you _definitely_ want to see the log messages if they are happening. Thus `error`.
- I somewhat crudely return early after the errors are logged. I felt this best mimicked what was happening before (ie. stop doing stuff when misconfigured). No point in gracefully logging if stuff just ends up crashing later anyways, ya know? 
- I opted to return no hooks in these scenarios, because I figured it was not worth paying the "cost" for things that would essentially be no-ops.

Each plugin is in a separate commit. I can submit two PRs if that helps at all with documentation or triage.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
