### PR TITLE
docs: Use URL encoding pattern in APQ examples

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -148,6 +148,7 @@ unawaited
 uncacheable
 undersupported
 undici
+urlencode
 unexecutable
 uninstrumented
 unparsable

--- a/docs/source/performance/apq.md
+++ b/docs/source/performance/apq.md
@@ -76,7 +76,8 @@ ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38
 1. Attempt to execute this query on your running server by providing its hash in a `curl` command, like so:
 
     ```shell
-    curl -g 'http://localhost:4000/graphql?extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
+    curl -g http://localhost:4000/graphql \
+      --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
     ```
 
     The first time you try this, Apollo Server responds with an error with the code `PERSISTED_QUERY_NOT_FOUND`. This tells us that Apollo Server hasn't yet received the associated query string.
@@ -84,7 +85,9 @@ ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38
 2. Send a followup request that includes both the query string _and_ its hash, like so:
 
     ```shell
-    curl -g 'http://localhost:4000/graphql?query={__typename}&extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
+    curl -g http://localhost:4000/graphql \
+      --data-urlencode 'query={__typename}' \
+      --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
     ```
 
     This time, the server persists the query string and then responds with the query result as we'd expect.
@@ -94,8 +97,8 @@ ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38
 3. Finally, attempt the request from step 1 again:
 
     ```shell
-    curl -g 'http://localhost:4000/graphql?extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
-    ```
+    curl -g http://localhost:4000/graphql \
+      --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'    ```
 
    This time, the server responds with the query result because it successfully located the associated query string in its cache.
 

--- a/docs/source/performance/apq.md
+++ b/docs/source/performance/apq.md
@@ -85,7 +85,7 @@ ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38
 2. Send a followup request that includes both the query string _and_ its hash, like so:
 
     ```shell
-    curl -g http://localhost:4000/graphql \
+    curl --get http://localhost:4000/graphql \
       --data-urlencode 'query={__typename}' \
       --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
     ```
@@ -97,7 +97,7 @@ ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38
 3. Finally, attempt the request from step 1 again:
 
     ```shell
-    curl -g http://localhost:4000/graphql \
+    curl --get http://localhost:4000/graphql \
       --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'    ```
 
    This time, the server responds with the query result because it successfully located the associated query string in its cache.

--- a/docs/source/performance/apq.md
+++ b/docs/source/performance/apq.md
@@ -76,7 +76,7 @@ ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38
 1. Attempt to execute this query on your running server by providing its hash in a `curl` command, like so:
 
     ```shell
-    curl -g http://localhost:4000/graphql \
+    curl --get http://localhost:4000/graphql \
       --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
     ```
 


### PR DESCRIPTION
This alters the format of the `curl` commands we provide for testing/demonstrating APQ usage to URL encode the parameters when sending `GET` requests.

In particular, this commit choses to adopt [`curl`'s `--data-urlencode`] patterns rather than relying on un-URL-encoded passing of values.  While the documentation examples do not use any reserved query-string characters which could be mis-interpreted as a delimiter (i.e., `&`, `=`, etc.) — and thus can get away without it (per [RFC 3986 3.4])  — it likely creates a better precedent to do so.  Much in the same way as it's conceivable that some parameters in a URL don't need [`encodeURIComponent`] 

[`curl`'s `--data-urlencode`]: https://curl.se/docs/manpage.html#--data-urlencode
[RFC 3986 3.4]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.4
[`encodeURIComponent`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
