### PR TITLE
docs(subscription): unify authentication param naming

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -499,7 +499,7 @@ import { createClient } from 'graphql-ws';
 const wsLink = new GraphQLWsLink(createClient({
   url: 'ws://localhost:4000/subscriptions',
   connectionParams: {
-    authorization: user.authToken,
+    authentication: user.authToken,
   },
 }));
 ```


### PR DESCRIPTION
Closes #6200.
