### PR TITLE
Add the ability to pass in extra Redis SET options when setting a value in the cache.

### DIFF
--- a/packages/apollo-server-cache-redis/src/__tests__/BaseRedisCache.test.ts
+++ b/packages/apollo-server-cache-redis/src/__tests__/BaseRedisCache.test.ts
@@ -2,34 +2,39 @@ import { BaseRedisCache, RedisClient } from '../index';
 import { runKeyValueCacheTests } from 'apollo-server-caching';
 import FakeTimers from '@sinonjs/fake-timers';
 
+const getRedisClient = (store: { [key: string]: string }, timeouts: NodeJS.Timer[]) => {
+  return {
+    set: jest.fn(
+      (key: string, value: string, ...args: Array<any>) => {
+        if (!store[key] || !args.includes("NX")) {
+          store[key] = value;
+          if (args[0] === 'EX' && args[1]) {
+            timeouts.push(setTimeout(() => delete store[key], args[1]* 1000));
+          }
+        }
+        return Promise.resolve();
+      },
+    ),
+    mget: jest.fn((...keys) =>
+      Promise.resolve(keys.map((key: string) => store[key])),
+    ),
+    flushdb: jest.fn(() => Promise.resolve()),
+    del: jest.fn((key: string) => {
+      const keysDeleted = store.hasOwnProperty(key) ? 1 : 0;
+      delete store[key];
+      return Promise.resolve(keysDeleted);
+    }),
+    quit: jest.fn(() => Promise.resolve()),
+  }
+}
+
 describe('BaseRedisCache', () => {
   it('run apollo-server-caching test suite', async () => {
     const store: { [key: string]: string } = {};
     const timeouts: NodeJS.Timer[] = [];
-    const testRedisClient: RedisClient = {
-      set: jest.fn(
-        (key: string, value: string, option?: string, ttl?: number) => {
-          store[key] = value;
-          if (option === 'EX' && ttl) {
-            timeouts.push(setTimeout(() => delete store[key], ttl * 1000));
-          }
-          return Promise.resolve();
-        },
-      ),
-      mget: jest.fn((...keys) =>
-        Promise.resolve(keys.map((key: string) => store[key])),
-      ),
-      flushdb: jest.fn(() => Promise.resolve()),
-      del: jest.fn((key: string) => {
-        const keysDeleted = store.hasOwnProperty(key) ? 1 : 0;
-        delete store[key];
-        return Promise.resolve(keysDeleted);
-      }),
-      quit: jest.fn(() => Promise.resolve()),
-    };
+    const testRedisClient: RedisClient = getRedisClient(store, timeouts);
     const cache = new BaseRedisCache({ client: testRedisClient });
     const clock = FakeTimers.install();
-
     try {
       await runKeyValueCacheTests(cache, (ms: number) => clock.tick(ms));
     } finally {
@@ -38,4 +43,30 @@ describe('BaseRedisCache', () => {
       await cache.close();
     }
   });
+
+  it('allows you to pass the NX option', async () => {
+    const store: { [key: string]: string } = {};
+    const timeouts: NodeJS.Timer[] = [];
+    const testRedisClient: RedisClient = getRedisClient(store, timeouts);
+    const cache = new BaseRedisCache({ client: testRedisClient });
+    const clock = FakeTimers.install();
+    try {
+      await cache.set('hello', 'world', { redisOptions: ["NX"] });
+      assertEqual(await cache.get('hello'), 'world');
+
+      await cache.set('hello', 'world again', { redisOptions: ["NX"] });
+      assertEqual(await cache.get('hello'), 'world');
+    } finally {
+      timeouts.forEach((t) => clearTimeout(t));
+      clock.uninstall();
+      await cache.close();
+    }
+  });
 });
+
+function assertEqual<T>(actual: T, expected: T) {
+  if (actual === expected) {
+    return;
+  }
+  throw Error(`Expected ${actual} to equal ${expected}`);
+}


### PR DESCRIPTION
Hi there

For the project I'm working on, we need to pass in the `NX` Redis caching option when setting a cache value.
(You can see all the Redis SET options here:  https://redis.io/commands/set)

ioredis accepts these Redis options, but the `BaseRedisCache` is too restrictive and expects only a `ttl` option to be passed in,
so I updated `BaseRedisCache` so that you can also include an attribute `redisOptions` as part of your passed-in options.

The Redis options are then passed to the ioredis client.

I've added a test for the `NX`  option. I'd be happy to also add tests for other Redis options, but I first wanted to make the PR and find out whether you'd be willing to accept it before spending more time on tests.

Thanks!






<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
