### PR TITLE
security: fix missing validation with `documentStore` + `gateway`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+- ⚠️ **SECURITY** `apollo-server-core`: Apollo Server 3.4.0 introduced a new `documentStore` constructor option (replacing the `experimental_approximateDocumentStoreMiB` option) which allows you to customize an internal cache used by ApolloServer to memoize the results of parsing and validating GraphQL operations. When this option was combined with the `gateway` option, it was possible for Apollo Server to attempt to execute invalid GraphQL operations. Specifically, if a server processed an operation and then its schema was updated with a change that made that operation no longer valid, the server could still attempt to execute the operation again without re-validating it against the new schema. The problem only lasts until the server is restarted. This release changes the semantics of the `documentStore` option so that a different key prefix is used each time the schema is updated. (As a side effect, you no longer have to be careful to avoid sharing a `documentStore` between multiple `ApolloServer` objects.)  **This update is highly recommended for any users that specify both `documentStore` and `gateway` in `new ApolloServer()`.**
+
 ## v3.6.5
 
 - `apollo-server-plugin-usage-reporting`: Stop distributing unnecessary `generated/reports.proto` file. Count executable operations. [PR #6239](https://github.com/apollographql/apollo-server/pull/6239)

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -220,8 +220,6 @@ new ApolloServer({
 
 </div>
 
-**Do not share a `documentStore` between multiple `ApolloServer` instances**, _unless_ you assign a unique prefix to each instance's entries (for example, using [`PrefixingKeyValueCache`](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-caching/src/PrefixingKeyValueCache.ts)). Apollo Server skips parsing and validating any operation that's present in its `documentStore`, so if servers with _different_ schemas share the _same_ `documentStore`, a server might execute an operation that its schema doesn't support.
-
 Pass `null` to disable this cache entirely.
 
 Available in Apollo Server v3.4.0 and later.

--- a/packages/apollo-server-core/src/__tests__/documentStore.test.ts
+++ b/packages/apollo-server-core/src/__tests__/documentStore.test.ts
@@ -86,12 +86,16 @@ describe('ApolloServerBase documentStore', () => {
 
     await server.executeOperation(operations.simple.op);
 
-    expect(Object.keys(cache)).toEqual([operations.simple.hash]);
-    expect(cache[operations.simple.hash]).toMatchObject(documentNodeMatcher);
+    const keys = Object.keys(cache);
+    expect(keys).toHaveLength(1);
+    const theKey = keys[0];
+    expect(theKey.split(':')).toHaveLength(2);
+    expect(theKey.split(':')[1]).toEqual(operations.simple.hash);
+    expect(cache[theKey]).toMatchObject(documentNodeMatcher);
 
     await server.executeOperation(operations.simple.op);
 
-    expect(Object.keys(cache)).toEqual([operations.simple.hash]);
+    expect(Object.keys(cache)).toEqual([theKey]);
 
     expect(getSpy.mock.calls.length).toBe(2);
     expect(setSpy.mock.calls.length).toBe(1);
@@ -113,4 +117,6 @@ describe('ApolloServerBase documentStore', () => {
 
     expect(result.data).toEqual({ hello: 'world' });
   });
+
+  it('documentStore with changing schema', async () => {});
 });

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -15,6 +15,7 @@ import {
   ValidationContext,
   FieldDefinitionNode,
   ResponsePath,
+  DocumentNode,
 } from 'graphql';
 
 // Note that by doing deep imports here we don't need to install React.
@@ -57,6 +58,7 @@ import resolvable, { Resolvable } from '@josephg/resolvable';
 import FakeTimers from '@sinonjs/fake-timers';
 import type { AddressInfo } from 'net';
 import request from 'supertest';
+import { InMemoryLRUCache } from 'apollo-server-caching';
 
 const quietLogger = loglevel.getLogger('quiet');
 quietLogger.setLevel(loglevel.levels.WARN);
@@ -2759,47 +2761,63 @@ export function testApolloServer<AS extends ApolloServerBase>(
     });
 
     describe('Gateway', () => {
-      it('receives schema updates from the gateway', async () => {
-        const makeQueryTypeWithField = (fieldName: string) =>
-          new GraphQLSchema({
-            query: new GraphQLObjectType({
-              name: 'QueryType',
-              fields: {
-                [fieldName]: {
-                  type: GraphQLString,
+      it.each([true, false])(
+        'receives schema updates from the gateway (with document store: %s)',
+        async (withDocumentStore: boolean) => {
+          const makeQueryTypeWithField = (fieldName: string) =>
+            new GraphQLSchema({
+              query: new GraphQLObjectType({
+                name: 'QueryType',
+                fields: {
+                  [fieldName]: {
+                    type: GraphQLString,
+                  },
                 },
-              },
-            }),
+              }),
+            });
+
+          const executor = (req: GraphQLRequestContextExecutionDidStart<any>) =>
+            (req.source as string).match(/1/)
+              ? Promise.resolve({ data: { testString1: 'hello' } })
+              : Promise.resolve({ data: { testString2: 'aloha' } });
+
+          const { gateway, triggers } = makeGatewayMock();
+
+          triggers.resolveLoad({
+            schema: makeQueryTypeWithField('testString1'),
+            executor,
           });
 
-        const executor = (req: GraphQLRequestContextExecutionDidStart<any>) =>
-          (req.source as string).match(/1/)
-            ? Promise.resolve({ data: { testString1: 'hello' } })
-            : Promise.resolve({ data: { testString2: 'aloha' } });
+          const { url: uri } = await createApolloServer({
+            gateway,
+            documentStore: withDocumentStore
+              ? new InMemoryLRUCache<DocumentNode>()
+              : undefined,
+          });
 
-        const { gateway, triggers } = makeGatewayMock();
+          const apolloFetch = createApolloFetch({ uri });
+          const result1 = await apolloFetch({ query: '{testString1}' });
 
-        triggers.resolveLoad({
-          schema: makeQueryTypeWithField('testString1'),
-          executor,
-        });
+          expect(result1.data).toEqual({ testString1: 'hello' });
+          expect(result1.errors).toBeUndefined();
 
-        const { url: uri } = await createApolloServer({
-          gateway,
-        });
+          triggers.triggerSchemaChange!(makeQueryTypeWithField('testString2'));
 
-        const apolloFetch = createApolloFetch({ uri });
-        const result1 = await apolloFetch({ query: '{testString1}' });
+          const result2 = await apolloFetch({ query: '{testString2}' });
+          expect(result2.data).toEqual({ testString2: 'aloha' });
+          expect(result2.errors).toBeUndefined();
 
-        expect(result1.data).toEqual({ testString1: 'hello' });
-        expect(result1.errors).toBeUndefined();
-
-        triggers.triggerSchemaChange!(makeQueryTypeWithField('testString2'));
-
-        const result2 = await apolloFetch({ query: '{testString2}' });
-        expect(result2.data).toEqual({ testString2: 'aloha' });
-        expect(result2.errors).toBeUndefined();
-      });
+          const invalidResult = await apolloFetch({ query: '{testString1}' });
+          expect(invalidResult.data).toBeUndefined();
+          expect(invalidResult.errors).toEqual([
+            {
+              extensions: { code: 'GRAPHQL_VALIDATION_FAILED' },
+              message:
+                'Cannot query field "testString1" on type "QueryType". Did you mean "testString2"?',
+            },
+          ]);
+        },
+      );
 
       it('passes apollo data to the gateway', async () => {
         const optionsSpy = jest.fn();


### PR DESCRIPTION
Apollo Server 3.4.0 introduced a new `documentStore` constructor option
(replacing the `experimental_approximateDocumentStoreMiB` option) which
allows you to customize an internal cache used by ApolloServer to
memoize the results of parsing and validating GraphQL operations. When
this option was combined with the `gateway` option, it was possible for
Apollo Server to attempt to execute invalid GraphQL operations.
Specifically, if a server processed an operation and then its schema was
updated with a change that made that operation no longer valid, the
server could still attempt to execute the operation again without
re-validating it against the new schema. (The problem only lasts until
the server is restarted.)

This release changes the semantics of the `documentStore` option so that
a different key prefix is used each time the schema is updated.

As a side effect, you no longer have to be careful to avoid sharing a
`documentStore` between multiple `ApolloServer` objects.

This update is highly recommended
for any users that specify both `documentStore` and `gateway` in `new
ApolloServer()`.

Paired with @trevor-scheer.