### PR TITLE
feat(body-parsing): support the `application/graphql+json` content-type

### DIFF
--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -126,10 +126,16 @@ export class ApolloServer<
     }
 
     if (bodyParserConfig === true) {
-      router.use(path, json());
+      router.use(path, json({
+          type: ['application/graphql+json', 'application/json']
+      }));
     } else if (bodyParserConfig !== false) {
-      router.use(path, json(bodyParserConfig));
+        if (typeof bodyParserConfig === 'object' && !bodyParserConfig.type) {
+            bodyParserConfig.type = ['application/graphql+json', 'application/json']
+        }
+        router.use(path, json(bodyParserConfig));
     }
+
 
     const landingPage = this.getLandingPage();
     router.use(path, (req, res, next) => {

--- a/packages/apollo-server-express/src/ApolloServer.ts
+++ b/packages/apollo-server-express/src/ApolloServer.ts
@@ -126,16 +126,21 @@ export class ApolloServer<
     }
 
     if (bodyParserConfig === true) {
-      router.use(path, json({
-          type: ['application/graphql+json', 'application/json']
-      }));
+      router.use(
+        path,
+        json({
+          type: ['application/graphql+json', 'application/json'],
+        }),
+      );
     } else if (bodyParserConfig !== false) {
-        if (typeof bodyParserConfig === 'object' && !bodyParserConfig.type) {
-            bodyParserConfig.type = ['application/graphql+json', 'application/json']
-        }
-        router.use(path, json(bodyParserConfig));
+      if (typeof bodyParserConfig === 'object' && !bodyParserConfig.type) {
+        bodyParserConfig.type = [
+          'application/graphql+json',
+          'application/json',
+        ];
+      }
+      router.use(path, json(bodyParserConfig));
     }
-
 
     const landingPage = this.getLandingPage();
     router.use(path, (req, res, next) => {

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -109,8 +109,15 @@ export class ApolloServer extends ApolloServerBase {
     }
 
     if (bodyParserConfig === true) {
-      middlewares.push(middlewareFromPath(path, bodyParser()));
+      middlewares.push(middlewareFromPath(path, bodyParser({
+        extendTypes: {
+          json: ['application/json', 'application/graphql+json']
+        }
+      })));
     } else if (bodyParserConfig !== false) {
+      if (typeof bodyParserConfig === 'object' && !bodyParserConfig.extendTypes) {
+        bodyParserConfig.extendTypes = { json: ['application/graphql+json', 'application/json'] }
+    }
       middlewares.push(middlewareFromPath(path, bodyParser(bodyParserConfig)));
     }
 

--- a/packages/apollo-server-koa/src/ApolloServer.ts
+++ b/packages/apollo-server-koa/src/ApolloServer.ts
@@ -109,15 +109,25 @@ export class ApolloServer extends ApolloServerBase {
     }
 
     if (bodyParserConfig === true) {
-      middlewares.push(middlewareFromPath(path, bodyParser({
-        extendTypes: {
-          json: ['application/json', 'application/graphql+json']
-        }
-      })));
+      middlewares.push(
+        middlewareFromPath(
+          path,
+          bodyParser({
+            extendTypes: {
+              json: ['application/json', 'application/graphql+json'],
+            },
+          }),
+        ),
+      );
     } else if (bodyParserConfig !== false) {
-      if (typeof bodyParserConfig === 'object' && !bodyParserConfig.extendTypes) {
-        bodyParserConfig.extendTypes = { json: ['application/graphql+json', 'application/json'] }
-    }
+      if (
+        typeof bodyParserConfig === 'object' &&
+        !bodyParserConfig.extendTypes
+      ) {
+        bodyParserConfig.extendTypes = {
+          json: ['application/graphql+json', 'application/json'],
+        };
+      }
       middlewares.push(middlewareFromPath(path, bodyParser(bodyParserConfig)));
     }
 

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -51,7 +51,7 @@ export function graphqlMicro(
           (contentType &&
             req.headers['content-length'] &&
             req.headers['content-length'] !== '0' &&
-            (typeis.is(contentType, 'application/json') || typeis.is(contentType, 'application/graphql+json')) &&
+            typeis.is(contentType, 'application/json', 'application/graphql+json') &&
             (await json(req)))
         : url.parse(req.url!, true).query;
 

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -51,7 +51,11 @@ export function graphqlMicro(
           (contentType &&
             req.headers['content-length'] &&
             req.headers['content-length'] !== '0' &&
-            typeis.is(contentType, 'application/json', 'application/graphql+json') &&
+            typeis.is(
+              contentType,
+              'application/json',
+              'application/graphql+json',
+            ) &&
             (await json(req)))
         : url.parse(req.url!, true).query;
 

--- a/packages/apollo-server-micro/src/microApollo.ts
+++ b/packages/apollo-server-micro/src/microApollo.ts
@@ -51,7 +51,7 @@ export function graphqlMicro(
           (contentType &&
             req.headers['content-length'] &&
             req.headers['content-length'] !== '0' &&
-            typeis.is(contentType, 'application/json') &&
+            (typeis.is(contentType, 'application/json') || typeis.is(contentType, 'application/graphql+json')) &&
             (await json(req)))
         : url.parse(req.url!, true).query;
 

--- a/packages/apollo-server/src/index.ts
+++ b/packages/apollo-server/src/index.ts
@@ -111,7 +111,10 @@ export class ApolloServer extends ApolloServerExpress {
     super.applyMiddleware({
       app: app,
       path: '/',
-      bodyParserConfig: { limit: '50mb' },
+      bodyParserConfig: {
+        limit: '50mb',
+        type: ['application/json', 'application/graphql+json'],
+      },
       onHealthCheck: this.onHealthCheck,
       cors:
         typeof this.cors !== 'undefined'


### PR DESCRIPTION
This PR aims to add support for the `application/graphql+json` content-type, this has been added to [the spec](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#content-types) here we see that we can support both `application/json` and `application/graphql+json`.

The main issue seems to be related to the body-parser used in koa and express as well as a check used in micro, an alternative would be to introduce a new body-parser.