### PR TITLE
Add types to executeOperation

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -959,7 +959,7 @@ export class ApolloServerBase<
       variables?: TVariables;
     },
     integrationContextArgument?: ContextFunctionParams,
-  ): Promise<Omit<GraphQLResponse, 'data'> & { data?: TData }> {
+  ): Promise<Omit<GraphQLResponse, 'data'> & { data?: TData | null }> {
     // Since this function is mostly for testing, you don't need to explicitly
     // start your server before calling it. (That also means you can use it with
     // `apollo-server` which doesn't support `start()`.)

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -953,7 +953,7 @@ export class ApolloServerBase<
    * `{req: express.Request, res: express.Response }` object) and to keep it
    * updated as you upgrade Apollo Server.
    */
-  public async executeOperation<TData = any, TVariables = Record<string, any>>(
+  public async executeOperation<TData = Record<string, any>, TVariables = Record<string, any>>(
     request: Omit<GraphQLRequest, 'query' | 'variables'> & {
       query?: string | DocumentNode;
       variables?: TVariables;

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -37,6 +37,7 @@ import {
   processGraphQLRequest,
   GraphQLRequestContext,
   GraphQLRequest,
+  GraphQLResponse,
   APQ_CACHE_PREFIX,
 } from './requestPipeline';
 
@@ -952,12 +953,13 @@ export class ApolloServerBase<
    * `{req: express.Request, res: express.Response }` object) and to keep it
    * updated as you upgrade Apollo Server.
    */
-  public async executeOperation(
-    request: Omit<GraphQLRequest, 'query'> & {
+  public async executeOperation<TData = any, TVariables = Record<string, any>>(
+    request: Omit<GraphQLRequest, 'query' | 'variables'> & {
       query?: string | DocumentNode;
+      variables?: TVariables;
     },
     integrationContextArgument?: ContextFunctionParams,
-  ) {
+  ): Promise<Omit<GraphQLResponse, 'data'> & { data?: TData }> {
     // Since this function is mostly for testing, you don't need to explicitly
     // start your server before calling it. (That also means you can use it with
     // `apollo-server` which doesn't support `start()`.)


### PR DESCRIPTION
When using `apollo-server-express` to fulfil a rest request internally we are using the executeOperation to avoid HTTP and we want it strongly typed like our client side queries. 
Rather than wrapping in a function to strictly type the variables and response of the query I've extended the function type to match how `useQuery` behaves in `apollo-client`.

Example usage
```   
const gqlResponse = await apolloServer.executeOperation<
      EventAllQuery,
      EventAllQueryVariables
    >(
      {
        query: gql`
          query EventAll($eventId: String!) {
            event(eventId: $eventId) {
              ... on AmericanFootballEvent {
                id
                name
                eventStatus {
                  description
                }
              }
            }
          }
        `,
        variables: {
          eventId: req.params.event_id,
        },
      },
      { req, res },
    )
```