### PR TITLE
docs: update with instructions on how to run lambda locally

### DIFF
--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -89,7 +89,26 @@ functions:
         cors: true
 ```
 
-### Running the Serverless Framework
+### Running Locally
+Using the `serverless` CLI, we can invoke our function locally to make sure it is running properly. As with any GraphQL "server", we need to send an operation for the schema to run as an HTTP request. You can store a mock HTTP request locally in a `query.json` file:
+
+```json
+{
+  "httpMethod": "POST",
+  "path": "/",
+  "headers": {
+    "content-type": "application/json"
+  },
+  "requestContext": {},
+  "body": "{\"operationName\": null, \"variables\": null, \"query\": \"{ hello }\"}"
+}
+```
+
+```sh
+serverless invoke local -f graphql -p query.json
+```
+
+### Deploying the Code
 
 After configuring the Serverless Framework, all you have to do to deploy is run `serverless deploy`
 


### PR DESCRIPTION
The docs are missing examples of how you can test your code locally before deploy. There is a certain structure to the HTTP request format so laying that out in the example can be helpful to get up and running.

https://www.serverless.com/framework/docs/providers/aws/cli-reference/invoke-local#local-function-invocation-with-a-data-file

![Screen Shot 2022-04-13 at 10 52 48 AM](https://user-images.githubusercontent.com/2446877/163240920-de797917-8ebb-43ec-8a08-60888e79a0ef.png)
