### PR TITLE
Removes leading $ in install commands

### DIFF
--- a/docs/source/integrations/middleware.mdx
+++ b/docs/source/integrations/middleware.mdx
@@ -295,7 +295,7 @@ You can call `server.getMiddleware` instead of `server.applyMiddleware` if you w
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above.
 
 ```
-$ npm install apollo-server-fastify apollo-server-core fastify graphql
+npm install apollo-server-fastify apollo-server-core fastify graphql
 ```
 
 <MultiCodeBlock>
@@ -356,7 +356,7 @@ You _must_ `await server.start()` before calling `server.createHandler`. You can
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above.
 
 ```
-$ npm install apollo-server-hapi @hapi/hapi graphql
+npm install apollo-server-hapi @hapi/hapi graphql
 ```
 
 <MultiCodeBlock>
@@ -402,7 +402,7 @@ You _must_ `await server.start()` before calling `server.applyMiddleware`. You c
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above.
 
 ```
-$ npm install apollo-server-koa apollo-server-core koa graphql
+npm install apollo-server-koa apollo-server-core koa graphql
 ```
 
 <MultiCodeBlock>
@@ -453,7 +453,7 @@ You can call `server.getMiddleware` instead of `server.applyMiddleware` if you w
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above. You should put this code in a file called `index.js` in order for the `micro` CLI to find it.
 
 ```
-$ npm install apollo-server-micro micro graphql
+npm install apollo-server-micro micro graphql
 ```
 
 <MultiCodeBlock>
@@ -490,7 +490,7 @@ This package is a layer around `apollo-server-express`, which uses the [`@vendia
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above.
 
 ```
-$ npm install apollo-server-lambda graphql
+npm install apollo-server-lambda graphql
 ```
 
 <MultiCodeBlock>
@@ -516,7 +516,7 @@ Because the Cloud Functions Node.js runtime uses Express, `apollo-server-cloud-f
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above.
 
 ```
-$ npm install apollo-server-cloud-functions graphql
+npm install apollo-server-cloud-functions graphql
 ```
 
 <MultiCodeBlock>
@@ -541,7 +541,7 @@ For more details on using `apollo-server-cloud-functions`, see the [documentatio
 The following example is roughly equivalent to the [`apollo-server` example](#apollo-server) above.
 
 ```
-$ npm install apollo-server-azure-functions graphql
+npm install apollo-server-azure-functions graphql
 ```
 
 <MultiCodeBlock>


### PR DESCRIPTION
This PR will remove the leading `$`'s from the `npm install`-lines, because they're not needed and reducing the usefulness of the "copy"-button. Also it will be more consistent because sometimes the leading `$`'s were there and sometimes not.