### PR TITLE
Improve ability to override fetcher; remove requestAgent option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,11 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/@apollo/utils.fetcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-1.0.0.tgz",
+      "integrity": "sha512-SpJH69ffk91BoYSVb12Dt/jFQKVOrm4NE59XUeHXRsha1xBmxjvZNN6qvYySAcGjloW4TtFZYlPkBpwjMRWymw=="
+    },
     "node_modules/@apollo/utils.isnodelike": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-1.1.0.tgz",
@@ -11850,6 +11855,7 @@
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^3.3.0",
         "@apollo/utils.createhash": "^1.0.0",
+        "@apollo/utils.fetcher": "^1.0.0",
         "@apollo/utils.isnodelike": "^1.0.0",
         "@apollo/utils.logger": "^1.0.0",
         "@apollographql/graphql-playground-html": "1.6.29",
@@ -11958,6 +11964,7 @@
       "requires": {
         "@apollo/usage-reporting-protobuf": "^3.3.0",
         "@apollo/utils.createhash": "^1.0.0",
+        "@apollo/utils.fetcher": "^1.0.0",
         "@apollo/utils.isnodelike": "^1.0.0",
         "@apollo/utils.logger": "^1.0.0",
         "@apollographql/graphql-playground-html": "1.6.29",
@@ -12001,6 +12008,11 @@
         "@apollo/utils.isnodelike": "^1.1.0",
         "sha.js": "^2.4.11"
       }
+    },
+    "@apollo/utils.fetcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-1.0.0.tgz",
+      "integrity": "sha512-SpJH69ffk91BoYSVb12Dt/jFQKVOrm4NE59XUeHXRsha1xBmxjvZNN6qvYySAcGjloW4TtFZYlPkBpwjMRWymw=="
     },
     "@apollo/utils.isnodelike": {
       "version": "1.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,6 +29,7 @@
     "@apollo/utils.createhash": "^1.0.0",
     "@apollo/utils.isnodelike": "^1.0.0",
     "@apollo/utils.logger": "^1.0.0",
+    "@apollo/utils.fetcher": "^1.0.0",
     "@apollographql/graphql-playground-html": "1.6.29",
     "@graphql-tools/mock": "^8.1.2",
     "@graphql-tools/schema": "^8.0.0",

--- a/packages/server/src/__tests__/integration/apolloServerTests.ts
+++ b/packages/server/src/__tests__/integration/apolloServerTests.ts
@@ -2024,7 +2024,8 @@ export function defineIntegrationTestSuiteApolloServerTests(
                   endpointUrl: fakeUsageReportingUrl,
                   reportIntervalMs: 1,
                   maxAttempts: 3,
-                  requestAgent,
+                  fetcher: (url, options) =>
+                    fetch(url, { ...options, agent: requestAgent }),
                   logger: quietLogger,
                   reportErrorFunction(error: Error) {
                     reportErrorPromiseResolve(error);

--- a/packages/server/src/plugin/schemaReporting/index.ts
+++ b/packages/server/src/plugin/schemaReporting/index.ts
@@ -3,11 +3,11 @@ import os from 'os';
 import type { InternalApolloServerPlugin } from '../../internalPlugin';
 import { v4 as uuidv4 } from 'uuid';
 import { printSchema, validateSchema, buildSchema } from 'graphql';
-import type fetch from 'node-fetch';
 import { SchemaReporter } from './schemaReporter';
 import { schemaIsFederated } from '../schemaIsFederated';
 import type { SchemaReport } from './generated/operations';
 import type { BaseContext } from '../../externalTypes';
+import type { Fetcher } from '@apollo/utils.fetcher';
 
 export interface ApolloServerPluginSchemaReportingOptions {
   /**
@@ -54,7 +54,7 @@ export interface ApolloServerPluginSchemaReportingOptions {
   /**
    * Specifies which Fetch API implementation to use when reporting schemas.
    */
-  fetcher?: typeof fetch;
+  fetcher?: Fetcher;
 }
 
 export function ApolloServerPluginSchemaReporting(

--- a/packages/server/src/plugin/usageReporting/options.ts
+++ b/packages/server/src/plugin/usageReporting/options.ts
@@ -6,10 +6,8 @@ import type {
   BaseContext,
 } from '../../externalTypes';
 import type { Logger } from '@apollo/utils.logger';
-import type fetch from 'node-fetch';
-import type { Agent as HttpAgent } from 'http';
-import type { Agent as HttpsAgent } from 'https';
 import type { Trace } from '@apollo/usage-reporting-protobuf';
+import type { Fetcher } from '@apollo/utils.fetcher';
 
 export interface ApolloServerPluginUsageReportingOptions<
   TContext extends BaseContext,
@@ -234,14 +232,9 @@ export interface ApolloServerPluginUsageReportingOptions<
    */
   sendReportsImmediately?: boolean;
   /**
-   * HTTP(s) agent to be used on the `fetch` call when sending reports to
-   * Apollo.
-   */
-  requestAgent?: HttpAgent | HttpsAgent | false;
-  /**
    * Specifies which Fetch API implementation to use when sending usage reports.
    */
-  fetcher?: typeof fetch;
+  fetcher?: Fetcher;
   /**
    * How often to send reports to Apollo. We'll also send reports when the
    * report gets big; see maxUncompressedReportSize.

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import { gzip } from 'zlib';
 import retry from 'async-retry';
 import { Report, ReportHeader, Trace } from '@apollo/usage-reporting-protobuf';
-import fetch, { Response } from 'node-fetch';
+import fetch from 'node-fetch';
 import type {
   GraphQLRequestListener,
   GraphQLServerListener,
@@ -35,6 +35,7 @@ import {
 } from './referencedFields';
 import type LRUCache from 'lru-cache';
 import type { HeaderMap } from '../../runHttpQuery';
+import type { Fetcher, FetcherResponse } from '@apollo/utils.fetcher';
 
 const reportHeaderDefaults = {
   hostname: os.hostname(),
@@ -290,8 +291,8 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
         });
 
         // Wrap fetcher with async-retry for automatic retrying
-        const fetcher = options.fetcher ?? fetch;
-        const response: Response = await retry(
+        const fetcher: Fetcher = options.fetcher ?? fetch;
+        const response: FetcherResponse = await retry(
           // Retry on network errors and 5xx HTTP
           // responses.
           async () => {
@@ -308,7 +309,6 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
                   accept: 'application/json',
                 },
                 body: compressed,
-                agent: options.requestAgent,
               },
             );
 


### PR DESCRIPTION
The usage reporting and schema reporting plugins talk to Apollo servers
using (by default) `node-fetch`, but they provide `fetcher` options to
let you customize the fetching.

However, some fetch implementations like `make-fetch-happen` v10 didn't
actually work, because they don't know how to detect `Request`/`Headers`
objects provided by `node-fetch`.  In addition, `make-fetch-happen`'s
TypeScript types aren't quite compatible with `typeof fetch` from
`node-fetch`.

We've created a new `@apollo/utils.fetcher` which defines a more minimal
fetch API as `Fetcher`; both `node-fetch` and `make-fetch-happen` fit
this typing. We are careful now to only pass portable options to our
fetch call (which are the only ones allowed by our new `Fetcher` type).

Specifically, we don't pass `Headers`/`Request` objects in (just plain
JSON-style objects), and we don't pass the `node-fetch`-specific
`agent` option.

The latter means we are **removing the `requestAgent` option from the
usage reporting plugin**. This option predated the `fetcher` option.
Instead of

    ApolloServerPluginUsageReporting({ requestAgent })

you can write

    import fetch from 'node-fetch';
    ApolloServerPluginUsageReporting({
      fetcher: (url, options) => fetch(url, {
        ...options,
        agent: requestAgent,
      }),
    });

Fixes #6046.
