### PR TITLE
Add Data and Variable types to executer operation

### DIFF
--- a/packages/server-types/src/types.ts
+++ b/packages/server-types/src/types.ts
@@ -139,12 +139,19 @@ export interface GraphQLRequest {
 
 export type VariableValues = { [name: string]: any };
 
+// Its not possible for this to be Record<string, any> without casting either the
+// result of executeOperation in ApolloServer.ts or the result of sendResponse and
+// sendErrorResponse in requestPipeline.ts.
+// By leaving this open as the wider object type it fulfills what a user can pass
+// in which is an extension of Record<string, any>.
+type GraphQLResponseData = Record<string | number | symbol, any>;
+
 // TODO(AS4): does this differ in an interesting way from GraphQLExecutionResult
 // and graphql-js ExecutionResult? It does have `http` but perhaps this can be an
 // "extends". Ah, the difference is about formatted vs throwable errors? Let's
 // make sure we at least understand it.
-export interface GraphQLResponse {
-  data?: Record<string, any> | null;
+export interface GraphQLResponse<TData = GraphQLResponseData> {
+  data?: TData | null;
   errors?: ReadonlyArray<GraphQLFormattedError>;
   extensions?: Record<string, any>;
   // TODO(AS4): Seriously consider whether this type makes sense at all or whether

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -1040,25 +1040,38 @@ export class ApolloServer<TContext extends BaseContext = BaseContext> {
    * The second object will be the `contextValue` object available in resolvers.
    */
   // TODO(AS4): document this
-  public async executeOperation(
+  public async executeOperation<
+    TData = Record<string, any>,
+    TVariables = Record<string, any>,
+  >(
     this: ApolloServer<BaseContext>,
     request: Omit<GraphQLRequest, 'query'> & {
       query?: string | DocumentNode;
+      variables?: TVariables;
     },
-  ): Promise<GraphQLResponse>;
-  public async executeOperation(
+  ): Promise<GraphQLResponse<TData>>;
+
+  public async executeOperation<
+    TData = Record<string, any>,
+    TVariables = Record<string, any>,
+  >(
     request: Omit<GraphQLRequest, 'query'> & {
       query?: string | DocumentNode;
+      variables?: TVariables;
     },
     contextValue: TContext,
-  ): Promise<GraphQLResponse>;
+  ): Promise<GraphQLResponse<TData>>;
 
-  async executeOperation(
+  async executeOperation<
+    TData = Record<string, any>,
+    TVariables = Record<string, any>,
+  >(
     request: Omit<GraphQLRequest, 'query'> & {
       query?: string | DocumentNode;
+      variables?: TVariables;
     },
     contextValue?: TContext,
-  ): Promise<GraphQLResponse> {
+  ): Promise<GraphQLResponse<TData>> {
     // Since this function is mostly for testing, you don't need to explicitly
     // start your server before calling it. (That also means you can use it with
     // `apollo-server` which doesn't support `start()`.)


### PR DESCRIPTION
Previously created this PR https://github.com/apollographql/apollo-server/pull/6311 I don't seem to have the power to decline my old PR so when someone gets to this please decline it to avoid confusion 
Was asked to move this to the version-4 branch and use a generic for `GraphQLResponse` rather than omit

Another comment was to use TypedDocumentNode I have no experience with this so can't quickly update the code to make use of this.

Reasoning
When using `apollo-server-express` to fulfil a rest request internally we are using the executeOperation to avoid HTTP and we want it strongly typed like our client side queries.
Rather than wrapping in a function to strictly type the variables and response of the query I've extended the function type to match how `useQuery` behaves in `apollo-client`.

Example usage
```
const gqlResponse = await apolloServer.executeOperation<
      EventAllQuery,
      EventAllQueryVariables
    >(
      {
        query: gql`
          query EventAll($eventId: String!) {
            event(eventId: $eventId) {
              ... on AmericanFootballEvent {
                id
                name
                eventStatus {
                  description
                }
              }
            }
          }
        `,
        variables: {
          eventId: req.params.event_id,
        },
      },
      { req, res },
    )
  ```