### PR TITLE
POST request example: consistent spacing for variable type

### DIFF
--- a/docs/source/requests.md
+++ b/docs/source/requests.md
@@ -16,7 +16,7 @@ Apollo Server accepts POST requests with a JSON body. A valid request contains a
 Let's say we want to execute the following query:
 
 ```graphql
-query GetBestSellers($category:ProductCategory) {
+query GetBestSellers($category: ProductCategory) {
   bestSellers(category: $category) {
     title
   }
@@ -27,7 +27,7 @@ query GetBestSellers($category:ProductCategory) {
 
 ```json
 {
-  "query":"query GetBestSellers($category:ProductCategory){bestSellers(category: $category){title}}",
+  "query":"query GetBestSellers($category: ProductCategory){bestSellers(category: $category){title}}",
   "operationName": "GetBestSellers",
   "variables": { "category": "BOOKS" }
 }
@@ -40,7 +40,7 @@ You can execute this query against an Apollo-hosted example server right now wit
 ```sh
 curl --request POST \
   -H 'Content-Type: application/json' \
-  --data '{"query":"query GetBestSellers($category:ProductCategory){bestSellers(category: $category){title}}", "operationName":"GetBestSellers", "variables":{"category":"BOOKS"}}' \
+  --data '{"query":"query GetBestSellers($category: ProductCategory){bestSellers(category: $category){title}}", "operationName":"GetBestSellers", "variables":{"category":"BOOKS"}}' \
   https://rover.apollo.dev/quickstart/products/graphql
 ```
 
@@ -77,5 +77,5 @@ Here's the same query from [POST requests](#post-requests) formatted for a `curl
 
 ```sh
 curl --request GET \
-  https://rover.apollo.dev/quickstart/products/graphql?query=query%20GetBestSellers%28%24category%3AProductCategory%29%7BbestSellers%28category%3A%20%24category%29%7Btitle%7D%7D&operationName=GetBestSellers&variables=%7B%22category%22%3A%22BOOKS%22%7D
+  https://rover.apollo.dev/quickstart/products/graphql?query=query%20GetBestSellers%28%24category%3A%20ProductCategory%29%7BbestSellers%28category%3A%20%24category%29%7Btitle%7D%7D&operationName=GetBestSellers&variables=%7B%22category%22%3A%22BOOKS%22%7D
 ```


### PR DESCRIPTION
Just improving a bit consistency about using spaces between the colon and variable type