### PR TITLE
Fix a bundle of dependency issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
-- _Nothing yet! Stay tuned._
+- Add a few missing dependencies to packages. [PR #6393](https://github.com/apollographql/apollo-server/pull/6393)
 
 ## v3.7.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21205,11 +21205,11 @@
         "apollo-server-errors": "file:../apollo-server-errors",
         "http-cache-semantics": "^4.1.0"
       },
-      "devDependencies": {
-        "apollo-server-types": "file:../apollo-server-types"
-      },
       "engines": {
         "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
       }
     },
     "packages/apollo-reporting-protobuf": {
@@ -21223,6 +21223,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
+        "@types/express": "4.17.13",
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-express": "file:../apollo-server-express",
         "express": "^4.17.1"
@@ -21587,6 +21588,7 @@
       "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
+        "@apollo/utils.logger": "^1.0.0",
         "apollo-reporting-protobuf": "file:../apollo-reporting-protobuf",
         "apollo-server-caching": "file:../apollo-server-caching",
         "apollo-server-env": "file:../apollo-server-env"
@@ -26994,7 +26996,6 @@
         "apollo-server-caching": "file:../apollo-server-caching",
         "apollo-server-env": "file:../apollo-server-env",
         "apollo-server-errors": "file:../apollo-server-errors",
-        "apollo-server-types": "file:../apollo-server-types",
         "http-cache-semantics": "^4.1.0"
       }
     },
@@ -27007,6 +27008,7 @@
     "apollo-server": {
       "version": "file:packages/apollo-server",
       "requires": {
+        "@types/express": "4.17.13",
         "apollo-server-core": "file:../apollo-server-core",
         "apollo-server-express": "file:../apollo-server-express",
         "apollo-server-integration-testsuite": "file:../apollo-server-integration-testsuite",
@@ -27229,6 +27231,7 @@
     "apollo-server-types": {
       "version": "file:packages/apollo-server-types",
       "requires": {
+        "@apollo/utils.logger": "^1.0.0",
         "apollo-reporting-protobuf": "file:../apollo-reporting-protobuf",
         "apollo-server-caching": "file:../apollo-server-caching",
         "apollo-server-env": "file:../apollo-server-env"

--- a/packages/apollo-datasource-rest/package.json
+++ b/packages/apollo-datasource-rest/package.json
@@ -24,7 +24,7 @@
     "apollo-server-errors": "file:../apollo-server-errors",
     "http-cache-semantics": "^4.1.0"
   },
-  "devDependencies": {
-    "apollo-server-types": "file:../apollo-server-types"
+  "peerDependencies": {
+    "graphql": "^15.3.0 || ^16.0.0"
   }
 }

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -10,8 +10,6 @@ import {
   fetch,
 } from 'apollo-server-env';
 
-import type { ValueOrPromise } from 'apollo-server-types';
-
 import { DataSource, DataSourceConfig } from 'apollo-datasource';
 
 import { HTTPCache } from './HTTPCache';
@@ -22,6 +20,7 @@ import {
   ForbiddenError,
 } from 'apollo-server-errors';
 
+type ValueOrPromise<T> = T | Promise<T>;
 declare module 'apollo-server-env/dist/fetch' {
   interface RequestInit {
     cacheOptions?:

--- a/packages/apollo-datasource-rest/tsconfig.json
+++ b/packages/apollo-datasource-rest/tsconfig.json
@@ -10,6 +10,5 @@
     { "path": "../apollo-datasource" },
     { "path": "../apollo-server-caching" },
     { "path": "../apollo-server-errors" },
-    { "path": "../apollo-server-types" },
   ]
 }

--- a/packages/apollo-server-types/package.json
+++ b/packages/apollo-server-types/package.json
@@ -11,6 +11,7 @@
     "node": ">=12.0"
   },
   "dependencies": {
+    "@apollo/utils.logger": "^1.0.0",
     "apollo-reporting-protobuf": "file:../apollo-reporting-protobuf",
     "apollo-server-caching": "file:../apollo-server-caching",
     "apollo-server-env": "file:../apollo-server-env"

--- a/packages/apollo-server/package.json
+++ b/packages/apollo-server/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "dependencies": {
+    "@types/express": "4.17.13",
     "apollo-server-core": "file:../apollo-server-core",
     "apollo-server-express": "file:../apollo-server-express",
     "express": "^4.17.1"


### PR DESCRIPTION
Some packages were depending on other packages that were only declared
as transitive dependencies. Clean this up by adding appropriate
dependencies (or in one case, just re-declaring ValueOrPromise and
dropping the apollo-server-types dependency).

The peer dep one is a bit funny.  But "Y has a peer dep on Z" means
"when you install Y you need to install Z", and so if X depends on Y,
then when you install X you need to install Z... so sure, that means X
needs to have a peer dep on Z too, I guess.

Fixes #6389.
Fixes #6390.
Fixes #6391.
Fixes #6392.
