### PR TITLE
CSRF prevention (from Apollo Server 3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 - _Nothing yet! Stay tuned._
 
+## v3.7.0
+
+- ⚠️ **SECURITY** `apollo-server-core`: Apollo Server now includes protection against [CSRF](https://owasp.org/www-community/attacks/csrf) and XS-Search attacks. We **highly recommend** enabling this feature by passing `csrfPrevention: true` to `new ApolloServer()`. If you rely on the ability to execute GraphQL operations via HTTP `GET` requests using a client other than Apollo Client Web, Apollo iOS, or Apollo Kotlin (formerly Apollo Android), you may need to first change the configuration of that client. See [the CSRF prevention docs](https://www.apollographql.com/docs/apollo-server/security/cors#preventing-cross-site-request-forgery-csrf) for more details. This vulnerability was reported by Jeffrey Hofmann; the feature was designed with advice from Luca Carettoni of Doyensec.
+
+## v3.6.8
+
+- `apollo-server-fastify`: This package now depends on the `@fastify/accepts` and `@fastify/cors` packages rather than their older deprecated names `fastify-accepts` and `fastify-cors`. There is no behavior change (except that you will no longer see deprecation messages). [PR #6366](https://github.com/apollographql/apollo-server/pull/6366)
+- `apollo-server-types`: The `Logger` TypeScript interface is now re-exported from the new `@apollo/utils.logger` package instead of defined directly in this package; other packages import it from the new package. There should be no observable change. [PR #6229](https://github.com/apollographql/apollo-serverpull/6229)
+
 ## v3.6.7
 
 - `apollo-server-core`: Update `@apollographql/apollo-tools` dependency to the latest version which now properly lists its peer dependencies. This fixes a problem with using Yarn3 PnP [PR #6273](https://github.com/apollographql/apollo-server/pull/6273)

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -22,6 +22,7 @@ bwvllq
 cacheability
 cacheable
 Cacheable
+Carettoni
 Changesets
 cimg
 circleci
@@ -44,6 +45,7 @@ direnv
 Direnv
 docset
 docstrings
+Doyensec
 DRYRUN
 eastus
 endregion
@@ -71,6 +73,7 @@ graphqlcodegenerator
 GraphQLJSON
 hackily
 herokuapp
+Hofmann
 hrtime
 htmls
 httpcache
@@ -87,6 +90,7 @@ linearizability
 linearizable
 Loftis
 loglevel
+Luca
 MAXAGE
 mget
 Mget
@@ -94,6 +98,7 @@ microrouter
 middlewares
 Middlewares
 millis
+monodocs
 mygraph
 myvariant
 namespacing
@@ -110,6 +115,8 @@ pbts
 pook
 Pook
 pooks
+preflighted
+preflighting
 prepended
 prestart
 Procfile
@@ -126,6 +133,7 @@ roadmap
 ROADMAP
 runtimes
 safelist
+safelisted
 safelisting
 Safelisting
 Scheer
@@ -157,7 +165,6 @@ unawaited
 uncacheable
 undersupported
 undici
-urlencode
 unexecutable
 uninstrumented
 unparsable
@@ -167,6 +174,7 @@ unsubscriber
 Unsubscriber
 Unversioned
 Uppercasing
+urlencode
 USERCONFIG
 uuidv
 vendia
@@ -175,4 +183,3 @@ websockets
 Wheelock's
 xorby
 YOURNAME
-monodocs

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@types/test-listen": "1.1.0",
         "@types/type-is": "1.6.3",
         "@types/uuid": "8.3.4",
+        "@types/whatwg-mimetype": "^2.1.1",
         "@vendia/serverless-express": "4.8.0",
         "awaiting": "3.0.0",
         "body-parser": "1.20.0",
@@ -3397,6 +3398,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-2.1.1.tgz",
+      "integrity": "sha512-ojnf89qt5AWnqsjyPqMLN8uVaxm5x23vxNQ1me6EPBOdJe1YYuIZUzg809MZUG8UU6HKhkr6ah4fi2WUvD0DFw==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -11610,6 +11617,14 @@
       "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
       "dev": true
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11860,7 +11875,8 @@
         "lru-cache": "^7.5.1",
         "negotiator": "^0.6.3",
         "node-fetch": "^2.6.7",
-        "uuid": "^8.0.0"
+        "uuid": "^8.0.0",
+        "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
         "node": ">=12.0"
@@ -11969,7 +11985,8 @@
         "lru-cache": "^7.5.1",
         "negotiator": "^0.6.3",
         "node-fetch": "^2.6.7",
-        "uuid": "^8.0.0"
+        "uuid": "^8.0.0",
+        "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -14689,6 +14706,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
+    "@types/whatwg-mimetype": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-2.1.1.tgz",
+      "integrity": "sha512-ojnf89qt5AWnqsjyPqMLN8uVaxm5x23vxNQ1me6EPBOdJe1YYuIZUzg809MZUG8UU6HKhkr6ah4fi2WUvD0DFw==",
       "dev": true
     },
     "@types/ws": {
@@ -21050,6 +21073,11 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
       "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
       "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/test-listen": "1.1.0",
     "@types/type-is": "1.6.3",
     "@types/uuid": "8.3.4",
+    "@types/whatwg-mimetype": "2.1.1",
     "@vendia/serverless-express": "4.8.0",
     "awaiting": "3.0.0",
     "body-parser": "1.20.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,7 +47,8 @@
     "lru-cache": "^7.5.1",
     "negotiator": "^0.6.3",
     "node-fetch": "^2.6.7",
-    "uuid": "^8.0.0"
+    "uuid": "^8.0.0",
+    "whatwg-mimetype": "^3.0.0"
   },
   "peerDependencies": {
     "graphql": "^16.3.0"

--- a/packages/server/src/__tests__/integration/httpServerTests.ts
+++ b/packages/server/src/__tests__/integration/httpServerTests.ts
@@ -250,7 +250,12 @@ export function defineIntegrationTestSuiteHttpServerTests(
     describe('graphqlHTTP', () => {
       it('rejects the request if the method is not POST or GET', async () => {
         app = await createApp();
-        const req = request(app).head('/graphql').send();
+        const req = request(app)
+          .head('/graphql')
+          // Make sure we get the error we're looking for, not the CSRF
+          // prevention error :)
+          .set('apollo-require-preflight', 't')
+          .send();
         return req.then((res) => {
           expect(res.status).toEqual(405);
           expect(res.headers['allow']).toEqual('GET, POST');
@@ -259,7 +264,11 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('throws an error if POST body is empty', async () => {
         app = await createApp();
-        const req = request(app).post('/graphql').type('text/plain').send('  ');
+        const req = request(app)
+          .post('/graphql')
+          .type('text/plain')
+          .set('apollo-require-preflight', 't')
+          .send('  ');
         return req.then((res) => {
           expect(res.status).toEqual(400);
           expect((res.error as HTTPError).text).toMatch('POST body missing');
@@ -283,6 +292,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const req = request(app)
           .post('/graphql')
           .type('text/plain')
+          .set('apollo-require-preflight', 't')
           .send(
             JSON.stringify({
               query: 'query test{ testString }',
@@ -326,7 +336,9 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('throws an error if GET query is missing', async () => {
         app = await createApp();
-        const res = await request(app).get(`/graphql`);
+        const res = await request(app)
+          .get(`/graphql`)
+          .set('apollo-require-preflight', 't');
         expect(res.status).toEqual(400);
         expect(JSON.parse((res.error as HTTPError).text))
           .toMatchInlineSnapshot(`
@@ -351,7 +363,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const query = {
           query: 'query test{ testString }',
         };
-        const req = request(app).get('/graphql').query(query);
+        const req = request(app)
+          .get('/graphql')
+          .set('apollo-require-preflight', 't')
+          .query(query);
         return req.then((res) => {
           expect(res.status).toEqual(200);
           expect(res.body.data).toEqual(expected);
@@ -366,7 +381,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const query = {
           query: '{ testString }',
         };
-        const req = request(app).get('/graphql').query(query);
+        const req = request(app)
+          .get('/graphql')
+          .set('apollo-require-preflight', 't')
+          .query(query);
         return req.then((res) => {
           expect(res.status).toEqual(200);
           expect(res.body.data).toEqual(expected);
@@ -388,7 +406,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const query = {
           query: 'mutation test{ testMutation(echo: "ping") }',
         };
-        const req = request(app).get('/graphql').query(query);
+        const req = request(app)
+          .get('/graphql')
+          .set('apollo-require-preflight', 't')
+          .query(query);
 
         await req.then((res) => {
           expect(res.status).toEqual(405);
@@ -432,7 +453,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
               }
             }`,
         };
-        const req = request(app).get('/graphql').query(query);
+        const req = request(app)
+          .get('/graphql')
+          .set('apollo-require-preflight', 't')
+          .query(query);
         await req.then((res) => {
           expect(res.status).toEqual(405);
           expect(res.headers['allow']).toEqual('POST');
@@ -461,7 +485,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const expected = {
           testArgument: 'hello world',
         };
-        const req = request(app).get('/graphql').query(query);
+        const req = request(app)
+          .get('/graphql')
+          .set('apollo-require-preflight', 't')
+          .query(query);
         return req.then((res) => {
           expect(res.status).toEqual(200);
           expect(res.body.data).toEqual(expected);
@@ -639,6 +666,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         });
         const req = request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             extensions: JSON.stringify({
               persistedQuery: {
@@ -693,6 +721,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         app = await createApp();
         const req = request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             extensions: JSON.stringify({
               persistedQuery: {
@@ -1347,6 +1376,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         // Intentionally fire off the request asynchronously, without await.
         const res = request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             query: 'query test{ testString }',
           })
@@ -1498,6 +1528,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
         const result = await request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             query,
             extensions: JSON.stringify({
@@ -1533,6 +1564,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
         const result = await request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             query,
             extensions: JSON.stringify({
@@ -1569,6 +1601,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
         const result = await request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             query,
             extensions: JSON.stringify({
@@ -1767,6 +1800,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         });
         const result = await request(app)
           .get('/graphql')
+          .set('apollo-require-preflight', 't')
           .query({
             extensions: JSON.stringify(extensions),
           });

--- a/packages/server/src/preventCsrf.ts
+++ b/packages/server/src/preventCsrf.ts
@@ -1,0 +1,99 @@
+import MIMEType from 'whatwg-mimetype';
+import { HttpQueryError } from './runHttpQuery';
+
+// Our recommended set of CSRF prevention headers. Operations that do not
+// provide a content-type such as `application/json` (in practice, this
+// means GET operations) must include at least one of these headers.
+// Apollo Client Web's default behavior is to always sends a
+// `content-type` even for `GET`, and Apollo iOS and Apollo Kotlin always
+// send `x-apollo-operation-name`. So if you set
+// `csrfPreventionRequestHeaders: true` then any `GET` operation from these
+// three client projects and any `POST` operation at all should work
+// successfully; if you need `GET`s from another kind of client to work,
+// just add `apollo-require-preflight: true` to their requests.
+export const recommendedCsrfPreventionRequestHeaders = [
+  'x-apollo-operation-name',
+  'apollo-require-preflight',
+];
+
+// See https://fetch.spec.whatwg.org/#cors-safelisted-request-header
+const NON_PREFLIGHTED_CONTENT_TYPES = [
+  'application/x-www-form-urlencoded',
+  'multipart/form-data',
+  'text/plain',
+];
+
+// We don't want random websites to be able to execute actual GraphQL operations
+// from a user's browser unless our CORS policy supports it. It's not good
+// enough just to ensure that the browser can't read the response from the
+// operation; we also want to prevent CSRF, where the attacker can cause side
+// effects with an operation or can measure the timing of a read operation. Our
+// goal is to ensure that we don't run the context function or execute the
+// GraphQL operation until the browser has evaluated the CORS policy, which
+// means we want all operations to be pre-flighted. We can do that by only
+// processing operations that have at least one header set that appears to be
+// manually set by the JS code rather than by the browser automatically.
+//
+// POST requests generally have a content-type `application/json`, which is
+// sufficient to trigger preflighting. So we take extra care with requests that
+// specify no content-type or that specify one of the three non-preflighted
+// content types. For those operations, we require (if this feature is enabled)
+// one of a set of specific headers to be set. By ensuring that every operation
+// either has a custom content-type or sets one of these headers, we know we
+// won't execute operations at the request of origins who our CORS policy will
+// block.
+export function preventCsrf(
+  headers: Map<string, string>,
+  csrfPreventionRequestHeaders: string[],
+) {
+  const contentType = headers.get('content-type');
+
+  // We have to worry about CSRF if it looks like this may have been a
+  // non-preflighted request. If we see a content-type header that is not one of
+  // the three CORS-safelisted MIME types (see
+  // https://fetch.spec.whatwg.org/#cors-safelisted-request-header) then we know
+  // it was preflighted and we don't have to worry.
+  if (contentType !== undefined) {
+    const contentTypeParsed = MIMEType.parse(contentType);
+    if (contentTypeParsed === null) {
+      // If we got null, then parsing the content-type failed... which is
+      // actually *ok* because that would lead to a preflight. (For example, the
+      // header is empty, or doesn't have a slash, or has bad characters.) The
+      // scary CSRF case is only if there's *not* an error. So it is actually
+      // fine for us to just `return` here. (That said, it would also be
+      // reasonable to reject such requests with provided yet unparsable
+      // Content-Type here.)
+      return;
+    }
+    if (!NON_PREFLIGHTED_CONTENT_TYPES.includes(contentTypeParsed.essence)) {
+      // We managed to parse a MIME type that was not one of the
+      // CORS-safelisted ones. (Probably application/json!) That means that if
+      // the client is a browser, the browser must have applied CORS
+      // preflighting and we don't have to worry about CSRF.
+      return;
+    }
+  }
+
+  // Either there was no content-type, or the content-type parsed properly as
+  // one of the three CORS-safelisted values. Let's look for another header that
+  // (if this was a browser) must have been set by the user's code and would
+  // have caused a preflight.
+  if (
+    csrfPreventionRequestHeaders.some((header) => {
+      const value = headers.get(header);
+      return value !== undefined && value.length > 0;
+    })
+  ) {
+    return;
+  }
+
+  throw new HttpQueryError(
+    400,
+    `This operation has been blocked as a potential Cross-Site Request Forgery ` +
+      `(CSRF). Please either specify a 'content-type' header (with a type that ` +
+      `is not one of ${NON_PREFLIGHTED_CONTENT_TYPES.join(', ')}) or provide ` +
+      `a non-empty value for one of the following headers: ${csrfPreventionRequestHeaders.join(
+        ', ',
+      )}\n`,
+  );
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -77,6 +77,22 @@ export interface PersistedQueryOptions {
   ttl?: number | null;
 }
 
+export interface CSRFPreventionOptions {
+  // CSRF prevention works by only processing operations from requests whose
+  // structure indicates that if they were sent by a web browser, then the
+  // browser would have had to send a preflight OPTIONS request already. We do
+  // this by specifying some headers that a browser will never automatically set
+  // and which will trigger the browser to preflight. Apollo Server will reject
+  // any operation that does not set at least one of these headers *and* does
+  // not set a content-type (to a header whose parsed type is not
+  // application/x-www-form-urlencoded, multipart/form-data, or text/plain). If
+  // CSRF prevention is enabled (eg, with `csrfPrevention: true`) this list
+  // defaults to ['x-apollo-operation-name', 'apollo-require-preflight']. This
+  // will allow POST operations from any client and GET operations from Apollo
+  // Client Web, Apollo iOS, and Apollo Kotlin.
+  requestHeaders?: string[];
+}
+
 // TODO(AS4): Organize this.
 interface ApolloServerOptionsBase<TContext extends BaseContext> {
   formatError?: (error: GraphQLError) => GraphQLFormattedError;
@@ -100,6 +116,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
   documentStore?: DocumentStore | null;
+  csrfPrevention?: CSRFPreventionOptions | boolean;
 
   // This is used for two different things: parsing the schema if you're a
   // SchemaFromTypeDefsConfig, *and* parsing operations. Arguably this is a bit


### PR DESCRIPTION
Unlike in AS3, this feature is on by default (and doesn't require
editing every framework integration).

Because it's on by default, we had to change a handful of tests to pass
apollo-require-preflight.
