### PR TITLE
Embedded Landing Pages 

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -176,3 +176,5 @@ websockets
 Wheelock's
 xorby
 YOURNAME
+Embeddable
+embeddable

--- a/packages/apollo-server-core/src/plugin/index.ts
+++ b/packages/apollo-server-core/src/plugin/index.ts
@@ -106,12 +106,12 @@ export function ApolloServerPluginLandingPageDisabled(): ApolloServerPlugin {
 import type {
   ApolloServerPluginLandingPageLocalDefaultOptions,
   ApolloServerPluginLandingPageProductionDefaultOptions,
-} from './landingPage/default';
+} from './landingPage/default/types';
 export type {
   ApolloServerPluginLandingPageDefaultBaseOptions,
   ApolloServerPluginLandingPageLocalDefaultOptions,
   ApolloServerPluginLandingPageProductionDefaultOptions,
-} from './landingPage/default';
+} from './landingPage/default/types';
 export function ApolloServerPluginLandingPageLocalDefault(
   options?: ApolloServerPluginLandingPageLocalDefaultOptions,
 ): ApolloServerPlugin {

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -97,6 +97,25 @@ id="embeddableExplorer"
 `;
 };
 
+const getEmbeddedSandboxHTML = () => {
+  // (version: string) => {
+  // TODO (Maya) update this to fetch from the `embeddable-sandbox` repo when the GCS service key is set up correctly
+  return `
+<div
+style="width: 100vw; height: 100vh;"
+id="embeddableSandbox"
+></div>
+<script src="https://embeddable-explorer.cdn.apollographql.com/mayaTest_sandbox/embeddable-sandbox.umd.production.min.js"></script>
+<script>
+  var initialEndpoint = window.location.href;
+  new window.EmbeddedSandbox({
+    target: '#embeddableSandbox',
+    initialEndpoint,
+  });
+</script>
+`;
+};
+
 const getNonEmbeddedLandingPageHTML = (
   version: string,
   config: LandingPageConfig,
@@ -176,12 +195,10 @@ curl --request POST \\
   --data '{"query":"query { __typename }"}'</code>
       </div>
     ${
-      config.shouldEmbed === true && 'graphRef' in config && !!config.graphRef
-        ? getEmbeddedExplorerHTML(version, config)
-        : config.shouldEmbed === true
-        ? // TODO maya implement Sandbox html
-          // getEmbeddedSandboxHTML(version, config)
-          `<div />`
+      config.shouldEmbed === true
+        ? 'graphRef' in config && !!config.graphRef
+          ? getEmbeddedExplorerHTML(version, config)
+          : getEmbeddedSandboxHTML()
         : getNonEmbeddedLandingPageHTML(version, config)
     }
     </div>

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -88,6 +88,11 @@ const getEmbeddedExplorerHTML = (
     };
 
   return `
+<style>
+  iframe {
+    background-color: white;
+  }
+</style>
 <div
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableExplorer"
@@ -108,6 +113,11 @@ const getEmbeddedSandboxHTML = () => {
   // (version: string) => {
   // TODO (Maya) update this to fetch from the `embeddable-sandbox` repo when the GCS service key is set up correctly
   return `
+<style>
+  iframe {
+    background-color: white;
+  }
+</style>
 <div
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -40,6 +40,17 @@ function encodeConfig(config: LandingPageConfig): string {
   return JSON.stringify(encodeURIComponent(JSON.stringify(config)));
 }
 
+// This function turns an object into a string and replaces
+// <, >, &, ' with their unicode chars to avoid adding html tags to
+// the landing page html that might be passed from the config
+function getConfigStringForHtml(config: LandingPageConfig) {
+  return JSON.stringify(config)
+    .replace('<', '\\u003c')
+    .replace('>', '\\u003e')
+    .replace('&', '\\u0026')
+    .replace("'", '\\u0027');
+}
+
 const getEmbeddedExplorerHTML = (
   version: string,
   config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions,
@@ -94,7 +105,9 @@ id="embeddableExplorer"
 <script src="https://embeddable-explorer.cdn.apollographql.com/${version}/embeddable-explorer.umd.production.min.js"></script>
 <script>
   var endpointUrl = window.location.href;
-  var embeddedExplorerConfig = ${JSON.stringify(embeddedExplorerParams)};
+  var embeddedExplorerConfig = ${getConfigStringForHtml(
+    embeddedExplorerParams,
+  )};
   new window.EmbeddedExplorer({
     ...embeddedExplorerConfig,
     endpointUrl,

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -42,7 +42,13 @@ function encodeConfig(config: LandingPageConfig): string {
 
 // This function turns an object into a string and replaces
 // <, >, &, ' with their unicode chars to avoid adding html tags to
-// the landing page html that might be passed from the config
+// the landing page html that might be passed from the config.
+// The only place these characters can appear in the output of
+// JSON.stringify is within string literals, where they can equally
+// well appear \u-escaped. This specifically means that
+// `</script>` won't terminate the script block early.
+// (Perhaps we should have done this instead of the triple-encoding
+// of encodeConfig for the main landing page.)
 function getConfigStringForHtml(config: LandingPageConfig) {
   return JSON.stringify(config)
     .replace('<', '\\u003c')

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -82,7 +82,7 @@ const getEmbeddedExplorerHTML = (
 
   return `
 <div
-style="width: 100vw; height: 100vh;"
+style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableExplorer"
 ></div>
 <script src="https://embeddable-explorer.cdn.apollographql.com/${version}/embeddable-explorer.umd.production.min.js"></script>
@@ -102,7 +102,7 @@ const getEmbeddedSandboxHTML = () => {
   // TODO (Maya) update this to fetch from the `embeddable-sandbox` repo when the GCS service key is set up correctly
   return `
 <div
-style="width: 100vw; height: 100vh;"
+style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"
 ></div>
 <script src="https://embeddable-explorer.cdn.apollographql.com/mayaTest_sandbox/embeddable-sandbox.umd.production.min.js"></script>

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -1,68 +1,10 @@
 import type { ImplicitlyInstallablePlugin } from '../../../ApolloServer';
-
-export interface ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * By default, the landing page plugin uses the latest version of the landing
-   * page published to Apollo's CDN. If you'd like to pin the current version,
-   * pass the SHA served at
-   * https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt
-   * here.
-   */
-  version?: string;
-  /**
-   * Set to false to suppress the footer which explains how to configure the
-   * landing page.
-   */
-  footer?: boolean;
-  /**
-   * Users can configure their landing page to link to Studio Explorer with a
-   * document loaded in the UI.
-   */
-  document?: string;
-  /**
-   * Users can configure their landing page to link to Studio Explorer with
-   * variables loaded in the UI.
-   */
-  variables?: Record<string, string>;
-  /**
-   * Users can configure their landing page to link to Studio Explorer with
-   * headers loaded in the UI.
-   */
-  headers?: Record<string, string>;
-  /**
-   * Users can configure their landing page to link to Studio Explorer with the
-   * setting to include/exclude cookies loaded in the UI.
-   */
-  includeCookies?: boolean;
-  // For Apollo use only.
-  __internal_apolloStudioEnv__?: 'staging' | 'prod';
-}
-
-export interface ApolloServerPluginLandingPageLocalDefaultOptions
-  extends ApolloServerPluginLandingPageDefaultBaseOptions {}
-
-export interface ApolloServerPluginLandingPageProductionDefaultOptions
-  extends ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * If specified, provide a link (with opt-in auto-redirect) to the Studio page
-   * for the given graphRef. (You need to explicitly pass this here rather than
-   * relying on the server's ApolloConfig, because if your server is publicly
-   * accessible you may not want to display the graph ref publicly.)
-   */
-  graphRef?: string;
-}
-
-// The actual config object read by the landing page's React component.
-interface LandingPageConfig {
-  graphRef?: string | undefined;
-  isProd?: boolean;
-  apolloStudioEnv?: 'staging' | 'prod';
-  document?: string;
-  variables?: Record<string, string>;
-  headers?: Record<string, string>;
-  includeCookies?: boolean;
-  footer?: boolean;
-}
+import type {
+  ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions,
+  ApolloServerPluginLandingPageLocalDefaultOptions,
+  ApolloServerPluginLandingPageProductionDefaultOptions,
+  LandingPageConfig,
+} from './types';
 
 export function ApolloServerPluginLandingPageLocalDefault(
   options: ApolloServerPluginLandingPageLocalDefaultOptions = {},

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -68,6 +68,11 @@ const getEmbeddedExplorerHTML = (
 
     endpointUrl: string;
   }
+  const productionLandingPageConfigOrDefault = {
+    displayOptions: {},
+    persistExplorerState: false,
+    ...(typeof config.embed === 'boolean' ? {} : config.embed),
+  };
   const embeddedExplorerParams: Omit<EmbeddableExplorerOptions, 'endpointUrl'> =
     {
       ...config,
@@ -75,9 +80,11 @@ const getEmbeddedExplorerHTML = (
       initialState: {
         ...config,
         displayOptions: {
-          ...config.displayOptions,
+          ...productionLandingPageConfigOrDefault.displayOptions,
         },
       },
+      persistExplorerState:
+        productionLandingPageConfigOrDefault.persistExplorerState,
     };
 
   return `
@@ -195,7 +202,7 @@ curl --request POST \\
   --data '{"query":"query { __typename }"}'</code>
       </div>
     ${
-      config.shouldEmbed === true
+      !!config.embed
         ? 'graphRef' in config && !!config.graphRef
           ? getEmbeddedExplorerHTML(version, config)
           : getEmbeddedSandboxHTML()

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -9,9 +9,6 @@ import type {
 export function ApolloServerPluginLandingPageLocalDefault(
   options: ApolloServerPluginLandingPageLocalDefaultOptions = {},
 ): ImplicitlyInstallablePlugin {
-  // We list known keys explicitly to get better typechecking, but we pass
-  // through extras in case we've added new keys to the splash page and haven't
-  // quite updated the plugin yet.
   const { version, __internal_apolloStudioEnv__, ...rest } = options;
   return ApolloServerPluginLandingPageDefault(version, {
     isProd: false,
@@ -23,9 +20,6 @@ export function ApolloServerPluginLandingPageLocalDefault(
 export function ApolloServerPluginLandingPageProductionDefault(
   options: ApolloServerPluginLandingPageProductionDefaultOptions = {},
 ): ImplicitlyInstallablePlugin {
-  // We list known keys explicitly to get better typechecking, but we pass
-  // through extras in case we've added new keys to the splash page and haven't
-  // quite updated the plugin yet.
   const { version, __internal_apolloStudioEnv__, ...rest } = options;
   return ApolloServerPluginLandingPageDefault(version, {
     isProd: true,

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -210,8 +210,8 @@ curl --request POST \\
   --data '{"query":"query { __typename }"}'</code>
       </div>
     ${
-      !!config.embed
-        ? 'graphRef' in config && !!config.graphRef
+      config.embed
+        ? 'graphRef' in config && config.graphRef
           ? getEmbeddedExplorerHTML(version, config)
           : getEmbeddedSandboxHTML(version)
         : getNonEmbeddedLandingPageHTML(version, config)

--- a/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/index.ts
@@ -109,9 +109,7 @@ id="embeddableExplorer"
 `;
 };
 
-const getEmbeddedSandboxHTML = () => {
-  // (version: string) => {
-  // TODO (Maya) update this to fetch from the `embeddable-sandbox` repo when the GCS service key is set up correctly
+const getEmbeddedSandboxHTML = (version: string) => {
   return `
 <style>
   iframe {
@@ -122,7 +120,7 @@ const getEmbeddedSandboxHTML = () => {
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"
 ></div>
-<script src="https://embeddable-explorer.cdn.apollographql.com/mayaTest_sandbox/embeddable-sandbox.umd.production.min.js"></script>
+<script src="https://embeddable-sandbox.cdn.apollographql.com/${version}/embeddable-sandbox.umd.production.min.js"></script>
 <script>
   var initialEndpoint = window.location.href;
   new window.EmbeddedSandbox({
@@ -215,7 +213,7 @@ curl --request POST \\
       !!config.embed
         ? 'graphRef' in config && !!config.graphRef
           ? getEmbeddedExplorerHTML(version, config)
-          : getEmbeddedSandboxHTML()
+          : getEmbeddedSandboxHTML(version)
         : getNonEmbeddedLandingPageHTML(version, config)
     }
     </div>

--- a/packages/apollo-server-core/src/plugin/landingPage/default/types.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/types.ts
@@ -1,0 +1,116 @@
+export interface ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * By default, the landing page plugin uses the latest version of the landing
+   * page published to Apollo's CDN. If you'd like to pin the current version,
+   * pass the SHA served at
+   * https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt
+   * here.
+   */
+  version?: string;
+  /**
+   * Set to false to suppress the footer which explains how to configure the
+   * landing page.
+   */
+  footer?: boolean;
+  /**
+   * Users can configure their landing page to link to Studio Explorer with a
+   * document loaded in the UI.
+   */
+  document?: string;
+  /**
+   * Users can configure their landing page to link to Studio Explorer with
+   * variables loaded in the UI.
+   */
+  variables?: Record<string, string>;
+  /**
+   * Users can configure their landing page to link to Studio Explorer with
+   * headers loaded in the UI.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Users can configure their landing page to link to Studio Explorer with the
+   * setting to include/exclude cookies loaded in the UI.
+   */
+  includeCookies?: boolean;
+  /**
+   * Users can configure their landing page to render an embedded Explorer if
+   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
+   */
+  shouldEmbed?: boolean;
+  // For Apollo use only.
+  __internal_apolloStudioEnv__?: 'staging' | 'prod';
+}
+
+export interface ApolloServerPluginNonEmbeddedLandingPageLocalDefaultOptions
+  extends ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * Users can configure their landing page to render an embedded Explorer if
+   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
+   */
+  shouldEmbed?: false;
+}
+
+export interface ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOptions
+  extends ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * If specified, provide a link (with opt-in auto-redirect) to the Studio page
+   * for the given graphRef. (You need to explicitly pass this here rather than
+   * relying on the server's ApolloConfig, because if your server is publicly
+   * accessible you may not want to display the graph ref publicly.)
+   */
+  graphRef?: string;
+  /**
+   * Users can configure their landing page to render an embedded Explorer if
+   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
+   */
+  shouldEmbed?: false;
+}
+
+export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
+  extends ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * Users can configure their landing page to render an embedded Explorer if
+   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
+   */
+  shouldEmbed: true;
+}
+
+export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
+  extends ApolloServerPluginLandingPageDefaultBaseOptions {
+  /**
+   * If specified, provide a link (with opt-in auto-redirect) to the Studio page
+   * for the given graphRef. (You need to explicitly pass this here rather than
+   * relying on the server's ApolloConfig, because if your server is publicly
+   * accessible you may not want to display the graph ref publicly.)
+   */
+  graphRef: string;
+  /**
+   * Users can configure their landing page to render an embedded Explorer if
+   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
+   */
+  shouldEmbed: true;
+  /**
+   * Display options can be configured for the embedded Explorer.
+   */
+  displayOptions?: {
+    // If showHeadersAndEnvVars is false, we don't show the tab where users can input headers & env vars.
+    showHeadersAndEnvVars: boolean;
+    // The initial state for the left documentation panel in Explorer. Users can expand this when using the Explorer.
+    docsPanelState: 'open' | 'closed';
+    // The theme for the embedded Explorer.  Users can configure this via settings using the Explorer.
+    theme: 'light' | 'dark';
+  };
+  persistExplorerState: boolean;
+}
+
+export type ApolloServerPluginLandingPageLocalDefaultOptions =
+  | ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
+  | ApolloServerPluginNonEmbeddedLandingPageLocalDefaultOptions;
+
+export type ApolloServerPluginLandingPageProductionDefaultOptions =
+  | ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
+  | ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOptions;
+
+export type LandingPageConfig =
+  | ApolloServerPluginLandingPageLocalDefaultOptions
+  | ApolloServerPluginLandingPageProductionDefaultOptions;

--- a/packages/apollo-server-core/src/plugin/landingPage/default/types.ts
+++ b/packages/apollo-server-core/src/plugin/landingPage/default/types.ts
@@ -27,16 +27,8 @@ export interface ApolloServerPluginLandingPageDefaultBaseOptions {
    * headers loaded in the UI.
    */
   headers?: Record<string, string>;
-  /**
-   * Users can configure their landing page to link to Studio Explorer with the
-   * setting to include/exclude cookies loaded in the UI.
-   */
+
   includeCookies?: boolean;
-  /**
-   * Users can configure their landing page to render an embedded Explorer if
-   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
-   */
-  shouldEmbed?: boolean;
   // For Apollo use only.
   __internal_apolloStudioEnv__?: 'staging' | 'prod';
 }
@@ -47,7 +39,7 @@ export interface ApolloServerPluginNonEmbeddedLandingPageLocalDefaultOptions
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  shouldEmbed?: false;
+  embed?: false;
 }
 
 export interface ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOptions
@@ -63,7 +55,7 @@ export interface ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOption
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  shouldEmbed?: false;
+  embed?: false;
 }
 
 export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
@@ -72,7 +64,7 @@ export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  shouldEmbed: true;
+  embed: true;
 }
 
 export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
@@ -88,20 +80,48 @@ export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  shouldEmbed: true;
+  embed: true | ApolloServerPluginEmbeddedLandingPageProductionConfigOptions;
+}
+
+type ApolloServerPluginEmbeddedLandingPageProductionConfigOptions = {
   /**
    * Display options can be configured for the embedded Explorer.
    */
   displayOptions?: {
-    // If showHeadersAndEnvVars is false, we don't show the tab where users can input headers & env vars.
+    /**
+     * If true, the embedded Explorer includes the panels for setting
+     * request headers and environment variables.
+     * If false, those panels are not present.
+     *
+     * The default value is true.
+     */
     showHeadersAndEnvVars: boolean;
-    // The initial state for the left documentation panel in Explorer. Users can expand this when using the Explorer.
+    /**
+     * If open, the Explorer's Documentation panel (the left column) is
+     * initially expanded. If closed, the panel is initially collapsed.
+     *
+     * The default value is open.
+     */
     docsPanelState: 'open' | 'closed';
-    // The theme for the embedded Explorer.  Users can configure this via settings using the Explorer.
+    /**
+     * If dark, the Explorer's dark theme is used. If light, the light theme is used.
+     *
+     * The default value is dark.
+     */
     theme: 'light' | 'dark';
   };
+  /**
+   * If true, the embedded Explorer uses localStorage to persist its state
+   * (including operations, tabs, variables, and headers) between user sessions.
+   * This state is automatically populated in the Explorer on page load.
+   *
+   * If false, the embedded Explorer loads with an example query
+   * based on your schema (unless you provide document).
+   *
+   * The default value is false.
+   */
   persistExplorerState: boolean;
-}
+};
 
 export type ApolloServerPluginLandingPageLocalDefaultOptions =
   | ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions


### PR DESCRIPTION
[JIRA](https://apollographql.atlassian.net/browse/NEBULA-948)

[Decision Record 53
](https://apollographql.quip.com/Ri1kAEJ7zDFT/053-Decision-Record-embedded-Apollo-Sandbox-in-AS4)

**Context**

We are exposing embedded options on the Apollo Server default landing page configs. There is one flag `embed` that controls whether or not the default landing page is embedded. If the user is running on prod, and `embed` is truthy and there is a graphRef provided, the embedded Explorer will be rendered. If the user is running on local, or no graphRef is provided, and `embed` is true, the embedded Sandbox should be rendered. 

The code that is being fetched in this landing page is from a cdn bucket serving built files from this repo https://github.com/apollographql/embeddable-explorer. 

**This PR**

Adds a config option `embed` to the default Apollo Server landing page. 

Reorganizes the types for possible configs inputting into the AS landing page default. There are local config types & prod config types, each having embedded and non embedded options.

**How to test**

Check out the code sandbox npm deploy preview below, and add to the landing page config. For example: 

```
      ApolloServerPluginLandingPageProductionDefault({
        document: "test",
        variables: { test: "value" },
        headers: { test: "value" },
        includeCookies: false,
        embed: true,
        displayOptions: {
          showHeadersAndEnvVars: true,
          docsPanelState: "open",
          theme: "dark",
        },
        persistExplorerState: false,
      }),
```