### PR TITLE
documentation: Mention custom cache headers with an example

### DIFF
--- a/docs/source/performance/caching.md
+++ b/docs/source/performance/caching.md
@@ -343,6 +343,32 @@ Cache-Control: max-age=60, private
 
 If you run Apollo Server behind a CDN or another caching proxy, you can configure it to use this header's value to cache responses appropriately. See your CDN's documentation for details (for example, here's the [documentation for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#expiration-individual-objects)).
 
+Some CDNs require custom headers for caching or custom values in the `cache-control` header like `s-maxage`. You can configure your `ApolloServer` instance accordingly by building your own [plugin](https://www.apollographql.com/docs/apollo-server/integrations/plugins):
+
+```javascript
+new ApolloServer({
+  plugins: [
+    ApolloServerPluginCacheControl({ calculateHttpHeaders: false }),
+    {
+      async requestDidStart() {
+        return {
+          async willSendResponse(requestContext) {
+            const { response, overallCachePolicy } = requestContext;
+            if (overallCachePolicy && response?.http && overallCachePolicy.maxAge) {
+              response.http.headers.set(
+                "cache-control",
+                `max-age=0, s-maxage=${overallCachePolicy.maxAge}, public` // or the values your CDN recommends
+              );
+            }
+          },
+        };
+      },
+    },
+  ],
+});
+```
+
+
 ### Using GET requests
 
 Because CDNs and caching proxies only cache GET requests (not POST requests, which Apollo Client sends for all operations by default), we recommend enabling [automatic persisted queries](./apq/) and the [`useGETForHashedQueries` option](./apq/) in Apollo Client.


### PR DESCRIPTION
While Apollo's caching system is straight forward in the docs. Many people need to specify custom HTTP response headers to enable edge caching in their CDNs. For example in Vercel, it is recommended to to set `max-age=0` and use `s-maxage=$` instead. Apollo supports such configuration. But it's not clearly mentioned anywhere in docs. This PR adds a small paragraph and a code example in `docs/source/performance/caching.md` that explains achieving such a configuration in apollo-server.
