### PR TITLE
Improved Azure Function middleware handling

### DIFF
--- a/packages/apollo-server-azure-functions/src/ApolloServer.ts
+++ b/packages/apollo-server-azure-functions/src/ApolloServer.ts
@@ -82,7 +82,7 @@ export class ApolloServer extends ApolloServerBase {
     let landingPage: LandingPage | null | undefined;
 
     return (context: Context, req: HttpRequest) => {
-      this.ensureStarted()
+      return this.ensureStarted()
         .then(() => {
           if (landingPage === undefined) {
             landingPage = this.getLandingPage();


### PR DESCRIPTION
Added a simple inner `return` statement to the `return` statement of `createHandler` within the `apollo-server-azure-functions` package.

The reason for this is improved middleware handling for Azure Functions. Now it will be possible to modify Azure Function `context` before letting it be handled by ApolloServer:

```typescript
const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
  const server = new ApolloServer({ typeDefs, resolvers });

  await server.createHandler()(context, req);
};

exports.graphqlHandler = httpTrigger;
```

Before, `server.createHandler()(context, req)` wouldn't return anything, making the Azure Function return a 204 since it didn't know how long to wait for the function to return anything. I needed the return for making middleware like https://www.npmjs.com/package/graphql-upload#function-processrequest possible in an Azure Function.