### PR TITLE
Stop using HttpQueryError in requestPipeline

### DIFF
--- a/packages/server/src/__tests__/runQuery.test.ts
+++ b/packages/server/src/__tests__/runQuery.test.ts
@@ -12,6 +12,7 @@ import { ApolloServer } from '../ApolloServer';
 import type {
   ApolloServerPlugin,
   BaseContext,
+  GraphQLRequest,
   GraphQLRequestExecutionListener,
   GraphQLRequestListener,
   GraphQLRequestListenerDidResolveField,
@@ -20,7 +21,6 @@ import type {
   GraphQLRequestListenerValidationDidEnd,
   GraphQLResponse,
 } from '../externalTypes';
-import type { GraphQLRequest } from '../requestPipeline';
 import type { ApolloServerOptions } from '../types';
 import { LRUCacheStore, sizeCalculation } from '../utils/LRUCacheStore';
 

--- a/packages/server/src/externalTypes/requestPipeline.ts
+++ b/packages/server/src/externalTypes/requestPipeline.ts
@@ -31,7 +31,7 @@ export type GraphQLRequestContextValidationDidStart<
 export type GraphQLRequestContextDidResolveOperation<
   TContext extends BaseContext,
 > = GraphQLRequestContextValidationDidStart<TContext> &
-  WithRequired<GraphQLRequestContext<TContext>, 'operation' | 'operationName'>;
+  WithRequired<GraphQLRequestContext<TContext>, 'operationName'>;
 export type GraphQLRequestContextDidEncounterErrors<
   TContext extends BaseContext,
 > = WithRequired<GraphQLRequestContext<TContext>, 'metrics' | 'errors'>;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,6 @@
 // TODO(AS4): Evaluate the full exposed API.
 
-export { HttpQueryError, isHttpQueryError } from './runHttpQuery';
+export { HttpQueryError } from './runHttpQuery';
 
 export {
   ApolloError,

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -1,7 +1,8 @@
 import { formatApolloErrors } from './errors';
-import type { GraphQLRequest, GraphQLResponse } from './requestPipeline';
 import type {
   BaseContext,
+  GraphQLRequest,
+  GraphQLResponse,
   HTTPGraphQLRequest,
   HTTPGraphQLResponse,
 } from './externalTypes';
@@ -60,10 +61,6 @@ export class HttpQueryError extends Error {
       bodyChunks: null,
     };
   }
-}
-
-export function isHttpQueryError(e: unknown): e is HttpQueryError {
-  return (e as any)?.name === 'HttpQueryError';
 }
 
 function fieldIfString(


### PR DESCRIPTION
There's a particular check for HttpQueryError that was added in #5287
just to make the "no mutations over GET" plugin work. But given that
that plugin is completely unconfigurable, it might as well just be part
of the request pipeline rather than a plugin. Doing that lets us
simplify sendErrorResponse to no longer have to know about
HttpQueryError for just that use case.

While we're at it, fixed a bug (which exists in AS3) where GET requests
with an invalid operation name threw a ReferenceError in the
checkOperationPlugin instead of the correct error. That's because the
type `GraphQLRequestContextDidResolveOperation` was incorrect:
`operation` is not in fact required at that point. Fix the type (and put
the appropriate `?` in `operation?.operation` in the new code location).

Also remove the unused `isHttpQueryError` function and tweak some
imports.
