### PR TITLE
AS4: default `embed` to `true` in landing pages

### DIFF
--- a/packages/server/src/__tests__/integration/apolloServerTests.ts
+++ b/packages/server/src/__tests__/integration/apolloServerTests.ts
@@ -2506,7 +2506,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
         url = (await createServer(makeServerConfig([]))).url;
         await get().expect(
           200,
-          /apollo-server-landing-page.cdn.apollographql.com\/_latest.*isProd[^t]+false/s,
+          /embeddable-sandbox.cdn.apollographql.com\/_latest\/embeddable-sandbox.umd.production.min.js/s,
         );
       });
 
@@ -2521,7 +2521,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
         ).url;
         await get().expect(
           200,
-          /apollo-server-landing-page.cdn.apollographql.com\/abcdef.*isProd[^t]+false/s,
+          /embeddable-sandbox.cdn.apollographql.com\/abcdef\/embeddable-sandbox.umd.production.min.js/s,
         );
       });
 

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -7,12 +7,17 @@ import type {
   LandingPageConfig,
 } from './types';
 
+
 export function ApolloServerPluginLandingPageLocalDefault<
   TContext extends BaseContext,
 >(
   options: ApolloServerPluginLandingPageLocalDefaultOptions = {},
 ): ImplicitlyInstallablePlugin<TContext> {
-  const { version, __internal_apolloStudioEnv__, ...rest } = options;
+  const { version, __internal_apolloStudioEnv__, ...rest } = {
+    // we default to Sandbox unless embed is specified as false
+    embed: true as const,
+    ...options,
+  };
   return ApolloServerPluginLandingPageDefault(version, {
     isProd: false,
     apolloStudioEnv: __internal_apolloStudioEnv__,

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -7,7 +7,6 @@ import type {
   LandingPageConfig,
 } from './types';
 
-
 export function ApolloServerPluginLandingPageLocalDefault<
   TContext extends BaseContext,
 >(

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -70,20 +70,18 @@ export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
 export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
   extends ApolloServerPluginLandingPageDefaultBaseOptions {
   /**
-   * If specified, provide a link (with opt-in auto-redirect) to the Studio page
-   * for the given graphRef. (You need to explicitly pass this here rather than
-   * relying on the server's ApolloConfig, because if your server is publicly
-   * accessible you may not want to display the graph ref publicly.)
+   * Use this registered's graphs schema to populate the embedded Explorer.
+   * Required if passing `embed: true`
    */
   graphRef: string;
   /**
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  embed: true | ApolloServerPluginEmbeddedLandingPageProductionConfigOptions;
+  embed: true | EmbeddableExplorerOptions;
 }
 
-type ApolloServerPluginEmbeddedLandingPageProductionConfigOptions = {
+type EmbeddableExplorerOptions = {
   /**
    * Display options can be configured for the embedded Explorer.
    */

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -75,8 +75,7 @@ export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
    */
   graphRef: string;
   /**
-   * Users can configure their landing page to render an embedded Explorer if
-   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
+   * Users can configure their landing page to render an embedded Explorer.
    */
   embed: true | EmbeddableExplorerOptions;
 }

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -39,7 +39,7 @@ export interface ApolloServerPluginNonEmbeddedLandingPageLocalDefaultOptions
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  embed?: false;
+  embed: false;
 }
 
 export interface ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOptions
@@ -64,7 +64,7 @@ export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  embed: true;
+  embed?: true;
 }
 
 export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions


### PR DESCRIPTION
There are no docs in this branch, right? So this is just the functional changes. 

Add a default of `embed:true` to the landing page config, so the embeds are rendered by default!