### PR TITLE
Refactor GraphQLResponse type; drop formatResponse

### DIFF
--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -224,7 +224,9 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
-    const result = await server.executeOperation({ query: 'query { error }' });
+    const { result } = await server.executeOperation({
+      query: 'query { error }',
+    });
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].extensions).toStrictEqual({
@@ -240,7 +242,9 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
-    const result = await server.executeOperation({ query: 'query { error }' });
+    const { result } = await server.executeOperation({
+      query: 'query { error }',
+    });
 
     expect(result.errors).toHaveLength(1);
     const extensions = result.errors?.[0].extensions;
@@ -255,7 +259,7 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
-    const result = await server.executeOperation({ query: '{ hello }' });
+    const { result } = await server.executeOperation({ query: '{ hello }' });
     expect(result.errors).toBeUndefined();
     expect(result.data?.hello).toBe('world');
   });
@@ -267,7 +271,7 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
-    const result = await server.executeOperation({
+    const { result } = await server.executeOperation({
       query: gql`
         {
           hello
@@ -285,7 +289,7 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
-    const result = await server.executeOperation({ query: '{' });
+    const { result } = await server.executeOperation({ query: '{' });
     expect(result.errors).toHaveLength(1);
     expect(result.errors?.[0].extensions?.code).toBe('GRAPHQL_PARSE_FAILED');
   });
@@ -297,7 +301,7 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
-    const result = await server.executeOperation(
+    const { result } = await server.executeOperation(
       { query: '{ contextFoo }' },
       { foo: 'bla' },
     );
@@ -338,14 +342,14 @@ describe('ApolloServer executeOperation', () => {
         ],
       });
       await server.start();
-      const result = await server.executeOperation(
+      const { result } = await server.executeOperation(
         { query: '{ n }' },
         { foo: 123 },
       );
       expect(result.errors).toBeUndefined();
       expect(result.data?.n).toBe(123);
 
-      const result2 = await server.executeOperation(
+      const { result: result2 } = await server.executeOperation(
         { query: '{ n }' },
         // It knows that context.foo is a number so it doesn't work as a string.
         // @ts-expect-error

--- a/packages/server/src/__tests__/documentStore.test.ts
+++ b/packages/server/src/__tests__/documentStore.test.ts
@@ -117,7 +117,7 @@ describe('ApolloServer documentStore', () => {
     ).schemaManager.getSchemaDerivedData();
     expect(documentStore).toBeNull();
 
-    const result = await server.executeOperation(operations.simple.op);
+    const { result } = await server.executeOperation(operations.simple.op);
 
     expect(result.data).toEqual({ hello: 'world' });
   });

--- a/packages/server/src/__tests__/integration/apolloServerTests.ts
+++ b/packages/server/src/__tests__/integration/apolloServerTests.ts
@@ -659,7 +659,12 @@ export function defineIntegrationTestSuiteApolloServerTests(
                 async didResolveOperation() {
                   throw new Error('known_error');
                 },
-                async willSendResponse({ response: { http, errors } }) {
+                async willSendResponse({
+                  response: {
+                    http,
+                    result: { errors },
+                  },
+                }) {
                   if (errors![0].message === 'known_error') {
                     http!.statusCode = 403;
                   }
@@ -680,7 +685,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
             async requestDidStart() {
               return {
                 async willSendResponse({ response }) {
-                  response.extensions = { myExtension: true };
+                  response.result.extensions = { myExtension: true };
                 },
               };
             },
@@ -702,7 +707,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
             async requestDidStart() {
               return {
                 async willSendResponse({ response }) {
-                  response.extensions = { myExtension: true };
+                  response.result.extensions = { myExtension: true };
                 },
               };
             },

--- a/packages/server/src/__tests__/plugin/cacheControl/collectCacheControlHints.ts
+++ b/packages/server/src/__tests__/plugin/cacheControl/collectCacheControlHints.ts
@@ -26,10 +26,10 @@ export async function collectCacheControlHintsAndPolicyIfCacheable(
         async requestDidStart() {
           return {
             async willSendResponse({ response, overallCachePolicy }) {
-              if (!response.extensions) {
-                response.extensions = {};
+              if (!response.result.extensions) {
+                response.result.extensions = {};
               }
-              response.extensions.__policyIfCacheable__ =
+              response.result.extensions.__policyIfCacheable__ =
                 overallCachePolicy.policyIfCacheable();
             },
           };
@@ -41,11 +41,11 @@ export async function collectCacheControlHintsAndPolicyIfCacheable(
   const response = await server.executeOperation({ query: source });
   await server.stop();
 
-  expect(response.errors).toBeUndefined();
+  expect(response.result.errors).toBeUndefined();
 
   return {
     hints: cacheHints,
-    policyIfCacheable: response.extensions!.__policyIfCacheable__,
+    policyIfCacheable: response.result.extensions!.__policyIfCacheable__ as any,
   };
 }
 

--- a/packages/server/src/__tests__/plugin/usageReporting/plugin.test.ts
+++ b/packages/server/src/__tests__/plugin/usageReporting/plugin.test.ts
@@ -109,10 +109,10 @@ describe('end-to-end', () => {
           async requestDidStart() {
             return {
               async willSendResponse({ response, metrics }) {
-                if (!response.extensions) {
-                  response.extensions = {};
+                if (!response.result.extensions) {
+                  response.result.extensions = {};
                 }
-                response.extensions.__metrics__ = metrics;
+                response.result.extensions.__metrics__ = metrics;
               },
             };
           },
@@ -154,7 +154,7 @@ describe('end-to-end', () => {
 
     return {
       report,
-      metrics: response.extensions!.__metrics__ as GraphQLRequestMetrics,
+      metrics: response.result.extensions!.__metrics__ as GraphQLRequestMetrics,
     };
   }
 

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -3,15 +3,15 @@ import type { Trace } from '@apollo/usage-reporting-protobuf';
 import type { Logger } from '@apollo/utils.logger';
 import type {
   DocumentNode,
+  FormattedExecutionResult,
   GraphQLError,
-  GraphQLFormattedError,
   GraphQLSchema,
   OperationDefinitionNode,
 } from 'graphql';
 import type Keyv from 'keyv';
 import type { CachePolicy } from './cacheControl';
 import type { BaseContext } from './context';
-import type { HTTPGraphQLRequest, HTTPGraphQLResponse } from './http';
+import type { HTTPGraphQLHead, HTTPGraphQLRequest } from './http';
 
 export interface GraphQLRequest {
   query?: string;
@@ -23,17 +23,11 @@ export interface GraphQLRequest {
 
 export type VariableValues = { [name: string]: any };
 
-// TODO(AS4): does this differ in an interesting way from GraphQLExecutionResult
-// and graphql-js ExecutionResult? It does have `http` but perhaps this can be an
-// "extends". Ah, the difference is about formatted vs throwable errors? Let's
-// make sure we at least understand it.
 export interface GraphQLResponse {
-  data?: Record<string, any> | null;
-  errors?: ReadonlyArray<GraphQLFormattedError>;
-  extensions?: Record<string, any>;
-  // TODO(AS4): Seriously consider whether this type makes sense at all or whether
-  // http response should just be its own top level thing on HTTPRequestContext?
-  http?: Pick<HTTPGraphQLResponse, 'headers' | 'statusCode'>;
+  // TODO(AS4): for incremental delivery, maybe we'll have an iterator here
+  // instead of a single result?
+  result: FormattedExecutionResult;
+  http: HTTPGraphQLHead;
 }
 
 export interface GraphQLRequestMetrics {
@@ -53,7 +47,7 @@ export interface GraphQLRequestMetrics {
 
 export interface GraphQLRequestContext<TContext extends BaseContext> {
   readonly request: GraphQLRequest;
-  readonly response?: GraphQLResponse;
+  readonly response: GraphQLResponse;
 
   logger: Logger;
 

--- a/packages/server/src/externalTypes/http.ts
+++ b/packages/server/src/externalTypes/http.ts
@@ -24,21 +24,24 @@ interface HTTPGraphQLResponseChunk {
   body: string;
 }
 
-export type HTTPGraphQLResponse = {
+export interface HTTPGraphQLHead {
   statusCode?: number;
   // need to figure out what headers this includes (eg JSON???)
   headers: Map<string, string>;
-} & (
-  | {
-      // TODO(AS4): document why we chose strings as output. (tl;dr: consistent
-      // rather than flexible JSON output. Can represent landing page. We can
-      // always add another entry point that returns un-serialized responses
-      // later.)
-      completeBody: string;
-      bodyChunks: null;
-    }
-  | {
-      completeBody: null;
-      bodyChunks: AsyncIterableIterator<HTTPGraphQLResponseChunk>;
-    }
-);
+}
+
+export type HTTPGraphQLResponse = HTTPGraphQLHead &
+  (
+    | {
+        // TODO(AS4): document why we chose strings as output. (tl;dr: consistent
+        // rather than flexible JSON output. Can represent landing page. We can
+        // always add another entry point that returns un-serialized responses
+        // later.)
+        completeBody: string;
+        bodyChunks: null;
+      }
+    | {
+        completeBody: null;
+        bodyChunks: AsyncIterableIterator<HTTPGraphQLResponseChunk>;
+      }
+  );

--- a/packages/server/src/externalTypes/index.ts
+++ b/packages/server/src/externalTypes/index.ts
@@ -33,7 +33,6 @@ export {
   PluginDefinition,
 } from './plugins';
 export {
-  GraphQLExecutionResult,
   GraphQLExecutor,
   GraphQLRequestContextDidEncounterErrors,
   GraphQLRequestContextDidResolveOperation,

--- a/packages/server/src/externalTypes/requestPipeline.ts
+++ b/packages/server/src/externalTypes/requestPipeline.ts
@@ -1,20 +1,11 @@
-import type { GraphQLError } from 'graphql';
+import type { ExecutionResult } from 'graphql';
 import type { WithRequired } from '../types';
 import type { BaseContext } from './context';
 import type { GraphQLRequestContext } from './graphql';
 
 export type GraphQLExecutor<TContext extends BaseContext> = (
   requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
-) => Promise<GraphQLExecutionResult>;
-
-// TODO(AS4): Can we just use graphql-js ExecutionResult? The main difference
-// seems to be any vs unknown, although we could at least use
-// `ExecutionResult<Record<string, any>, Record<string, any>>`.
-export type GraphQLExecutionResult = {
-  data?: Record<string, any> | null;
-  errors?: ReadonlyArray<GraphQLError>;
-  extensions?: Record<string, any>;
-};
+) => Promise<ExecutionResult>;
 
 export type GraphQLRequestContextDidResolveSource<
   TContext extends BaseContext,
@@ -51,4 +42,4 @@ export type GraphQLRequestContextExecutionDidStart<
 export type GraphQLRequestContextWillSendResponse<
   TContext extends BaseContext,
 > = GraphQLRequestContextDidResolveSource<TContext> &
-  WithRequired<GraphQLRequestContext<TContext>, 'metrics' | 'response'>;
+  WithRequired<GraphQLRequestContext<TContext>, 'metrics'>;

--- a/packages/server/src/plugin/cacheControl/index.ts
+++ b/packages/server/src/plugin/cacheControl/index.ts
@@ -254,7 +254,7 @@ export function ApolloServerPluginCacheControl<TContext extends BaseContext>(
           if (
             calculateHttpHeaders &&
             policyIfCacheable &&
-            !response.errors &&
+            !response.result.errors &&
             response.http
           ) {
             response.http.headers.set(

--- a/packages/server/src/plugin/inlineTrace/index.ts
+++ b/packages/server/src/plugin/inlineTrace/index.ts
@@ -115,7 +115,8 @@ export function ApolloServerPluginInlineTrace<TContext extends BaseContext>(
           );
 
           const extensions =
-            response.extensions || (response.extensions = Object.create(null));
+            response.result.extensions ||
+            (response.result.extensions = Object.create(null));
 
           // This should only happen if another plugin is using the same name-
           // space within the `extensions` object and got to it before us.

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -11,12 +11,7 @@ import type {
 } from 'graphql';
 import type Keyv from 'keyv';
 import type { ApolloConfig, ApolloConfigInput } from './config';
-import type {
-  BaseContext,
-  GraphQLExecutor,
-  GraphQLRequestContext,
-  GraphQLResponse,
-} from './externalTypes';
+import type { BaseContext, GraphQLExecutor } from './externalTypes';
 import type { PluginDefinition } from './externalTypes/plugins';
 
 export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
@@ -102,10 +97,6 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   rootValue?: ((parsedQuery: DocumentNode) => any) | any;
   validationRules?: Array<(context: ValidationContext) => any>;
   executor?: GraphQLExecutor<TContext>;
-  formatResponse?: (
-    response: GraphQLResponse,
-    requestContext: GraphQLRequestContext<TContext>,
-  ) => GraphQLResponse | null;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   cache?: Keyv<string>;
   includeStackTracesInErrorResponses?: boolean;


### PR DESCRIPTION
Previously, the GraphQLResponse type contains the fields that are
returned in the body of a GraphQL response, plus an `http` field with
statusCode and headers.

Now, we put the body fields (the "result") inside a `result` field next
to `http`. This lets us just use the graphql-js ExecutionResult and
FormattedExecutionResult types in a bunch of places as well. Among other
things, this set us up for an incremental delivery world where sometimes
there's an async iterator of these results instead of a single result.

Changes vs v3 include:
- The `GraphQLResponse` type as seen on plugin
  `GraphQLRequestContext.response` has most of its fields move to a
  `result` sub-object. Also, the types of values in the objects under
  `data` and `extensions` become `unknown` instead of `any` (so
  consumers may need to do some casts).
- Remove `formatResponse` hook. The newer plugin API `willSendResponse`
  can do anything that it can do.
- `GraphQLRequestContext.response` is always set, as is
  `GraphQLResponse.http`.
- `GraphQLExecutionResult` is replaced with the nearly identical
  `ExecutionResult`. This is the type returned by the gateway execute
  command. The same slight typing difference about any vs unknown
  applies here but should be pretty irrelevant as the executor is
  producing these values.
- If a resolveOperation hook throws or if the main execute call throws,
  return 500 status code instead of 400.

Internal changes include:
- Various functions in requestPipeline no longer return the
  GraphQLResponse (which can just be read off of
  requestContext.response).
- New HTTPGraphQLHead type and newHTTPGraphQLHead() function
  (previously we used a `Pick<HTTPGraphQLResponse>` thing for this).
- Instead of turning sendErrorResponse calls into 400s in runHttpQuery
  as a weird special case, just do it directly in sendErrorResponse.
  These errors will now also contain a `content-length` header.
