### PR TITLE
New API to support serverless frameworks

### DIFF
--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -967,6 +967,11 @@ export class ApolloServer<TContext extends BaseContext = BaseContext> {
     httpGraphQLRequest: HTTPGraphQLRequest;
     context: ContextThunk<TContext>;
   }): Promise<HTTPGraphQLResponse> {
+    // TODO(AS4): This throws if we started in the background and there was an
+    // error, but instead of throwing it should return an appropriate error
+    // response. Note that we can make the serverIsStartedInBackground case of
+    // the `rejected load promise is thrown by server.start` test tighter once
+    // we fix this.
     const runningServerState = await this._ensureStarted();
 
     if (

--- a/packages/server/src/__tests__/express/integration.test.ts
+++ b/packages/server/src/__tests__/express/integration.test.ts
@@ -2,7 +2,6 @@ import { json } from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 import http from 'http';
-import type { AddressInfo } from 'net';
 import {
   ApolloServer,
   ApolloServerOptions,
@@ -10,6 +9,7 @@ import {
 } from '../..';
 import { expressMiddleware } from '../../express';
 import type { BaseContext } from '../../externalTypes';
+import { urlForHttpServer } from '../../utils/urlForHttpServer';
 import type {
   CreateServerForIntegrationTestsOptions,
   CreateServerForIntegrationTestsResult,
@@ -46,16 +46,3 @@ defineIntegrationTestSuite(async function (
   });
   return { server, url: urlForHttpServer(httpServer) };
 });
-
-function urlForHttpServer(httpServer: http.Server): string {
-  const { address, port } = httpServer.address() as AddressInfo;
-
-  // Convert IPs which mean "any address" (IPv4 or IPv6) into localhost
-  // corresponding loopback ip. Note that the url field we're setting is
-  // primarily for consumption by our test suite. If this heuristic is wrong for
-  // your use case, explicitly specify a frontend host (in the `host` option to
-  // ApolloServer.listen).
-  const hostname = address === '' || address === '::' ? 'localhost' : address;
-
-  return `http://${hostname}:${port}`;
-}

--- a/packages/server/src/__tests__/express/integrationServerless.test.ts
+++ b/packages/server/src/__tests__/express/integrationServerless.test.ts
@@ -1,0 +1,55 @@
+import { json } from 'body-parser';
+import cors from 'cors';
+import express from 'express';
+import http from 'http';
+import { ApolloServer, ApolloServerOptions } from '../..';
+import { expressMiddleware } from '../../express';
+import type { BaseContext } from '../../externalTypes';
+import { urlForHttpServer } from '../../utils/urlForHttpServer';
+import type {
+  CreateServerForIntegrationTestsOptions,
+  CreateServerForIntegrationTestsResult,
+} from '../integration';
+import { defineIntegrationTestSuite } from '../integration';
+
+defineIntegrationTestSuite(
+  async function (
+    serverOptions: ApolloServerOptions<BaseContext>,
+    testOptions?: CreateServerForIntegrationTestsOptions,
+  ): Promise<CreateServerForIntegrationTestsResult> {
+    const app = express();
+    const httpServer = http.createServer(app);
+    // For started-in-background servers (ie serverless) we typically don't
+    // drain in practice (serverless environments run one operation at a
+    // time). Also, in certain tests where server startup fails we won't be
+    // legally allowed to call stop() (because you can't stop something that
+    // hasn't started)... but unlike in the started-in-foreground case, we
+    // will have already started the http server listening. So we can't just
+    // rely on the drain plugin to do our server-closing; we do it ourselves
+    // in the extraCleanup block.
+    const server = new ApolloServer(serverOptions);
+
+    server.startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests();
+
+    app.use(
+      cors(),
+      json(),
+      expressMiddleware(server, {
+        context: testOptions?.context,
+      }),
+    );
+    await new Promise<void>((resolve) => {
+      httpServer.listen({ port: 0 }, resolve);
+    });
+    return {
+      server,
+      url: urlForHttpServer(httpServer),
+      async extraCleanup() {
+        await new Promise((resolve) => {
+          httpServer.close(resolve);
+        });
+      },
+    };
+  },
+  { serverIsStartedInBackground: true },
+);

--- a/packages/server/src/__tests__/integration/apolloServerTests.ts
+++ b/packages/server/src/__tests__/integration/apolloServerTests.ts
@@ -39,6 +39,7 @@ import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginLandingPageGraphQLPlayground,
   ApolloServerPluginLandingPageLocalDefault,
+  ApolloServerPluginUsageReportingDisabled,
 } from '../..';
 import fetch from 'node-fetch';
 import type {
@@ -57,7 +58,6 @@ import type {
   CreateServerForIntegrationTestsResult,
 } from '.';
 import type { SchemaLoadOrUpdateCallback } from '../../types';
-import { HeaderMap } from '../../runHttpQuery';
 
 const quietLogger = loglevel.getLogger('quiet');
 quietLogger.setLevel(loglevel.levels.WARN);
@@ -154,6 +154,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
 ) {
   describe('apolloServerTests.ts', () => {
     let serverToCleanUp: ApolloServer | null = null;
+    let extraCleanup: (() => Promise<void>) | null = null;
 
     async function createServer(
       config: ApolloServerOptions<BaseContext>,
@@ -164,6 +165,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
         options,
       );
       serverToCleanUp = serverInfo.server;
+      extraCleanup = serverInfo.extraCleanup ?? null;
       return serverInfo;
     }
 
@@ -180,8 +182,10 @@ export function defineIntegrationTestSuiteApolloServerTests(
     async function stopServer() {
       try {
         await serverToCleanUp?.stop();
+        await extraCleanup?.();
       } finally {
         serverToCleanUp = null;
+        extraCleanup = null;
       }
     }
     afterEach(stopServer);
@@ -475,20 +479,35 @@ export function defineIntegrationTestSuiteApolloServerTests(
             // We should be able to run the server setup code (which calls
             // startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests)
             // but actual operations will fail, like the function name says.
-            const server = (await createServer({ gateway })).server;
-            await expect(
-              server.executeHTTPGraphQLRequest({
-                httpGraphQLRequest: {
-                  method: 'POST',
-                  headers: new HeaderMap([
-                    ['content-type', 'application-json'],
-                  ]),
-                  body: JSON.stringify({ query: '{__typename}' }),
-                  searchParams: {},
-                },
-                context: async () => ({}),
-              }),
-            ).rejects.toThrowError(loadError);
+            // (But the error it throws should be masked.)
+            const error = jest.fn();
+            const logger = {
+              debug: jest.fn(),
+              info: jest.fn(),
+              warn: jest.fn(),
+              error,
+            };
+            const url = await createServerAndGetUrl({ gateway, logger });
+            // We don't need to call stop() on the server since it fails to start.
+            serverToCleanUp = null;
+            const res = await request(url)
+              .post('/')
+              .send({ query: '{__typename}' });
+            // TODO(AS4): This is currently throwing from
+            // executeHTTPGraphQLRequest but should instead be formatted either
+            // as text/plain or application/json.
+            expect(res.status).toEqual(500);
+            expect(res.text).toMatch(
+              /This data graph is missing a valid configuration. More details may be available in the server logs./,
+            );
+
+            expect(error).toHaveBeenCalledTimes(2);
+            expect(error.mock.calls[0][0]).toBe(
+              `An error occurred during Apollo Server startup. All GraphQL requests will now fail. The startup error was: ${loadError.message}`,
+            );
+            expect(error.mock.calls[1][0]).toBe(
+              `An error occurred during Apollo Server startup. All GraphQL requests will now fail. The startup error was: ${loadError.message}`,
+            );
           } else {
             // createServer awaits start() so should throw.
             await expect(createServer({ gateway })).rejects.toThrowError(
@@ -2346,17 +2365,15 @@ export function defineIntegrationTestSuiteApolloServerTests(
 
         const { gateway, triggers } = makeGatewayMock({ optionsSpy });
         triggers.resolveLoad({ schema, executor: async () => ({}) });
-        await createServerAndGetUrl(
-          {
-            gateway,
-            apollo: {
-              key: 'service:tester:1234abc',
-              graphRef: 'tester@staging',
-            },
-            logger: quietLogger,
+        const { server } = await createServer({
+          gateway,
+          apollo: {
+            key: 'service:tester:1234abc',
+            graphRef: 'tester@staging',
           },
-          { noRequestsMade: true },
-        );
+          logger: quietLogger,
+          plugins: [ApolloServerPluginUsageReportingDisabled()],
+        });
 
         expect(optionsSpy).toHaveBeenLastCalledWith({
           apollo: {
@@ -2366,6 +2383,11 @@ export function defineIntegrationTestSuiteApolloServerTests(
             graphRef: 'tester@staging',
           },
         });
+
+        // Executing an operation ensures that (even if
+        // serverIsStartedInBackground) startup completes, so that we can
+        // legally call stop().
+        await server.executeOperation({ query: '{__typename}' });
       });
 
       it('unsubscribes from schema update on close', async () => {

--- a/packages/server/src/__tests__/integration/httpServerTests.ts
+++ b/packages/server/src/__tests__/integration/httpServerTests.ts
@@ -214,11 +214,10 @@ const schema = new GraphQLSchema({
 export function defineIntegrationTestSuiteHttpServerTests(
   createServer: CreateServerForIntegrationTests,
   options: {
-    serverlessFramework?: boolean;
+    serverIsStartedInBackground?: boolean;
   } = {},
 ) {
   describe('httpServerLevelTests.ts', () => {
-    let app: any;
     let didEncounterErrors: jest.MockedFunction<
       NonNullable<GraphQLRequestListener<BaseContext>['didEncounterErrors']>
     >;
@@ -248,7 +247,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
     describe('graphqlHTTP', () => {
       it('rejects the request if the method is not POST or GET', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .head('/')
           // Make sure we get the error we're looking for, not the CSRF
@@ -262,7 +261,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if POST body is empty', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .post('/')
           .type('text/plain')
@@ -275,7 +274,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if POST body is missing even with content-type', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app).post('/').type('application/json').send();
         return req.then((res) => {
           expect(res.status).toEqual(400);
@@ -284,7 +283,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if invalid content-type', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .post('/')
           .type('text/plain')
@@ -301,7 +300,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if POST operation is missing', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app).post('/').send({});
         return req.then((res) => {
           expect(res.status).toEqual(400);
@@ -310,7 +309,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if POST operation is empty', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app).post('/').send({ query: '' });
         return req.then((res) => {
           expect(res.status).toEqual(400);
@@ -319,7 +318,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if POST JSON is malformed', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .post('/')
           .type('application/json')
@@ -331,7 +330,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('throws an error if GET query is missing', async () => {
-        app = await createApp();
+        const app = await createApp();
         const res = await request(app)
           .get(`/`)
           .set('apollo-require-preflight', 't');
@@ -352,7 +351,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a basic GET request', async () => {
-        app = await createApp();
+        const app = await createApp();
         const expected = {
           testString: 'it works',
         };
@@ -370,7 +369,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a basic implicit GET request', async () => {
-        app = await createApp();
+        const app = await createApp();
         const expected = {
           testString: 'it works',
         };
@@ -389,7 +388,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('throws error if trying to use mutation using GET request', async () => {
         didEncounterErrors = jest.fn();
-        app = await createApp({
+        const app = await createApp({
           schema,
           plugins: [
             {
@@ -428,7 +427,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('throws error if trying to use mutation with fragment using GET request', async () => {
         didEncounterErrors = jest.fn();
-        app = await createApp({
+        const app = await createApp({
           schema,
           plugins: [
             {
@@ -473,7 +472,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a GET request with variables', async () => {
-        app = await createApp();
+        const app = await createApp();
         const query = {
           query: 'query test($echo: String){ testArgument(echo: $echo) }',
           variables: JSON.stringify({ echo: 'world' }),
@@ -492,7 +491,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a basic request', async () => {
-        app = await createApp();
+        const app = await createApp();
         const expected = {
           testString: 'it works',
         };
@@ -604,7 +603,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('cache-control not set without any hints', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
         });
         const expected = {
@@ -621,7 +620,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('cache-control set with dynamic hint', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
         });
         const expected = {
@@ -638,7 +637,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('cache-control set with defaultMaxAge', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
           plugins: [ApolloServerPluginCacheControl({ defaultMaxAge: 5 })],
         });
@@ -656,7 +655,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns PersistedQueryNotSupported to a GET request if PQs disabled', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
           persistedQueries: false,
         });
@@ -685,7 +684,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns PersistedQueryNotSupported to a POST request if PQs disabled', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
           persistedQueries: false,
         });
@@ -714,7 +713,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns PersistedQueryNotFound to a GET request', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .get('/')
           .set('apollo-require-preflight', 't')
@@ -739,7 +738,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns PersistedQueryNotFound to a POST request', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .post('/')
           .send({
@@ -763,7 +762,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a request with variables', async () => {
-        app = await createApp();
+        const app = await createApp();
         const expected = {
           testArgument: 'hello world',
         };
@@ -780,7 +779,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('POST does not handle a request with variables as string', async () => {
-        app = await createApp();
+        const app = await createApp();
         const res = await request(app).post('/').send({
           query: 'query test($echo: String!){ testArgument(echo: $echo) }',
           variables: '{ "echo": "world" }',
@@ -792,7 +791,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('POST does not handle a request with extensions as string', async () => {
-        app = await createApp();
+        const app = await createApp();
         const res = await request(app).post('/').send({
           query: 'query test($echo: String!){ testArgument(echo: $echo) }',
           extensions: '{ "echo": "world" }',
@@ -804,7 +803,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a request with operationName', async () => {
-        app = await createApp();
+        const app = await createApp();
         const expected = {
           testString: 'it works',
         };
@@ -824,7 +823,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle introspection request', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .post('/')
           .send({ query: getIntrospectionQuery() });
@@ -837,7 +836,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('does not accept a query AST', async () => {
-        app = await createApp();
+        const app = await createApp();
         const req = request(app)
           .post('/')
           .send({
@@ -854,7 +853,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle batch requests', async () => {
-        app = await createApp({ schema, allowBatchedHttpRequests: true });
+        const app = await createApp({ schema, allowBatchedHttpRequests: true });
         const expected = [
           {
             data: {
@@ -891,7 +890,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle non-batch requests when allowBatchedHttpRequests is true', async () => {
-        app = await createApp({ schema, allowBatchedHttpRequests: true });
+        const app = await createApp({ schema, allowBatchedHttpRequests: true });
         const expected = {
           data: {
             testString: 'it works',
@@ -913,7 +912,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle batch requests with one element', async () => {
-        app = await createApp({ schema, allowBatchedHttpRequests: true });
+        const app = await createApp({ schema, allowBatchedHttpRequests: true });
         const expected = [
           {
             data: {
@@ -942,7 +941,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const parallels = 100;
         const delayPerReq = 40;
 
-        app = await createApp({ schema, allowBatchedHttpRequests: true });
+        const app = await createApp({ schema, allowBatchedHttpRequests: true });
         const expected = Array(parallels).fill({
           data: { testStringWithDelay: 'it works' },
         });
@@ -962,7 +961,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       }, 3000); // this test will fail due to timeout if running serially.
 
       it('disables batch requests by default', async () => {
-        app = await createApp();
+        const app = await createApp();
 
         const res = await request(app)
           .post('/')
@@ -989,7 +988,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('clones batch context', async () => {
-        app = await createApp(
+        const app = await createApp(
           {
             schema,
             allowBatchedHttpRequests: true,
@@ -1026,7 +1025,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('executes batch context if it is a function', async () => {
         let callCount = 0;
-        app = await createApp(
+        const app = await createApp(
           {
             schema,
             allowBatchedHttpRequests: true,
@@ -1075,7 +1074,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('can handle a request with a mutation', async () => {
-        app = await createApp();
+        const app = await createApp();
         const expected = {
           testMutation: 'not really a mutation, but who cares: world',
         };
@@ -1092,7 +1091,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('willSendResponse can be equivalent to the old formatResponse function', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
           plugins: [
             {
@@ -1123,7 +1122,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('passes the context to the resolver', async () => {
         const expected = 'context works';
-        app = await createApp(
+        const app = await createApp(
           {
             schema,
           },
@@ -1140,7 +1139,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('passes the rootValue to the resolver', async () => {
         const expected = 'it passes rootValue';
-        app = await createApp({
+        const app = await createApp({
           schema,
           rootValue: expected,
         });
@@ -1156,7 +1155,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       it('passes the rootValue function result to the resolver', async () => {
         const expectedQuery = 'query: it passes rootValue';
         const expectedMutation = 'mutation: it passes rootValue';
-        app = await createApp({
+        const app = await createApp({
           schema,
           rootValue: (documentNode: DocumentNode) => {
             const op = getOperationAST(documentNode, undefined);
@@ -1178,7 +1177,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('returns errors', async () => {
         const expected = 'Secret error message';
-        app = await createApp({
+        const app = await createApp({
           schema,
         });
         const req = request(app).post('/').send({
@@ -1192,7 +1191,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('applies formatError if provided', async () => {
         const expected = '--blank--';
-        app = await createApp({
+        const app = await createApp({
           schema,
           formatError: (_, error) => {
             expect(error instanceof Error).toBe(true);
@@ -1210,7 +1209,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
       it('formatError receives error that passes instanceof checks', async () => {
         const expected = '--blank--';
-        app = await createApp({
+        const app = await createApp({
           schema,
           formatError: (_, error) => {
             expect(error instanceof Error).toBe(true);
@@ -1228,7 +1227,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('allows for custom error formatting to sanitize', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema: TestSchema,
           formatError(error) {
             return { message: 'Custom error format: ' + error.message };
@@ -1251,7 +1250,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('allows for custom error formatting to elaborate', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema: TestSchema,
           formatError(error) {
             return {
@@ -1280,7 +1279,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('sends internal server error when formatError fails', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
           formatError: () => {
             throw new Error('I should be caught');
@@ -1308,7 +1307,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
             },
           };
         };
-        app = await createApp({
+        const app = await createApp({
           schema,
           validationRules: [alwaysInvalidRule],
         });
@@ -1322,11 +1321,12 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
     });
 
-    if (options.serverlessFramework) {
-      // This tests the serverless-specific behavior that ensures that startup
-      // finishes before serving a request. Non-serverless frameworks don't have
-      // this behavior: they assert that you've done `await server.start()`
-      // earlier in the process.
+    if (options.serverIsStartedInBackground) {
+      // This tests the behavior designed for serverless frameworks that ensures
+      // that startup finishes before serving a request. We don't have to worry
+      // about this for non-serverless frameworks because you should have
+      // already done `await server.start()` before calling (eg)
+      // `expressMiddleware`.
       it('calls serverWillStart before serving a request', async () => {
         // We'll use this to determine the order in which
         // the events we're expecting to happen actually occur and validate
@@ -1336,11 +1336,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
         const pluginStartedBarrier = resolvable();
         const letPluginFinishBarrier = resolvable();
 
-        // We want this to create the app as fast as `createApp` will allow.
-        // for integrations whose `applyMiddleware` currently returns a
-        // Promise we want them to resolve at whatever eventual pace they
-        // will so we can make sure that things are happening in order.
-        const unawaitedApp = createApp({
+        // Create the server. This test only runs when
+        // serverIsStartedInBackground, so this serverWillStart plugin will run
+        // "in the background".
+        const url = await createApp({
           schema,
           plugins: [
             {
@@ -1354,19 +1353,8 @@ export function defineIntegrationTestSuiteHttpServerTests(
           ],
         });
 
-        // Account for the fact that `createApp` might return a Promise,
-        // and might not, depending on the integration's implementation of
-        // createApp.  This is entirely to account for the fact that
-        // non-async implementations of `applyMiddleware` leverage a
-        // middleware as the technique for yielding to `startWillStart`
-        // hooks while their `async` counterparts simply `await` those same
-        // hooks.  In a future where we make the behavior of `applyMiddleware`
-        // the same across all integrations, this should be changed to simply
-        // `await unawaitedApp`.
-        app = 'then' in unawaitedApp ? await unawaitedApp : unawaitedApp;
-
         // Intentionally fire off the request asynchronously, without await.
-        const res = request(app)
+        const res = request(url)
           .get('/')
           .set('apollo-require-preflight', 't')
           .query({
@@ -1377,9 +1365,9 @@ export function defineIntegrationTestSuiteHttpServerTests(
             return res;
           });
 
-        // At this point calls might be [] or ['zero'] because the back-compat
-        // code kicks off start() asynchronously. We can safely wait on
-        // the plugin's serverWillStart to begin.
+        // At this point calls might be [] or ['zero'] because we are starting
+        // in the background. We can safely wait on the plugin's serverWillStart
+        // to begin.
         await pluginStartedBarrier;
         expect(calls).toEqual(['zero']);
         letPluginFinishBarrier.resolve();
@@ -1394,7 +1382,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
 
     describe('status code', () => {
       it('allows setting a custom status code', async () => {
-        app = await createApp({
+        const app = await createApp({
           schema,
           plugins: [
             {
@@ -1482,7 +1470,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('when ttlSeconds is set, passes ttl to the apq cache set call', async () => {
-        app = await createApqApp({ ttl: 900 });
+        const app = await createApqApp({ ttl: 900 });
 
         await request(app).post('/').send({
           extensions,
@@ -1497,7 +1485,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('when ttlSeconds is unset, ttl is not passed to apq cache', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         await request(app).post('/').send({
           extensions,
@@ -1516,7 +1504,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('errors when version is not specified', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         const result = await request(app)
           .get('/')
@@ -1552,7 +1540,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('errors when version is unsupported', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         const result = await request(app)
           .get('/')
@@ -1589,7 +1577,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('errors when hash is mismatched', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         const result = await request(app)
           .get('/')
@@ -1628,7 +1616,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns PersistedQueryNotFound on the first try', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         const result = await request(app).post('/').send({
           extensions,
@@ -1652,7 +1640,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
         expect(didResolveSource).not.toHaveBeenCalled();
       });
       it('returns result on the second try', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         await request(app).post('/').send({
           extensions,
@@ -1690,7 +1678,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns with batched persisted queries', async () => {
-        app = await createApqApp({}, true); // allow batching
+        const app = await createApqApp({}, true); // allow batching
 
         const errors = await request(app)
           .post('/')
@@ -1737,7 +1725,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns result on the persisted query', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         await request(app).post('/').send({
           extensions,
@@ -1763,7 +1751,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns error when hash does not match', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         const response = await request(app)
           .post('/')
@@ -1784,7 +1772,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
       });
 
       it('returns correct result using get request', async () => {
-        app = await createApqApp();
+        const app = await createApqApp();
 
         await request(app).post('/').send({
           extensions,

--- a/packages/server/src/__tests__/integration/httpServerTests.ts
+++ b/packages/server/src/__tests__/integration/httpServerTests.ts
@@ -223,6 +223,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
     >;
 
     let serverToCleanUp: ApolloServer | null = null;
+    let extraCleanup: (() => Promise<void>) | null = null;
 
     async function createApp(
       config?: ApolloServerOptions<BaseContext>,
@@ -230,6 +231,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
     ): Promise<string> {
       const serverInfo = await createServer(config ?? { schema }, options);
       serverToCleanUp = serverInfo.server;
+      extraCleanup = serverInfo.extraCleanup ?? null;
       return serverInfo.url;
     }
 
@@ -239,8 +241,10 @@ export function defineIntegrationTestSuiteHttpServerTests(
     async function stopServer() {
       try {
         await serverToCleanUp?.stop();
+        await extraCleanup?.();
       } finally {
         serverToCleanUp = null;
+        extraCleanup = null;
       }
     }
     afterEach(stopServer);

--- a/packages/server/src/__tests__/integration/index.ts
+++ b/packages/server/src/__tests__/integration/index.ts
@@ -23,7 +23,7 @@ export type CreateServerForIntegrationTests = (
 export function defineIntegrationTestSuite(
   createServer: CreateServerForIntegrationTests,
   options: {
-    serverlessFramework?: boolean;
+    serverIsStartedInBackground?: boolean;
   } = {},
 ) {
   describe('integration tests', () => {

--- a/packages/server/src/__tests__/integration/index.ts
+++ b/packages/server/src/__tests__/integration/index.ts
@@ -7,11 +7,10 @@ import { defineIntegrationTestSuiteHttpServerTests } from './httpServerTests';
 export interface CreateServerForIntegrationTestsResult {
   server: ApolloServer<BaseContext>;
   url: string;
+  extraCleanup?: () => Promise<void>;
 }
 
 export interface CreateServerForIntegrationTestsOptions {
-  suppressStartCall?: boolean;
-  noRequestsMade?: boolean;
   context?: ContextThunk;
 }
 

--- a/packages/server/src/__tests__/standalone/integration.test.ts
+++ b/packages/server/src/__tests__/standalone/integration.test.ts
@@ -1,9 +1,8 @@
-import type http from 'http';
-import type { AddressInfo } from 'net';
 import { ApolloServer } from '../../ApolloServer';
 import type { BaseContext } from '../../externalTypes';
 import { standaloneServer } from '../../standalone';
 import type { ApolloServerOptions } from '../../types';
+import { urlForHttpServer } from '../../utils/urlForHttpServer';
 import type {
   CreateServerForIntegrationTestsOptions,
   CreateServerForIntegrationTestsResult,
@@ -24,16 +23,3 @@ defineIntegrationTestSuite(async function (
     url: urlForHttpServer(standaloneServerInstance['httpServer']),
   };
 });
-
-function urlForHttpServer(httpServer: http.Server): string {
-  const { address, port } = httpServer.address() as AddressInfo;
-
-  // Convert IPs which mean "any address" (IPv4 or IPv6) into localhost
-  // corresponding loopback ip. Note that the url field we're setting is
-  // primarily for consumption by our test suite. If this heuristic is wrong for
-  // your use case, explicitly specify a frontend host (in the `host` option to
-  // ApolloServer.listen).
-  const hostname = address === '' || address === '::' ? 'localhost' : address;
-
-  return `http://${hostname}:${port}`;
-}

--- a/packages/server/src/externalTypes/plugins.ts
+++ b/packages/server/src/externalTypes/plugins.ts
@@ -21,7 +21,8 @@ export interface GraphQLServiceContext {
   schema: GraphQLSchema;
   apollo: ApolloConfig;
   // TODO(AS4): Make sure we document that we removed `persistedQueries`.
-  serverlessFramework: boolean;
+  // TODO(AS4): Note change of serverlessFramework to startedInBackground.
+  startedInBackground: boolean;
 }
 
 export interface GraphQLSchemaContext {

--- a/packages/server/src/plugin/usageReporting/options.ts
+++ b/packages/server/src/plugin/usageReporting/options.ts
@@ -224,11 +224,12 @@ export interface ApolloServerPluginUsageReportingOptions<
   /**
    * Sends a usage report after every request. This options is useful for
    * stateless environments like Amazon Lambda where processes handle only a
-   * small number of requests before terminating. It defaults to true when
-   * used with an ApolloServer subclass for a serverless framework (Amazon
-   * Lambda, Google Cloud Functions, or Azure Functions), or false otherwise.
-   * (Note that "immediately" does not mean synchronously with completing the
-   * response, but "very soon", such as after a setImmediate call.)
+   * small number of requests before terminating. It defaults to true when the
+   * ApolloServer was started in the background with
+   * `startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests`
+   * (generally used with serverless frameworks), or false otherwise. (Note that
+   * "immediately" does not mean synchronously with completing the response, but
+   * "very soon", such as after a setImmediate call.)
    */
   sendReportsImmediately?: boolean;
   /**

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -106,7 +106,7 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
     async serverWillStart({
       logger: serverLogger,
       apollo,
-      serverlessFramework,
+      startedInBackground,
     }: GraphQLServiceContext): Promise<GraphQLServerListener> {
       // Use the plugin-specific logger if one is provided; otherwise the general server one.
       const logger = options.logger ?? serverLogger;
@@ -130,7 +130,7 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
       // environments aren't designed around letting us run a background task to
       // send reports later or hook into container destruction to flush buffered reports.
       const sendReportsImmediately =
-        options.sendReportsImmediately ?? serverlessFramework;
+        options.sendReportsImmediately ?? startedInBackground;
 
       // Since calculating the signature and referenced fields for usage
       // reporting is potentially an expensive operation, we'll cache the data

--- a/packages/server/src/standalone/index.ts
+++ b/packages/server/src/standalone/index.ts
@@ -2,13 +2,13 @@ import { json } from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 import http from 'http';
-import type { AddressInfo, ListenOptions } from 'net';
-import { format as urlFormat } from 'url';
+import type { ListenOptions } from 'net';
 import type { ApolloServer } from '../ApolloServer';
 import { ExpressContext, expressMiddleware } from '../express';
 import type { BaseContext, ContextFunction } from '../externalTypes';
 import { ApolloServerPluginDrainHttpServer } from '../plugin';
 import type { WithRequired } from '../types';
+import { urlForHttpServer } from '../utils/urlForHttpServer';
 
 interface HTTPServerOptions<TContext extends BaseContext> {
   context?: ContextFunction<[ExpressContext], TContext>;
@@ -60,23 +60,6 @@ class ApolloServerStandalone<TContext extends BaseContext> {
       this.httpServer.listen(listenOptions, resolve);
     });
 
-    const addressInfo = this.httpServer.address() as AddressInfo;
-
-    // Convert IPs which mean "any address" (IPv4 or IPv6) into localhost
-    // corresponding loopback ip. If this heuristic is wrong for your use case,
-    // explicitly specify a frontend host (in the `host` option to `listen`).
-    let hostForUrl = addressInfo.address;
-    if (hostForUrl === '' || hostForUrl === '::') {
-      hostForUrl = 'localhost';
-    }
-
-    const url = urlFormat({
-      protocol: 'http',
-      hostname: hostForUrl,
-      port: addressInfo.port,
-      pathname: '/',
-    });
-
-    return { url };
+    return { url: urlForHttpServer(this.httpServer) };
   }
 }

--- a/packages/server/src/utils/urlForHttpServer.ts
+++ b/packages/server/src/utils/urlForHttpServer.ts
@@ -1,0 +1,21 @@
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+import { format } from 'url';
+
+export function urlForHttpServer(httpServer: Server): string {
+  const { address, port } = httpServer.address() as AddressInfo;
+
+  // Convert IPs which mean "any address" (IPv4 or IPv6) into localhost
+  // corresponding loopback ip. Note that the url field we're setting is
+  // primarily for consumption by our test suite. If this heuristic is wrong for
+  // your use case, explicitly specify a frontend host (in the `host` option
+  // when listening).
+  const hostname = address === '' || address === '::' ? 'localhost' : address;
+
+  return format({
+    protocol: 'http',
+    hostname,
+    port,
+    pathname: '/',
+  });
+}


### PR DESCRIPTION
The main difference for Apollo Server between serverless and other
frameworks is that serverless frameworks typically need to provide a
request handler *synchronously* on startup. So our model of "you must
call `await server.start()` before your web server listens" doesn't
work.

(The reason we introduced that model (optionally in AS2.22 and required
in AS3) was that previously, it was easy to set up your server in a way
that if it failed to load its schema (eg, from Studio), it would still
start listening and just fail every operation forever. This model lets
your server fail fast if startup fails. However, it doesn't work for
serverless integrations.)

The other minor differences are that the default value of
stopOnTerminationSignals is false for serverless integrations and the
default value of the usage reporting plugin's sendReportsImmediately is
true for serverless integrations; the latter was implemented via the
serverlessFramework option to the plugin serverWillStart API. In both
cases, this merely affected the default values and could be overridden
explicitly to true or false by the user.

The AS3 implementation was based on *subclassing* and overriding a
serverlessFramework() method; if this is true, the ApolloServer
constructor would start the startup process "in the background", logging
errors.

In AS4 we don't subclass ApolloServer at all.  Our new implementation
works by providing a synchronous alternative to `start()` called
`startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests()`.
The length of the name is intended to discourage its use directly by app
writers when they are building non-serverless apps and `await
server.start()` is an option.

Calling this function works similarly to the implicit call at the end of
the AS3 serverless constructor. Additionally, it allows
`server.assertStarted()` to succeed even if startup is still ongoing.

The intended usage goes like this:

For the standalone server, the user does not need to call start at all:

   await startStandaloneServer(server);

(This assumes the API of #6489.)

For a non-serverless middleware, the user should await `start()`. Note
that `expressMiddleware` itself calls `assertStarted`.

  await server.start();
  app.use(expressMiddleware(server));
  app.listen();

For a serverless middleware (not implemented in core), the user doesn't
have to call any start-related function:

  exports.handler = lambdaHandler(server);

`lambdaHandler` should call
`startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests`
for you.

In some cases, a serverless middleware might be implemented in terms of
a non-serverless middleware. For example, one approach to implementing
`lambdaHandler` would be to combine `expressMiddleware` with `express`
and `@vendia/serverless-express`. This is why we have the special case
that `assertStarted` (called by `expressMiddleware`) doesn't throw if
startup is currently taking place in the background.

We continue to have the default values of stopOnTerminationSignals and
sendReportsImmediately be influenced by whether you called start or
startInBackgroundHandlingStartupErrorsByLoggingAndFailingAllRequests. We
do change the serverWillStart option from serverlessFramework to
startedInBackground.

While we're at it, we added a new logged warning if any operations start
executing during the stopping or stopped phase encouraging users to use
a drain plugin.

Note: we add an invocation of the integration tests that combines Express
with this new API. That's not because we think people using Express should
use the API; it just means we were able to ensure that the tests could potentially
work with the new API.  This helped us discover that (in the start-in-background case)
executeHTTPGraphQLRequest throws rather than returns an error response if
startup failed, which we should fix in a subsequent PR.

Fixes #6039.
