### PR TITLE
Make top-level errors consistent and observable

### DIFF
--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -93,8 +93,10 @@ export class UserInputError extends GraphQLError {
 // document it, and maybe consider using it for more of the errors in
 // runHttpQuery instead of just returning text/plain errors.
 export class BadRequestError extends GraphQLError {
-  constructor(message: string, extensions?: Record<string, any>) {
-    super(message, { extensions: { ...extensions, code: 'BAD_REQUEST' } });
+  constructor(message: string, options?: { extensions?: Record<string, any> }) {
+    super(message, {
+      extensions: { ...options?.extensions, code: 'BAD_REQUEST' },
+    });
 
     this.name = 'BadRequestError';
   }
@@ -154,10 +156,7 @@ export function formatApolloErrors(
   });
 
   function enrichError(maybeError: unknown): GraphQLFormattedError {
-    const error: Error =
-      maybeError instanceof Error
-        ? maybeError
-        : new GraphQLError('Unexpected error value: ' + String(maybeError));
+    const error: Error = ensureError(maybeError);
 
     const graphqlError: GraphQLError =
       error instanceof GraphQLError
@@ -193,4 +192,10 @@ export function formatApolloErrors(
 
     return { ...graphqlError.toJSON(), extensions };
   }
+}
+
+export function ensureError(maybeError: unknown): Error {
+  return maybeError instanceof Error
+    ? maybeError
+    : new GraphQLError('Unexpected error value: ' + String(maybeError));
 }

--- a/packages/server/src/externalTypes/plugins.ts
+++ b/packages/server/src/externalTypes/plugins.ts
@@ -45,6 +45,18 @@ export interface ApolloServerPlugin<TContext extends BaseContext> {
     requestContext: GraphQLRequestContext<TContext>,
   ): Promise<GraphQLRequestListener<TContext> | void>;
 
+  // TODO(AS4): Document all these.
+  unexpectedErrorProcessingRequest?({
+    requestContext,
+    error,
+  }: {
+    requestContext: GraphQLRequestContext<TContext>;
+    error: Error;
+  }): Promise<void>;
+  contextCreationDidFail?({ error }: { error: Error }): Promise<void>;
+  invalidRequestWasReceived?({ error }: { error: Error }): Promise<void>;
+  startupDidFail?({ error }: { error: Error }): Promise<void>;
+
   // See the similarly named field on ApolloServer for details. Note that it
   // appears that this only works if it is a *field*, not a *method*, which is
   // why `requestDidStart` (which takes a TContext wrapped in something) is not

--- a/packages/server/src/httpBatching.ts
+++ b/packages/server/src/httpBatching.ts
@@ -4,7 +4,8 @@ import type {
   HTTPGraphQLResponse,
 } from './externalTypes';
 import type { ApolloServerInternals, SchemaDerivedData } from './ApolloServer';
-import { HeaderMap, HttpQueryError, runHttpQuery } from './runHttpQuery';
+import { HeaderMap, runHttpQuery } from './runHttpQuery';
+import { BadRequestError } from './errors';
 
 export async function runBatchHttpQuery<TContext extends BaseContext>(
   batchRequest: Omit<HTTPGraphQLRequest, 'body'> & { body: any[] },
@@ -78,8 +79,5 @@ export async function runPotentiallyBatchedHttpQuery<
       internals,
     );
   }
-  return new HttpQueryError(
-    400,
-    'Operation batching disabled.',
-  ).asHTTPGraphQLResponse();
+  throw new BadRequestError('Operation batching disabled.');
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,5 @@
 // TODO(AS4): Evaluate the full exposed API.
 
-export { HttpQueryError } from './runHttpQuery';
-
 export {
   SyntaxError,
   ValidationError,

--- a/packages/server/src/preventCsrf.ts
+++ b/packages/server/src/preventCsrf.ts
@@ -1,5 +1,5 @@
 import MIMEType from 'whatwg-mimetype';
-import { HttpQueryError } from './runHttpQuery';
+import { BadRequestError } from './errors';
 
 // Our recommended set of CSRF prevention headers. Operations that do not
 // provide a content-type such as `application/json` (in practice, this
@@ -87,8 +87,7 @@ export function preventCsrf(
     return;
   }
 
-  throw new HttpQueryError(
-    400,
+  throw new BadRequestError(
     `This operation has been blocked as a potential Cross-Site Request Forgery ` +
       `(CSRF). Please either specify a 'content-type' header (with a type that ` +
       `is not one of ${NON_PREFLIGHTED_CONTENT_TYPES.join(', ')}) or provide ` +

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -267,9 +267,15 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
   // it's generally how HTTP requests should work, and additionally it makes us
   // less vulnerable to mutations running over CSRF, if you turn off our CSRF
   // prevention feature.)
-  if (request.http?.method === 'GET' && operation?.operation !== 'query') {
+  if (
+    request.http?.method === 'GET' &&
+    operation?.operation &&
+    operation.operation !== 'query'
+  ) {
     return await sendErrorResponse(
-      new GraphQLError('GET supports only query operation'),
+      new BadRequestError(
+        `GET requests only support query operations, not ${operation.operation} operations`,
+      ),
       undefined,
       { statusCode: 405, headers: new HeaderMap([['allow', 'POST']]) },
     );


### PR DESCRIPTION
Previously, errors that weren't specially cased as part of the "request
pipeline" were not observable by plugins. (In some but not all cases,
they were visible to formatError hooks.) Some "HTTP-level" errors were
handled by returning text/plain responses, whereas many other errors
were handled by returning GraphQL-style JSON responses (using
the formatError hook).

This change makes things more consistent by returning all errors as JSON
responses (using the formatError hook). In addition, for better
observability, several new top-level plugin APIs are introduced that are
called when various kinds of errors occur. Specifically:

- New plugin hook `startupDidFail`. This is called once if startup fails
  (eg, if a serverWillStart plugin throws or if gateway fails to load
  the schema). (If this hook throws, its error is logged.) Future calls to
  executeHTTPGraphQLRequest (if the server was started in the
  background) now return a formatted JSON error instead of throwing.

- New plugin hook `contextCreationDidFail`. (If this hook throws, its
  error is logged.) As before, these errors are sent as formatted JSON
  errors.

- New plugin hook `invalidRequestWasReceived`. This is called for all
  the errors that occur before being able to construct a GraphQLRequest
  from an HTTPGraphQLRequest; this includes things like the top-level
  fields being of the wrong type, missing body, CSRF failure, etc).
  These errors are now sent as formatted JSON instead of as text/plain.

- New plugin hook `unexpectedErrorProcessingRequest`. This is called if
  `processGraphQLRequest` throws (typically because a plugin hook
  threw). We are making the assumption that this means there is a
  programming error, so we are making the behavior change that the
  thrown error will be logged and "Internal server error" will be sent
  in the HTTP response.

- Fix grammar of "GET supports only query operation" and don't return it
  if the operation is unknown.

Fixes #6140. Part of #6053.
