### PR TITLE
Remove graphql-tag re-export

### DIFF
--- a/WIP/migration.mdx
+++ b/WIP/migration.mdx
@@ -460,4 +460,5 @@ Existing implementations of `KeyValueCache` should continue to work.
 - ApolloServer.logger should probably be public readonly in AS4
 - Ensure errors thrown in context creation is handled in a helpful way
 - Apollo Server plugins: expose server instance to plugins
-- In general we just need to go over the full exported API and list what’s gone and where it’s gone
+- In general we just need to go over the full exported API and list what’s gone and where it’s gone. (This includes the re-export of `gql` from `graphql-tag`)
+

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,7 +43,6 @@
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "graphql-tag": "^2.11.0",
     "loglevel": "^1.6.8",
     "lru-cache": "^7.10.1",
     "negotiator": "^0.6.3",

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -1,5 +1,5 @@
 import { ApolloServer } from '../ApolloServer';
-import { ApolloServerOptions, GatewayInterface, gql } from '..';
+import type { ApolloServerOptions, GatewayInterface } from '..';
 import type { GraphQLSchema } from 'graphql';
 import type { ApolloServerPlugin, BaseContext } from '../externalTypes';
 import {
@@ -9,6 +9,7 @@ import {
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { HeaderMap } from '../runHttpQuery';
 import { mockLogger } from './mockLogger';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   type Query {

--- a/packages/server/src/__tests__/integration/apolloServerTests.ts
+++ b/packages/server/src/__tests__/integration/apolloServerTests.ts
@@ -28,7 +28,6 @@ import { createApolloFetch, ApolloFetch, ParsedResponse } from './apolloFetch';
 import {
   AuthenticationError,
   UserInputError,
-  gql,
   ApolloServerOptions,
   ApolloServer,
   GatewayInterface,
@@ -59,6 +58,7 @@ import type {
 } from '.';
 import type { SchemaLoadOrUpdateCallback } from '../../types';
 import { mockLogger } from '../mockLogger';
+import gql from 'graphql-tag';
 
 const quietLogger = loglevel.getLogger('quiet');
 quietLogger.setLevel(loglevel.levels.WARN);

--- a/packages/server/src/gql.ts
+++ b/packages/server/src/gql.ts
@@ -1,8 +1,0 @@
-// This currently provides the ability to have syntax highlighting as well as
-// consistency between client and server gql tags
-import type { DocumentNode } from 'graphql';
-import gqlTag from 'graphql-tag';
-export const gql: (
-  template: TemplateStringsArray | string,
-  ...substitutions: any[]
-) => DocumentNode = gqlTag;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,4 @@ export { ApolloConfig, ApolloConfigInput } from './config';
 
 export * from './externalTypes';
 
-// TODO(AS4): Why re-export graphql-tag?
-export * from './gql';
 export * from './plugin';

--- a/packages/server/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/server/src/plugin/schemaReporting/schemaReporter.ts
@@ -1,8 +1,6 @@
-import { gql } from '../../gql';
 import fetch from 'node-fetch';
 import type { GraphQLRequest } from '../../externalTypes';
 import type { Logger } from '@apollo/utils.logger';
-import { print } from 'graphql';
 import type {
   SchemaReport,
   SchemaReportMutationVariables,
@@ -11,21 +9,20 @@ import type {
 } from './generated/operations';
 import type { Fetcher } from '@apollo/utils.fetcher';
 
-export const schemaReportGql = print(gql`
-  mutation SchemaReport($report: SchemaReport!, $coreSchema: String) {
-    reportSchema(report: $report, coreSchema: $coreSchema) {
-      __typename
-      ... on ReportSchemaError {
-        message
-        code
-      }
-      ... on ReportSchemaResponse {
-        inSeconds
-        withCoreSchema
-      }
+export const schemaReportGql = `mutation SchemaReport($report: SchemaReport!, $coreSchema: String) {
+  reportSchema(report: $report, coreSchema: $coreSchema) {
+    __typename
+    ... on ReportSchemaError {
+      message
+      code
+    }
+    ... on ReportSchemaResponse {
+      inSeconds
+      withCoreSchema
     }
   }
-`);
+}
+`;
 
 // This class is meant to be a thin shim around the gql mutations.
 export class SchemaReporter {


### PR DESCRIPTION
In general, "import a package just to re-export its symbol" is a pattern
we're trying to avoid.

And using graphql-tag at all in servers isn't particular necessary,
compared to in clients:
- Putting your schema inline in TS (outside of simple tests) doesn't
  have much advantage over using separate files
- Syntax highlighting can generally be accomplished via string constants
  that start with `#graphql`
- APIs like `typeDefs` that take parsed documents also take strings
- graphql-tag caches the AST, which can be relevant in clients if you're
  putting an operation inside a function but is not really relevant for
  once-on-startup schemas

People who want to use `gql` can use `graphql-tag` directly.

Fixes #6527.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
