### PR TITLE
Reinstate bounded `documentStore` (revert mistake)

### DIFF
--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -728,7 +728,7 @@ export class ApolloServerBase<
       // random prefix each time we get a new schema.
       documentStore:
         this.config.documentStore === undefined
-          ? new UnboundedCache()
+          ? new InMemoryLRUCache()
           : this.config.documentStore === null
           ? null
           : new PrefixingKeyValueCache(

--- a/packages/apollo-server-core/src/__tests__/documentStore.test.ts
+++ b/packages/apollo-server-core/src/__tests__/documentStore.test.ts
@@ -3,7 +3,7 @@ import type { DocumentNode } from 'graphql';
 
 import { ApolloServerBase } from '../ApolloServer';
 import assert from 'assert';
-import { UnboundedCache } from '../utils/UnboundedCache';
+import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
 
 const typeDefs = gql`
   type Query {
@@ -54,7 +54,7 @@ describe('ApolloServerBase documentStore', () => {
     const options = await server.graphQLServerOptions();
     const embeddedStore = options.documentStore;
     assert(embeddedStore);
-    expect(embeddedStore).toBeInstanceOf(UnboundedCache);
+    expect(embeddedStore).toBeInstanceOf(InMemoryLRUCache);
 
     await server.executeOperation(operations.simple.op);
 


### PR DESCRIPTION
The `documentStore` didn't need to be changed to an `UnboundedCache` since it was previously bounded with a `maxSize`. This is undoing a mistake.
For reference: https://github.com/apollographql/apollo-server/blob/72f663e4881d45320e27c5c4a676f78c36d3c3fa/packages/apollo-server-core/src/ApolloServer.ts#L918

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
