### PR TITLE
Stop using require to get package version

### DIFF
--- a/packages/server/src/__tests__/tsconfig.json
+++ b/packages/server/src/__tests__/tsconfig.json
@@ -8,6 +8,6 @@
     "lib": ["es2019", "es2019.array", "esnext.asynciterable", "dom"],
   },
   "references": [
-    { "path": "../../" }
+    { "path": "../../src" }
   ]
 }

--- a/packages/server/src/plugin/schemaReporting/index.ts
+++ b/packages/server/src/plugin/schemaReporting/index.ts
@@ -8,6 +8,7 @@ import { schemaIsFederated } from '../schemaIsFederated';
 import type { SchemaReport } from './generated/operations';
 import type { BaseContext } from '../../externalTypes';
 import type { Fetcher } from '@apollo/utils.fetcher';
+import { version } from '../../../package.json';
 
 export interface ApolloServerPluginSchemaReportingOptions {
   /**
@@ -138,9 +139,7 @@ export function ApolloServerPluginSchemaReporting<TContext extends BaseContext>(
         // "An identifier for the server instance. Length must be <= 256 characters.
         serverId:
           process.env.APOLLO_SERVER_ID || process.env.HOSTNAME || os.hostname(),
-        libraryVersion: `@apollo/server@${
-          require('../../../package.json').version
-        }`,
+        libraryVersion: `@apollo/server@${version}`,
       };
       let currentSchemaReporter: SchemaReporter | undefined;
 

--- a/packages/server/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/server/src/plugin/schemaReporting/schemaReporter.ts
@@ -8,6 +8,7 @@ import type {
   ReportSchemaResponse,
 } from './generated/operations';
 import type { Fetcher } from '@apollo/utils.fetcher';
+import { version } from '../../../package.json';
 
 export const schemaReportGql = `mutation SchemaReport($report: SchemaReport!, $coreSchema: String) {
   reportSchema(report: $report, coreSchema: $coreSchema) {
@@ -53,7 +54,7 @@ export class SchemaReporter {
       'Content-Type': 'application/json',
       'x-api-key': options.apiKey,
       'apollographql-client-name': 'ApolloServerPluginSchemaReporting',
-      'apollographql-client-version': require('../../../package.json').version,
+      'apollographql-client-version': version,
     };
 
     this.endpointUrl =

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -36,10 +36,11 @@ import type {
 } from './options';
 import { OurReport } from './stats';
 import { makeTraceDetails } from './traceDetails';
+import { version } from '../../../package.json';
 
 const reportHeaderDefaults = {
   hostname: os.hostname(),
-  agentVersion: `@apollo/server@${require('../../../package.json').version}`,
+  agentVersion: `@apollo/server@${version}`,
   runtimeVersion: `node ${process.version}`,
   // XXX not actually uname, but what node has easily.
   uname: `${os.platform()}, ${os.type()}, ${os.release()}, ${os.arch()})`,

--- a/packages/server/src/tsconfig.json
+++ b/packages/server/src/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../dist",
+    "resolveJsonModule": true,
+  },
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "**/__tests__"
+  ],
+  "references": [
+    {
+      "path": "../"
+    },
+  ]
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../../tsconfig.base",
   "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist"
+    "rootDir": ".",
+    "outDir": ".",
+    "composite": true,
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/__tests__"],
-  "references": []
+  "files": ["package.json"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,5 +21,6 @@
     "lib": ["es2019", "esnext.asynciterable"],
     "types": ["node"],
     "baseUrl": ".",
+    "resolveJsonModule": true,
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,6 @@
   "files": [],
   "include": [],
   "references": [
-    { "path": "./packages/server" }
+    { "path": "./packages/server/src" }
   ]
 }


### PR DESCRIPTION
Multiple tsconfig.json files seem to be required here; see
https://stackoverflow.com/questions/55753163/package-json-is-not-under-rootdir

Part of work towards ESM support.
