### PR TITLE
[BUG] fix: add missing await to catch errors thrown in parsingDidEnd()

### DIFF
--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -245,7 +245,7 @@ export async function processGraphQLRequest<TContext>(
 
     try {
       requestContext.document = parse(query, config.parseOptions);
-      parsingDidEnd();
+      await parsingDidEnd();
     } catch (syntaxError) {
       await parsingDidEnd(syntaxError as Error);
       // XXX: This cast is pretty sketchy, as other error types can be thrown


### PR DESCRIPTION
Currently, errors throwing during the post-parsing phase hook fly by this try/catch block because of the missing await. They then bubble up into the outer scope and are treated as INTERNAL_SERVER_ERRORS. This took me quite a while to figure out (hard to spot that missing `await` there).

There are also other incidents in this code base where errors are incorrectly thrown as INTERNAL_SERVER_ERROR where they should instead be BAD_USER_INPUT (e.g. missing `query`). Maybe something you'd want to fix too?

Thanks!