### PR TITLE
Add code comment explaining why httpServer in code snippets

### DIFF
--- a/docs/source/api/plugin/drain-http-server.mdx
+++ b/docs/source/api/plugin/drain-http-server.mdx
@@ -34,6 +34,9 @@ const http = require('http');
 
 async function startApolloServer() {
   const app = express();
+  // Our httpServer handles incoming requests to our Express app.
+  // Below, we tell Apollo Server to "drain" this httpServer,
+  // enabling our servers to shut down gracefully.
   const httpServer = http.createServer(app);
   const server = new ApolloServer({
     typeDefs,

--- a/docs/source/integrations/middleware.mdx
+++ b/docs/source/integrations/middleware.mdx
@@ -164,9 +164,13 @@ import http from 'http';
 async function startApolloServer(typeDefs, resolvers) {
   // Required logic for integrating with Express
   const app = express();
+  // Our httpServer handles incoming requests to our Express app.
+  // Below, we tell Apollo Server to "drain" this httpServer,
+  // enabling our servers to shut down gracefully.
   const httpServer = http.createServer(app);
 
-  // Same ApolloServer initialization as before, plus the drain plugin.
+  // Same ApolloServer initialization as before, plus the drain plugin
+  // for our httpServer.
   const server = new ApolloServer({
     typeDefs,
     resolvers,


### PR DESCRIPTION
We've received feedback from people confused about why we add `httpServer`'s in code snippets throughout the docs (e.g., snippets with the `ApolloServerPluginDrainHttpServer`  plugin). I took a shot at adding in an explanation in two places that felt most relevant. 