### PR TITLE
tsconfig: simplify and update

### DIFF
--- a/packages/server/src/__tests__/tsconfig.json
+++ b/packages/server/src/__tests__/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "../../../../tsconfig.test.base",
   "include": ["**/*"],
-  "compilerOptions": {
-    // @apollo/client doesn't work without dom types, and we use it in our tests
-    // to test that the real persisted query link works. Perhaps we can make this
-    // more tightly scoped later.
-    "lib": ["es2019", "es2019.array", "esnext.asynciterable", "dom"],
-  },
   "references": [
     { "path": "../../" },
     { "path": "../../../integration-testsuite" }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es2019",
+    "target": "es2020",
     "module": "esnext",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -18,7 +18,7 @@
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
     "importsNotUsedAsValues": "error",
-    "lib": ["es2019", "esnext.asynciterable"],
+    "lib": ["es2020"],
     "types": ["node"],
     "baseUrl": ".",
   }

--- a/tsconfig.test.base.json
+++ b/tsconfig.test.base.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["es2019", "es2019.array", "esnext.asynciterable"],
     "types": ["node", "jest"],
   }
 }


### PR DESCRIPTION
- Node 14 as minimum requirement lets us target es2020 (see eg
  https://github.com/tsconfig/bases/blob/main/bases/node14.json)
- Stuff like array and asynciterable is just built in to es2020
  by now as far as I can tell
- We don't appear to need dom in our tests any more (for @apollo/client)
  probably because the test does deep imports into @apollo/client
