### PR TITLE
Make AS/ASP invariant in TContext; move logger/cache to server in plugins

### DIFF
--- a/WIP/migration.mdx
+++ b/WIP/migration.mdx
@@ -403,6 +403,10 @@ Remove persistedQueries field from GraphQLServerContext
 
 requestDidStart hooks are called in parallel rather than in series.
 
+The `logger` and `cache` fields are no longer on `GraphQLRequestContext`. Instead, `GraphQLRequestContext` has a `server: ApolloServer` field, and `logger` and `cache` are public readonly fields on `ApolloServer`.
+
+The `logger` field is no longer part of the argument to `serverWillStart`, but `server` is instead, and `logger` is a public readonly field on `ApolloServer`.
+
 ## New APIs
 
 ### `addPlugin` function

--- a/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
+++ b/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
@@ -174,7 +174,7 @@ export default function plugin<TContext extends BaseContext>(
       outerRequestContext: GraphQLRequestContext<any>,
     ): Promise<GraphQLRequestListener<any>> {
       const cache = new PrefixingKeyValueCache(
-        options.cache ?? outerRequestContext.cache,
+        options.cache ?? outerRequestContext.server.cache,
         'fqc:',
       );
 
@@ -267,7 +267,7 @@ export default function plugin<TContext extends BaseContext>(
         },
 
         async willSendResponse(requestContext) {
-          const logger = requestContext.logger || console;
+          const logger = requestContext.server.logger || console;
 
           if (!isGraphQLQuery(requestContext)) {
             return;

--- a/packages/server/src/__tests__/logger.test.ts
+++ b/packages/server/src/__tests__/logger.test.ts
@@ -15,14 +15,14 @@ describe('logger', () => {
       `,
       plugins: [
         {
-          async serverWillStart({ logger }) {
+          async serverWillStart({ server: { logger } }) {
             logger.debug(KNOWN_DEBUG_MESSAGE);
           },
         },
       ],
     });
 
-    const defaultLogger = server['internals'].logger as loglevel.Logger;
+    const defaultLogger = server.logger as loglevel.Logger;
     const debugSpy = jest.spyOn(defaultLogger, 'debug');
     await server.start();
 
@@ -42,7 +42,7 @@ describe('logger', () => {
       `,
       plugins: [
         {
-          async serverWillStart({ logger }) {
+          async serverWillStart({ server: { logger } }) {
             logger.debug(KNOWN_DEBUG_MESSAGE);
           },
         },

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -1,5 +1,4 @@
 import type { Trace } from '@apollo/usage-reporting-protobuf';
-import type { Logger } from '@apollo/utils.logger';
 import type {
   DocumentNode,
   FormattedExecutionResult,
@@ -7,10 +6,10 @@ import type {
   GraphQLSchema,
   OperationDefinitionNode,
 } from 'graphql';
-import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 import type { CachePolicy } from './cacheControl';
 import type { BaseContext } from './context';
 import type { HTTPGraphQLHead, HTTPGraphQLRequest } from './http';
+import type { ApolloServer } from '../ApolloServer';
 
 export interface GraphQLRequest {
   query?: string;
@@ -45,15 +44,14 @@ export interface GraphQLRequestMetrics {
 }
 
 export interface GraphQLRequestContext<TContext extends BaseContext> {
+  readonly server: ApolloServer<TContext>;
+
   readonly request: GraphQLRequest;
   readonly response: GraphQLResponse;
-
-  logger: Logger;
 
   readonly schema: GraphQLSchema;
 
   readonly contextValue: TContext;
-  readonly cache: KeyValueCache<string>;
 
   readonly queryHash?: string;
 

--- a/packages/server/src/externalTypes/plugins.ts
+++ b/packages/server/src/externalTypes/plugins.ts
@@ -1,5 +1,5 @@
-import type { Logger } from '@apollo/utils.logger';
 import type { GraphQLResolveInfo, GraphQLSchema } from 'graphql';
+import type { ApolloServer } from '../ApolloServer';
 import type { ApolloConfig } from './constructor';
 import type { BaseContext } from './context';
 import type { GraphQLRequestContext, GraphQLResponse } from './graphql';
@@ -14,8 +14,8 @@ import type {
   GraphQLRequestContextWillSendResponse,
 } from './requestPipeline';
 
-export interface GraphQLServerContext {
-  logger: Logger;
+export interface GraphQLServerContext<TContext extends BaseContext> {
+  server: ApolloServer<TContext>;
   schema: GraphQLSchema;
   apollo: ApolloConfig;
   // TODO(AS4): Make sure we document that we removed `persistedQueries`.
@@ -34,9 +34,9 @@ export type PluginDefinition<TContext extends BaseContext> =
   | ApolloServerPlugin<TContext>
   | (() => ApolloServerPlugin<TContext>);
 
-export interface ApolloServerPlugin<TContext extends BaseContext> {
+export interface ApolloServerPlugin<in out TContext extends BaseContext> {
   serverWillStart?(
-    service: GraphQLServerContext,
+    service: GraphQLServerContext<TContext>,
   ): Promise<GraphQLServerListener | void>;
 
   requestDidStart?(
@@ -54,14 +54,6 @@ export interface ApolloServerPlugin<TContext extends BaseContext> {
   contextCreationDidFail?({ error }: { error: Error }): Promise<void>;
   invalidRequestWasReceived?({ error }: { error: Error }): Promise<void>;
   startupDidFail?({ error }: { error: Error }): Promise<void>;
-
-  // See the similarly named field on ApolloServer for details. Note that it
-  // appears that this only works if it is a *field*, not a *method*, which is
-  // why `requestDidStart` (which takes a TContext wrapped in something) is not
-  // sufficient.
-  //
-  // TODO(AS4): Upgrade to TS 4.7 and use `in` instead.
-  __forceTContextToBeContravariant?: (contextValue: TContext) => void;
 }
 
 export interface GraphQLServerListener {

--- a/packages/server/src/plugin/inlineTrace/index.ts
+++ b/packages/server/src/plugin/inlineTrace/index.ts
@@ -39,7 +39,7 @@ export function ApolloServerPluginInlineTrace<TContext extends BaseContext>(
     __internal_plugin_id__() {
       return 'InlineTrace';
     },
-    async serverWillStart({ schema, logger }) {
+    async serverWillStart({ schema, server }) {
       // Handle the case that the plugin was implicitly installed. We only want it
       // to actually be active if the schema appears to be federated. If you don't
       // like the log line, just install `ApolloServerPluginInlineTrace()` in
@@ -47,7 +47,7 @@ export function ApolloServerPluginInlineTrace<TContext extends BaseContext>(
       if (enabled === null) {
         enabled = schemaIsFederated(schema);
         if (enabled) {
-          logger.info(
+          server.logger.info(
             'Enabling inline tracing for this federated service. To disable, use ' +
               'ApolloServerPluginInlineTraceDisabled.',
           );

--- a/packages/server/src/plugin/schemaReporting/index.ts
+++ b/packages/server/src/plugin/schemaReporting/index.ts
@@ -72,8 +72,9 @@ export function ApolloServerPluginSchemaReporting<TContext extends BaseContext>(
     __internal_plugin_id__() {
       return 'SchemaReporting';
     },
-    async serverWillStart({ apollo, schema, logger }) {
+    async serverWillStart({ apollo, schema, server }) {
       const { key, graphRef } = apollo;
+      const { logger } = server;
       if (!key) {
         throw Error(
           'To use ApolloServerPluginSchemaReporting, you must provide an Apollo API ' +

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -18,7 +18,6 @@ import type {
   GraphQLRequestContextWillSendResponse,
   GraphQLRequestListener,
   GraphQLServerListener,
-  GraphQLServerContext,
 } from '../../externalTypes';
 import type { InternalApolloServerPlugin } from '../../internalPlugin';
 import type { HeaderMap } from '../../runHttpQuery';
@@ -105,12 +104,12 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
     },
 
     async serverWillStart({
-      logger: serverLogger,
+      server,
       apollo,
       startedInBackground,
-    }: GraphQLServerContext): Promise<GraphQLServerListener> {
+    }): Promise<GraphQLServerListener> {
       // Use the plugin-specific logger if one is provided; otherwise the general server one.
-      const logger = options.logger ?? serverLogger;
+      const logger = options.logger ?? server.logger;
       const { key, graphRef } = apollo;
       if (!(key && graphRef)) {
         throw new Error(
@@ -382,14 +381,11 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
       };
 
       requestDidStartHandler = ({
-        logger: requestLogger,
         metrics,
         schema,
         request: { http, variables },
       }): GraphQLRequestListener<TContext> => {
-        // Request specific log output should go into the `logger` from the
-        // request context when it's provided.
-        const logger = requestLogger ?? options.logger ?? serverLogger;
+        const logger = options.logger ?? server.logger;
         const treeBuilder: TraceTreeBuilder = new TraceTreeBuilder({
           rewriteError: options.rewriteError,
           logger,

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -50,6 +50,7 @@ import {
 import { HeaderMap, newHTTPGraphQLHead } from './runHttpQuery.js';
 import type { ApolloServerInternals, SchemaDerivedData } from './ApolloServer';
 import { isDefined } from './utils/isDefined.js';
+import type { Logger } from '@apollo/utils.logger';
 
 export const APQ_CACHE_PREFIX = 'apq:';
 
@@ -90,6 +91,7 @@ const getPersistedQueryErrorHttp = () => ({
 export async function processGraphQLRequest<TContext extends BaseContext>(
   schemaDerivedData: SchemaDerivedData,
   internals: ApolloServerInternals<TContext>,
+  logger: Logger,
   requestContext: Mutable<GraphQLRequestContext<TContext>>,
 ) {
   const requestListeners = (
@@ -192,7 +194,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         queryHash,
       );
     } catch (err) {
-      internals.logger.warn(
+      logger.warn(
         'An error occurred while attempting to read from the documentStore. ' +
           (err as Error)?.message || err,
       );
@@ -263,7 +265,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
       Promise.resolve(
         schemaDerivedData.documentStore.set(queryHash, requestContext.document),
       ).catch((err) =>
-        internals.logger.warn(
+        logger.warn(
           'Could not store validated document. ' + err?.message || err,
         ),
       );
@@ -340,7 +342,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
           ? { ttl: internals.persistedQueries?.ttl }
           : undefined,
       ),
-    ).catch(internals.logger.warn);
+    ).catch(logger.warn);
   }
 
   const responseFromPlugin = await invokeHooksUntilDefinedAndNonNull(

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -6,12 +6,14 @@ import type {
   HTTPGraphQLResponse,
 } from './externalTypes';
 import {
+  ApolloServer,
   ApolloServerInternals,
   internalExecuteOperation,
   SchemaDerivedData,
 } from './ApolloServer.js';
 import type { FormattedExecutionResult } from 'graphql';
 import { BadRequestError } from './errors.js';
+import type { Logger } from '@apollo/utils.logger';
 
 // TODO(AS4): keep rethinking whether Map is what we want or if we just
 // do want to use (our own? somebody else's?) Headers class.
@@ -100,10 +102,12 @@ export const badMethodErrorMessage =
   'Apollo Server supports only GET/POST requests.';
 
 export async function runHttpQuery<TContext extends BaseContext>(
+  server: ApolloServer<TContext>,
   httpRequest: HTTPGraphQLRequest,
   contextValue: TContext,
   schemaDerivedData: SchemaDerivedData,
   internals: ApolloServerInternals<TContext>,
+  logger: Logger,
 ): Promise<HTTPGraphQLResponse> {
   let graphQLRequest: GraphQLRequest;
 
@@ -168,9 +172,11 @@ export async function runHttpQuery<TContext extends BaseContext>(
   }
 
   const graphQLResponse = await internalExecuteOperation({
+    server,
     graphQLRequest,
     contextValue,
     internals,
+    logger,
     schemaDerivedData,
   });
 


### PR DESCRIPTION
This change does two things, which we originally thought were kind of
connected but maybe aren't.

First, we switch the implementation of contravariance from a hacky
`__forceTContextToBeContravariant` field to the new TS 4.7 variance
annotations. But in fact, instead of making it contravariant, we make it
invariant: `ApolloServer<X>` can only be assigned to `ApolloServer<Y>`
when X and Y are the same. This is because:

- An `ApolloServer<{foo: number}>` is not a `ApolloServer<{}>`, because
  you can invoke `executeOperation` on the latter with an empty context
  object, which would confuse the former (this is the contravariance we
  already had).
- An `ApolloServer<{}>` is not a `ApolloServer<{foo: number}>`, because
  you can invoke `addPlugin` on the latter with a plugin whose methods
  expect to be called with a `contextValue` with `{foo: number}` on it,
  which isn't the case for the former.

Considering the second condition is why this is now invariant (`in
out`).  We're not quite sure why TS couldn't figure this out for us, but
it can't.

Second, we add `server: ApolloServer` to various plugin hook arguments
(`GraphQLRequestContext` and `GraphQLServerContext`). This makes
`logger` and `cache` on `GraphQLRequestContext` somewhat redundant, so
we make those fields into public readonly fields on `ApolloServer` and
remove them from the plugin hook arguments. (We thought this was related
to the other part because adding `server` appeared to require invariance
instead of contravariance, but it turns out that we needed invariance
anyway due to `addPlugin`.)

Note that this means that anyone consuming our `.d.ts` files must be on
TS4.7. Before v4.0.0 we'll probably fix that; see #6423.

Fixes #6264. Fixes #6082.
