### PR TITLE
✍️ add embed sandbox option to Getting Started doc

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -21,13 +21,6 @@ const server = new ApolloServer({
 	resolvers,
   csrfPrevention: true,  // highly recommended
   cache: 'bounded',
-  /**
-   * What's up with this embed: true option?
-   * These are our recommended settings for using AS;
-   * they aren't the defaults in AS3 for backwards-compatibility reasons but
-   * will be the defaults in AS4. For production environments, use
-   * ApolloServerPluginLandingPageProductionDefault instead.
-  **/
   plugins: [
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
@@ -763,13 +756,6 @@ async function startApolloServer() {
     cache: 'bounded',
     plugins: [
       ApolloServerPluginDrainHttpServer({ httpServer }),
-      /**
-       * What's up with this embed: true option?
-       * These are our recommended settings for using AS;
-       * they aren't the defaults in AS3 for backwards-compatibility reasons but
-       * will be the defaults in AS4. For production environments, use
-       * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -21,6 +21,16 @@ const server = new ApolloServer({
 	resolvers,
   csrfPrevention: true,  // highly recommended
   cache: 'bounded',
+  /**
+   * What's up with this embed: true option?
+   * These are our recommended settings for using AS;
+   * they aren't the defaults in AS3 for backwards-compatibility reasons but
+   * will be the defaults in AS4. For production environments, use
+   * ApolloServerPluginLandingPageProductionDefault instead.
+  **/
+  plugins: [
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -737,7 +747,10 @@ Here's an example of using `applyMiddleware` with `apollo-server-express`.
 ```ts title="index.ts"
 const express = require('express');
 const { ApolloServer } = require('apollo-server-express');
-const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
+const {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 const { typeDefs, resolvers } = require('./schema');
 
 async function startApolloServer() {
@@ -748,7 +761,17 @@ async function startApolloServer() {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
-    plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
+    plugins: [
+      ApolloServerPluginDrainHttpServer({ httpServer }),
+      /**
+       * What's up with this embed: true option?
+       * These are our recommended settings for using AS;
+       * they aren't the defaults in AS3 for backwards-compatibility reasons but
+       * will be the defaults in AS4. For production environments, use
+       * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
 
   await server.start();

--- a/docs/source/api/plugin/cache-control.md
+++ b/docs/source/api/plugin/cache-control.md
@@ -32,13 +32,6 @@ const server = new ApolloServer({
       // Don't send the `cache-control` response header.
       calculateHttpHeaders: false,
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -60,13 +53,6 @@ const server = new ApolloServer({
   cache: "bounded",
   plugins: [
     ApolloServerPluginCacheControlDisabled(),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/api/plugin/cache-control.md
+++ b/docs/source/api/plugin/cache-control.md
@@ -15,7 +15,10 @@ If you want to configure this plugin, import it from the `apollo-server-core` pa
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginCacheControl } from "apollo-server-core";
+import {
+  ApolloServerPluginCacheControl,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
@@ -29,6 +32,14 @@ const server = new ApolloServer({
       // Don't send the `cache-control` response header.
       calculateHttpHeaders: false,
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```
@@ -37,14 +48,27 @@ If you don't want to use cache control at all, you can explicitly disable it wit
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginCacheControlDisabled } from "apollo-server-core";
+import {
+  ApolloServerPluginCacheControlDisabled,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: "bounded",
-  plugins: [ApolloServerPluginCacheControlDisabled()],
+  plugins: [
+    ApolloServerPluginCacheControlDisabled(),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/api/plugin/drain-http-server.mdx
+++ b/docs/source/api/plugin/drain-http-server.mdx
@@ -28,7 +28,10 @@ Here's a basic example of how to use it with Express. See the [framework integra
 ```ts title="index.ts"
 const express = require('express');
 const { ApolloServer } = require('apollo-server-express');
-const { ApolloServerPluginDrainHttpServer } = require('apollo-server-core');
+const {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const { typeDefs, resolvers } = require('./schema');
 const http = require('http');
 
@@ -40,7 +43,17 @@ async function startApolloServer() {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
-    plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
+    plugins: [
+      ApolloServerPluginDrainHttpServer({ httpServer }),
+      /**
+       * What's up with this embed: true option?
+       * These are our recommended settings for using AS;
+       * they aren't the defaults in AS3 for backwards-compatibility reasons but
+       * will be the defaults in AS4. For production environments, use
+       * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
 
   await server.start();

--- a/docs/source/api/plugin/drain-http-server.mdx
+++ b/docs/source/api/plugin/drain-http-server.mdx
@@ -45,13 +45,6 @@ async function startApolloServer() {
     cache: 'bounded',
     plugins: [
       ApolloServerPluginDrainHttpServer({ httpServer }),
-      /**
-       * What's up with this embed: true option?
-       * These are our recommended settings for using AS;
-       * they aren't the defaults in AS3 for backwards-compatibility reasons but
-       * will be the defaults in AS4. For production environments, use
-       * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });

--- a/docs/source/api/plugin/inline-trace.md
+++ b/docs/source/api/plugin/inline-trace.md
@@ -15,7 +15,10 @@ If you want to configure this plugin (or if you want to use it in a graph that i
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginInlineTrace } from "apollo-server-core";
+import {
+  ApolloServerPluginInlineTrace,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
@@ -26,6 +29,14 @@ const server = new ApolloServer({
     ApolloServerPluginInlineTrace({
       rewriteError: (err) => err.message.match(SENSITIVE_REGEX) ? null : err,
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```
@@ -34,14 +45,27 @@ If you don't want to use the inline trace plugin even though your schema defines
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginInlineTraceDisabled } from "apollo-server-core";
+import {
+  ApolloServerPluginInlineTraceDisabled,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: "bounded",
-  plugins: [ApolloServerPluginInlineTraceDisabled()],
+  plugins: [
+    ApolloServerPluginInlineTraceDisabled(),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/api/plugin/inline-trace.md
+++ b/docs/source/api/plugin/inline-trace.md
@@ -29,13 +29,6 @@ const server = new ApolloServer({
     ApolloServerPluginInlineTrace({
       rewriteError: (err) => err.message.match(SENSITIVE_REGEX) ? null : err,
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -57,13 +50,6 @@ const server = new ApolloServer({
   cache: "bounded",
   plugins: [
     ApolloServerPluginInlineTraceDisabled(),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/api/plugin/schema-reporting.md
+++ b/docs/source/api/plugin/schema-reporting.md
@@ -17,7 +17,10 @@ Additionally, you must explicitly enable schema reporting. If you just want to t
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginSchemaReporting } from "apollo-server-core";
+import {
+  ApolloServerPluginSchemaReporting,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
@@ -26,6 +29,14 @@ const server = new ApolloServer({
   cache: "bounded",
   plugins: [
     ApolloServerPluginSchemaReporting(),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```

--- a/docs/source/api/plugin/schema-reporting.md
+++ b/docs/source/api/plugin/schema-reporting.md
@@ -29,13 +29,6 @@ const server = new ApolloServer({
   cache: "bounded",
   plugins: [
     ApolloServerPluginSchemaReporting(),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -19,7 +19,10 @@ You can configure the usage reporting plugin's behavior by including it in the `
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginUsageReporting } from "apollo-server-core";
+import {
+  ApolloServerPluginUsageReporting,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
@@ -30,6 +33,14 @@ const server = new ApolloServer({
     ApolloServerPluginUsageReporting({
       fieldLevelInstrumentation: 0.5,
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```
@@ -449,14 +460,27 @@ If you _don't_ want to install the usage reporting plugin and you _are_ providin
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginUsageReportingDisabled } from "apollo-server-core";
+import {
+  ApolloServerPluginUsageReportingDisabled,
+  ApolloServerPluginLandingPageLocalDefault,
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: "bounded",
-  plugins: [ApolloServerPluginUsageReportingDisabled()],
+  plugins: [
+    ApolloServerPluginUsageReportingDisabled(),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/api/plugin/usage-reporting.md
+++ b/docs/source/api/plugin/usage-reporting.md
@@ -33,13 +33,6 @@ const server = new ApolloServer({
     ApolloServerPluginUsageReporting({
       fieldLevelInstrumentation: 0.5,
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -472,13 +465,6 @@ const server = new ApolloServer({
   cache: "bounded",
   plugins: [
     ApolloServerPluginUsageReportingDisabled(),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/builtin-plugins.md
+++ b/docs/source/builtin-plugins.md
@@ -40,14 +40,7 @@ const server = new ApolloServer({
     ApolloServerPluginUsageReporting({
       sendVariableValues: { all: true },
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
-    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }), // recommended
   ],
 });
 ```

--- a/docs/source/builtin-plugins.md
+++ b/docs/source/builtin-plugins.md
@@ -25,7 +25,10 @@ You can install a plugin that isn't installed by default (or customize a default
 
 ```js
 import { ApolloServer } from "apollo-server";
-import { ApolloServerPluginUsageReporting } from "apollo-server-core";
+import {
+  ApolloServerPluginUsageReporting,
+  ApolloServerPluginLandingPageLocalDefault
+} from "apollo-server-core";
 
 const server = new ApolloServer({
   typeDefs,
@@ -37,6 +40,14 @@ const server = new ApolloServer({
     ApolloServerPluginUsageReporting({
       sendVariableValues: { all: true },
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```

--- a/docs/source/data/data-sources.mdx
+++ b/docs/source/data/data-sources.mdx
@@ -56,6 +56,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: "bounded",
+  plugins: [
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
   dataSources: () => {
     return {
       moviesAPI: new MoviesAPI(),

--- a/docs/source/data/data-sources.mdx
+++ b/docs/source/data/data-sources.mdx
@@ -57,13 +57,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: "bounded",
   plugins: [
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
   dataSources: () => {

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -344,6 +344,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: "bounded",
+  plugins: [
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
   formatError: (err) => {
     // Don't give the specific errors to the client.
     if (err.message.startsWith('Database Error: ')) {
@@ -394,7 +404,10 @@ Let's say our server is `throw`ing an `AuthenticationError` whenever an incorrec
 
 ```js {7-17}
 const { ApolloServer, AuthenticationError } = require("apollo-server");
-const { ApolloServerPluginUsageReporting } = require("apollo-server-core");
+const {
+  ApolloServerPluginUsageReporting,
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const server = new ApolloServer({
   typeDefs,
   resolvers,
@@ -412,6 +425,14 @@ const server = new ApolloServer({
         return err;
       }
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```
@@ -426,7 +447,10 @@ We can check these properties when determining whether an error should be report
 
 ```js {7-17}
 const { ApolloServer } = require("apollo-server");
-const { ApolloServerPluginUsageReporting } = require("apollo-server-core");
+const {
+  ApolloServerPluginUsageReporting,
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const server = new ApolloServer({
   typeDefs,
   resolvers,
@@ -445,6 +469,14 @@ const server = new ApolloServer({
         return err;
       }
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```
@@ -465,7 +497,10 @@ The `rewriteError` function can ensure that such information is not sent to Apol
 
 ```js {7-13}
 const { ApolloServer } = require("apollo-server");
-const { ApolloServerPluginUsageReporting } = require("apollo-server-core");
+const {
+  ApolloServerPluginUsageReporting,
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const server = new ApolloServer({
   typeDefs,
   resolvers,
@@ -479,6 +514,14 @@ const server = new ApolloServer({
         return err;
       }
     }),
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 ```
@@ -517,6 +560,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
-  plugins: [setHttpPlugin],
+  plugins: [
+    setHttpPlugin,
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -345,13 +345,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: "bounded",
   plugins: [
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
   formatError: (err) => {
@@ -425,13 +418,6 @@ const server = new ApolloServer({
         return err;
       }
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -469,13 +455,6 @@ const server = new ApolloServer({
         return err;
       }
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -514,13 +493,6 @@ const server = new ApolloServer({
         return err;
       }
     }),
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -562,13 +534,6 @@ const server = new ApolloServer({
   cache: 'bounded',
   plugins: [
     setHttpPlugin,
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/data/file-uploads.mdx
+++ b/docs/source/data/file-uploads.mdx
@@ -23,6 +23,9 @@ const {
   graphqlUploadExpress, // A Koa implementation is also exported.
 } = require('graphql-upload');
 const { finished } = require('stream/promises');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 
 const typeDefs = gql`
   # The implementation for this scalar is provided by the
@@ -80,6 +83,16 @@ async function startServer() {
     // Using graphql-upload without CSRF prevention is very insecure.
     csrfPrevention: true,
     cache: 'bounded',
+    plugins: [
+      /**
+       * What's up with this embed: true option?
+       * These are our recommended settings for using AS;
+       * they aren't the defaults in AS3 for backwards-compatibility reasons but
+       * will be the defaults in AS4. For production environments, use
+       * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
   await server.start();
 
@@ -104,6 +117,9 @@ startServer();
 
 ```js
 const { ApolloServer, gql } = require('apollo-server-fastify');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const { GraphQLUpload, processRequest } = require('graphql-upload');
 const { finished } = require('stream/promises');
 
@@ -183,6 +199,16 @@ const start = async () => {
       // Using graphql-upload without CSRF prevention is very insecure.
       csrfPrevention: true,
       cache: 'bounded',
+      plugins: [
+        /**
+         * What's up with this embed: true option?
+         * These are our recommended settings for using AS;
+         * they aren't the defaults in AS3 for backwards-compatibility reasons but
+         * will be the defaults in AS4. For production environments, use
+         * ApolloServerPluginLandingPageProductionDefault instead.
+        **/
+        ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+      ],
     });
 
     // Start Apollo Server

--- a/docs/source/data/file-uploads.mdx
+++ b/docs/source/data/file-uploads.mdx
@@ -84,13 +84,6 @@ async function startServer() {
     csrfPrevention: true,
     cache: 'bounded',
     plugins: [
-      /**
-       * What's up with this embed: true option?
-       * These are our recommended settings for using AS;
-       * they aren't the defaults in AS3 for backwards-compatibility reasons but
-       * will be the defaults in AS4. For production environments, use
-       * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -200,13 +193,6 @@ const start = async () => {
       csrfPrevention: true,
       cache: 'bounded',
       plugins: [
-        /**
-         * What's up with this embed: true option?
-         * These are our recommended settings for using AS;
-         * they aren't the defaults in AS3 for backwards-compatibility reasons but
-         * will be the defaults in AS4. For production environments, use
-         * ApolloServerPluginLandingPageProductionDefault instead.
-        **/
         ApolloServerPluginLandingPageLocalDefault({ embed: true }),
       ],
     });

--- a/docs/source/data/resolvers.mdx
+++ b/docs/source/data/resolvers.mdx
@@ -109,6 +109,9 @@ The following example defines a hardcoded data set, a schema, and a resolver map
 
 ```javascript
 const { ApolloServer, gql } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 
 // Hardcoded data store
 const books = [
@@ -150,6 +153,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 // Launch the server
@@ -242,6 +255,9 @@ Here's a code sample that can resolve the query above with this resolver chain:
 
 ```javascript
 const { ApolloServer, gql } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 
 const libraries = [
   {
@@ -333,6 +349,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+     * What's up with this embed: true option?
+     * These are our recommended settings for using AS;
+     * they aren't the defaults in AS3 for backwards-compatibility reasons but
+     * will be the defaults in AS4. For production environments, use
+     * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 // Launch the server
@@ -401,8 +427,18 @@ const server = new ApolloServer({
   cache: 'bounded',
   context: ({ req }) => ({
     authScope: getScope(req.headers.authorization)
-  })
-}));
+  }),
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
+});
 
 // Example resolver
 (parent, args, context, info) => {

--- a/docs/source/data/resolvers.mdx
+++ b/docs/source/data/resolvers.mdx
@@ -154,13 +154,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -350,13 +343,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-     * What's up with this embed: true option?
-     * These are our recommended settings for using AS;
-     * they aren't the defaults in AS3 for backwards-compatibility reasons but
-     * will be the defaults in AS4. For production environments, use
-     * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -429,13 +415,6 @@ const server = new ApolloServer({
     authScope: getScope(req.headers.authorization)
   }),
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -87,13 +87,6 @@ To run both an Express app _and_ a separate WebSocket server for subscriptions, 
       csrfPrevention: true,
       cache: "bounded",
       plugins: [
-        /**
-        * What's up with this embed: true option?
-        * These are our recommended settings for using AS;
-        * they aren't the defaults in AS3 for backwards-compatibility reasons but
-        * will be the defaults in AS4. For production environments, use
-        * ApolloServerPluginLandingPageProductionDefault instead.
-        **/
         ApolloServerPluginLandingPageLocalDefault({ embed: true }),
       ],
     });
@@ -137,13 +130,6 @@ To run both an Express app _and_ a separate WebSocket server for subscriptions, 
               };
             },
           },
-          /**
-          * What's up with this embed: true option?
-          * These are our recommended settings for using AS;
-          * they aren't the defaults in AS3 for backwards-compatibility reasons but
-          * will be the defaults in AS4. For production environments, use
-          * ApolloServerPluginLandingPageProductionDefault instead.
-          **/
           ApolloServerPluginLandingPageLocalDefault({ embed: true }),
         ],
       });
@@ -206,13 +192,6 @@ const server = new ApolloServer({
         };
       },
     },
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -57,7 +57,10 @@ To run both an Express app _and_ a separate WebSocket server for subscriptions, 
 
     ```ts title="index.ts"
     import { createServer } from 'http';
-    import { ApolloServerPluginDrainHttpServer } from "apollo-server-core";
+    import {
+      ApolloServerPluginDrainHttpServer,
+      ApolloServerPluginLandingPageLocalDefault,
+    } from "apollo-server-core";
     import { makeExecutableSchema } from '@graphql-tools/schema';
     import { WebSocketServer } from 'ws';
     import { useServer } from 'graphql-ws/lib/use/ws';
@@ -83,6 +86,16 @@ To run both an Express app _and_ a separate WebSocket server for subscriptions, 
       schema,
       csrfPrevention: true,
       cache: "bounded",
+      plugins: [
+        /**
+        * What's up with this embed: true option?
+        * These are our recommended settings for using AS;
+        * they aren't the defaults in AS3 for backwards-compatibility reasons but
+        * will be the defaults in AS4. For production environments, use
+        * ApolloServerPluginLandingPageProductionDefault instead.
+        **/
+        ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+      ],
     });
     ```
 
@@ -124,6 +137,14 @@ To run both an Express app _and_ a separate WebSocket server for subscriptions, 
               };
             },
           },
+          /**
+          * What's up with this embed: true option?
+          * These are our recommended settings for using AS;
+          * they aren't the defaults in AS3 for backwards-compatibility reasons but
+          * will be the defaults in AS4. For production environments, use
+          * ApolloServerPluginLandingPageProductionDefault instead.
+          **/
+          ApolloServerPluginLandingPageLocalDefault({ embed: true }),
         ],
       });
     ```
@@ -185,6 +206,14 @@ const server = new ApolloServer({
         };
       },
     },
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 await server.start();

--- a/docs/source/deployment/azure-functions.mdx
+++ b/docs/source/deployment/azure-functions.mdx
@@ -79,6 +79,9 @@ To set up the `apollo-server-azure-functions` library, replace the content of yo
 
 ```javascript
 const { ApolloServer, gql } = require('apollo-server-azure-functions');
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 
 // Schema definition.
 const typeDefs = gql`
@@ -100,6 +103,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 exports.graphqlHandler = server.createHandler();
 ```

--- a/docs/source/deployment/azure-functions.mdx
+++ b/docs/source/deployment/azure-functions.mdx
@@ -104,13 +104,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/deployment/gcp-functions.mdx
+++ b/docs/source/deployment/gcp-functions.mdx
@@ -8,6 +8,9 @@ This tutorial helps you deploy Apollo Server to Google Cloud Functions. It uses 
 
 ```javascript title="index.js"
 const { ApolloServer, gql } = require('apollo-server-cloud-functions');
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 
 // Construct a schema, using GraphQL schema language
 const typeDefs = gql`
@@ -28,6 +31,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.handler = server.createHandler();
@@ -146,6 +159,9 @@ To obtain information about a currently executing Google Cloud Function (HTTP he
 
 ```javascript
 const { ApolloServer, gql } = require('apollo-server-cloud-functions');
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 
 // Construct a schema, using GraphQL schema language
 const typeDefs = gql`
@@ -171,6 +187,16 @@ const server = new ApolloServer({
     req,
     res,
   }),
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.handler = server.createHandler();

--- a/docs/source/deployment/gcp-functions.mdx
+++ b/docs/source/deployment/gcp-functions.mdx
@@ -32,13 +32,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -188,13 +181,6 @@ const server = new ApolloServer({
     res,
   }),
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -35,6 +35,9 @@ Next, set up the schema's type definitions and resolvers, and pass them to the `
 // graphql.js
 
 const { ApolloServer, gql } = require('apollo-server-lambda');
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 
 // Construct a schema, using GraphQL schema language
 const typeDefs = gql`
@@ -55,6 +58,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.graphqlHandler = server.createHandler();
@@ -197,6 +210,9 @@ The `event` object contains the API Gateway event (HTTP headers, HTTP method, bo
 
 ```js
 const { ApolloServer, gql } = require('apollo-server-lambda');
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 
 // Construct a schema, using GraphQL schema language
 const typeDefs = gql`
@@ -224,6 +240,16 @@ const server = new ApolloServer({
     context,
     expressRequest: express.req,
   }),
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.graphqlHandler = server.createHandler();

--- a/docs/source/deployment/lambda.md
+++ b/docs/source/deployment/lambda.md
@@ -59,13 +59,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -241,13 +234,6 @@ const server = new ApolloServer({
     expressRequest: express.req,
   }),
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -229,20 +229,23 @@ configure the landing page to embed the Apollo Sandbox for your endpoint. In the
 all requests go through your Apollo Server endpoint so no CORS configuration is required.
 See all configuration options for the landing pages [here](/api/plugin/landing-pages/).
 
-```js title="index.js" {9-12}
+```js title="index.js"
 import {
   ApolloServerPluginLandingPageLocalDefault
-} from "apollo-server-core";// The ApolloServer constructor requires two parameters: your schema
+} from "apollo-server-core";
+// The ApolloServer constructor requires two parameters: your schema
 // definition and your set of resolvers.
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  // highlight-start
   // modify your landing page config with the `plugins` option
   plugins: [
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
+  // highlight-end
 });
 
 // The `listen` method launches a web server.

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -153,6 +153,15 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  /**
+   * What's up with this embed: true option?
+   * These are our recommended settings for using AS;
+   * they aren't the defaults in AS3 for backwards-compatibility reasons but
+   * will be the defaults in AS4.
+  **/
+  plugins: [
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 // The `listen` method launches a web server.
@@ -160,6 +169,7 @@ server.listen().then(({ url }) => {
   console.log(`🚀  Server ready at ${url}`);
 });
 ```
+
 
 ## Step 7: Start the server
 
@@ -222,37 +232,6 @@ Paste this string into the Operations panel and click the blue button in the upp
 One of the most important concepts of GraphQL is that clients can choose to query _only for the fields they need_. Delete `author` from the query string and execute it again. The response updates to include only the `title` field for each book!
 
 > **Note:** If your server is deployed to an environment where `NODE_ENV` is set to `production`, introspection is **disabled** by default. This prevents Apollo Sandbox from working properly. To enable introspection, set `introspection: true` in [the options to `ApolloServer`'s constructor](./api/apollo-server/#constructor).
-
-> **Note:** If you have a CORS configured, your Apollo Server endpoint will need to safelist
-https://studio.apollographql.com to use Sandbox on apollographql.com. Instead, you can choose to
-configure the landing page to embed the Apollo Sandbox for your endpoint. In the embedded Sandbox,
-all requests go through your Apollo Server endpoint so no CORS configuration is required.
-See all configuration options for the landing pages [here](/api/plugin/landing-pages/).
-
-```js title="index.js"
-import {
-  ApolloServerPluginLandingPageLocalDefault
-} from "apollo-server-core";
-// The ApolloServer constructor requires two parameters: your schema
-// definition and your set of resolvers.
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-  csrfPrevention: true,
-  cache: 'bounded',
-  // highlight-start
-  // modify your landing page config with the `plugins` option
-  plugins: [
-    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
-  ],
-  // highlight-end
-});
-
-// The `listen` method launches a web server.
-server.listen().then(({ url }) => {
-  console.log(`🚀  Server ready at ${url}`);
-});
-```
 
 ## Combined example
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -230,8 +230,9 @@ all requests go through your Apollo Server endpoint so no CORS configuration is 
 See all configuration options for the landing pages [here](/api/plugin/landing-pages/).
 
 ```js title="index.js" {9-12}
-import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
-// The ApolloServer constructor requires two parameters: your schema
+import {
+  ApolloServerPluginLandingPageLocalDefault
+} from "apollo-server-core";// The ApolloServer constructor requires two parameters: your schema
 // definition and your set of resolvers.
 const server = new ApolloServer({
   typeDefs,

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -229,7 +229,7 @@ configure the landing page to embed the Apollo Sandbox for your endpoint. In the
 all requests go through your Apollo Server endpoint so no CORS configuration is required.
 See all configuration options for the landing pages [here](/api/plugin/landing-pages/).
 
-```js title="index.js"
+```js title="index.js" {9-12}
 import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 // The ApolloServer constructor requires two parameters: your schema
 // definition and your set of resolvers.

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -219,9 +219,35 @@ Paste this string into the Operations panel and click the blue button in the upp
 
 <img class="screenshot" src="./images/sandbox-response.jpg" width="400" alt="Sandbox response panel"/>
 
+One of the most important concepts of GraphQL is that clients can choose to query _only for the fields they need_. Delete `author` from the query string and execute it again. The response updates to include only the `title` field for each book!
+
 > **Note:** If your server is deployed to an environment where `NODE_ENV` is set to `production`, introspection is **disabled** by default. This prevents Apollo Sandbox from working properly. To enable introspection, set `introspection: true` in [the options to `ApolloServer`'s constructor](./api/apollo-server/#constructor).
 
-One of the most important concepts of GraphQL is that clients can choose to query _only for the fields they need_. Delete `author` from the query string and execute it again. The response updates to include only the `title` field for each book!
+> **Note:** If you have a CORS configuration set up, your Apollo Server endpoint will need to whitelist
+https://studio.apollographql.com to use Sandbox on apollographql.com. You can choose instead to
+configure the landing page to embed the Apollo Sandbox on your endpoint. In the embedded Sandbox,
+all requests go through your Apollo Server endpoint, so no CORS configuration is required.
+See all configuration options for the landing pages [here](/api/plugin/landing-pages/).
+
+```js title="index.js"
+// The ApolloServer constructor requires two parameters: your schema
+// definition and your set of resolvers.
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  csrfPrevention: true,
+  cache: 'bounded',
+  // modify your landing page config with the `plugins` option
+  plugins: [
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
+});
+
+// The `listen` method launches a web server.
+server.listen().then(({ url }) => {
+  console.log(`🚀  Server ready at ${url}`);
+});
+```
 
 ## Combined example
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -175,7 +175,6 @@ server.listen().then(({ url }) => {
 });
 ```
 
-
 ## Step 7: Start the server
 
 We're ready to start our server! Run the following from your project's root

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -146,6 +146,10 @@ backward compatibility.)
 Add the following to the bottom of `index.js`:
 
 ```js title="index.js"
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
+
 // The ApolloServer constructor requires two parameters: your schema
 // definition and your set of resolvers.
 const server = new ApolloServer({
@@ -157,7 +161,8 @@ const server = new ApolloServer({
    * What's up with this embed: true option?
    * These are our recommended settings for using AS;
    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-   * will be the defaults in AS4.
+   * will be the defaults in AS4. For production environments, use
+   * ApolloServerPluginLandingPageProductionDefault instead.
   **/
   plugins: [
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -202,6 +202,8 @@ Visit `http://localhost:4000` in your browser. Apollo Server's default landing p
 
 Click **Query your server** to open Sandbox.
 
+> **Note:** If your server is deployed to an environment where `NODE_ENV` is set to `production`, introspection is **disabled** by default. This prevents Apollo Sandbox from working properly. To enable introspection, set `introspection: true` in [the options to `ApolloServer`'s constructor](./api/apollo-server/#constructor).
+
 > You can also:
 >
 > * Select **Automatically redirect to Studio next time** if you want to open Sandbox automatically whenever you visit `localhost:4000`
@@ -234,8 +236,6 @@ Paste this string into the Operations panel and click the blue button in the upp
 <img class="screenshot" src="./images/sandbox-response.jpg" width="400" alt="Sandbox response panel"/>
 
 One of the most important concepts of GraphQL is that clients can choose to query _only for the fields they need_. Delete `author` from the query string and execute it again. The response updates to include only the `title` field for each book!
-
-> **Note:** If your server is deployed to an environment where `NODE_ENV` is set to `production`, introspection is **disabled** by default. This prevents Apollo Sandbox from working properly. To enable introspection, set `introspection: true` in [the options to `ApolloServer`'s constructor](./api/apollo-server/#constructor).
 
 ## Combined example
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -223,13 +223,14 @@ One of the most important concepts of GraphQL is that clients can choose to quer
 
 > **Note:** If your server is deployed to an environment where `NODE_ENV` is set to `production`, introspection is **disabled** by default. This prevents Apollo Sandbox from working properly. To enable introspection, set `introspection: true` in [the options to `ApolloServer`'s constructor](./api/apollo-server/#constructor).
 
-> **Note:** If you have a CORS configuration set up, your Apollo Server endpoint will need to whitelist
-https://studio.apollographql.com to use Sandbox on apollographql.com. You can choose instead to
-configure the landing page to embed the Apollo Sandbox on your endpoint. In the embedded Sandbox,
-all requests go through your Apollo Server endpoint, so no CORS configuration is required.
+> **Note:** If you have a CORS configured, your Apollo Server endpoint will need to safelist
+https://studio.apollographql.com to use Sandbox on apollographql.com. Instead, you can choose to
+configure the landing page to embed the Apollo Sandbox for your endpoint. In the embedded Sandbox,
+all requests go through your Apollo Server endpoint so no CORS configuration is required.
 See all configuration options for the landing pages [here](/api/plugin/landing-pages/).
 
 ```js title="index.js"
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 // The ApolloServer constructor requires two parameters: your schema
 // definition and your set of resolvers.
 const server = new ApolloServer({

--- a/docs/source/integrations/middleware.mdx
+++ b/docs/source/integrations/middleware.mdx
@@ -139,13 +139,6 @@ async function startApolloServer(typeDefs, resolvers) {
     csrfPrevention: true,
     cache: "bounded",
     plugins: [
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -190,13 +183,6 @@ async function startApolloServer(typeDefs, resolvers) {
     cache: 'bounded',
     plugins: [
       ApolloServerPluginDrainHttpServer({ httpServer }),
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -266,13 +252,6 @@ async function startApolloServer(typeDefs, resolvers) {
     csrfPrevention: true,
     cache: 'bounded',
     plugins: [
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -320,13 +299,6 @@ async function startApolloServer(typeDefs, resolvers) {
     cache: 'bounded',
     plugins: [
       ApolloServerPluginDrainHttpServer({ httpServer }),
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -394,13 +366,6 @@ async function startApolloServer(typeDefs, resolvers) {
     plugins: [
       fastifyAppClosePlugin(app),
       ApolloServerPluginDrainHttpServer({ httpServer: app.server }),
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -456,13 +421,6 @@ async function startApolloServer(typeDefs, resolvers) {
     cache: 'bounded',
     plugins: [
       ApolloServerPluginStopHapiServer({ hapiServer: app }),
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -516,13 +474,6 @@ async function startApolloServer(typeDefs, resolvers) {
     cache: 'bounded',
     plugins: [
       ApolloServerPluginDrainHttpServer({ httpServer }),
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
@@ -574,13 +525,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -627,13 +571,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -669,13 +606,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -710,13 +640,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/integrations/middleware.mdx
+++ b/docs/source/integrations/middleware.mdx
@@ -128,6 +128,9 @@ Let's say our `apollo-server` implementation uses the following code:
 
 ```ts title="index.ts"
 import { ApolloServer } from "apollo-server";
+import {
+  ApolloServerPluginLandingPageLocalDefault
+} from "apollo-server-core";
 
 async function startApolloServer(typeDefs, resolvers) {
   const server = new ApolloServer({
@@ -135,6 +138,16 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     csrfPrevention: true,
     cache: "bounded",
+    plugins: [
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
   const { url } = await server.listen();
   console.log(`🚀 Server ready at ${url}`);
@@ -157,7 +170,10 @@ Next, we can modify our code to match the following:
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-express';
-import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
+import {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 import express from 'express';
 import http from 'http';
 
@@ -172,7 +188,17 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
-    plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
+    plugins: [
+      ApolloServerPluginDrainHttpServer({ httpServer }),
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
 
   // More required logic for integrating with Express
@@ -239,6 +265,16 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
+    plugins: [
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
   const { url } = await server.listen();
   console.log(`🚀 Server ready at ${url}`);
@@ -267,7 +303,10 @@ npm install apollo-server-express apollo-server-core express graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-express';
-import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
+import {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 import express from 'express';
 import http from 'http';
 
@@ -279,7 +318,17 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
-    plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
+    plugins: [
+      ApolloServerPluginDrainHttpServer({ httpServer }),
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
   await server.start();
   server.applyMiddleware({ app });
@@ -316,7 +365,10 @@ npm install apollo-server-fastify apollo-server-core fastify graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-fastify';
-import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
+import {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 import { ApolloServerPlugin } from 'apollo-server-plugin-base';
 import fastify, { FastifyInstance } from 'fastify';
 
@@ -342,6 +394,14 @@ async function startApolloServer(typeDefs, resolvers) {
     plugins: [
       fastifyAppClosePlugin(app),
       ApolloServerPluginDrainHttpServer({ httpServer: app.server }),
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });
 
@@ -382,6 +442,9 @@ import {
   ApolloServer,
   ApolloServerPluginStopHapiServer
 } from 'apollo-server-hapi';
+import {
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 import Hapi from '@hapi/hapi';
 
 async function startApolloServer(typeDefs, resolvers) {
@@ -391,7 +454,17 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
-    plugins: [ApolloServerPluginStopHapiServer({ hapiServer: app })],
+    plugins: [
+      ApolloServerPluginStopHapiServer({ hapiServer: app }),
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
 
   await server.start();
@@ -427,7 +500,10 @@ npm install apollo-server-koa apollo-server-core koa graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-koa';
-import { ApolloServerPluginDrainHttpServer } from 'apollo-server-core';
+import {
+  ApolloServerPluginDrainHttpServer,
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 import Koa from 'koa';
 import http from 'http';
 
@@ -438,7 +514,17 @@ async function startApolloServer(typeDefs, resolvers) {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
-    plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
+    plugins: [
+      ApolloServerPluginDrainHttpServer({ httpServer }),
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
 
   await server.start();
@@ -480,12 +566,23 @@ npm install apollo-server-micro micro graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-micro';
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 module.exports = server.start().then(() => server.createHandler());
@@ -522,12 +619,23 @@ npm install apollo-server-lambda graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-lambda';
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.handler = server.createHandler();
@@ -553,12 +661,23 @@ npm install apollo-server-cloud-functions graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-cloud-functions';
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.handler = server.createHandler();
@@ -583,12 +702,23 @@ npm install apollo-server-azure-functions graphql
 
 ```ts title="index.ts"
 import { ApolloServer } from 'apollo-server-azure-functions';
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 exports.handler = server.createHandler();

--- a/docs/source/integrations/plugins.md
+++ b/docs/source/integrations/plugins.md
@@ -223,7 +223,7 @@ const server = new ApolloServer({
       async serverWillStart() {
         console.log('Server starting up!');
       },
-    }
+    },
   ],
 })
 ```

--- a/docs/source/monitoring/health-checks.md
+++ b/docs/source/monitoring/health-checks.md
@@ -50,13 +50,6 @@ const server = new ApolloServer({
     }
   },
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/monitoring/health-checks.md
+++ b/docs/source/monitoring/health-checks.md
@@ -31,6 +31,7 @@ If you'd like the health check to do more than just "always return success", you
 
 ```js {10-18}
 import { ApolloServer, gql } from 'apollo-server';
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 
 // Undefined for brevity.
 const typeDefs = gql``;
@@ -48,6 +49,16 @@ const server = new ApolloServer({
       throw new Error('...');
     }
   },
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 server.listen().then(({ url }) => {

--- a/docs/source/monitoring/metrics.md
+++ b/docs/source/monitoring/metrics.md
@@ -86,13 +86,6 @@ const server = new ApolloServer({
         }
       },
     }),
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -141,13 +134,6 @@ const server = new ApolloServer({
   cache: 'bounded',
   plugins: [
     myPlugin,
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ]
 });

--- a/docs/source/monitoring/metrics.md
+++ b/docs/source/monitoring/metrics.md
@@ -57,7 +57,10 @@ For more advanced cases, or to use headers other than the default headers, pass 
 
 ```js {10-25}
 const { ApolloServer } = require("apollo-server");
-const { ApolloServerPluginUsageReporting } = require("apollo-server-core");
+const {
+  ApolloServerPluginUsageReporting,
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 
 const server = new ApolloServer({
   typeDefs,
@@ -83,6 +86,14 @@ const server = new ApolloServer({
         }
       },
     }),
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
 
@@ -129,7 +140,15 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    myPlugin
+    myPlugin,
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ]
 });
 ```

--- a/docs/source/performance/apq.md
+++ b/docs/source/performance/apq.md
@@ -128,7 +128,10 @@ type Author @cacheControl(maxAge: 60) {
 See [the cache control documentation](./caching) for more details, including how to define the `@cacheControl` directive, how to specify hints dynamically inside resolvers, how to set a default `maxAge` for all fields, and how to specify that a field should be cached for specific users only (in which case CDNs should ignore it). For example, to set a default max age other than `0` modify the Apollo Server constructor to include `cacheControl`:
 
 ```js
-import { ApolloServerPluginCacheControl } from 'apollo-server-core';
+import {
+  ApolloServerPluginCacheControl,
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 
 const server = new ApolloServer({
   typeDefs,
@@ -136,7 +139,17 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   // The max age is calculated in seconds
-  plugins: [ApolloServerPluginCacheControl({ defaultMaxAge: 5 })],
+  plugins: [
+    ApolloServerPluginCacheControl({ defaultMaxAge: 5 }),
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -203,6 +216,16 @@ const server = new ApolloServer({
     ttl: 900, // 15 minutes
     // highlight-end
   },
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -217,6 +240,16 @@ const server = new ApolloServer({
   persistedQueries: {
     ttl: null, // highlight-line
   },
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -233,5 +266,15 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   persistedQueries: false, // highlight-line
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```

--- a/docs/source/performance/apq.md
+++ b/docs/source/performance/apq.md
@@ -141,13 +141,6 @@ const server = new ApolloServer({
   // The max age is calculated in seconds
   plugins: [
     ApolloServerPluginCacheControl({ defaultMaxAge: 5 }),
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -217,13 +210,6 @@ const server = new ApolloServer({
     // highlight-end
   },
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -241,13 +227,6 @@ const server = new ApolloServer({
     ttl: null, // highlight-line
   },
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -267,13 +246,6 @@ const server = new ApolloServer({
   cache: 'bounded',
   persistedQueries: false, // highlight-line
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/performance/cache-backends.mdx
+++ b/docs/source/performance/cache-backends.mdx
@@ -102,6 +102,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: new KeyvAdapter(new Keyv("redis://user:pass@localhost:6379")), // highlight-line
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -124,6 +134,16 @@ const server = new ApolloServer({
     })
   ),
   // highlight-end
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -161,6 +181,16 @@ const server = new ApolloServer({
     disableBatchReads: true,
   }),
   // highlight-end
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -201,6 +231,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: new KeyvAdapter(new Keyv({ store: memcache })), // highlight-line
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/performance/cache-backends.mdx
+++ b/docs/source/performance/cache-backends.mdx
@@ -103,13 +103,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: new KeyvAdapter(new Keyv("redis://user:pass@localhost:6379")), // highlight-line
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -135,13 +128,6 @@ const server = new ApolloServer({
   ),
   // highlight-end
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -182,13 +168,6 @@ const server = new ApolloServer({
   }),
   // highlight-end
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -232,13 +211,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: new KeyvAdapter(new Keyv({ store: memcache })), // highlight-line
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/proxy-configuration.md
+++ b/docs/source/proxy-configuration.md
@@ -27,6 +27,9 @@ After the `global-agent` dependency has been installed, invoke its `bootstrap` m
 
 ```js {2-5}
 const { ApolloServer, gql } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 const { bootstrap: bootstrapGlobalAgent } = require('global-agent');
 
 // Setup global support for environment variable based proxy configuration.
@@ -39,6 +42,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  /**
+   * What's up with this embed: true option?
+   * These are our recommended settings for using AS;
+   * they aren't the defaults in AS3 for backwards-compatibility reasons but
+   * will be the defaults in AS4. For production environments, use
+   * ApolloServerPluginLandingPageProductionDefault instead.
+  **/
+  plugins: [
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/proxy-configuration.md
+++ b/docs/source/proxy-configuration.md
@@ -42,13 +42,6 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
-  /**
-   * What's up with this embed: true option?
-   * These are our recommended settings for using AS;
-   * they aren't the defaults in AS3 for backwards-compatibility reasons but
-   * will be the defaults in AS4. For production environments, use
-   * ApolloServerPluginLandingPageProductionDefault instead.
-  **/
   plugins: [
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],

--- a/docs/source/schema/creating-directives.mdx
+++ b/docs/source/schema/creating-directives.mdx
@@ -346,13 +346,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/schema/creating-directives.mdx
+++ b/docs/source/schema/creating-directives.mdx
@@ -274,6 +274,9 @@ This example defines an `@uppercase` directive for this purpose:
 
 ```js title="index.js"
 const { ApolloServer, gql } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const { mapSchema, getDirective, MapperKind } = require('@graphql-tools/utils');
 const { defaultFieldResolver } = require('graphql');
@@ -342,6 +345,16 @@ const server = new ApolloServer({
   schema,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 server.listen().then(({ url }) => {

--- a/docs/source/schema/custom-scalars.md
+++ b/docs/source/schema/custom-scalars.md
@@ -121,13 +121,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -188,13 +181,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -248,13 +234,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/schema/custom-scalars.md
+++ b/docs/source/schema/custom-scalars.md
@@ -88,6 +88,9 @@ After you define your `GraphQLScalarType` instance, you include it in the same [
 
 ```js {21-24}
 const { ApolloServer, gql } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const { GraphQLScalarType, Kind } = require('graphql');
 
 const typeDefs = gql`
@@ -117,6 +120,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -126,6 +139,9 @@ In this example, we create a custom scalar called `Odd` that can only contain od
 
 ```js title="index.js"
 const { ApolloServer, gql, UserInputError } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const { GraphQLScalarType, Kind } = require('graphql');
 
 // Basic schema
@@ -171,6 +187,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 server.listen().then(({ url }) => {
@@ -194,6 +220,9 @@ Then `require` the `GraphQLJSON` object and add it to the resolver map as usual:
 
 ```js
 const { ApolloServer, gql } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 const GraphQLJSON = require('graphql-type-json');
 
 const typeDefs = gql`
@@ -218,6 +247,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 server.listen().then(({ url }) => {

--- a/docs/source/schema/unions-interfaces.md
+++ b/docs/source/schema/unions-interfaces.md
@@ -133,6 +133,16 @@ const server = new ApolloServer({
   resolvers,
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 server.listen().then(({ url }) => {

--- a/docs/source/schema/unions-interfaces.md
+++ b/docs/source/schema/unions-interfaces.md
@@ -134,13 +134,6 @@ const server = new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/security/authentication.md
+++ b/docs/source/security/authentication.md
@@ -43,13 +43,6 @@ const server = new ApolloServer({
    return { user };
  },
  plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -245,13 +238,6 @@ new ApolloServer({
   csrfPrevention: true,
   cache: 'bounded',
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/security/authentication.md
+++ b/docs/source/security/authentication.md
@@ -16,6 +16,9 @@ The example below extracts a user token from the HTTP `Authorization` header inc
 
 ```js
 const { ApolloServer } = require('apollo-server');
+const {
+  ApolloServerPluginLandingPageLocalDefault,
+} = require('apollo-server-core');
 
 const server = new ApolloServer({
  typeDefs,
@@ -39,6 +42,16 @@ const server = new ApolloServer({
    // Add the user to the context
    return { user };
  },
+ plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 
 server.listen().then(({ url }) => {
@@ -231,6 +244,16 @@ new ApolloServer({
   schema: makeExecutableSchema({ typeDefs, resolvers, schemaTransforms }),
   csrfPrevention: true,
   cache: 'bounded',
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/security/cors.mdx
+++ b/docs/source/security/cors.mdx
@@ -103,6 +103,16 @@ const server = new ApolloServer({
   cors: {
     origin: ["https://www.your-app.example", "https://studio.apollographql.com"]
   },
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 
@@ -151,6 +161,16 @@ const server = new ApolloServer({
     origin: yourOrigin,
     credentials: true
   },
+  plugins: [
+    /**
+    * What's up with this embed: true option?
+    * These are our recommended settings for using AS;
+    * they aren't the defaults in AS3 for backwards-compatibility reasons but
+    * will be the defaults in AS4. For production environments, use
+    * ApolloServerPluginLandingPageProductionDefault instead.
+    **/
+    ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+  ],
 });
 ```
 

--- a/docs/source/security/cors.mdx
+++ b/docs/source/security/cors.mdx
@@ -104,13 +104,6 @@ const server = new ApolloServer({
     origin: ["https://www.your-app.example", "https://studio.apollographql.com"]
   },
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });
@@ -162,13 +155,6 @@ const server = new ApolloServer({
     credentials: true
   },
   plugins: [
-    /**
-    * What's up with this embed: true option?
-    * These are our recommended settings for using AS;
-    * they aren't the defaults in AS3 for backwards-compatibility reasons but
-    * will be the defaults in AS4. For production environments, use
-    * ApolloServerPluginLandingPageProductionDefault instead.
-    **/
     ApolloServerPluginLandingPageLocalDefault({ embed: true }),
   ],
 });

--- a/docs/source/security/cors.mdx
+++ b/docs/source/security/cors.mdx
@@ -108,7 +108,7 @@ const server = new ApolloServer({
 
 Under the hood, the batteries-included `apollo-server` wraps around middleware provided by the [`cors`](https://github.com/expressjs/cors#configuration-options) npm package, enabling you to configure the `Access-Control-Allow-Origin` header via the `origin` option. The example above enables CORS requests from `https://www.your-app.example`, along with `https://studio.apollographql.com`.
 
-> Note if you plan to use [Apollo Studio Explorer](https://www.apollographql.com/docs/studio/explorer/explorer/) as a GraphQL web IDE you should include `https://studio.apollographql.com` in your list of valid origins.
+> Note if you plan to use [Apollo Studio Explorer](https://www.apollographql.com/docs/studio/explorer/explorer/) as a GraphQL web IDE you should include `https://studio.apollographql.com` in your list of valid origins. However, if you choose to embed the [Apollo Studio Explorer](https://www.apollographql.com/docs/studio/explorer/embed-explorer/) or [Sandbox](https://www.apollographql.com/docs/studio/explorer/sandbox/#embedding-sandbox), you don't need to add Studio to your CORS configuration at all. Requests will go through the page embedding Studio.
 
 If you're using another integration of Apollo Server, you can add the `cors` configuration option to your framework-specific middleware function to change your server's CORS behavior. To learn more about the CORS defaults and options for your integration of Apollo Server, see [CORS configuration options](../api/apollo-server/#cors-1).
 

--- a/docs/source/security/terminating-ssl.mdx
+++ b/docs/source/security/terminating-ssl.mdx
@@ -39,13 +39,6 @@ async function startApolloServer() {
     csrfPrevention: true,
     cache: 'bounded',
     plugins: [
-      /**
-      * What's up with this embed: true option?
-      * These are our recommended settings for using AS;
-      * they aren't the defaults in AS3 for backwards-compatibility reasons but
-      * will be the defaults in AS4. For production environments, use
-      * ApolloServerPluginLandingPageProductionDefault instead.
-      **/
       ApolloServerPluginLandingPageLocalDefault({ embed: true }),
     ],
   });

--- a/docs/source/security/terminating-ssl.mdx
+++ b/docs/source/security/terminating-ssl.mdx
@@ -14,6 +14,9 @@ Here's an example that uses HTTPS in production and HTTP in development:
 ```ts title="index.ts"
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
+import {
+  ApolloServerPluginLandingPageLocalDefault,
+} from 'apollo-server-core';
 import typeDefs from './graphql/schema';
 import resolvers from './graphql/resolvers';
 import fs from 'fs';
@@ -35,6 +38,16 @@ async function startApolloServer() {
     resolvers,
     csrfPrevention: true,
     cache: 'bounded',
+    plugins: [
+      /**
+      * What's up with this embed: true option?
+      * These are our recommended settings for using AS;
+      * they aren't the defaults in AS3 for backwards-compatibility reasons but
+      * will be the defaults in AS4. For production environments, use
+      * ApolloServerPluginLandingPageProductionDefault instead.
+      **/
+      ApolloServerPluginLandingPageLocalDefault({ embed: true }),
+    ],
   });
   await server.start();
 


### PR DESCRIPTION
Folks might run into CORS issues from the getting started apollo server doc. Now we can provide them with a quick answer: embed the Sandbox instead of using our hosted one!