### PR TITLE
Fix content-length calculation for batch queries

### DIFF
--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -184,11 +184,6 @@ export async function runHttpQuery<TContext extends BaseContext>(
     orderExecutionResultFields(graphQLResponse.result),
   );
 
-  graphQLResponse.http.headers.set(
-    'content-length',
-    Buffer.byteLength(body, 'utf8').toString(),
-  );
-
   return {
     ...graphQLResponse.http,
     completeBody: body,


### PR DESCRIPTION
Previously, we calculated the Content-Length HTTP response header in
runHttpQuery, which runs once for each GraphQL operation. When using
HTTP batching, we failed to recalculate Content-Length for the full
response, and so we sent a Content-Length that was too small.

In practice, many HTTP servers will recalculate Content-Length anyway.
For example, Express's `res.send` (which we use in expressMiddleware in
AS4, though we did not use it in AS3) will override the Content-Length
that you set, which is why tests did not fail previously (and the added
batching test does not fail even without the fix). Lambda/API Gateway
also overrides Content-Length. (We discovered this while working on a
proof of concept for Lambda support, whose test suite used a mock Lambda
server that used http.Server directly without Express.)

Because of this, we simplify our approach to just not set Content-Length
in Apollo Server. (This lets us skip the O(n) calculation that will be
ignored in many frameworks anyway.) However, we do add end-to-end tests
that Content-Length is set, so that integration authors for frameworks
that don't automatically set the header are reminded to do so.