### PR TITLE
Update error message when graph ref and variant are specified

### DIFF
--- a/packages/apollo-server-core/src/determineApolloConfig.ts
+++ b/packages/apollo-server-core/src/determineApolloConfig.ts
@@ -50,7 +50,7 @@ export function determineApolloConfig(
     if (graphVariant) {
       throw new Error(
         'Cannot specify both graph ref and graph variant. Please use ' +
-          '`apollo.graphRef` or `APOLLO_GRAPH_REF` without also setting the graph ID.',
+          '`apollo.graphRef` or `APOLLO_GRAPH_REF` without also setting the graph variant.',
       );
     }
   } else if (graphId) {


### PR DESCRIPTION
This request updates the error message when these two variables are specified. Ran into this today and was a little confused by the messaging. Thank you!