### PR TITLE
checkpoint for downlevel-dts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "codecov": "3.8.3",
         "cors": "2.8.5",
         "cspell": "6.4.0",
+        "downlevel-dts": "^0.10.0",
         "eslint": "8.20.0",
         "eslint-plugin-import": "2.26.0",
         "express": "4.18.1",
@@ -5967,6 +5968,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/downlevel-dts": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.10.0.tgz",
+      "integrity": "sha512-AZ7tnUy4XJArsjv6Bcuivvxx+weMvOGHF6seu7e7PVOqMDHMSlfgMl1kt+F4Y2+5TmDwKWHOdimM1DZKihQs8Q==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.3",
+        "typescript": "next"
+      },
+      "bin": {
+        "downlevel-dts": "index.js"
+      }
+    },
+    "node_modules/downlevel-dts/node_modules/typescript": {
+      "version": "4.8.0-dev.20220721",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.0-dev.20220721.tgz",
+      "integrity": "sha512-Fj63XtbG9v6ATuu3VEpXuTGsYoiZpdpROiXt9FxAk/pdpKsjjNGEuhAq36Vm4WncG0EoakXXbwm9eaZTt8vcbQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/dset": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
@@ -7739,6 +7767,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/invariant": {
@@ -10520,6 +10557,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "dev": true,
@@ -11080,6 +11129,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -12612,7 +12678,7 @@
       },
       "peerDependencies": {
         "@apollo/server": "^4.0.0-alpha.0",
-        "graphql": "^16.0.0"
+        "graphql": "^16.5.0"
       }
     },
     "packages/server": {
@@ -17181,6 +17247,25 @@
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "dev": true
     },
+    "downlevel-dts": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.10.0.tgz",
+      "integrity": "sha512-AZ7tnUy4XJArsjv6Bcuivvxx+weMvOGHF6seu7e7PVOqMDHMSlfgMl1kt+F4Y2+5TmDwKWHOdimM1DZKihQs8Q==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.3",
+        "typescript": "next"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.8.0-dev.20220721",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.0-dev.20220721.tgz",
+          "integrity": "sha512-Fj63XtbG9v6ATuu3VEpXuTGsYoiZpdpROiXt9FxAk/pdpKsjjNGEuhAq36Vm4WncG0EoakXXbwm9eaZTt8vcbQ==",
+          "dev": true
+        }
+      }
+    },
     "dset": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
@@ -18396,6 +18481,12 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -20279,6 +20370,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "dev": true,
@@ -20648,6 +20748,17 @@
     },
     "shebang-regex": {
       "version": "3.0.0"
+    },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "codecov": "3.8.3",
     "cors": "2.8.5",
     "cspell": "6.4.0",
+    "downlevel-dts": "^0.10.0",
     "eslint": "8.20.0",
     "eslint-plugin-import": "2.26.0",
     "express": "4.18.1",

--- a/packages/plugin-response-cache/package.json
+++ b/packages/plugin-response-cache/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "index.d.ts": ["dist/ts3.4/index.d.ts"] },
+    ">=4.7": { "index.d.ts": ["dist/esm/index.d.ts"] }
+  },
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/packages/server/errors/package.json
+++ b/packages/server/errors/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "main": "../dist/cjs/errors/index.js",
   "module": "../dist/esm/errors/index.js",
-  "types": "../dist/esm/errors/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "index.d.ts": ["../dist/ts3.4/errors/index.d.ts"] },
+    ">=4.7": { "index.d.ts": ["../dist/esm/errors/index.d.ts"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/express4/package.json
+++ b/packages/server/express4/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "main": "../dist/cjs/express4/index.js",
   "module": "../dist/esm/express4/index.js",
-  "types": "../dist/esm/express4/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "index.d.ts": ["../dist/ts3.4/express4/index.d.ts"] },
+    ">=4.7": { "index.d.ts": ["../dist/esm/express4/index.d.ts"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "dist/esm/index.d.ts": ["dist/ts3.4/index.d.ts"] }
+  },
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/packages/server/plugin/cacheControl/package.json
+++ b/packages/server/plugin/cacheControl/package.json
@@ -4,5 +4,8 @@
   "main": "../../dist/cjs/plugin/cacheControl/index.js",
   "module": "../../dist/esm/plugin/cacheControl/index.js",
   "types": "../../dist/esm/plugin/cacheControl/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/cacheControl/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/disabled/package.json
+++ b/packages/server/plugin/disabled/package.json
@@ -4,5 +4,8 @@
   "main": "../../dist/cjs/plugin/disabled/index.js",
   "module": "../../dist/esm/plugin/disabled/index.js",
   "types": "../../dist/esm/plugin/disabled/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/disabled/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/drainHttpServer/package.json
+++ b/packages/server/plugin/drainHttpServer/package.json
@@ -4,5 +4,8 @@
   "main": "../../dist/cjs/plugin/drainHttpServer/index.js",
   "module": "../../dist/esm/plugin/drainHttpServer/index.js",
   "types": "../../dist/esm/plugin/drainHttpServer/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/drainHttpServer/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/inlineTrace/package.json
+++ b/packages/server/plugin/inlineTrace/package.json
@@ -4,5 +4,8 @@
   "main": "../../dist/cjs/plugin/inlineTrace/index.js",
   "module": "../../dist/esm/plugin/inlineTrace/index.js",
   "types": "../../dist/esm/plugin/inlineTrace/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/inlineTrace/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/landingPage/default/package.json
+++ b/packages/server/plugin/landingPage/default/package.json
@@ -4,5 +4,8 @@
   "main": "../../../dist/cjs/plugin/landingPage/default/index.js",
   "module": "../../../dist/esm/plugin/landingPage/default/index.js",
   "types": "../../../dist/esm/plugin/landingPage/default/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/landingPage/default/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/landingPage/graphqlPlayground/package.json
+++ b/packages/server/plugin/landingPage/graphqlPlayground/package.json
@@ -4,5 +4,8 @@
   "main": "../../../dist/cjs/plugin/landingPage/graphqlPlayground/index.js",
   "module": "../../../dist/esm/plugin/landingPage/graphqlPlayground/index.js",
   "types": "../../../dist/esm/plugin/landingPage/graphqlPlayground/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/landingPage/graphqlPlayground/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/schemaReporting/package.json
+++ b/packages/server/plugin/schemaReporting/package.json
@@ -4,5 +4,8 @@
   "main": "../../dist/cjs/plugin/schemaReporting/index.js",
   "module": "../../dist/esm/plugin/schemaReporting/index.js",
   "types": "../../dist/esm/plugin/schemaReporting/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/schemaReporting/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/plugin/usageReporting/package.json
+++ b/packages/server/plugin/usageReporting/package.json
@@ -4,5 +4,8 @@
   "main": "../../dist/cjs/plugin/usageReporting/index.js",
   "module": "../../dist/esm/plugin/usageReporting/index.js",
   "types": "../../dist/esm/plugin/usageReporting/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "*": ["dist/ts3.4/plugin/usageReporting/*"] }
+  },
   "sideEffects": false
 }

--- a/packages/server/standalone/package.json
+++ b/packages/server/standalone/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "main": "../dist/cjs/standalone/index.js",
   "module": "../dist/esm/standalone/index.js",
-  "types": "../dist/esm/standalone/index.d.ts",
+  "typesVersions": {
+    "<4.7": { "index.d.ts": ["../dist/ts3.4/standalone/index.d.ts"] },
+    ">=4.7": { "index.d.ts": ["../dist/esm/standalone/index.d.ts"] }
+  },
   "sideEffects": false
 }

--- a/scripts/postcompile.mjs
+++ b/scripts/postcompile.mjs
@@ -10,6 +10,7 @@
 import path from 'path';
 import { writeFileSync } from 'fs';
 import rimraf from 'rimraf';
+import { execSync } from 'child_process';
 
 // Tell Node what kinds of files the ".js" files in these subdirectories are.
 for (const dir of ['plugin-response-cache', 'server']) {
@@ -24,4 +25,10 @@ for (const dir of ['plugin-response-cache', 'server']) {
 
   // Remove CJS .d.ts files: we don't need two copies!
   rimraf.sync(`packages/${dir}/dist/cjs/**/*.d.ts`);
+
+  // Rewrite .d.ts files so that older versions of TypeScript can process them.
+  // `typesVersions` keys in package.json files help TypeScript find these.
+  execSync(
+    `downlevel-dts packages/${dir}/dist/esm/ packages/${dir}/dist/ts3.4/`,
+  );
 }


### PR DESCRIPTION
This is an attempt at addressing #6423. However, it sure seems like
`typesVersions` is kinda janky and doesn't work as well as we'd like.
One particular thing I've found is that it doesn't play well with the
`../dist` lines we have in our package.json files, because it only gets
applied if the previously resolved path is under the directory it is in:
https://github.com/microsoft/TypeScript/blob/7b764164ede080afff02ec731dfea72b3f4f73f3/src/compiler/moduleNameResolver.ts#L1942

(Yeah, the typesVersions clauses are not consistent across all of the
files here: I was doing a test that only looked at the top-level and
`/standalone` ones so those are the ones I was iterating on.)

It's possible this is fixable but maybe we should just bump the TS
requirement to v4.7.
