### PR TITLE
HTTPGraphQLRequest.searchParams -> HTTPGraphQLRequest.search

### DIFF
--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -603,6 +603,19 @@ export function defineIntegrationTestSuiteHttpServerTests(
         );
       });
 
+      it('does not accept multiple query search parameters', async () => {
+        const app = await createApp();
+        const res = await request(app)
+          // cspell:ignore Bfoo Bbar
+          .get('/?query=%7Bfoo%7D&query=%7Bbar%7D')
+          .set('apollo-require-preflight', 't')
+          .send();
+        expect(res.status).toEqual(400);
+        expect(res.text).toMatch(
+          "The 'query' search parameter may only be specified once",
+        );
+      });
+
       it('can handle a GET request with variables', async () => {
         const app = await createApp();
         const query = {

--- a/packages/plugin-response-cache/src/__tests__/integration.test.ts
+++ b/packages/plugin-response-cache/src/__tests__/integration.test.ts
@@ -142,7 +142,9 @@ describe('Response caching', () => {
       ],
     });
 
-    const { url } = await startStandaloneServer(server);
+    const { url } = await startStandaloneServer(server, {
+      listen: { port: 0 },
+    });
 
     function httpHeader(result: Response, header: string): string | null {
       const value = result.headers[header] ?? null;

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -194,7 +194,7 @@ describe('ApolloServer start', () => {
         method: 'POST',
         headers: new HeaderMap([['content-type', 'application-json']]),
         body: JSON.stringify({ query: '{__typename}' }),
-        searchParams: {},
+        search: '',
       },
       context: async () => ({}),
     };

--- a/packages/server/src/__tests__/plugin/cacheControl/cacheControlPlugin.test.ts
+++ b/packages/server/src/__tests__/plugin/cacheControl/cacheControlPlugin.test.ts
@@ -50,7 +50,8 @@ describe('plugin', () => {
           httpGraphQLRequest: {
             method: 'GET',
             headers: new Map([['apollo-require-preflight', 't']]),
-            searchParams: { query: '{hello}' },
+            // cspell:ignore Bhello
+            search: 'query=%7Bhello%7D',
             body: {},
           },
           context: async () => ({}),

--- a/packages/server/src/__tests__/standalone/standaloneSpecific.test.ts
+++ b/packages/server/src/__tests__/standalone/standaloneSpecific.test.ts
@@ -72,7 +72,7 @@ describe('Typings: TContext inference', () => {
     });
 
     // @ts-expect-error
-    await startStandaloneServer(server, {}, { port: 0 });
+    await startStandaloneServer(server, { listen: { port: 0 } });
     await server.stop();
   });
 

--- a/packages/server/src/express4/index.ts
+++ b/packages/server/src/express4/index.ts
@@ -6,6 +6,7 @@ import type {
   ContextFunction,
   HTTPGraphQLRequest,
 } from '../externalTypes';
+import { parse as urlParse } from 'url';
 
 export interface ExpressContextFunctionArgument {
   req: express.Request;
@@ -74,7 +75,7 @@ export function expressMiddleware<TContext extends BaseContext>(
     const httpGraphQLRequest: HTTPGraphQLRequest = {
       method: req.method.toUpperCase(),
       headers,
-      searchParams: req.query,
+      search: urlParse(req.url).search ?? '',
       body: req.body,
     };
 

--- a/packages/server/src/externalTypes/http.ts
+++ b/packages/server/src/externalTypes/http.ts
@@ -15,7 +15,7 @@ export interface HTTPGraphQLRequest {
   search: string;
   // read by your body-parser or whatever. we poke at it to make it into
   // the right real type.
-  body: any;
+  body: unknown;
 }
 
 // TODO(AS4): Should this be exported for integrations?

--- a/packages/server/src/externalTypes/http.ts
+++ b/packages/server/src/externalTypes/http.ts
@@ -5,11 +5,14 @@ export interface HTTPGraphQLRequest {
   // lowercase header name, multiple headers joined with ', ' like Headers.get
   // does
   headers: Map<string, string>;
-  // no name normalization. can theoretically have deeply nested stuff if you
-  // use a search parameter parser like `qs` (used by `express` by default) that does
-  // that and you want to look for that in your own plugin. AS itself will only
-  // look for a handful of keys and will validate their value types.
-  searchParams: any;
+  /**
+   * The part of the URL after the question mark (not including the #fragment),
+   * or the empty string if there is no question mark. Including the question
+   * mark in this string is allowed but not required. Do not %-decode this
+   * string. You can get this from a standard Node request with
+   * `url.parse(request.url).search ?? ''`.
+   */
+  search: string;
   // read by your body-parser or whatever. we poke at it to make it into
   // the right real type.
   body: any;

--- a/packages/server/src/httpBatching.ts
+++ b/packages/server/src/httpBatching.ts
@@ -13,7 +13,8 @@ import { BadRequestError } from './internalErrorClasses.js';
 
 export async function runBatchHttpQuery<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
-  batchRequest: Omit<HTTPGraphQLRequest, 'body'> & { body: any[] },
+  batchRequest: HTTPGraphQLRequest,
+  body: unknown[],
   contextValue: TContext,
   schemaDerivedData: SchemaDerivedData,
   internals: ApolloServerInternals<TContext>,
@@ -26,10 +27,10 @@ export async function runBatchHttpQuery<TContext extends BaseContext>(
     completeBody: '',
   };
   const responseBodies = await Promise.all(
-    batchRequest.body.map(async (body: any) => {
+    body.map(async (bodyPiece: unknown) => {
       const singleRequest: HTTPGraphQLRequest = {
         ...batchRequest,
-        body,
+        body: bodyPiece,
       };
 
       const response = await runHttpQuery(
@@ -85,6 +86,7 @@ export async function runPotentiallyBatchedHttpQuery<
     return await runBatchHttpQuery(
       server,
       httpGraphQLRequest,
+      httpGraphQLRequest.body as unknown[],
       contextValue,
       schemaDerivedData,
       internals,


### PR DESCRIPTION
Instead of being an object whose exactly semantics are framework-defined
(what does specifying a parameter twice look like? can you construct
weird nested structures by putting brackets in parameter names?) just
receive the raw search string from the URL so that Apollo Server can
parse it in a consistent way. This also means we can consistently reject
requests that specify `query` more than once, say.

Also fix a few tests that listen on port 4000 instead of an ephemeral
port.
