### PR TITLE
add github link for now

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -311,12 +311,21 @@ Paste this string into the Operations panel and click the blue button in the upp
 
 One of the most important concepts of GraphQL is that clients can choose to query _only for the fields they need_. Delete `author` from the query string and execute it again. The response updates to include only the `title` field for each book!
 
-## Combined example
+## Complete example
 
+You can view and fork the complete example on Github:
+
+<div align="left">
+  <ButtonLink href="https://github.com/apollographql/docs-examples/tree/main/apollo-server/v4/getting-started" size="lg">
+    See the full example!
+  </ButtonLink>
+</div>
+
+<!-- TODO(AS4) fix code sandbox link
 You can view and fork this complete example on CodeSandbox:
  <a href="https://codesandbox.io/s/github/apollographql/docs-examples/tree/main/apollo-server/v4/getting-started?fontsize=14&hidenavigation=1&theme=dark">
   <img alt="Edit server-getting-started" src="https://codesandbox.io/static/img/play-codesandbox.svg" />
-</a>
+</a> -->
 
 ## Next steps
 


### PR DESCRIPTION
Replacing the broken CodeSandbox link with a Github link for now. 