### PR TITLE
Error extensions improvements

### DIFF
--- a/.changeset/small-suits-compare.md
+++ b/.changeset/small-suits-compare.md
@@ -1,0 +1,14 @@
+---
+"@apollo/server-integration-testsuite": patch
+"@apollo/server": patch
+---
+
+Refactor error formatting.
+
+Remove `error.extensions.exception`; you can add it back yourself with `formatError`. `error.extensions.exception.stacktrace` is now available on `error.extensions.stacktrace`.
+
+Provide `unwrapResolverError` function in `@apollo/server/errors`; useful for your `formatError` hook.
+
+No more TS `declare module` describing the `exception` extension (partially incorrectly).
+
+Rename the (new in v4) constructor option `includeStackTracesInErrorResponses` to `includeStacktraceInErrorResponses`.

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -166,10 +166,10 @@ The `startStandaloneServer` function accepts two arguments; the first is the ins
 <td>
 
   An optional `listen` configuration option. The `listen` option accepts an object with the same properties as the [`net.Server.listen` options object](https://nodejs.org/api/net.html#serverlistenoptions-callback).
-  
+
   For example, in Apollo Server 3, if you used `server.listen(4321)`, you'll now pass `listen: { port: 4321 }` to the `startStandaloneServer` function in Apollo Server 4. If you didn't pass any arguments to Apollo Server 3's `server.listen()` method; you don't need to specify this `listen` option.
 </td>
-  
+
 </tr>
 
 </tbody>
@@ -654,15 +654,15 @@ In Apollo Server 3, the `debug` constructor option (which defaults to `true` unl
    - Apollo Server 3 rarely sends messages at the `DEBUG` level, so this primarily affects plugins that use the provided `logger` to send `DEBUG` messages.
 - The `debug` flag is also available to plugins on `GraphQLRequestContext` to use as they wish.
 
-Apollo Server 4 removes the `debug` constructor option. In its place is a new `includeStackTracesInErrorResponses` option which controls its namesake feature. Like `debug`, this option defaults to `true` unless the `NODE_ENV` environment variable is either `production` or `test`.
+Apollo Server 4 removes the `debug` constructor option. In its place is a new `includeStacktraceInErrorResponses` option which controls its namesake feature. Like `debug`, this option defaults to `true` unless the `NODE_ENV` environment variable is either `production` or `test`.
 
-If you use `debug` in Apollo Server 3, you can use `includeStackTracesInErrorResponses` with the same value in Apollo Server 4:
+If you use `debug` in Apollo Server 3, you can use `includeStacktraceInErrorResponses` with the same value in Apollo Server 4:
 
 ```ts
 const apolloServerInstance = new ApolloServer<MyContext>({
   typeDefs,
   resolvers,
-  includeStackTracesInErrorResponses: true,
+  includeStacktraceInErrorResponses: true,
 });
 ```
 
@@ -678,6 +678,8 @@ const server = new ApolloServer({
   // ...
 });
 ```
+
+(Note that the stack traces themselves have moved from `extensions.exception.stacktrace` to `extensions.stacktrace`.)
 
 ### `formatResponse` hook
 
@@ -1082,7 +1084,9 @@ expect(result.data?.hello).toBe('Hello world!'); // -> true
 
 </MultiCodeBlock>
 
-### `formatError` hook improvements
+### Error formatting changes
+
+#### `formatError` improvements
 
 Apollo Server 3 supports the `formatError` hook, which has the following signature:
 
@@ -1100,12 +1104,17 @@ In Apollo Server 4, this becomes:
 
 Above, `formattedError` is the default JSON object sent in the response according to the [GraphQL specification](https://spec.graphql.org/draft/#sec-Errors), and `error` is the originally thrown error. If you need a field from the original error that isn't in `GraphQLFormattedError`, you can access that value from the `error` argument.
 
+One caveat: if the error was thrown inside a resolver, `error` is not the error your resolver code threw; it is a `GraphQLError` wrapping it and adding helpful context such as the `path` in the operation to the resolver's field. If you want the exact error you threw, Apollo Server 4 provides the `unwrapResolverError` function in `@apollo/server/errors`, which removes this outer layer if you pass it a resolver error (and returns its argument otherwise).
+
 So, you can format errors like this:
 
 ```ts
+import { unwrapResolverError } from '@apollo/server/errors';
+
+new ApolloServer({
   formatError: (formattedError, error) => {
     // Don't give the specific errors to the client.
-    if (error instanceof CustomDBError) {
+    if (unwrapResolverError(error) instanceof CustomDBError) {
       return { message: 'Internal server error' };
     }
 
@@ -1122,7 +1131,91 @@ So, you can format errors like this:
     // be manipulated in other ways, as long as it's returned.
     return formattedError;
   },
+  // ...
+});
 ```
+
+#### `error.extensions.exception` is removed
+
+When Apollo Server 3 formats an error, it may add an extension called `exception`. This extension is an object with a field for every *enumerable* property of the originally thrown error. (This does not apply if the originally thrown error was already a `GraphQLError`.) In addition, [when in dev/debug mode](#debug), `exception` contains an array of strings called `stacktrace`.
+
+For example, if this code runs in a resolver:
+
+```js
+const e = new Error("hello");
+e.extraProperty = "bye";
+throw e;
+```
+
+then (in debug mode) Apollo Server 3 will format the error like this:
+
+```js
+{
+  "errors": [
+    {
+      "message": "hello",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": ["x"],
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR",
+        "exception": {
+          "extraProperty": "bye",
+          "stacktrace": [
+            "Error: hello",
+            "    at Object.x (file:///private/tmp/as3-t/server.mjs:8:27)",
+            "    at field.resolve (/private/tmp/as3-t/node_modules/apollo-server-core/dist/utils/schemaInstrumentation.js:56:26)",
+            // more lines elided
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+It was often hard to predict exactly which properties of which errors would be publicly exposed in this manner, which could lead to surprising information leaks.
+
+In Apollo Server 4, there is no `exception` extension. The `stacktrace` is provided directly on `extensions`. If you'd like to copy some or all properties from the original error onto the formatted error, you can do that with the `formatError` hook.
+
+If you'd like your errors to be formatted like they are in Apollo Server 3 (with the stack trace and the enumerable properties of the original error on the `exception` extension), you can provide this `formatError` implementation:
+
+<MultiCodeBlock>
+
+```ts
+function formatError(
+  formattedError: GraphQLFormattedError,
+  error: unknown,
+) {
+  const originalError = unwrapResolverError(error);
+  const exception: Record<string, unknown> = {
+    ...(typeof originalError === 'object' ? originalError : null),
+  };
+  delete exception.extensions;
+  if (formattedError.extensions?.stacktrace) {
+    exception.stacktrace = formattedError.extensions.stacktrace;
+  }
+  const extensions: Record<string, unknown> = {
+    ...formattedError.extensions,
+    exception,
+  };
+  delete extensions.stacktrace;
+  return {
+    ...formattedError,
+    extensions,
+  };
+}
+```
+
+</MultiCodeBlock>
+
+Apollo Server 3.5.0 and newer included a TypeScript `declare module` declaration that teaches TypeScript that `error.extensions.exception.stacktrace` is an array of strings on *all* `GraphQLError` objects. Apollo Server 4 does not provide a replacement for this: that is, we do not tell TypeScript the type of `error.extensions.code` or `error.extensions.stacktrace`. (The Apollo Server 3 `declare module` declaration also incorrectly teaches TypeScript that `error.extensions.exception.code` is a string, which should have been `error.extensions.code` instead.)
+
+
 
 ### HTTP error handling changes
 
@@ -1390,7 +1483,7 @@ The `@apollo/utils.fetcher` package has a more precise name and only supports ar
 
 ### `@apollo/cache-control-types`
 
-In Apollo Server 3, you could import the `CacheScope`, `CacheHint`, `CacheAnnotation`, `CachePolicy`, and `ResolveInfoCacheControl` types from your chosen Apollo Server package. 
+In Apollo Server 3, you could import the `CacheScope`, `CacheHint`, `CacheAnnotation`, `CachePolicy`, and `ResolveInfoCacheControl` types from your chosen Apollo Server package.
 
 In Apollo Server 4,  the new `@apollo/cache-control-types` package exports the [`CacheScope`](#cachescope-type), `CacheHint`, `CacheAnnotation`, `CachePolicy`, and `ResolveInfoCacheControl` types. This enables libraries that work with multiple GraphQL servers (such as `@apollo/subgraph`) to refer to these types without depending on `@apollo/server`.
 

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -150,7 +150,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   rootValue?: ((parsedQuery: DocumentNode) => any) | any;
   validationRules: Array<(context: ValidationContext) => any>;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
-  includeStackTracesInErrorResponses: boolean;
+  includeStacktraceInErrorResponses: boolean;
   persistedQueries?: WithRequired<PersistedQueryOptions, 'cache'>;
   nodeEnv: string;
   allowBatchedHttpRequests: boolean;
@@ -285,8 +285,8 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         ...(introspectionEnabled ? [] : [NoIntrospection]),
       ],
       fieldResolver: config.fieldResolver,
-      includeStackTracesInErrorResponses:
-        config.includeStackTracesInErrorResponses ??
+      includeStacktraceInErrorResponses:
+        config.includeStacktraceInErrorResponses ??
         (nodeEnv !== 'production' && nodeEnv !== 'test'),
       persistedQueries:
         config.persistedQueries === false
@@ -1058,8 +1058,8 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       ]),
       completeBody: prettyJSONStringify({
         errors: normalizeAndFormatErrors([error], {
-          includeStackTracesInErrorResponses:
-            this.internals.includeStackTracesInErrorResponses,
+          includeStacktraceInErrorResponses:
+            this.internals.includeStacktraceInErrorResponses,
           formatError: this.internals.formatError,
         }),
       }),

--- a/packages/server/src/__tests__/runQuery.test.ts
+++ b/packages/server/src/__tests__/runQuery.test.ts
@@ -138,13 +138,13 @@ it('returns a syntax error if the query string contains one', async () => {
 // Maybe we used to log field errors and we want to make sure we don't do that?
 // Our Jest tests automatically fail if anything is logged to the console.
 it.each([true, false])(
-  'does not call console.error if in an error occurs and includeStackTracesInErrorResponses is %s',
-  async (includeStackTracesInErrorResponses) => {
+  'does not call console.error if in an error occurs and includeStacktraceInErrorResponses is %s',
+  async (includeStacktraceInErrorResponses) => {
     const query = `query { testError }`;
     const res = await runQuery(
       {
         schema,
-        includeStackTracesInErrorResponses,
+        includeStacktraceInErrorResponses,
       },
       { query },
     );

--- a/packages/server/src/errorNormalize.ts
+++ b/packages/server/src/errorNormalize.ts
@@ -7,16 +7,7 @@ import {
 } from 'graphql';
 import { ApolloServerErrorCode } from './errors/index.js';
 
-declare module 'graphql' {
-  export interface GraphQLErrorExtensions {
-    code?: string;
-    exception?: {
-      stacktrace?: ReadonlyArray<string>;
-    };
-  }
-}
-
-// This function accepts any value that were thrown and convert it to GraphQLFormatterError.
+// This function accepts any value that were thrown and convert it to GraphQLFormattedError.
 // It also add default extensions.code and copy stack trace onto an extension if requested.
 // This function should not throw.
 export function normalizeAndFormatErrors(
@@ -26,7 +17,7 @@ export function normalizeAndFormatErrors(
       formattedError: GraphQLFormattedError,
       error: unknown,
     ) => GraphQLFormattedError;
-    includeStackTracesInErrorResponses?: boolean;
+    includeStacktraceInErrorResponses?: boolean;
   } = {},
 ): Array<GraphQLFormattedError> {
   const formatError = options.formatError ?? ((error) => error);
@@ -34,8 +25,8 @@ export function normalizeAndFormatErrors(
     try {
       return formatError(enrichError(error), error);
     } catch (formattingError) {
-      if (options.includeStackTracesInErrorResponses) {
-        // includeStackTracesInErrorResponses is used in development
+      if (options.includeStacktraceInErrorResponses) {
+        // includeStacktraceInErrorResponses is used in development
         // so it will be helpful to show errors thrown by formatError hooks in that mode
         return enrichError(formattingError);
       } else {
@@ -58,25 +49,12 @@ export function normalizeAndFormatErrors(
         ApolloServerErrorCode.INTERNAL_SERVER_ERROR,
     };
 
-    const { originalError } = graphqlError;
-    if (originalError != null && !(originalError instanceof GraphQLError)) {
-      const originalErrorEnumerableEntries = Object.entries(
-        originalError,
-      ).filter(([key]) => key !== 'extensions');
-
-      if (originalErrorEnumerableEntries.length > 0) {
-        extensions.exception = {
-          ...extensions.exception,
-          ...Object.fromEntries(originalErrorEnumerableEntries),
-        };
-      }
-    }
-
-    if (options.includeStackTracesInErrorResponses) {
-      extensions.exception = {
-        ...extensions.exception,
-        stacktrace: graphqlError.stack?.split('\n'),
-      };
+    if (options.includeStacktraceInErrorResponses) {
+      // Note that if ensureGraphQLError created graphqlError from an
+      // originalError, graphqlError.stack will be the same as
+      // originalError.stack due to some special code in the GraphQLError
+      // constructor.
+      extensions.stacktrace = graphqlError.stack?.split('\n');
     }
 
     return { ...graphqlError.toJSON(), extensions };

--- a/packages/server/src/errors/index.ts
+++ b/packages/server/src/errors/index.ts
@@ -1,3 +1,5 @@
+import { GraphQLError } from 'graphql';
+
 export enum ApolloServerErrorCode {
   INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR',
   GRAPHQL_PARSE_FAILED = 'GRAPHQL_PARSE_FAILED',
@@ -7,4 +9,20 @@ export enum ApolloServerErrorCode {
   BAD_USER_INPUT = 'BAD_USER_INPUT',
   OPERATION_RESOLUTION_FAILURE = 'OPERATION_RESOLUTION_FAILURE',
   BAD_REQUEST = 'BAD_REQUEST',
+}
+
+/**
+ * unwrapResolverError is a useful helper function for `formatError` hooks.
+ * Errors thrown in resolvers are wrapped by graphql-js in a GraphQLError that
+ * adds context such as the `path` to the field in the operation. If you'd like
+ * to look directly at the original error thrown in the resolver (with whatever
+ * data is on that error object, but without fields like `path`), you can use
+ * this function. Note that other GraphQLErrors that contain `originalError`
+ * (like parse errors) are not unwrapped by this function.
+ */
+export function unwrapResolverError(error: unknown): unknown {
+  if (error instanceof GraphQLError && error.path && error.originalError) {
+    return error.originalError;
+  }
+  return error;
 }

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -98,7 +98,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   executor?: GraphQLExecutor<TContext>;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   cache?: KeyValueCache<string>;
-  includeStackTracesInErrorResponses?: boolean;
+  includeStacktraceInErrorResponses?: boolean;
   logger?: Logger;
   allowBatchedHttpRequests?: boolean;
 

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -69,7 +69,8 @@ export interface GraphQLRequestContext<TContext extends BaseContext> {
    * Unformatted errors which have occurred during the request. Note that these
    * are present earlier in the request pipeline and differ from **formatted**
    * errors which are the result of running the user-configurable `formatError`
-   * transformation function over specific errors.
+   * transformation function over specific errors; these can eventually be found
+   * in `response.result.errors`.
    */
   readonly errors?: ReadonlyArray<GraphQLError>;
 

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -559,12 +559,12 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
   }
 
   function formatErrors(
-    errors: ReadonlyArray<unknown>,
+    errors: ReadonlyArray<GraphQLError>,
   ): ReadonlyArray<GraphQLFormattedError> {
     return normalizeAndFormatErrors(errors, {
       formatError: internals.formatError,
-      includeStackTracesInErrorResponses:
-        internals.includeStackTracesInErrorResponses,
+      includeStacktraceInErrorResponses:
+        internals.includeStacktraceInErrorResponses,
     });
   }
 }


### PR DESCRIPTION
This PR does a few things:

(a) Moves `error.extensions.exception.stacktrace` to
    `error.extensions.stacktrace`.

(b) Removes the rest of `error.extensions.exception`. This contained
    enumerable properties of the original error, which could lead to
    surprising information leakage.

(c) Documents that change and provides a `formatError` hook
    in the migration guide to maintain AS3 behavior.

(d) Provide an `unwrapResolverError` function in `@apollo/server/errors`
    to help get back the original error in the resolver error case, which is
    a helpful part of the documented `formatError` recommendations
    (since the old error formatting put stuff from that unwrapped error
    on the `exception` extension).

(e) Gets rid of the `declare module` which made
    `error.extensions.exception.code`/`error.extensions.exception.stacktrace`
    have a non-unknown value. Note that this declaration (added in 3.5.0) was
    actually inaccurate as `code` really goes directly on `extensions` rather than
    on `exception`. We could have instead preserved the declaration
    and adapted it to the new location of `stacktrace` and the correct
    location of `code`.

  - Pro: `declare module` is a bit scary and doesn't always merge well if
    you have more than one of them (eg, if you end up with both AS3 and AS4
    in your TypeScript build: AS3 had a different `declare module` where
    `code` was nested under `exception`).

  - Con: End users who catch our errors can't get "correct" typing for
    `error.extensions.code` or `error.extensions.stacktrace`.

  - Pro: That's only "correct" if you assume all GraphQLErrors use
    extensions compatible with the definition; it might be better to export
    a helper function that takes a `GraphQLError` and returns the
    code/exception if it looks like it has the right shape. And nobody seems
    to have even noticed that the declaration has been wrong for almost a
    year, so how much value is it providing?

(f) Renames the (new in v4) constructor option
    includeStackTracesInErrorResponses to
    includeStacktraceInErrorResponses, to match the extension name.

(g) Removes a test around error handling a particular `yup` style of errors
    that is probably not relevant any more.

This is to some degree part of #6719 because we're concerned about the
effect of the `declare module` on the Gateway transition.
