### PR TITLE
Usage reporting: fix TS declaration of fieldLevelInstrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
-- _Nothing yet! Stay tuned._
+- Fix the TypeScript declaration of the `fieldLevelInstrumentation` option to `ApolloServerPluginUsageReporting` to show that the function may return a number in addition to a boolean. This now matches the implementation and docs. [PR #6763](https://github.com/apollographql/apollo-server/pull/6763)
 
 ## v3.10.0
 

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -120,7 +120,7 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
     | number
     | ((
         request: GraphQLRequestContextDidResolveOperation<TContext>,
-      ) => Promise<boolean>);
+      ) => Promise<number | boolean>);
 
   /**
    * This option allows you to choose if a particular request should be


### PR DESCRIPTION
Note that the `const fieldLevelInstrumentation` which this got assigned
to actually already inferred (roughly) the correct type because the type
got merged with a number-returning function from another case.
