### PR TITLE
Port #6763 from AS3

### DIFF
--- a/.changeset/spicy-lions-deliver.md
+++ b/.changeset/spicy-lions-deliver.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+Port #6763 from AS3 (fix fieldLevelInstrumentation type declaration)

--- a/packages/server/src/plugin/usageReporting/options.ts
+++ b/packages/server/src/plugin/usageReporting/options.ts
@@ -123,7 +123,7 @@ export interface ApolloServerPluginUsageReportingOptions<
     | number
     | ((
         request: GraphQLRequestContextDidResolveOperation<TContext>,
-      ) => Promise<boolean>);
+      ) => Promise<number | boolean>);
 
   /**
    * This option allows you to choose if a particular request should be


### PR DESCRIPTION
Usage reporting: fix TS declaration of fieldLevelInstrumentation

Note that the `const fieldLevelInstrumentation` which this got assigned
to actually already inferred (roughly) the correct type because the type
got merged with a number-returning function from another case.
