### PR TITLE
Renaming "integrations" sidebar section to "Server frameworks" 

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -15,7 +15,7 @@
         "Migrating to Apollo Server 4": "/migration",
         "Changelog": "https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md"
       },
-      "Integrations": {
+      "Server frameworks": {
         "Building integrations": "/integrations/building-integrations"
       }
   }


### PR DESCRIPTION
Looping back to this, I like Trevor's "Server frameworks" suggestion for the name of the sidebar section. 