### PR TITLE
CI: require changesets before merging into version-4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,13 @@ jobs:
       - setup-node
       - run: npm run lint
 
+  Changesets:
+    docker:
+    - image: cimg/base:stable
+    steps:
+      - setup-node
+      - run: npm run changeset-check
+
   Spell check:
     docker:
     - image: cimg/base:stable
@@ -106,3 +113,4 @@ workflows:
       - ESLint
       - Spell check
       - Smoke test built package
+      - Changesets

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "spell-check": "cspell lint '**' --no-progress || (echo 'Add any real words to cspell-dict.txt.'; exit 1)",
-    "changeset-publish": "changeset publish"
+    "changeset-publish": "changeset publish",
+    "changeset-check": "changeset status --verbose --since=origin/version-4"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Changes that don't touch packages don't require changesets.

If you made a change to a package that you don't want to show up as a
changeset, just run `changeset --empty` like the error says.

(This does assume that your remote is named `origin`. We pass
`origin/version-4` instead of `version-4` because that way CI doesn't
have to actually create a local `version-4` branch. We don't set
`baseBranch` to `origin/version-4` in config.json because enforcing the
remote name even on `changeset add` users seems bad.)
