### PR TITLE
v4: don't pass parseOptions to makeExecutableSchema

### DIFF
--- a/.changeset/old-insects-smash.md
+++ b/.changeset/old-insects-smash.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+`parseOptions` is now only used for parsing operations, not for schemas too. Its TS type now only includes options recognized by `graphql-js` itself.

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -1295,6 +1295,49 @@ You can no longer type `CacheScope.Public` or `CacheScope.Private`. Instead, jus
 
 You can now import `CacheScope` from the new `@apollo/cache-control-types` package (instead of importing it from an Apollo Server package). This enables libraries that work with multiple GraphQL servers (such as `@apollo/subgraph`) to refer to `CacheScope` without depending on `@apollo/server`.
 
+
+### `parseOptions` only affects operation parsing
+
+In Apollo Server 3, the `parseOptions` constructor option is used to modify how GraphQL parsing works in two unrelated places: when parsing GraphQL operations, and when parsing the schema if the schema is provided via `typeDefs`. If you are using `typeDefs`, you cannot control these options (such as `noLocation`) independently. In addition, the TypeScript definition of the `parseOptions` option uses a type (from the `@graphql-tools/schema` package whose `makeExecutableSchema` function implements the `typeDefs` option) that contains options such as `assumeValidSDL` which are only relevant for parsing schemas.
+
+In Apollo Server 4, the `parseOptions` constructor option is only used when parsing GraphQL operations, and its TypeScript type only contains options relevant to parsing operations.
+
+If you used both of the `parseOptions` and `typeDefs` constructor options in Apollo Server 3 like this:
+
+```ts
+const parseOptions = { noLocation: true };
+new ApolloServer({
+  typeDefs,
+  resolvers,
+  parseOptions,
+});
+```
+
+and you would like to continue to apply the same options to both operation and schema parsing in Apollo Server 4, run `npm install @graphql-tools/schema`, and change your code to this:
+
+```ts
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+
+const parseOptions = { noLocation: true };
+new ApolloServer({
+  schema: makeExecutableSchema({
+    typeDefs,
+    resolvers,
+    // Note that if you're using `@graphql-tools/schema` v9 or newer, the parse
+    // options such as noLocation are passed *directly* to makeExecutableSchema,
+    // which we accomplish here with the `...` syntax.
+    // In older versions, pass it as a single option named `parseOptions`
+    // (ie, remove the `...`).
+    ...parseOptions,
+  }),
+  // This one affects operation parsing. Note that if you set any SDL-specific
+  // options in parseOptions, you'll need to pass a `parseOptions` here that
+  // does not contain those options.
+  parseOptions,
+});
+```
+
 ## Plugin API changes
 
 ### Fields on `GraphQLRequestContext`

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -672,7 +672,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       return config.schema;
     }
 
-    const { typeDefs, resolvers, parseOptions } = config;
+    const { typeDefs, resolvers } = config;
     const augmentedTypeDefs = Array.isArray(typeDefs) ? typeDefs : [typeDefs];
 
     // For convenience, we allow you to pass a few options that we pass through
@@ -684,7 +684,6 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
     return makeExecutableSchema({
       typeDefs: augmentedTypeDefs,
       resolvers,
-      parseOptions,
     });
   }
 

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -5,6 +5,7 @@ import type {
   GraphQLFieldResolver,
   GraphQLFormattedError,
   GraphQLSchema,
+  ParseOptions,
   ValidationContext,
 } from 'graphql';
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
@@ -93,11 +94,9 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   documentStore?: DocumentStore | null;
   csrfPrevention?: CSRFPreventionOptions | boolean;
 
-  // This is used for two different things: parsing the schema if you're a
-  // SchemaFromTypeDefsConfig, *and* parsing operations. Arguably this is a bit
-  // weird. If you need to parse schemas with different options, just be a
-  // SchemaProvidedConfig and call makeExecutableSchema yourself.
-  parseOptions?: IExecutableSchemaDefinition<TContext>['parseOptions'];
+  // Used for parsing operations; unlike in AS3, this is not also used for
+  // parsing the schema.
+  parseOptions?: ParseOptions;
 }
 
 interface ApolloServerOptionsWithGateway<TContext extends BaseContext>


### PR DESCRIPTION
This is prompted by the @graphql-tools/schema v9 upgrade, which gets rid
of `parseOptions` and rolls it directly into arguments to
`makeExecutableSchema`. But the status quo doesn't make much sense
anyway, as a comment already noted. So let's just make this option do
only one thing.
