### PR TITLE
Port GHSA-2fvv-qxrq-7jq6 fix from v3

### DIFF
--- a/.changeset/stale-sheep-search.md
+++ b/.changeset/stale-sheep-search.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+Port GHSA-2fvv-qxrq-7jq6 fix from v3 (remove XSS from default landing page HTML)

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -29,6 +29,14 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         graphRef: 'graph@current',
       };
     expect(getEmbeddedExplorerHTML(version, config)).toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Explorer cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
       <style>
         iframe {
           background-color: white;
@@ -59,6 +67,14 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         graphRef: 'graph@current',
       };
     expect(getEmbeddedExplorerHTML(version, config)).toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Explorer cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
       <style>
         iframe {
           background-color: white;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -20,6 +20,14 @@ describe('Landing Page Config HTML', () => {
       embed: true,
     };
     expect(getEmbeddedSandboxHTML(version, config)).toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Sandbox cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
       <style>
         iframe {
           background-color: white;
@@ -49,6 +57,14 @@ describe('Landing Page Config HTML', () => {
       embed: true,
     };
     expect(getEmbeddedSandboxHTML(version, config)).toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Sandbox cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
       <style>
         iframe {
           background-color: white;

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -64,6 +64,10 @@ export const getEmbeddedExplorerHTML = (
     };
 
   return `
+<div class="fallback">
+  <h1>Welcome to Apollo Server</h1>
+  <p>Apollo Explorer cannot be loaded; it appears that you might be offline.</p>
+</div>
 <style>
   iframe {
     background-color: white;
@@ -92,6 +96,10 @@ export const getEmbeddedSandboxHTML = (
   config: LandingPageConfig,
 ) => {
   return `
+<div class="fallback">
+  <h1>Welcome to Apollo Server</h1>
+  <p>Apollo Sandbox cannot be loaded; it appears that you might be offline.</p>
+</div>
 <style>
   iframe {
     background-color: white;

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -64,6 +64,10 @@ const getNonEmbeddedLandingPageHTML = (
   const encodedConfig = encodeConfig(config);
 
   return `
+ <div class="fallback">
+  <h1>Welcome to Apollo Server</h1>
+  <p>The full landing page cannot be loaded; it appears that you might be offline.</p>
+</div>
 <script>window.landingPage = ${encodedConfig};</script>
 <script src="https://apollo-server-landing-page.cdn.apollographql.com/${version}/static/js/main.js"></script>`;
 };
@@ -126,15 +130,6 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
           100% {opacity:1; }
         }
       </style>
-      <div class="fallback">
-        <h1>Welcome to Apollo Server</h1>
-        <p>It appears that you might be offline. POST to this endpoint to query your graph:</p>
-        <code style="white-space: pre;">
-curl --request POST \\
-  --header 'content-type: application/json' \\
-  --url '<script>document.write(window.location.href)</script>' \\
-  --data '{"query":"query { __typename }"}'</code>
-      </div>
     ${
       config.embed
         ? 'graphRef' in config && config.graphRef


### PR DESCRIPTION
See
https://github.com/apollographql/apollo-server/security/advisories/GHSA-2fvv-qxrq-7jq6
for details.

This removes the curl command from the no-bundle fallback on the default
landing page.
