### PR TITLE
usage reporting/inline trace plugins: mask errors, change option name

### DIFF
--- a/.changeset/twenty-cooks-repair.md
+++ b/.changeset/twenty-cooks-repair.md
@@ -1,0 +1,6 @@
+---
+"@apollo/server-integration-testsuite": patch
+"@apollo/server": patch
+---
+
+Usage reporting and inline trace plugins: replace `rewriteError` with `sendErrorsInTraces`/`includeErrors`, and mask all errors by default.

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -930,6 +930,50 @@ ApolloServerPluginUsageReporting({
 });
 ```
 
+### `rewriteError` plugin option
+
+In Apollo Server 3, you can specify a function to rewrite errors before sending them to Apollo's server via the `rewriteError` option to `ApolloServerPluginUsageReporting` (for monoliths) and `ApolloServerPluginInlineTrace` (for subgraphs).
+
+In Apollo Server 4, you specify the same function as the `transform` option on the `sendErrorsInTrace` option to `ApolloServerPluginUsageReporting` and the `includeErrors` option to `ApolloServerPluginInlineTrace`.
+
+(Additionally, the [default behavior has changed to mask errors](#usage-reporting-and-inline-trace-plugins-mask-errors-by-default).)
+
+So, where you previously wrote:
+
+```ts
+// monoliths
+new ApolloServer({
+  plugins: [ApolloServerPluginUsageReporting({ rewriteError })],
+  // ...
+})
+
+// subgraphs
+new ApolloServer({
+  plugins: [ApolloServerPluginInlineTrace({ rewriteError })],
+  // ...
+})
+```
+
+you can now write:
+
+```ts
+// monoliths
+new ApolloServer({
+  plugins: [ApolloServerPluginUsageReporting({
+    sendErrorsInTrace: { transform: rewriteError },
+  })],
+  // ...
+})
+
+// subgraphs
+new ApolloServer({
+  plugins: [ApolloServerPluginInlineTrace({
+    includeErrors: { transform: rewriteError },
+  })],
+  // ...
+})
+```
+
 
 ### Doubly-escaped `variables` and `extensions` in requests
 
@@ -1502,6 +1546,35 @@ new ApolloServer({
 ```
 
 </MultiCodeBlock>
+
+
+### Usage reporting and inline trace plugins mask errors by default
+
+In Apollo Server 3, traces sent to Apollo's servers from monolith servers by the usage reporting plugin contain the full message and extensions of every GraphQL error that occurs in the operation by default. Similarly, inline traces sent from subgraphs to Apollo Gateways (which are then sent to Apollo's servers) contain full error details by default. You can modify or drop these errors with `rewriteError` options to the appropriate plugins.
+
+In Apollo Server 4, error details are *not* included in traces by default. By default, error messages are replaced with `<masked>` and error extensions are replaced with a single extension `maskedBy` naming the plugin which performed the masking (`ApolloServerPluginUsageReporting` or `ApolloServerPluginInlineTrace`).
+
+To restore the Apollo Server 3 behavior, you can pass `{ unmodified: true }` to an option on each plugin:
+
+```ts
+// monoliths
+new ApolloServer({
+  plugins: [ApolloServerPluginUsageReporting({
+    sendErrorsInTrace: { unmodified: true },
+  })],
+  // ...
+})
+
+// subgraphs
+new ApolloServer({
+  plugins: [ApolloServerPluginInlineTrace({
+    includeErrors: { unmodified: true },
+  })],
+  // ...
+})
+```
+
+(As [described above](#rewriteerror-plugin-option), the `rewriteError` option has been replaced by a `transform` option on `sendErrorsInTrace` or `includeErrors`.)
 
 ## Renamed packages
 

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -59,6 +59,7 @@ import {
 } from './runHttpQuery.js';
 import { SchemaManager } from './utils/schemaManager.js';
 import { isDefined } from './utils/isDefined.js';
+import { UnreachableCaseError } from './utils/UnreachableCaseError.js';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import type { ApolloServerOptionsWithStaticSchema } from './externalTypes/constructor';
 import type { GatewayExecutor } from '@apollo/server-gateway-interface';
@@ -127,15 +128,6 @@ type ServerState =
       phase: 'stopped';
       stopError: Error | null;
     };
-
-// Throw this in places that should be unreachable (because all other cases have
-// been handled, reducing the type of the argument to `never`). TypeScript will
-// complain if in fact there is a valid type for the argument.
-class UnreachableCaseError extends Error {
-  constructor(val: never) {
-    super(`Unreachable case: ${val}`);
-  }
-}
 
 // TODO(AS4): Move this to its own file or something. Also organize the fields.
 

--- a/packages/server/src/plugin/usageReporting/index.ts
+++ b/packages/server/src/plugin/usageReporting/index.ts
@@ -3,6 +3,7 @@ export type {
   ApolloServerPluginUsageReportingOptions,
   SendValuesBaseOptions,
   VariableValueOptions,
+  SendErrorsOptions,
   ClientInfo,
   GenerateClientInfo,
 } from './options.js';

--- a/packages/server/src/plugin/usageReporting/options.ts
+++ b/packages/server/src/plugin/usageReporting/options.ts
@@ -47,12 +47,26 @@ export interface ApolloServerPluginUsageReportingOptions<
    */
   sendHeaders?: SendValuesBaseOptions;
   /**
-   * By default, all errors get reported to Apollo servers. You can specify
-   * a filter function to exclude specific errors from being reported by
-   * returning an explicit `null`, or you can mask certain details of the error
-   * by modifying it and returning the modified error.
+   * By default, if a trace contains errors, the errors are reported to Apollo
+   * servers with the message `<masked>`. The errors are associated with
+   * specific paths in the operation, but do not include the original error
+   * message or any extensions such as the error `code`, as those details may
+   * contain your users' private data. The extension `maskedBy:
+   * 'ApolloServerPluginUsageReporting'` is added.
+   *
+   * If you'd like details about the error included in traces, set this option.
+   * This option can take several forms:
+   *
+   * - { masked: true }: mask error messages and omit extensions (DEFAULT)
+   * - { unmodified: true }: send all error messages and extensions to Apollo
+   *   servers
+   * - { transform: ... }: a custom function for transforming errors. This
+   *   function receives a `GraphQLError` and may return a `GraphQLError`
+   *   (either a new error, or its potentially-modified argument) or `null`.
+   *   This error is used in the report to Apollo servers; if `null`, the error
+   *   is not included in traces or error statistics.
    */
-  rewriteError?: (err: GraphQLError) => GraphQLError | null;
+  sendErrorsInTraces?: SendErrorsOptions;
 
   // We should strongly consider changing the default to false in AS4.
 
@@ -320,6 +334,11 @@ export type VariableValueOptions =
       ) => Record<string, any>;
     }
   | SendValuesBaseOptions;
+
+export type SendErrorsOptions =
+  | { unmodified: true }
+  | { masked: true }
+  | { transform: (err: GraphQLError) => GraphQLError | null };
 
 export interface ClientInfo {
   clientName?: string;

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -388,7 +388,8 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
       }): GraphQLRequestListener<TContext> => {
         const logger = options.logger ?? server.logger;
         const treeBuilder: TraceTreeBuilder = new TraceTreeBuilder({
-          rewriteError: options.rewriteError,
+          maskedBy: 'ApolloServerPluginUsageReporting',
+          sendErrors: options.sendErrorsInTraces,
           logger,
         });
         treeBuilder.startTiming();

--- a/packages/server/src/utils/UnreachableCaseError.ts
+++ b/packages/server/src/utils/UnreachableCaseError.ts
@@ -1,0 +1,10 @@
+/**
+ * Throw this in places that should be unreachable (because all other cases have
+ * been handled, reducing the type of the argument to `never`). TypeScript will
+ * complain if in fact there is a valid type for the argument.
+ */
+export class UnreachableCaseError extends Error {
+  constructor(val: never) {
+    super(`Unreachable case: ${val}`);
+  }
+}


### PR DESCRIPTION
We replace the `rewriteError` option with `sendErrorsInTraces` (usage
reporting) and `includeErrors` (inline trace), which takes `{unmodified:
true}`, `{masked:true}`, and `{transform}` variants. This is similar to
`sendVariableValues` and `sendHeaders`.

Like those two options, this now defaults to a more redacted version:
`{masked: true}`. This will reduce unintentional reporting of PII.

Part of #6051.

Paired with @bonnici.
