### PR TITLE
Added unit tests for masked and unmodified error logging options

### DIFF
--- a/.changeset/ninety-tips-unite.md
+++ b/.changeset/ninety-tips-unite.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server-integration-testsuite": patch
+---
+
+Added unit tests to cover `unmodified` and `masked` error reporting options

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -1313,7 +1313,9 @@ export function defineIntegrationTestSuiteApolloServerTests(
 
             it('unmodified', async () => {
               throwError.mockImplementationOnce(() => {
-                throw new Error('should be unmodified');
+                throw new GraphQLError('should be unmodified', {
+                  extensions: { custom: 'extension' },
+                });
               });
 
               await setupApolloServerAndFetchPair({
@@ -1344,18 +1346,27 @@ export function defineIntegrationTestSuiteApolloServerTests(
               expect(trace.root!.child!.length).toBe(1);
 
               // The child should maintain the path and message
-              expect(trace.root!.child![0].error).toMatchObject([
-                {
-                  json: '{"message":"should be unmodified","locations":[{"line":1,"column":2}],"path":["fieldWhichWillError"]}',
-                  message: 'should be unmodified',
-                  location: [{ column: 2, line: 1 }],
-                },
-              ]);
+              expect(trace.root!.child![0].error).toMatchInlineSnapshot(`
+                Array [
+                  Object {
+                    "json": "{\\"message\\":\\"should be unmodified\\",\\"locations\\":[{\\"line\\":1,\\"column\\":2}],\\"path\\":[\\"fieldWhichWillError\\"],\\"extensions\\":{\\"custom\\":\\"extension\\"}}",
+                    "location": Array [
+                      Object {
+                        "column": 2,
+                        "line": 1,
+                      },
+                    ],
+                    "message": "should be unmodified",
+                  },
+                ]
+              `);
             });
 
             it('masked', async () => {
               throwError.mockImplementationOnce(() => {
-                throw new Error('should be masked');
+                throw new GraphQLError('should be masked', {
+                  extensions: { custom: 'extension' },
+                });
               });
 
               await setupApolloServerAndFetchPair({
@@ -1386,13 +1397,20 @@ export function defineIntegrationTestSuiteApolloServerTests(
               expect(trace.root!.child!.length).toBe(1);
 
               // The child should maintain the path, but have its message masked
-              expect(trace.root!.child![0].error).toMatchObject([
-                {
-                  json: '{"message":"<masked>","locations":[{"line":1,"column":2}],"path":["fieldWhichWillError"],"extensions":{"maskedBy":"ApolloServerPluginUsageReporting"}}',
-                  message: '<masked>',
-                  location: [{ column: 2, line: 1 }],
-                },
-              ]);
+              expect(trace.root!.child![0].error).toMatchInlineSnapshot(`
+                Array [
+                  Object {
+                    "json": "{\\"message\\":\\"<masked>\\",\\"locations\\":[{\\"line\\":1,\\"column\\":2}],\\"path\\":[\\"fieldWhichWillError\\"],\\"extensions\\":{\\"maskedBy\\":\\"ApolloServerPluginUsageReporting\\"}}",
+                    "location": Array [
+                      Object {
+                        "column": 2,
+                        "line": 1,
+                      },
+                    ],
+                    "message": "<masked>",
+                  },
+                ]
+              `);
             });
           });
         });

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -1310,6 +1310,92 @@ export function defineIntegrationTestSuiteApolloServerTests(
                 },
               ]);
             });
+
+            it('unmodified', async () => {
+              throwError.mockImplementationOnce(() => {
+                throw new Error('should be unmodified');
+              });
+
+              await setupApolloServerAndFetchPair({
+                sendErrorsInTraces: {
+                  unmodified: true,
+                },
+              });
+
+              const result = await apolloFetch({
+                query: `{fieldWhichWillError}`,
+              });
+              expect(result.data).toEqual({
+                fieldWhichWillError: null,
+              });
+              expect(result.errors).toBeDefined();
+              expect(result.errors[0].message).toEqual(
+                'should be unmodified',
+              );
+              expect(throwError).toHaveBeenCalledTimes(1);
+
+              const reports = await reportIngress.promiseOfReports;
+              expect(reports.length).toBe(1);
+              const trace = Object.values(reports[0].tracesPerQuery)[0]
+                .trace![0] as Trace;
+
+              // There should be no error at the root, our error is a child.
+              expect(trace.root!.error).toStrictEqual([]);
+
+              // There should only be one child.
+              expect(trace.root!.child!.length).toBe(1);
+
+              // The child should maintain the path and message
+              expect(trace.root!.child![0].error).toMatchObject([
+                {
+                  json: '{"message":"should be unmodified","locations":[{"line":1,"column":2}],"path":["fieldWhichWillError"]}',
+                  message: 'should be unmodified',
+                  location: [{ column: 2, line: 1 }],
+                },
+              ]);
+            });
+
+            it('masked', async () => {
+              throwError.mockImplementationOnce(() => {
+                throw new Error('should be masked');
+              });
+
+              await setupApolloServerAndFetchPair({
+                sendErrorsInTraces: {
+                  masked: true,
+                },
+              });
+
+              const result = await apolloFetch({
+                query: `{fieldWhichWillError}`,
+              });
+              expect(result.data).toEqual({
+                fieldWhichWillError: null,
+              });
+              expect(result.errors).toBeDefined();
+              expect(result.errors[0].message).toEqual('should be masked');
+              expect(throwError).toHaveBeenCalledTimes(1);
+
+              const reports = await reportIngress.promiseOfReports;
+              expect(reports.length).toBe(1);
+              const trace = Object.values(reports[0].tracesPerQuery)[0]
+                .trace![0] as Trace;
+
+              // There should be no error at the root, our error is a child.
+              expect(trace.root!.error).toStrictEqual([]);
+
+              // There should only be one child.
+              expect(trace.root!.child!.length).toBe(1);
+
+              // The child should maintain the path, but have its message masked
+              expect(trace.root!.child![0].error).toMatchObject([
+                {
+                  json: '{"message":"<masked>","locations":[{"line":1,"column":2}],"path":["fieldWhichWillError"],"extensions":{"maskedBy":"ApolloServerPluginUsageReporting"}}',
+                  message: '<masked>',
+                  location: [{ column: 2, line: 1 }],
+                },
+              ]);
+            });
           });
         });
       });

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -1329,9 +1329,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
                 fieldWhichWillError: null,
               });
               expect(result.errors).toBeDefined();
-              expect(result.errors[0].message).toEqual(
-                'should be unmodified',
-              );
+              expect(result.errors[0].message).toEqual('should be unmodified');
               expect(throwError).toHaveBeenCalledTimes(1);
 
               const reports = await reportIngress.promiseOfReports;


### PR DESCRIPTION
Added some unit tests to cover the new error reporting options introduced in https://github.com/apollographql/apollo-server/pull/6794. The transform case was already covered but I added two new tests for the unmodified and masked options.