### PR TITLE
Rename HTTPGraphQLHead.statusCode to status

### DIFF
--- a/.changeset/famous-parents-argue.md
+++ b/.changeset/famous-parents-argue.md
@@ -1,0 +1,7 @@
+---
+"@apollo/server-integration-testsuite": patch
+"@apollo/server-plugin-response-cache": patch
+"@apollo/server": patch
+---
+
+Rename response.http.statusCode back to status like it was in AS3.

--- a/docs/source/integrations/building-integrations.md
+++ b/docs/source/integrations/building-integrations.md
@@ -205,7 +205,7 @@ In the above code snippet, the `httpGraphQLRequest` variable is our `HTTPGraphQL
 #### Handle errors
 
 The `executeHTTPGraphQLRequest` method does not throw. Instead, it returns an
-object containing helpful errors and a specific `statusCode` when applicable.
+object containing helpful errors and a specific `status` when applicable.
 You should handle this object accordingly, based on the error handling
 conventions that apply to your framework.
 
@@ -219,7 +219,7 @@ After awaiting the Promise returned by `executeHTTPGraphQLRequest`, we receive a
 
 ```ts
 interface HTTPGraphQLHead {
-  statusCode?: number;
+  status?: number;
   headers: Map<string, string>;
 }
 
@@ -243,6 +243,6 @@ with the appropriate status code and headers, and finally sends the body:
 for (const [key, value] of httpGraphQLResponse.headers) {
   res.setHeader(key, value);
 }
-res.statusCode = httpGraphQLResponse.statusCode || 200;
+res.statusCode = httpGraphQLResponse.status || 200;
 res.send(httpGraphQLResponse.completeBody);
 ```

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -646,7 +646,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
                   },
                 }) {
                   if (errors![0].message === 'known_error') {
-                    http!.statusCode = 403;
+                    http!.status = 403;
                   }
                 },
               };

--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -1669,7 +1669,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
               async requestDidStart() {
                 return {
                   async willSendResponse({ response: { http } }) {
-                    http!.statusCode = 403;
+                    http!.status = 403;
                   },
                 };
               },

--- a/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
+++ b/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
@@ -219,7 +219,7 @@ export default function plugin<TContext extends BaseContext>(
             return {
               result: { data: value.data },
               http: {
-                statusCode: undefined,
+                status: undefined,
                 headers: new Map(),
               },
             };

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -988,13 +988,13 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         error.message = `Context creation failed: ${error.message}`;
         // If we explicitly provide an error code that isn't
         // INTERNAL_SERVER_ERROR, we'll treat it as a client error.
-        const statusCode =
+        const status =
           error instanceof GraphQLError &&
           error.extensions.code &&
           error.extensions.code !== ApolloServerErrorCode.INTERNAL_SERVER_ERROR
             ? 400
             : 500;
-        return this.errorResponse(error, newHTTPGraphQLHead(statusCode));
+        return this.errorResponse(error, newHTTPGraphQLHead(status));
       }
 
       return await runPotentiallyBatchedHttpQuery(
@@ -1027,7 +1027,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           // subclasses, maybe?
           maybeError.message === badMethodErrorMessage
             ? {
-                statusCode: 405,
+                status: 405,
                 headers: new HeaderMap([['allow', 'GET, POST']]),
               }
             : newHTTPGraphQLHead(400),
@@ -1042,7 +1042,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
     httpGraphQLHead: HTTPGraphQLHead = newHTTPGraphQLHead(),
   ): HTTPGraphQLResponse {
     return {
-      statusCode: httpGraphQLHead.statusCode ?? 500,
+      status: httpGraphQLHead.status ?? 500,
       headers: new HeaderMap([
         ...httpGraphQLHead.headers,
         ['content-type', 'application/json'],

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -211,7 +211,7 @@ describe('ApolloServer start', () => {
         "headers": Map {
           "content-type" => "application/json",
         },
-        "statusCode": 500,
+        "status": 500,
       }
     `);
 
@@ -224,7 +224,7 @@ describe('ApolloServer start', () => {
         "headers": Map {
           "content-type" => "application/json",
         },
-        "statusCode": 500,
+        "status": 500,
       }
     `);
 

--- a/packages/server/src/express4/index.ts
+++ b/packages/server/src/express4/index.ts
@@ -93,7 +93,7 @@ export function expressMiddleware<TContext extends BaseContext>(
         for (const [key, value] of httpGraphQLResponse.headers) {
           res.setHeader(key, value);
         }
-        res.statusCode = httpGraphQLResponse.statusCode || 200;
+        res.statusCode = httpGraphQLResponse.status || 200;
         res.send(httpGraphQLResponse.completeBody);
       })
       .catch(next);

--- a/packages/server/src/externalTypes/http.ts
+++ b/packages/server/src/externalTypes/http.ts
@@ -28,7 +28,7 @@ interface HTTPGraphQLResponseChunk {
 }
 
 export interface HTTPGraphQLHead {
-  statusCode?: number;
+  status?: number;
   // TODO(AS4): need to figure out what headers this includes (eg JSON???)
   headers: Map<string, string>;
 }

--- a/packages/server/src/httpBatching.ts
+++ b/packages/server/src/httpBatching.ts
@@ -51,9 +51,9 @@ export async function runBatchHttpQuery<TContext extends BaseContext>(
         combinedResponse.headers.set(key, value);
       }
       // If two responses both want to set the status code, one of them will win.
-      // Note that the normal success case leaves statusCode empty.
-      if (response.statusCode) {
-        combinedResponse.statusCode = response.statusCode;
+      // Note that the normal success case leaves status empty.
+      if (response.status) {
+        combinedResponse.status = response.status;
       }
       return response.completeBody;
     }),

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -90,7 +90,7 @@ function isBadUserInputGraphQLError(error: GraphQLError): boolean {
 // that may mask the contents of an error response. (Otherwise, the default
 // status code for a response with `errors` but no `data` (even null) is 400.)
 const getPersistedQueryErrorHttp = () => ({
-  statusCode: 200,
+  status: 200,
   headers: new HeaderMap([
     ['cache-control', 'private, no-cache, must-revalidate'],
   ]),
@@ -306,7 +306,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
           `GET requests only support query operations, not ${operation.operation} operations`,
         ),
       ],
-      { statusCode: 405, headers: new HeaderMap([['allow', 'POST']]) },
+      { status: 405, headers: new HeaderMap([['allow', 'POST']]) },
     );
   }
 
@@ -414,7 +414,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
       enablePluginsForSchemaResolvers(schemaDerivedData.schema);
     }
 
-    let statusCodeIfExecuteThrows = 500;
+    let statusIfExecuteThrows = 500;
     try {
       const result = await execute(
         requestContext as GraphQLRequestContextExecutionDidStart<TContext>,
@@ -429,7 +429,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
             'Unexpected error: Apollo Server did not resolve an operation but execute did not return errors',
           );
         }
-        statusCodeIfExecuteThrows = 400;
+        statusIfExecuteThrows = 400;
         throw new OperationResolutionError(result.errors[0]);
       }
 
@@ -469,7 +469,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
 
       return await sendErrorResponse(
         [ensureGraphQLError(executionError)],
-        newHTTPGraphQLHead(statusCodeIfExecuteThrows),
+        newHTTPGraphQLHead(statusIfExecuteThrows),
       );
     }
   }
@@ -504,8 +504,8 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
   }
 
   function updateResponseHTTP(http: HTTPGraphQLHead) {
-    if (http.statusCode) {
-      requestContext.response.http.statusCode = http.statusCode;
+    if (http.status) {
+      requestContext.response.http.status = http.status;
     }
     for (const [name, value] of http.headers) {
       // TODO(AS4): this is overwriting rather than appending. However we should
@@ -559,8 +559,8 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
 
     updateResponseHTTP(http);
 
-    if (!requestContext.response.http.statusCode) {
-      requestContext.response.http.statusCode = 400;
+    if (!requestContext.response.http.status) {
+      requestContext.response.http.status = 400;
     }
 
     await invokeWillSendResponse();

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -234,9 +234,9 @@ export function cloneObject<T extends Object>(object: T): T {
   return Object.assign(Object.create(Object.getPrototypeOf(object)), object);
 }
 
-export function newHTTPGraphQLHead(statusCode?: number): HTTPGraphQLHead {
+export function newHTTPGraphQLHead(status?: number): HTTPGraphQLHead {
   return {
-    statusCode,
+    status,
     headers: new HeaderMap(),
   };
 }

--- a/packages/server/src/utils/makeGatewayGraphQLRequestContext.ts
+++ b/packages/server/src/utils/makeGatewayGraphQLRequestContext.ts
@@ -129,8 +129,8 @@ export function makeGatewayGraphQLRequestContext<TContext extends BaseContext>(
   if ('extensions' in as4Result) {
     response.extensions = as4Result.extensions;
   }
-  if ('statusCode' in as4RequestContext.response.http) {
-    response.http!.status = as4RequestContext.response.http.statusCode;
+  if ('status' in as4RequestContext.response.http) {
+    response.http!.status = as4RequestContext.response.http.status;
   }
 
   return {


### PR DESCRIPTION
This matches the name in the Fetch Response API, so that
`requestContext.response.http.status` does not have to change between
AS3 and AS4. I think the previous rename was inspired by the Node HTTP
response object's field name, but there are enough adjustments for AS4;
let's avoid this little one.
