### PR TITLE
changeset: run `npm i` when making versioning PR

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,6 +27,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npm run changeset-publish
+          version: npm run changeset-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15045,7 +15045,7 @@
     },
     "packages/integration-testsuite": {
       "name": "@apollo/server-integration-testsuite",
-      "version": "4.0.0-alpha.3",
+      "version": "4.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
@@ -15065,7 +15065,7 @@
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.0-alpha.3",
+        "@apollo/server": "^4.0.0-alpha.5",
         "@jest/globals": "28.x",
         "graphql": "^16.5.0",
         "jest": "28.x"
@@ -15073,7 +15073,7 @@
     },
     "packages/plugin-response-cache": {
       "name": "@apollo/server-plugin-response-cache",
-      "version": "4.0.0-alpha.2",
+      "version": "4.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.createhash": "^1.1.0",
@@ -15083,13 +15083,13 @@
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.0-alpha.3",
+        "@apollo/server": "^4.0.0-alpha.5",
         "graphql": "^16.5.0"
       }
     },
     "packages/server": {
       "name": "@apollo/server",
-      "version": "4.0.0-alpha.3",
+      "version": "4.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prettier-fix": "prettier --write .",
     "spell-check": "cspell lint '**' --no-progress || (echo 'Add any real words to cspell-dict.txt.'; exit 1)",
     "changeset-publish": "changeset publish",
-    "changeset-check": "changeset status --verbose --since=origin/version-4"
+    "changeset-check": "changeset status --verbose --since=origin/version-4",
+    "changeset-version": "changeset version && npm i"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Otherwise the `version` lines in package-lock.json don't get updated
until the next time you run `npm i`. (That's why this PR has random
package-lock.json changes!)
