### PR TITLE
Plugins: no server; interface contravariant; no factory functions

### DIFF
--- a/.changeset/wet-kiwis-play.md
+++ b/.changeset/wet-kiwis-play.md
@@ -1,0 +1,15 @@
+---
+"@apollo/server-integration-testsuite": patch
+"@apollo/server-plugin-response-cache": patch
+"@apollo/server": patch
+---
+
+Several changes relating to plugins:
+
+- Remove the `server` field on `GraphQLRequestContext` and `GraphQLServerContext` (ie, the arguments to most plugin hook methods). This was added during AS4 development and did not exist in AS3.
+
+- Add `logger` and `cache` fields to `GraphQLRequestContext` and `GraphQLServerContext`. The `logger` fields and `GraphQLRequestContext.cache` existed in AS3 and had been previously removed for redundancy with the `server` field. (Unlike in AS3, `logger` is readonly.)
+
+- `ApolloServerPlugin` is now declared as `<in TContext extends BaseContext = BaseContext>` rather than `<in out TContext>`. This means that you can declare a plugin that doesn't care about `contextValue` to simply implement `ApolloServerPlugin` and it will work with any `ApolloServer<NoMatterWhatContext>`. This should make it easy to write plugins that don't care about context.
+
+- Remove the ability to specify a factory function as an element of the `plugins` list in the `ApolloServer` constructor. (Reducing the number of ways to specify constructor options helps keep type errors simpler.) As far as we know the main use case for this (referring to the `ApolloServer` itself when creating the plugin) can be handled with the new-in-AS4 `ApolloServer.addPlugin` method.

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -1383,7 +1383,7 @@ Most plugin API hooks take a `GraphQLRequestContext` object as their first argum
 
 The `context` field has been renamed `contextValue` for consistency with the `graphql-js` API and to help differentiate from the `context` option of integration functions (the *function* which returns a context value).
 
-Apollo Server 4 removes the  `logger` and `cache` fields from `GraphQLRequestContext`. These fields are now available as `public readonly` fields on the `ApolloServer` object.  The `GraphQLRequestContext` object now provides the `ApolloServer` object in a new field named `server`. This means you should replace `requestContext.logger` and `requestContext.cache` with `requestContext.server.logger` and `requestContext.server.cache` respectively.
+The `GraphQLRequestContext.logger` field is now `readonly`. If you depended on the ability to change the `logger`, please file an issue.
 
 Apollo Server 4 removes the `schemaHash` field from `GraphQLRequestContext`. This field is an unstable hash of a JSON encoding resulting from running a GraphQL introspection query against your schema. The `schemaHash` field is not guaranteed to change when the schema changes (e.g., it is not affected by changes to schema directive applications). If you want a schema hash, you can use `graphql-js`'s `printSchema` function on the `schema` field and then hash the output.
 
@@ -1395,8 +1395,6 @@ Apollo Server 4 removes the `debug` field from `GraphQLRequestContext` because `
 Apollo Server 4 makes several changes to the `GraphQLServerContext` object.
 
 Apollo Server 4 renames the TypeScript type for the argument to the `serverWillStart` plugin hook from  `GraphQLServiceContext` to `GraphQLServerContext`, for consistency with the hook name.
-
-Apollo Server 4  removes the `logger` field from the `GraphQLServerContext` object. This field is now available as a `public readonly` field on the `ApolloServer` object, which `GraphQLServerContext` provides via a new field named `server`. This means `serviceContext.logger` should be replaced with `serverContext.server.logger`.
 
 Apollo Server 4 removes the `schemaHash` field (see the [previous section](#fields-on-graphqlrequestcontext) for details).
 
@@ -1430,6 +1428,44 @@ Additionally, the  `data` and `extensions` fields are both type `Record<string, 
 The value of `http.headers` is now a `Map` (with lower-case keys) rather than a Fetch API `Headers` object.
 
 > We plan to implement experimental support for incremental delivery (`@defer`/`@stream`) before the v4.0.0 release and expect this to change the structure of `GraphQLResponse` further.
+
+### `plugins` constructor argument does not take factory functions
+
+In Apollo Server 3, each element of the `plugins` array provided to `new ApolloServer` could either be an `ApolloServerPlugin` (ie, an object with fields like `requestDidStart`) or a zero-argument "factory" function returning an `ApolloServerPlugin`.
+
+In Apollo Server 4, each element must be an `ApolloServerPlugin`. If you used a factory function in order to refer to the `ApolloServer` object itself when setting up your plugin, you may want to use the new `ApolloServer.addPlugin` method which you may call on your `ApolloServer` before you call `start` or `startStandaloneServer`.
+
+For example, if your Apollo Server 3 code looked like this:
+
+<MultiCodeBlock>
+
+```ts
+const server = new ApolloServer({
+  typeDefs,
+  plugins: [
+    makeFirstPlugin,
+    () => makeSecondPlugin(server),
+  ],
+});
+```
+
+</MultiCodeBlock>
+
+then your Apollo Server 4 code can look like this:
+
+<MultiCodeBlock>
+
+```ts
+const server = new ApolloServer({
+  typeDefs,
+  plugins: [
+    makeFirstPlugin(),
+  ],
+});
+server.addPlugin(makeSecondPlugin(server));
+```
+
+</MultiCodeBlock>
 
 ### Changes to plugin semantics
 

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -33,7 +33,7 @@ import type {
   ApolloServerOptions,
   ApolloServer,
   BaseContext,
-  PluginDefinition,
+  ApolloServerPlugin,
 } from '@apollo/server';
 import fetch from 'node-fetch';
 
@@ -541,7 +541,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
       let serverInstance: ApolloServer<BaseContext>;
 
       const setupApolloServerAndFetchPairForPlugins = async (
-        plugins: PluginDefinition<BaseContext>[] = [],
+        plugins: ApolloServerPlugin<BaseContext>[] = [],
       ) => {
         const { server, url } = await createServer(
           {
@@ -878,7 +878,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
               ApolloServerPluginUsageReportingOptions<any>
             > = {},
             constructorOptions: Partial<CreateServerForIntegrationTests> = {},
-            plugins: PluginDefinition<BaseContext>[] = [],
+            plugins: ApolloServerPlugin<BaseContext>[] = [],
           ) => {
             const uri = await createServerAndGetUrl({
               typeDefs: gql`

--- a/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
+++ b/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
@@ -174,7 +174,7 @@ export default function plugin<TContext extends BaseContext>(
       outerRequestContext: GraphQLRequestContext<any>,
     ): Promise<GraphQLRequestListener<any>> {
       const cache = new PrefixingKeyValueCache(
-        options.cache ?? outerRequestContext.server.cache,
+        options.cache ?? outerRequestContext.cache,
         'fqc:',
       );
 
@@ -267,7 +267,7 @@ export default function plugin<TContext extends BaseContext>(
         },
 
         async willSendResponse(requestContext) {
-          const logger = requestContext.server.logger || console;
+          const logger = requestContext.logger || console;
 
           if (!isGraphQLQuery(requestContext)) {
             return;

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -42,6 +42,7 @@ import type {
   PersistedQueryOptions,
   HTTPGraphQLHead,
   ContextThunk,
+  GraphQLRequestContext,
 } from './externalTypes';
 import { runPotentiallyBatchedHttpQuery } from './httpBatching.js';
 import { InternalPluginId, pluginIsInternal } from './internalPlugin.js';
@@ -202,20 +203,6 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
 
     const isDev = nodeEnv !== 'production';
 
-    // Plugins can be (for some reason) provided as a function, which we have to
-    // call first to get the actual plugin. Note that more plugins can be added
-    // before `start()` with `addPlugin()` (eg, plugins that want to take this
-    // ApolloServer as an argument), and `start()` will call
-    // `ensurePluginInstantiation` to add default plugins.
-    const plugins: ApolloServerPlugin<TContext>[] = (config.plugins ?? []).map(
-      (plugin) => {
-        if (typeof plugin === 'function') {
-          return plugin();
-        }
-        return plugin;
-      },
-    );
-
     const state: ServerState = config.gateway
       ? // ApolloServer has been initialized but we have not yet tried to load the
         // schema from the gateway. That will wait until `start()` or
@@ -293,7 +280,10 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       nodeEnv,
       allowBatchedHttpRequests: config.allowBatchedHttpRequests ?? false,
       apolloConfig,
-      plugins,
+      // Note that more plugins can be added before `start()` with `addPlugin()`
+      // (eg, plugins that want to take this ApolloServer as an argument), and
+      // `start()` will call `addDefaultPlugins` to add default plugins.
+      plugins: config.plugins ?? [],
       parseOptions: config.parseOptions ?? {},
       state,
       stopOnTerminationSignals: config.stopOnTerminationSignals,
@@ -377,8 +367,9 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       });
 
       const schemaDerivedData = schemaManager.getSchemaDerivedData();
-      const service: GraphQLServerContext<TContext> = {
-        server: this,
+      const service: GraphQLServerContext = {
+        logger: this.logger,
+        cache: this.cache,
         schema: schemaDerivedData.schema,
         apollo: this.internals.apolloConfig,
         startedInBackground,
@@ -1154,8 +1145,9 @@ export async function internalExecuteOperation<TContext extends BaseContext>({
   const httpGraphQLHead = newHTTPGraphQLHead();
   httpGraphQLHead.headers.set('content-type', 'application/json');
 
-  const requestContext = {
-    server,
+  const requestContext: GraphQLRequestContext<TContext> = {
+    logger: server.logger,
+    cache: server.cache,
     schema: schemaDerivedData.schema,
     request: graphQLRequest,
     response: { result: {}, http: httpGraphQLHead },

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -489,19 +489,27 @@ describe('ApolloServer executeOperation', () => {
         },
       };
 
+      // A plugin that expects specific fields to be set is not a plugin that
+      // doesn't promise to set any fields.
       // @ts-expect-error
       takesPlugin<BaseContext>(specificPlugin);
-      // @ts-expect-error
+      // This is OK: plugins only get to read context, not write it, so a plugin
+      // that reads no interesting fields can be used as a plugin that is
+      // hypothetically allowed to read some interesting fields but chooses not
+      // to.
       takesPlugin<SpecificContext>(basePlugin);
 
+      // You can't use a plugin that expects specific fields to exist with a
+      // server that doesn't require them to be set when executing operations.
       new ApolloServer<BaseContext>({
         typeDefs: 'type Query { x: ID }',
         // @ts-expect-error
         plugins: [specificPlugin],
       });
+      // A plugin that doesn't expect any fields to be set works fine with a
+      // server that sets some fields when executing operations.
       new ApolloServer<SpecificContext>({
         typeDefs: 'type Query { x: ID }',
-        // @ts-expect-error
         plugins: [basePlugin],
       });
     });

--- a/packages/server/src/__tests__/logger.test.ts
+++ b/packages/server/src/__tests__/logger.test.ts
@@ -15,7 +15,7 @@ describe('logger', () => {
       `,
       plugins: [
         {
-          async serverWillStart({ server: { logger } }) {
+          async serverWillStart({ logger }) {
             logger.debug(KNOWN_DEBUG_MESSAGE);
           },
         },
@@ -42,7 +42,7 @@ describe('logger', () => {
       `,
       plugins: [
         {
-          async serverWillStart({ server: { logger } }) {
+          async serverWillStart({ logger }) {
             logger.debug(KNOWN_DEBUG_MESSAGE);
           },
         },

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -11,7 +11,7 @@ import type {
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 import type { GatewayInterface } from '@apollo/server-gateway-interface';
 import type { BaseContext } from '.';
-import type { PluginDefinition } from './plugins';
+import type { ApolloServerPlugin } from './plugins';
 
 export type DocumentStore = KeyValueCache<DocumentNode>;
 
@@ -86,7 +86,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   allowBatchedHttpRequests?: boolean;
 
   introspection?: boolean;
-  plugins?: PluginDefinition<TContext>[];
+  plugins?: ApolloServerPlugin<TContext>[];
   persistedQueries?: PersistedQueryOptions | false;
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -9,7 +9,8 @@ import type {
 import type { CachePolicy } from '@apollo/cache-control-types';
 import type { BaseContext } from './context';
 import type { HTTPGraphQLHead, HTTPGraphQLRequest } from './http';
-import type { ApolloServer } from '../ApolloServer';
+import type { Logger } from '@apollo/utils.logger';
+import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 
 export interface GraphQLRequest {
   query?: string;
@@ -44,7 +45,8 @@ export interface GraphQLRequestMetrics {
 }
 
 export interface GraphQLRequestContext<TContext extends BaseContext> {
-  readonly server: ApolloServer<TContext>;
+  readonly logger: Logger;
+  readonly cache: KeyValueCache<string>;
 
   readonly request: GraphQLRequest;
   readonly response: GraphQLResponse;

--- a/packages/server/src/externalTypes/index.ts
+++ b/packages/server/src/externalTypes/index.ts
@@ -29,7 +29,6 @@ export type {
   GraphQLServerListener,
   GraphQLServerContext,
   LandingPage,
-  PluginDefinition,
 } from './plugins.js';
 export type {
   GraphQLRequestContextDidEncounterErrors,

--- a/packages/server/src/externalTypes/plugins.ts
+++ b/packages/server/src/externalTypes/plugins.ts
@@ -1,5 +1,6 @@
+import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
+import type { Logger } from '@apollo/utils.logger';
 import type { GraphQLResolveInfo, GraphQLSchema } from 'graphql';
-import type { ApolloServer } from '../ApolloServer';
 import type { ApolloConfig } from './constructor';
 import type { BaseContext } from './context';
 import type { GraphQLRequestContext, GraphQLResponse } from './graphql';
@@ -14,8 +15,10 @@ import type {
   GraphQLRequestContextWillSendResponse,
 } from './requestPipeline';
 
-export interface GraphQLServerContext<TContext extends BaseContext> {
-  server: ApolloServer<TContext>;
+export interface GraphQLServerContext {
+  readonly logger: Logger;
+  readonly cache: KeyValueCache<string>;
+
   schema: GraphQLSchema;
   apollo: ApolloConfig;
   // TODO(AS4): Make sure we document that we removed `persistedQueries`.
@@ -28,15 +31,11 @@ export interface GraphQLSchemaContext {
   coreSupergraphSdl?: string;
 }
 
-// A plugin can return an interface that matches `ApolloServerPlugin`, or a
-// factory function that returns `ApolloServerPlugin`.
-export type PluginDefinition<TContext extends BaseContext> =
-  | ApolloServerPlugin<TContext>
-  | (() => ApolloServerPlugin<TContext>);
-
-export interface ApolloServerPlugin<in out TContext extends BaseContext> {
+export interface ApolloServerPlugin<
+  in TContext extends BaseContext = BaseContext,
+> {
   serverWillStart?(
-    service: GraphQLServerContext<TContext>,
+    service: GraphQLServerContext,
   ): Promise<GraphQLServerListener | void>;
 
   requestDidStart?(

--- a/packages/server/src/plugin/cacheControl/index.ts
+++ b/packages/server/src/plugin/cacheControl/index.ts
@@ -1,4 +1,4 @@
-import type { ApolloServerPlugin, BaseContext } from '../../externalTypes';
+import type { ApolloServerPlugin } from '../../externalTypes';
 import {
   DirectiveNode,
   getNamedType,
@@ -47,9 +47,9 @@ export interface ApolloServerPluginCacheControlOptions {
   __testing__cacheHints?: Map<string, CacheHint>;
 }
 
-export function ApolloServerPluginCacheControl<TContext extends BaseContext>(
+export function ApolloServerPluginCacheControl(
   options: ApolloServerPluginCacheControlOptions = Object.create(null),
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   let typeAnnotationCache: LRUCache<GraphQLCompositeType, CacheAnnotation>;
 
   let fieldAnnotationCache: LRUCache<

--- a/packages/server/src/plugin/disabled/index.ts
+++ b/packages/server/src/plugin/disabled/index.ts
@@ -6,10 +6,8 @@ import type {
   InternalPluginId,
 } from '../../internalPlugin';
 
-function disabledPlugin<TContext extends BaseContext>(
-  id: InternalPluginId,
-): ApolloServerPlugin<TContext> {
-  const plugin: InternalApolloServerPlugin<TContext> = {
+function disabledPlugin(id: InternalPluginId): ApolloServerPlugin {
+  const plugin: InternalApolloServerPlugin<BaseContext> = {
     __internal_plugin_id__() {
       return id;
     },
@@ -17,26 +15,18 @@ function disabledPlugin<TContext extends BaseContext>(
   return plugin;
 }
 
-export function ApolloServerPluginCacheControlDisabled<
-  TContext extends BaseContext,
->(): ApolloServerPlugin<TContext> {
+export function ApolloServerPluginCacheControlDisabled(): ApolloServerPlugin<BaseContext> {
   return disabledPlugin('CacheControl');
 }
 
-export function ApolloServerPluginInlineTraceDisabled<
-  TContext extends BaseContext,
->(): ApolloServerPlugin<TContext> {
+export function ApolloServerPluginInlineTraceDisabled(): ApolloServerPlugin<BaseContext> {
   return disabledPlugin('InlineTrace');
 }
 
-export function ApolloServerPluginLandingPageDisabled<
-  TContext extends BaseContext,
->(): ApolloServerPlugin<TContext> {
+export function ApolloServerPluginLandingPageDisabled(): ApolloServerPlugin<BaseContext> {
   return disabledPlugin('LandingPageDisabled');
 }
 
-export function ApolloServerPluginUsageReportingDisabled<
-  TContext extends BaseContext,
->(): ApolloServerPlugin<TContext> {
+export function ApolloServerPluginUsageReportingDisabled(): ApolloServerPlugin<BaseContext> {
   return disabledPlugin('UsageReporting');
 }

--- a/packages/server/src/plugin/drainHttpServer/index.ts
+++ b/packages/server/src/plugin/drainHttpServer/index.ts
@@ -1,5 +1,5 @@
 import type http from 'http';
-import type { ApolloServerPlugin, BaseContext } from '../../externalTypes';
+import type { ApolloServerPlugin } from '../../externalTypes';
 import { Stopper } from './stoppable.js';
 
 /**
@@ -23,9 +23,9 @@ export interface ApolloServerPluginDrainHttpServerOptions {
  * See https://www.apollographql.com/docs/apollo-server/api/plugin/drain-http-server/
  * for details.
  */
-export function ApolloServerPluginDrainHttpServer<TContext extends BaseContext>(
+export function ApolloServerPluginDrainHttpServer(
   options: ApolloServerPluginDrainHttpServerOptions,
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   const stopper = new Stopper(options.httpServer);
   return {
     async serverWillStart() {

--- a/packages/server/src/plugin/inlineTrace/index.ts
+++ b/packages/server/src/plugin/inlineTrace/index.ts
@@ -3,7 +3,7 @@ import { TraceTreeBuilder } from '../traceTreeBuilder.js';
 import type { SendErrorsOptions } from '../usageReporting/index.js';
 import { internalPlugin } from '../../internalPlugin.js';
 import { schemaIsFederated } from '../schemaIsFederated.js';
-import type { ApolloServerPlugin, BaseContext } from '../../externalTypes';
+import type { ApolloServerPlugin } from '../../externalTypes';
 
 export interface ApolloServerPluginInlineTraceOptions {
   /**
@@ -44,15 +44,15 @@ export interface ApolloServerPluginInlineTraceOptions {
 // on the `extensions`.`ftv1` property of the response.  The Apollo Gateway
 // utilizes this data to construct the full trace and submit it to Apollo's
 // usage reporting ingress.
-export function ApolloServerPluginInlineTrace<TContext extends BaseContext>(
+export function ApolloServerPluginInlineTrace(
   options: ApolloServerPluginInlineTraceOptions = Object.create(null),
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   let enabled: boolean | null = options.__onlyIfSchemaIsFederated ? null : true;
   return internalPlugin({
     __internal_plugin_id__() {
       return 'InlineTrace';
     },
-    async serverWillStart({ schema, server }) {
+    async serverWillStart({ schema, logger }) {
       // Handle the case that the plugin was implicitly installed. We only want it
       // to actually be active if the schema appears to be federated. If you don't
       // like the log line, just install `ApolloServerPluginInlineTrace()` in
@@ -60,7 +60,7 @@ export function ApolloServerPluginInlineTrace<TContext extends BaseContext>(
       if (enabled === null) {
         enabled = schemaIsFederated(schema);
         if (enabled) {
-          server.logger.info(
+          logger.info(
             'Enabling inline tracing for this federated service. To disable, use ' +
               'ApolloServerPluginInlineTraceDisabled.',
           );

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -15,11 +15,9 @@ export type {
   ApolloServerPluginLandingPageProductionDefaultOptions,
 };
 
-export function ApolloServerPluginLandingPageLocalDefault<
-  TContext extends BaseContext,
->(
+export function ApolloServerPluginLandingPageLocalDefault(
   options: ApolloServerPluginLandingPageLocalDefaultOptions = {},
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   const { version, __internal_apolloStudioEnv__, ...rest } = {
     // we default to Sandbox unless embed is specified as false
     embed: true as const,
@@ -32,11 +30,9 @@ export function ApolloServerPluginLandingPageLocalDefault<
   });
 }
 
-export function ApolloServerPluginLandingPageProductionDefault<
-  TContext extends BaseContext,
->(
+export function ApolloServerPluginLandingPageProductionDefault(
   options: ApolloServerPluginLandingPageProductionDefaultOptions = {},
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   const { version, __internal_apolloStudioEnv__, ...rest } = options;
   return ApolloServerPluginLandingPageDefault(version, {
     isProd: true,

--- a/packages/server/src/plugin/landingPage/graphqlPlayground/index.ts
+++ b/packages/server/src/plugin/landingPage/graphqlPlayground/index.ts
@@ -7,7 +7,6 @@
 import { renderPlaygroundPage } from '@apollographql/graphql-playground-html';
 import type {
   ApolloServerPlugin,
-  BaseContext,
   GraphQLServerListener,
 } from '../../../externalTypes';
 
@@ -27,13 +26,11 @@ export type ApolloServerPluginLandingPageGraphQLPlaygroundOptions = Parameters<
   typeof renderPlaygroundPage
 >[0];
 
-export function ApolloServerPluginLandingPageGraphQLPlayground<
-  TContext extends BaseContext,
->(
+export function ApolloServerPluginLandingPageGraphQLPlayground(
   options: ApolloServerPluginLandingPageGraphQLPlaygroundOptions = Object.create(
     null,
   ),
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   return {
     async serverWillStart(): Promise<GraphQLServerListener> {
       return {

--- a/packages/server/src/plugin/schemaReporting/index.ts
+++ b/packages/server/src/plugin/schemaReporting/index.ts
@@ -5,7 +5,7 @@ import { printSchema, validateSchema, buildSchema } from 'graphql';
 import { SchemaReporter } from './schemaReporter.js';
 import { schemaIsFederated } from '../schemaIsFederated.js';
 import type { SchemaReport } from './generated/operations';
-import type { ApolloServerPlugin, BaseContext } from '../../externalTypes';
+import type { ApolloServerPlugin } from '../../externalTypes';
 import type { Fetcher } from '@apollo/utils.fetcher';
 import { packageVersion } from '../../generated/packageVersion.js';
 import { computeCoreSchemaHash } from '../../utils/computeCoreSchemaHash.js';
@@ -58,23 +58,22 @@ export interface ApolloServerPluginSchemaReportingOptions {
   fetcher?: Fetcher;
 }
 
-export function ApolloServerPluginSchemaReporting<TContext extends BaseContext>(
+export function ApolloServerPluginSchemaReporting(
   {
     initialDelayMaxMs,
     overrideReportedSchema,
     endpointUrl,
     fetcher,
   }: ApolloServerPluginSchemaReportingOptions = Object.create(null),
-): ApolloServerPlugin<TContext> {
+): ApolloServerPlugin {
   const bootId = uuidv4();
 
   return internalPlugin({
     __internal_plugin_id__() {
       return 'SchemaReporting';
     },
-    async serverWillStart({ apollo, schema, server }) {
+    async serverWillStart({ apollo, schema, logger }) {
       const { key, graphRef } = apollo;
-      const { logger } = server;
       if (!key) {
         throw Error(
           'To use ApolloServerPluginSchemaReporting, you must provide an Apollo API ' +

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -105,12 +105,12 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
     },
 
     async serverWillStart({
-      server,
+      logger: serverLogger,
       apollo,
       startedInBackground,
     }): Promise<GraphQLServerListener> {
       // Use the plugin-specific logger if one is provided; otherwise the general server one.
-      const logger = options.logger ?? server.logger;
+      const logger = options.logger ?? serverLogger;
       const { key, graphRef } = apollo;
       if (!(key && graphRef)) {
         throw new Error(
@@ -386,7 +386,6 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
         schema,
         request: { http, variables },
       }): GraphQLRequestListener<TContext> => {
-        const logger = options.logger ?? server.logger;
         const treeBuilder: TraceTreeBuilder = new TraceTreeBuilder({
           maskedBy: 'ApolloServerPluginUsageReporting',
           sendErrors: options.sendErrorsInTraces,


### PR DESCRIPTION
Previously on `version-4`, we had made `ApolloServerPlugin<TContext>`
"invariant" in `TContext` via the new `in out` annotation. That's
because we had added a `server` field to `GraphQLRequestContext` and
`GraphQLServerContext`.

The issue here is that because you can invoke
`server.executeOperation(op, contextValue)`, then a
`ApolloServerPlugin<BaseContext>` was not assignable to
`ApolloServerPlugin<SomeSpecificContext>`, because the former was able
to call `requestContext.executeOperation(op, {})`, and a server whose
context has additional required fields could not load this plugin. This
essentially meant that you couldn't have a single object (not created by
a generic function or generic class) that was a plugin that works with
any server, even if it doesn't actually care about context values at
all.

When trying to dogfood AS4 it became clear that this was annoying. So
let's fix it by removing `server` from those objects and making
`ApolloServerPlugin` "contravariant" instead. This means that plugins
can only *receive* `contextValue`, not *send* it. And so
`ApolloServerPlugin<BaseContext>` (a plugin that doesn't bother to read
any fields from `contextValue`) can be assigned to
`ApolloServerPlugin<SpecificContext>` (a plugin that is permitted to
read specific fields on `contextValue`, though it may choose not to).

After removing `server`, restore `logger` (now `readonly`) and `cache`
to `GraphQLRequestContext` and `GraphQLServerContext` (`cache` is
actually new to `GraphQLServerContext` in AS4). They had previously been
removed for redundancy.

This un-does the fix to https://github.com/apollographql/apollo-server/issues/6264. If your plugin needs access to the
`server` object, you can just pass it to your plugin's
constructor/factory yourself. This wasn't an option in AS3 because there
was no `server.addPlugin` method... or actually, you could do it with
the plugin factory feature.

Note that we do leave `ApolloServer<TContext>` as invariant in
`TContext`, for the reasons described in a comment above the class.

While we're at it, remove the unnecessary ability to specify plugins as
factory functions. As far as we know, the main use case for this feature
is to refer to the `ApolloServer` itself in the expression creating the
plugin, but the new `addPlugin` method lets you do the same thing.
Reducing the number of ways to specify constructor options helps keep
type errors simpler.