### PR TITLE
Rename property for RESTDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 ## vNEXT
 
 - [apollo-datasource-rest] Add option to disable GET cache [PR #6650](https://github.com/apollographql/apollo-server/pull/6650)
+- [apollo-datasource-rest] Rename property to `memoizeGetRequests`
 
 ## v3.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
-- [apollo-datasource-rest] Add option to disable GET cache [PR #6650](https://github.com/apollographql/apollo-server/pull/6650)
-- [apollo-datasource-rest] Rename property to `memoizeGetRequests`
+- [apollo-datasource-rest] Add option to disable GET cache [PR #6650](https://github.com/apollographql/apollo-server/pull/6650) and [PR #6834](https://github.com/apollographql/apollo-server/pull/6834)
 
 ## v3.10.1
 

--- a/docs/source/data/data-sources.mdx
+++ b/docs/source/data/data-sources.mdx
@@ -163,7 +163,7 @@ class MoviesAPI extends RESTDataSource {
   constructor() {
     super();
     // Defaults to true
-    this.requestCacheEnabled = false;
+    this.memoizeGetRequests = false;
   }
 
   // Outgoing requests are never cached, however the response cache is still enabled

--- a/docs/source/data/data-sources.mdx
+++ b/docs/source/data/data-sources.mdx
@@ -152,13 +152,13 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
-##### `requestCacheEnabled`
+##### `memoizeGetRequests`
 By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It makes the assumption that all responses from HTTP GET calls are cacheable by their URL.
 If a request is made with the same cache key (URL by default) but with an HTTP method other than GET, the cached request is then cleared.
 
-If you would like to disable the GET request cache, set the `requestCacheEnabled` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
+If you would like to disable the GET request cache, set the `memoizeGetRequests` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
 
-```js title="requestCacheEnabled.js"
+```js title="memoizeGetRequests.js"
 class MoviesAPI extends RESTDataSource {
   constructor() {
     super();

--- a/packages/apollo-datasource-rest/README.md
+++ b/packages/apollo-datasource-rest/README.md
@@ -80,7 +80,7 @@ class MoviesAPI extends RESTDataSource {
   constructor() {
     super();
     // Defaults to true
-    this.requestCacheEnabled = false;
+    this.memoizeGetRequests = false;
   }
 
   // Outgoing requests are never cached, however the response cache is still enabled

--- a/packages/apollo-datasource-rest/README.md
+++ b/packages/apollo-datasource-rest/README.md
@@ -69,13 +69,13 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
-#### `requestCacheEnabled`
+#### `memoizeGetRequests`
 By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It makes the assumption that all responses from HTTP GET calls are cacheable by their URL.
 If a request is made with the same cache key (URL by default) but with an HTTP method other than GET, the cached request is then cleared.
 
-If you would like to disable the GET request cache, set the `requestCacheEnabled` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
+If you would like to disable the GET request cache, set the `memoizeGetRequests` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
 
-```js title="requestCacheEnabled.js"
+```js title="memoizeGetRequests.js"
 class MoviesAPI extends RESTDataSource {
   constructor() {
     super();

--- a/packages/apollo-datasource-rest/src/RESTDataSource.ts
+++ b/packages/apollo-datasource-rest/src/RESTDataSource.ts
@@ -50,7 +50,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
   context!: TContext;
   memoizedResults = new Map<string, Promise<any>>();
   baseURL?: string;
-  requestCacheEnabled: boolean = true;
+  memoizeGetRequests: boolean = true;
 
   constructor(private httpFetch?: typeof fetch) {
     super();
@@ -268,7 +268,7 @@ export abstract class RESTDataSource<TContext = any> extends DataSource {
 
     // Cache GET requests based on the calculated cache key
     // Disabling the request cache does not disable the response cache
-    if (this.requestCacheEnabled) {
+    if (this.memoizeGetRequests) {
       if (request.method === 'GET') {
         let promise = this.memoizedResults.get(cacheKey);
         if (promise) return promise;

--- a/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
+++ b/packages/apollo-datasource-rest/src/__tests__/RESTDataSource.test.ts
@@ -639,7 +639,7 @@ describe('RESTDataSource', () => {
     it('allows disabling the GET cache', async () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
-        override requestCacheEnabled = false;
+        override memoizeGetRequests = false;
 
         getFoo(id: number) {
           return this.get(`foo/${id}`);
@@ -808,7 +808,7 @@ describe('RESTDataSource', () => {
     it('allows setting cache options for each request', async () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
-        override requestCacheEnabled = false;
+        override memoizeGetRequests = false;
 
         getFoo(id: number) {
           return this.get(`foo/${id}`);
@@ -837,7 +837,7 @@ describe('RESTDataSource', () => {
     it('allows setting a short TTL for the cache', async () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
-        override requestCacheEnabled = false;
+        override memoizeGetRequests = false;
 
         getFoo(id: number) {
           return this.get(`foo/${id}`);


### PR DESCRIPTION
Rename property for RESTDataSource from `requestCacheEnabled` to `memoizeGetRequests`

From the initial PR, the name of the new property was a little confusing since there are actually two caches, but what is being cached is the response data in the end

Original PR https://github.com/apollographql/apollo-server/pull/6650