### PR TITLE
Upgrade @apollo/server-gateway-interface to laxer version

### DIFF
--- a/.changeset/chatty-baboons-search.md
+++ b/.changeset/chatty-baboons-search.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+Upgrade @apollo/server-gateway-interface to have laxer definition of overallCachePolicy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,9 +288,9 @@
       "link": true
     },
     "node_modules/@apollo/server-gateway-interface": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.1.tgz",
-      "integrity": "sha512-YZ+bwSJJIYrIe22NDhF+DA+T9S1PV/sv3Ywp30Ao1RhtlXX7lBSRbu+meZxE1FNkC3nkbj63sUAUEmWiHO/jhw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.3.tgz",
+      "integrity": "sha512-XYdxr73Ld6DzQ4/LsCOo4ElOyJVcgPDJUybv43htN9AN5ninto9mwLfo2Q8FVkRH5FMIe57EycsHnIyBu7wDPg==",
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
         "@apollo/utils.fetcher": "^1.0.0",
@@ -15113,7 +15113,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/server-gateway-interface": "^1.0.0",
+        "@apollo/server-gateway-interface": "^1.0.3",
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
         "@apollo/utils.createhash": "^1.1.0",
         "@apollo/utils.fetcher": "^1.0.0",
@@ -15294,7 +15294,7 @@
       "version": "file:packages/server",
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/server-gateway-interface": "^1.0.0",
+        "@apollo/server-gateway-interface": "^1.0.3",
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
         "@apollo/utils.createhash": "^1.1.0",
         "@apollo/utils.fetcher": "^1.0.0",
@@ -15326,9 +15326,9 @@
       }
     },
     "@apollo/server-gateway-interface": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.1.tgz",
-      "integrity": "sha512-YZ+bwSJJIYrIe22NDhF+DA+T9S1PV/sv3Ywp30Ao1RhtlXX7lBSRbu+meZxE1FNkC3nkbj63sUAUEmWiHO/jhw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.3.tgz",
+      "integrity": "sha512-XYdxr73Ld6DzQ4/LsCOo4ElOyJVcgPDJUybv43htN9AN5ninto9mwLfo2Q8FVkRH5FMIe57EycsHnIyBu7wDPg==",
       "requires": {
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
         "@apollo/utils.fetcher": "^1.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",
-    "@apollo/server-gateway-interface": "^1.0.0",
+    "@apollo/server-gateway-interface": "^1.0.3",
     "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
     "@apollo/utils.createhash": "^1.1.0",
     "@apollo/utils.fetcher": "^1.0.0",


### PR DESCRIPTION
This should unblock Renovate getting us to the latest 0.x gateway.
