### PR TITLE
Ensure `executionDidEnd` hooks are only called once

### DIFF
--- a/.changeset/spotty-days-eat.md
+++ b/.changeset/spotty-days-eat.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+Ensure executionDidEnd hooks are only called once (when they throw)

--- a/packages/server/src/__tests__/runQuery.test.ts
+++ b/packages/server/src/__tests__/runQuery.test.ts
@@ -427,7 +427,7 @@ describe('request pipeline life-cycle hooks', () => {
         expect(executionDidEnd).toHaveBeenCalledTimes(1);
       });
 
-      it('is called twice if it throws (undesirable)', async () => {
+      it('is only called once if it throws', async () => {
         const executionDidEnd = jest.fn(() => {
           throw new Error('boom');
         });
@@ -459,7 +459,7 @@ describe('request pipeline life-cycle hooks', () => {
           ),
         ).rejects.toThrowError(/Internal server error/);
 
-        expect(executionDidEnd).toHaveBeenCalledTimes(2);
+        expect(executionDidEnd).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith(
           'Unexpected error processing request: Error: boom',
         );

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -459,8 +459,6 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         ...result,
         errors: resultErrors ? formatErrors(resultErrors) : undefined,
       };
-
-      await Promise.all(executionListeners.map((l) => l.executionDidEnd?.()));
     } catch (executionMaybeError: unknown) {
       const executionError = ensureError(executionMaybeError);
       await Promise.all(
@@ -472,6 +470,8 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         newHTTPGraphQLHead(statusIfExecuteThrows),
       );
     }
+
+    await Promise.all(executionListeners.map((l) => l.executionDidEnd?.()));
   }
 
   await invokeWillSendResponse();


### PR DESCRIPTION
Reproduction in first commit, resolution with test updates in second commit.

`executionDidEnd` hooks are currently called within both the try and catch clauses of the same block. This means that if a hook throws, they'll be called _again_ in the catch.

Similar to changes made for `parsingDidEnd` in https://github.com/apollographql/apollo-server/issues/6679, we now call the `executionDidEnd` hooks _after_ the try/catch and within the catch. This ensures they'll only ever be called once.

Fixes #6567
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
