### PR TITLE
Fix typo in usage reporting plugin log message

### DIFF
--- a/.changeset/shaggy-schools-sparkle.md
+++ b/.changeset/shaggy-schools-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Fixed usage reporting plugin log message

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -352,7 +352,7 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
           if (parsedBody.tracesIgnored === true) {
             logger.debug(
               "This graph's organization does not have access to traces; sending all " +
-                'subsequent operations as traces.',
+                'subsequent operations as stats.',
             );
             sendTraces = false;
           }


### PR DESCRIPTION
Noticed this typo when debugging some stats/trace related issues.