### PR TITLE
feat: pass Context to `formatError`

### DIFF
--- a/.changeset/stupid-teachers-think.md
+++ b/.changeset/stupid-teachers-think.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+Pass context as third argument to `formatError`.

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -138,6 +138,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   formatError?: (
     formattedError: GraphQLFormattedError,
     error: unknown,
+    context?: TContext,
   ) => GraphQLFormattedError;
   // TODO(AS4): Is there a way (with generics/codegen?) to make
   // this "any" more specific? In AS3 there was technically a

--- a/packages/server/src/errorNormalize.ts
+++ b/packages/server/src/errorNormalize.ts
@@ -6,7 +6,7 @@ import {
   GraphQLFormattedError,
 } from 'graphql';
 import { ApolloServerErrorCode } from './errors/index.js';
-import type { HTTPGraphQLHead } from './externalTypes/http.js';
+import type { BaseContext, HTTPGraphQLHead } from './externalTypes/index.js';
 import {
   HeaderMap,
   mergeHTTPGraphQLHead,
@@ -21,12 +21,14 @@ import {
 // are removed from the formatted error.
 //
 // This function should not throw.
-export function normalizeAndFormatErrors(
+export function normalizeAndFormatErrors<TContext extends BaseContext>(
   errors: ReadonlyArray<unknown>,
   options: {
+    context?: TContext;
     formatError?: (
       formattedError: GraphQLFormattedError,
       error: unknown,
+      context?: TContext,
     ) => GraphQLFormattedError;
     includeStacktraceInErrorResponses?: boolean;
   } = {},
@@ -41,7 +43,7 @@ export function normalizeAndFormatErrors(
     httpFromErrors,
     formattedErrors: errors.map((error) => {
       try {
-        return formatError(enrichError(error), error);
+        return formatError(enrichError(error), error, options.context);
       } catch (formattingError) {
         if (options.includeStacktraceInErrorResponses) {
           // includeStacktraceInErrorResponses is used in development

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -458,7 +458,9 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         executionListeners.map((l) => l.executionDidEnd?.(executionError)),
       );
 
-      return await sendErrorResponse(requestContext.contextValue, [ensureGraphQLError(executionError)]);
+      return await sendErrorResponse(requestContext.contextValue, [
+        ensureGraphQLError(executionError),
+      ]);
     }
 
     await Promise.all(executionListeners.map((l) => l.executionDidEnd?.()));


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->

We add a logger to our context, which amongst other things has a bound trace ID. So we'd like to use this logger when we log in it so we can follow the trace.

---

I'm not 100% happy with this, as we'd like to also get access to the trace ID when context creation _fails_. This is available on the `request` object, but I'm not sure how to thread that through (or if we should). I've not included tests for this reason - it might not be the correct solution to my issue, and I don't wanna spend time writing tests for code I don't think will land.

In my case, I don't really need the _context_ per se, as long as I get the arguments passed to the context _creator_.