### PR TITLE
didEncounterErrors is now allowed to modify requestContext.errors

### DIFF
--- a/.changeset/early-jokes-bathe.md
+++ b/.changeset/early-jokes-bathe.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+didEncounterErrors is allowed to mutate requestContext.errors.

--- a/packages/server/src/__tests__/runQuery.test.ts
+++ b/packages/server/src/__tests__/runQuery.test.ts
@@ -808,7 +808,12 @@ describe('request pipeline life-cycle hooks', () => {
   });
 
   describe('didEncounterErrors', () => {
-    const didEncounterErrors = jest.fn(async () => {});
+    const didEncounterErrors = jest.fn(async ({ errors }) => {
+      // Add an extension if it's an execution error.
+      if (errors[0].path) {
+        errors[0].extensions.encountered = true;
+      }
+    });
     const plugins: ApolloServerPlugin<BaseContext>[] = [
       {
         async requestDidStart() {
@@ -880,6 +885,7 @@ describe('request pipeline life-cycle hooks', () => {
         'Secret error message',
       );
       expect(response).toHaveProperty('data.testError', null);
+      expect(response).toHaveProperty('errors[0].extensions.encountered', true);
 
       expect(didEncounterErrors).toBeCalledWith(
         expect.objectContaining({

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -72,9 +72,12 @@ export interface GraphQLRequestContext<TContext extends BaseContext> {
    * are present earlier in the request pipeline and differ from **formatted**
    * errors which are the result of running the user-configurable `formatError`
    * transformation function over specific errors; these can eventually be found
-   * in `response.result.errors`.
+   * in `response.result.errors`. The didEncounterErrors hook is allowed to
+   * change the elements of this array (either by manipulating the array
+   * directly or by mutating individual errors), though it should not replace
+   * the array object itself.
    */
-  readonly errors?: ReadonlyArray<GraphQLError>;
+  readonly errors?: GraphQLError[];
 
   readonly metrics: GraphQLRequestMetrics;
 


### PR DESCRIPTION
Previously it could mutate individual errors but now it can add or remove them too, and this is explicit.

Refactor error handling code in requestPipeline to make it clear that didEncounterErrors is always called before normalizeAndFormatErrors.
