### PR TITLE
Revert "didEncounterErrors is now allowed to modify requestContext.er…

### DIFF
--- a/.changeset/early-jokes-bathe.md
+++ b/.changeset/early-jokes-bathe.md
@@ -1,5 +1,0 @@
----
-'@apollo/server': patch
----
-
-didEncounterErrors is allowed to mutate requestContext.errors.

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -72,12 +72,9 @@ export interface GraphQLRequestContext<TContext extends BaseContext> {
    * are present earlier in the request pipeline and differ from **formatted**
    * errors which are the result of running the user-configurable `formatError`
    * transformation function over specific errors; these can eventually be found
-   * in `response.result.errors`. The didEncounterErrors hook is allowed to
-   * change the elements of this array (either by manipulating the array
-   * directly or by mutating individual errors), though it should not replace
-   * the array object itself.
+   * in `response.result.errors`.
    */
-  readonly errors?: GraphQLError[];
+  readonly errors?: ReadonlyArray<GraphQLError>;
 
   readonly metrics: GraphQLRequestMetrics;
 


### PR DESCRIPTION
…rors (#6927)"

This reverts commit 5c64150de4ea5cfaf272b2ac037039b0491add81.

A few reasons:

- The refactoring change (combining "format errors" with "put them in the response") doesn't really make sense for incremental delivery (#6382)
- The change to let you remove all the errors from the array in the handler leads to unclear results if that gets done for a response like a parse or validation error
- Wasn't exactly solving a real problem

If you need to make major changes to the structure of your response, you can always do that in willSendResponse.