### PR TITLE
Docs follow-up from #6936

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -330,8 +330,6 @@ An object containing configuration options for connecting Apollo Server to [Apol
 
 Controls whether to allow [Batching Queries](../workflow/requests/#batching) in a single HTTP Request. Defaults to `false`. If a request comes in formatted as an array rather than as a single request object, an error will be thrown ( i.e., `Operation batching disabled`) _unless_ batching is enabled.
 
-> Note: In the case of duplicate response headers across separate requests, the later request's header will take precedence on a per-header basis.
-
 </td>
 </tr>
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -1134,11 +1134,9 @@ const result = await server.executeOperation({
   query: 'query helloContext { hello }',
 }, {
   // highlight-start
-  contextValue: {
-    // A half-hearted attempt at making something vaguely like an express.Request,
-    // and not bothering to make the express.Response at all.
-    req: { headers: { name: 'world' } },
-  }
+  // A half-hearted attempt at making something vaguely like an express.Request,
+  // and not bothering to make the express.Response at all.
+  req: { headers: { name: 'world' } },
   // highlight-end
 });
 

--- a/docs/source/workflow/requests.md
+++ b/docs/source/workflow/requests.md
@@ -67,7 +67,7 @@ If you have enabled HTTP batching, you can send a batch of queries in a single `
 
 If you send a batched request, Apollo Server responds with a corresponding array of GraphQL responses.
 
-> Note: In the case of duplicate response headers across separate requests, the later request's header will take precedence on a per-header basis.
+> Note: If multiple operations in a request try to set the same HTTP response header ([via error extensions or plugins](../data/errors#setting-http-status-code-and-headers)), headers from later operations will take precedence on a per-header basis.
 
 ## GET requests
 


### PR DESCRIPTION
- A bit more clarity about batching and HTTP headers in one place; not even bothering in another place (it seems a bit specific for the options reference, which links to the first place anyway)
- Revert accidental change to AS3 example
