### PR TITLE
Add generics for data and variables to executeOperation

### DIFF
--- a/.changeset/witty-toes-grin.md
+++ b/.changeset/witty-toes-grin.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Add generics for response data and variables to server.executeOperation; allow inference from TypedQueryDocumentNode.

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -631,7 +631,7 @@ Below are the available fields for the first argument of `executeOperation`:
 
 <td>
 
-**Required**. The GraphQL operation to run. Note that you must use the `query` field even if the operation is a mutation.
+**Required**. The GraphQL operation to run. Note that you must use the `query` field even if the operation is a mutation. This may also be a [`TypedQueryDocumentNode`](https://github.com/graphql/graphql-js/blob/main/src/utilities/typedQueryDocumentNode.ts), in which case TypeScript types for the `variables` option and `response.body.singleResult.data` will be automatically inferred.
 
 </td>
 </tr>

--- a/packages/server/src/externalTypes/graphql.ts
+++ b/packages/server/src/externalTypes/graphql.ts
@@ -17,10 +17,12 @@ import type {
   GraphQLExperimentalFormattedSubsequentIncrementalExecutionResult,
 } from './incrementalDeliveryPolyfill.js';
 
-export interface GraphQLRequest {
+export interface GraphQLRequest<
+  TVariables extends VariableValues = VariableValues,
+> {
   query?: string;
   operationName?: string;
-  variables?: VariableValues;
+  variables?: TVariables;
   extensions?: Record<string, any>;
   http?: HTTPGraphQLRequest;
 }
@@ -32,10 +34,10 @@ export type VariableValues = { [name: string]: any };
 // GraphQL operation uses incremental delivery directives such as `@defer` or
 // `@stream`. Note that incremental delivery currently requires using a
 // pre-release of graphql-js v17.
-export type GraphQLResponseBody =
+export type GraphQLResponseBody<TData = Record<string, unknown>> =
   | {
       kind: 'single';
-      singleResult: FormattedExecutionResult;
+      singleResult: FormattedExecutionResult<TData>;
     }
   | {
       kind: 'incremental';
@@ -43,12 +45,15 @@ export type GraphQLResponseBody =
       subsequentResults: AsyncIterable<GraphQLExperimentalFormattedSubsequentIncrementalExecutionResult>;
     };
 
-export type GraphQLInProgressResponse = {
+export type GraphQLInProgressResponse<TData = Record<string, unknown>> = {
   http: HTTPGraphQLHead;
-  body?: GraphQLResponseBody;
+  body?: GraphQLResponseBody<TData>;
 };
 
-export type GraphQLResponse = WithRequired<GraphQLInProgressResponse, 'body'>;
+export type GraphQLResponse<TData = Record<string, unknown>> = WithRequired<
+  GraphQLInProgressResponse<TData>,
+  'body'
+>;
 
 export interface GraphQLRequestMetrics {
   // It would be more accurate to call this fieldLevelInstrumentation (it is


### PR DESCRIPTION
This lets you manually specify the these types when calling the method; typically you generate these types with a codegen tool like graphql-code-generator. This matches a common pattern used in client development.

This doesn't let you specify the types for incremental delivery responses; we could potentially add that later.

This also lets you use TypedQueryDocumentNode (from graphql-js) as the `query`; if you do so, we can infer the two generic types automatically. (This type is less popular than the earlier TypedDocumentNode from `@graphql-typed-document-node/core` and we should probably support the latter as well; in the interest of reducing dependencies we don't yet, but we can extend to support that later.)

Adapted from an original PR #6384 by @jacksenior.
