### PR TITLE
Bump minimum graphql-js to v16.6.0 from v16.5.0

### DIFF
--- a/.changeset/real-games-dance.md
+++ b/.changeset/real-games-dance.md
@@ -1,0 +1,7 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server-plugin-response-cache': patch
+'@apollo/server': patch
+---
+
+Require graphql@16.6 as a peer dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15676,7 +15676,7 @@
       "peerDependencies": {
         "@apollo/server": "^4.0.0-alpha.13",
         "@jest/globals": "28.x || 29.x",
-        "graphql": "^16.5.0",
+        "graphql": "^16.6.0",
         "jest": "28.x || 29.x"
       }
     },
@@ -15707,7 +15707,7 @@
       },
       "peerDependencies": {
         "@apollo/server": "^4.0.0-alpha.12",
-        "graphql": "^16.5.0"
+        "graphql": "^16.6.0"
       }
     },
     "packages/server": {
@@ -15745,7 +15745,7 @@
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "graphql": "^16.5.0"
+        "graphql": "^16.6.0"
       }
     },
     "packages/server/node_modules/lru-cache": {

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@apollo/server": "^4.0.0-alpha.13",
     "@jest/globals": "28.x || 29.x",
-    "graphql": "^16.5.0",
+    "graphql": "^16.6.0",
     "jest": "28.x || 29.x"
   },
   "volta": {

--- a/packages/plugin-response-cache/package.json
+++ b/packages/plugin-response-cache/package.json
@@ -34,6 +34,6 @@
   },
   "peerDependencies": {
     "@apollo/server": "^4.0.0-alpha.12",
-    "graphql": "^16.5.0"
+    "graphql": "^16.6.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -111,7 +111,7 @@
     "whatwg-mimetype": "^3.0.0"
   },
   "peerDependencies": {
-    "graphql": "^16.5.0"
+    "graphql": "^16.6.0"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
Might as well require the latest and greatest when bumping our major version.

Fixes #6070.
