### PR TITLE
🏷️ [apollo-server-plugin-base]: Let `GraphQLRequestListener` `Promise<void>` also return `void`

### DIFF
--- a/packages/apollo-server-plugin-base/src/index.ts
+++ b/packages/apollo-server-plugin-base/src/index.ts
@@ -108,23 +108,23 @@ export interface GraphQLRequestListener<
 > extends AnyFunctionMap {
   didResolveSource?(
     requestContext: GraphQLRequestContextDidResolveSource<TContext>,
-  ): Promise<void>;
+  ): Promise<void> | void;
 
   parsingDidStart?(
     requestContext: GraphQLRequestContextParsingDidStart<TContext>,
-  ): Promise<GraphQLRequestListenerParsingDidEnd | void>;
+  ): Promise<GraphQLRequestListenerParsingDidEnd | void> | void;
 
   validationDidStart?(
     requestContext: GraphQLRequestContextValidationDidStart<TContext>,
-  ): Promise<GraphQLRequestListenerValidationDidEnd | void>;
+  ): Promise<GraphQLRequestListenerValidationDidEnd | void> | void;
 
   didResolveOperation?(
     requestContext: GraphQLRequestContextDidResolveOperation<TContext>,
-  ): Promise<void>;
+  ): Promise<void> | void;
 
   didEncounterErrors?(
     requestContext: GraphQLRequestContextDidEncounterErrors<TContext>,
-  ): Promise<void>;
+  ): Promise<void> | void;
 
   // If this hook is defined, it is invoked immediately before GraphQL execution
   // would take place. If its return value resolves to a non-null
@@ -137,11 +137,11 @@ export interface GraphQLRequestListener<
 
   executionDidStart?(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
-  ): Promise<GraphQLRequestExecutionListener | void>;
+  ): Promise<GraphQLRequestExecutionListener | void> | void;
 
   willSendResponse?(
     requestContext: GraphQLRequestContextWillSendResponse<TContext>,
-  ): Promise<void>;
+  ): Promise<void> | void;
 }
 
 export interface GraphQLRequestExecutionListener<


### PR DESCRIPTION
When creating Apollo Server plugins, I see patterns like 
```ts
  return Promise.resolve({
    willSendResponse: (requestContext): Promise<void> => {
      if (!locationDataMutableState.shouldSetCookie) {
        return Promise.resolve();
      }
return Promise.resolve();
```
.

I would rather write
```ts
  return {
    willSendResponse: async (requestContext): Promise<void> => {
      if (!locationDataMutableState.shouldSetCookie) {
        return;
      }
      return;
```
but eslint's `require-await` rule requires `async` functions to have an `await` in them.  I could simply disable the lint for these functions, but upon further reflection I realized that it doesn't really make sense to _require_ a `Promise<void>` and not just a `void`.

This commit allows any method that can return a `Promise<void>` to also return a `void` so we can write code like

```ts
    willSendResponse: (requestContext): void => {
      if (!locationDataMutableState.shouldSetCookie) {
        return;
      }
      return;
    }
```

Note: if you're `await`ing the return value of these this couldn't possibly cause any change in behavior.  However, if you are relying on `.then` you will need to check if it's a `Promise` or not.

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
