### PR TITLE
cache control plugin: set `cache-control: no-store` by default

### DIFF
--- a/.changeset/forty-beds-cough.md
+++ b/.changeset/forty-beds-cough.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server': patch
+---
+
+The cache control plugin sets `cache-control: no-store` for uncacheable responses. Pass `calculateHttpHeaders: 'if-cacheable'` to the cache control plugin to restore AS3 behavior.

--- a/docs/source/api/plugin/cache-control.mdx
+++ b/docs/source/api/plugin/cache-control.mdx
@@ -91,11 +91,11 @@ This option was popular in Apollo Server 2 as a workaround for the problem solve
 
 ###### `calculateHttpHeaders`
 
-`boolean`
+`boolean | 'if-cacheable'`
 </td>
 <td>
 
-By default, the cache control plugin sets the `cache-control` HTTP response header to `max-age=MAXAGE, public` or `max-age=MAXAGE, private` if the request is cacheable. If you specify `calculateHttpHeaders: false`, it will not set this header. The `requestContext.overallCachePolicy` field will still be calculated, and the [response cache plugin](../../performance/caching/#caching-with-responsecacheplugin-advanced) will still work.
+By default, the cache control plugin sets the `cache-control` HTTP response header to `max-age=MAXAGE, public` or `max-age=MAXAGE, private` if the request is cacheable, and to `no-store` if the request is not cacheable. If you specify `calculateHttpHeaders: false`, it will not set this header. If you specify `calculateHttpHeaders: 'if-cacheable'`, it will only set the header if the request is cacheable. (A response is cacheable if its overall cache policy has a non-zero `maxAge`, and the body is a single result rather than an incremental delivery response, and the body contains no errors.) Setting this option does not prevent the `requestContext.overallCachePolicy` field from being calculated, nor does it prevent the [response cache plugin](../../performance/caching/#caching-with-responsecacheplugin-advanced) from working.
 
 </td>
 </tr>

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -1345,6 +1345,33 @@ In Apollo Server 4, if your server _hasn't_ set up draining and it receives an o
 
 If you are using the `startStandaloneServer` function, your server drains automatically. If you are using `expressMiddleware` or another `http.Server`-based web server, you can add draining using the  [`ApolloServerPluginDrainHttpServer` plugin](./api/plugin/drain-http-server/#using-the-plugin).
 
+### Cache control plugin sets `cache-control` header for uncached requests
+
+The cache control plugin is installed by default. It does two things: it calculates `requestContext.overallCachePolicy` based on static and dynamic hints, and it sets the `Cache-Control` response HTTP header.
+
+In Apollo Server 3, the cache control plugin only sets the `Cache-Control` header when the response is cacheable.
+
+In Apollo Server 4, the cache control plugin also sets the `Cache-Control` header (to the value `no-store`) when the response is not cacheable.
+
+To restore the behavior from Apollo Server 3, you can install the cache control plugin and set `calculateHttpHeaders: 'if-cacheable'`:
+
+<MultiCodeBlock>
+
+```ts
+import { ApolloServer } from '@apollo/server';
+import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl';
+
+new ApolloServer({
+  // ...
+  plugins: [
+    ApolloServerPluginCacheControl({ calculateHttpHeaders: 'if-cacheable' }),
+  ],
+});
+```
+
+</MultiCodeBlock>
+
+
 ### `CacheScope` type
 
 In Apollo Server 4,  `CacheScope` is now a union of strings (`PUBLIC` or `PRIVATE`) rather than an enum:

--- a/docs/source/performance/caching.md
+++ b/docs/source/performance/caching.md
@@ -128,7 +128,7 @@ You can decide how to cache a particular field's result _while_ you're resolving
 
 The `cacheControl` object includes a `setCacheHint` method, which you call like so:
 
-```ts 
+```ts
 const resolvers = {
   Query: {
     post: (_, { id }, _, info) => {
@@ -331,13 +331,20 @@ The effect of setting `honorSubgraphCacheControlHeader` to `false` is to have no
 
 ## Caching with a CDN
 
-Whenever Apollo Server sends an operation response that has a non-zero `maxAge`, it includes a `Cache-Control` HTTP header that describes the response's cache policy.
+Whenever Apollo Server sends an operation response that is cacheable, it includes a `Cache-Control` HTTP header that describes the response's cache policy.
 
-The header has this format:
+To be cacheable, all of the following must be true:
+- The operation has a non-zero `maxAge`.
+- The operation has a single response rather than an [incremental delivery](../workflow/requests#incremental-delivery-experimental) response.
+- There are no errors in the response.
+
+When the response is cacheable, the header has this format:
 
 ```
 Cache-Control: max-age=60, private
 ```
+
+When the response is not cacheable, the header has the value `Cache-Control: no-store`.
 
 If you run Apollo Server behind a CDN or another caching proxy, you can configure it to use this header's value to cache responses appropriately. See your CDN's documentation for details (for example, here's the [documentation for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#expiration-individual-objects)).
 

--- a/packages/plugin-response-cache/src/__tests__/integration.test.ts
+++ b/packages/plugin-response-cache/src/__tests__/integration.test.ts
@@ -282,7 +282,7 @@ describe('Response caching', () => {
       expect(result.body.data.uncached).toBe('value:uncached');
       expectCacheMiss('cached');
       expectCacheMiss('uncached');
-      expect(httpHeader(result, 'cache-control')).toBe(null);
+      expect(httpHeader(result, 'cache-control')).toBe('no-store');
       expect(httpHeader(result, 'age')).toBe(null);
     }
 
@@ -295,7 +295,7 @@ describe('Response caching', () => {
       expect(result.body.data.uncached).toBe('value:uncached');
       expectCacheMiss('cached');
       expectCacheMiss('uncached');
-      expect(httpHeader(result, 'cache-control')).toBe(null);
+      expect(httpHeader(result, 'cache-control')).toBe('no-store');
       expect(httpHeader(result, 'age')).toBe(null);
     }
 


### PR DESCRIPTION
As pointed out in #2605, browsers cache many GET requests by default, so "not cacheable" shouldn't be the same as "don't set a cache-control header". This PR makes the backwards-incompatible change to the cache control plugin to make it always set the cache-control header to something if it is enabled (with calculateHttpHeaders not set to false), perhaps `no-store`. (If some other plugin or error already set the header, it does not override it with `no-store`.)

To restore AS3 behavior:

    ApolloServerPluginCacheControl({ calculateHttpHeaders: 'if-cacheable' })

Fixes #2605.
