### PR TITLE
usage reporting: fix memory leak

### DIFF
--- a/.changeset/tasty-elephants-give.md
+++ b/.changeset/tasty-elephants-give.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Fix a slow memory leak in the usage reporting plugin (#6983).


### PR DESCRIPTION
A data structure in the usage reporting plugin would get a new entry each time the server's schema changed. Old entries would never be deleted, though their values would be shrunk to a minimum size.

It seems that this was not good enough and is producing notable memory leaks for some folks. So let's fix it!

The reason for the old behavior was to be really careful to never write to a report that may have already been taken out of the map and sent. Previously this was accomplished by having the main entry in the map never change. Now this is accomplished by making sure that we never write to the report any later than immediately (and synchronously) after we pull it out of the map.

Fixes #6983.
