### PR TITLE
Add INTROSPECTION_DISABLED error enum, set it on validation errors

### DIFF
--- a/.changeset/lovely-terms-compare.md
+++ b/.changeset/lovely-terms-compare.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server': patch
+---
+
+Add additional extension to introspection validation errors

--- a/.changeset/lovely-terms-compare.md
+++ b/.changeset/lovely-terms-compare.md
@@ -3,4 +3,4 @@
 '@apollo/server': patch
 ---
 
-Add additional extension to introspection validation errors
+Errors resulting from an attempt to use introspection when it is not enabled now have an additional `validationErrorCode: 'INTROSPECTION_DISABLED'` extension; this value is part of a new enum `ApolloServerValidationErrorCode` exported from `@apollo/server/errors`.

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -73,6 +73,10 @@ import type {
   GatewayInterface,
   GatewaySchemaLoadOrUpdateCallback,
 } from '@apollo/server-gateway-interface';
+import {
+  ApolloServerErrorCode,
+  ApolloServerValidationErrorCode,
+} from '@apollo/server/errors';
 
 const quietLogger = loglevel.getLogger('quiet');
 function mockLogger() {
@@ -240,6 +244,12 @@ export function defineIntegrationTestSuiteApolloServerTests(
           expect(introspectionResult.errors[0].message).toMatch(
             /introspection/,
           );
+          expect(introspectionResult.errors[0].extensions?.code).toEqual(
+            ApolloServerErrorCode.GRAPHQL_VALIDATION_FAILED,
+          );
+          expect(
+            introspectionResult.errors[0].extensions.validationErrorCode,
+          ).toEqual(ApolloServerValidationErrorCode.INTROSPECTION_DISABLED);
           expect(formatError.mock.calls.length).toEqual(
             introspectionResult.errors.length,
           );
@@ -248,6 +258,9 @@ export function defineIntegrationTestSuiteApolloServerTests(
           expect(result.data).toBeUndefined();
           expect(result.errors).toBeDefined();
           expect(result.errors[0].message).toMatch(/Not allowed/);
+          expect(result.errors[0].extensions?.code).toEqual(
+            ApolloServerErrorCode.GRAPHQL_VALIDATION_FAILED,
+          );
           expect(formatError.mock.calls.length).toEqual(
             introspectionResult.errors.length + result.errors.length,
           );
@@ -281,7 +294,10 @@ export function defineIntegrationTestSuiteApolloServerTests(
           expect(result.errors).toBeDefined();
           expect(result.errors.length).toEqual(1);
           expect(result.errors[0].extensions.code).toEqual(
-            'GRAPHQL_VALIDATION_FAILED',
+            ApolloServerErrorCode.GRAPHQL_VALIDATION_FAILED,
+          );
+          expect(result.errors[0].extensions.validationErrorCode).toEqual(
+            ApolloServerValidationErrorCode.INTROSPECTION_DISABLED,
           );
         });
 

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -30,7 +30,10 @@ import {
   ensureGraphQLError,
   normalizeAndFormatErrors,
 } from './errorNormalize.js';
-import { ApolloServerErrorCode } from './errors/index.js';
+import {
+  ApolloServerErrorCode,
+  ApolloServerValidationErrorCode,
+} from './errors/index.js';
 import type {
   ApolloServerPlugin,
   BaseContext,
@@ -76,7 +79,13 @@ const NoIntrospection: ValidationRule = (context: ValidationContext) => ({
       context.reportError(
         new GraphQLError(
           'GraphQL introspection is not allowed by Apollo Server, but the query contained __schema or __type. To enable introspection, pass introspection: true to ApolloServer in production',
-          { nodes: [node] },
+          {
+            nodes: [node],
+            extensions: {
+              validationErrorCode:
+                ApolloServerValidationErrorCode.INTROSPECTION_DISABLED,
+            },
+          },
         ),
       );
     }

--- a/packages/server/src/errors/index.ts
+++ b/packages/server/src/errors/index.ts
@@ -11,6 +11,10 @@ export enum ApolloServerErrorCode {
   BAD_REQUEST = 'BAD_REQUEST',
 }
 
+export enum ApolloServerValidationErrorCode {
+  INTROSPECTION_DISABLED = 'INTROSPECTION_DISABLED',
+}
+
 /**
  * unwrapResolverError is a useful helper function for `formatError` hooks.
  * Errors thrown in resolvers are wrapped by graphql-js in a GraphQLError that


### PR DESCRIPTION
This PR implements the feature discussed in #7033.

A new error enum `ApolloServerErrorCode.INTROSPECTION_DISABLED` was added and used when creating an introspection validation error.   This will allow better handling of this specific error condition for observers of `didEncounterErrors` events. 

I intend to use this to suppress logging of these errors when someone attempts to point a studio sandbox at my production servers and leaves schema auto-update on. :|

To make this work with the existing code, it is now possible to set any custom GraphQLError.extensions.code when calling `ValidationContext.reportError()`. Someone can now wire through their own validation error codes and see them on the `didEncounterErrors` events instead of them all being masked as GRAPHQL_VALIDATION_FAILED (which is really the root reason for this PR). 



Looking for feedback if you want to use the suspect typescript cast in the `ValidationError` constructor:
```ts
 (graphqlError.extensions?.code as ApolloServerErrorCode) 
```
or change the `GraphQLErrorWithCode` constructor signature to use:
```ts
code: ApolloServerErrorCode | unknown,
```

 