### PR TITLE
Fix Node.js `engines` to require Node v14.16.0

### DIFF
--- a/.changeset/clever-years-think.md
+++ b/.changeset/clever-years-think.md
@@ -1,0 +1,7 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server-plugin-response-cache': patch
+'@apollo/server': patch
+---
+
+Raise minimum `engines` requirement from Node.js v14.0.0 to v14.16.0. This is the minimum version of Node 14 supported by the `engines` requirement of `graphql@16.6.0`.

--- a/.changeset/dull-timers-yawn.md
+++ b/.changeset/dull-timers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Require Node.js v14 rather than v12. This change was intended for v4.0.0 and the documentation already stated this requirement, but was left off of the package.json `engines` field in `@apollo/server` inadvertently.`

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -10,7 +10,7 @@ This tutorial helps you:
 - Run an instance of Apollo Server that lets you execute queries against your schema
 
 This tutorial assumes that you are familiar with the command line and
-JavaScript and have installed a recent Node.js (14+) version. Additionally, for those interested, this tutorial includes an optional section describing how to set up Apollo Server with TypeScript.
+JavaScript and have installed a recent Node.js (v14.16.0+) version. Additionally, for those interested, this tutorial includes an optional section describing how to set up Apollo Server with TypeScript.
 
 ## Step 1: Create a new project
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -339,9 +339,11 @@ Once you've updated your imports, you can remove your project's dependency on `a
 
 ### Node.js
 
-Apollo Server 4 supports Node.js 14 and later. (Apollo Server 3 supports Node.js 12.) This includes all [LTS and Current versions at the time of release](https://nodejs.org/en/about/releases/).
+Apollo Server 4 supports Node.js 14.16.0 and later. (Apollo Server 3 supports Node.js 12.) This includes all [LTS and Current major versions at the time of release](https://nodejs.org/en/about/releases/).
 
 If you're using Node.js 12, upgrade your runtime before upgrading to Apollo Server 4.
+
+(Apollo Server 4 specifically requires v14.16.0 instead of merely v14.0.0, because that is the minimum version of Node.js 14 supported by our minimum supported version of `graphql`, as described in the next section.)
 
 ### `graphql`
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=14",
+    "node": ">=14.16.0",
     "npm": "^8.5.0"
   },
   "devDependencies": {

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=14.16.0"
   },
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",

--- a/packages/plugin-response-cache/package.json
+++ b/packages/plugin-response-cache/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=14.16.0"
   },
   "dependencies": {
     "@apollo/utils.createhash": "^1.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -81,7 +81,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "engines": {
-    "node": ">=12.0"
+    "node": ">=14.16.0"
   },
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",


### PR DESCRIPTION
This makes two kinds of changes:

- Despite documenting that Apollo Server 4 requires Node 14, we inadvertently left the `engines` line in `@apollo/server` at `>= 12`. Fix this to require v14 as intended.
- AS4 requires `graphql@16.6.0`, and the minimum version of Node 14 supported by that version is v14.16.0, so there's no point in pretending we support v14.0.0. So adjust all of our engines lines to require v14.16.0. (We don't bother with the Playground plugin, which we're about to delete.)
