### PR TITLE
Fix v4 regression: gateways should be able to set HTTP response metadata

### DIFF
--- a/.changeset/spicy-mayflies-lick.md
+++ b/.changeset/spicy-mayflies-lick.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server': patch
+---
+
+Fix v4 regression: gateway implementations should be able to set HTTP response headers and the status code.

--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -2655,5 +2655,66 @@ content-type: application/json; charset=utf-8\r
         );
       });
     });
+
+    describe('gateway execution', () => {
+      it('executor can read and write response HTTP headers and status', async () => {
+        const app = await createApp({
+          plugins: [
+            {
+              async requestDidStart({ response }) {
+                response.http.headers.set('header-in', 'send this in');
+                return {
+                  async willSendResponse({ response }) {
+                    response.http.headers.set(
+                      'got-status-from-plugin',
+                      `${response.http.status}`,
+                    );
+                  },
+                };
+              },
+            },
+          ],
+          gateway: {
+            async load() {
+              return {
+                schema,
+                async executor(requestContext) {
+                  const http = requestContext.response?.http!;
+                  http.headers.set(
+                    'header-out',
+                    http.headers.get('header-in') === 'send this in'
+                      ? 'got it'
+                      : 'did not',
+                  );
+                  http.status = 202;
+                  return { data: { testString: 'hi' } };
+                },
+              };
+            },
+            async stop() {},
+            onSchemaLoadOrUpdate(f) {
+              f({ apiSchema: schema, coreSupergraphSdl: '' });
+              return () => {};
+            },
+          },
+        });
+
+        const res = await request(app)
+          .post('/')
+          .send({ query: `{testString}` });
+
+        expect(res.status).toEqual(202);
+        expect(res.headers['header-in']).toEqual('send this in');
+        expect(res.headers['header-out']).toEqual('got it');
+        expect(res.headers['got-status-from-plugin']).toEqual('202');
+        expect(res.body).toMatchInlineSnapshot(`
+          {
+            "data": {
+              "testString": "hi",
+            },
+          }
+        `);
+      });
+    });
   });
 }


### PR DESCRIPTION
The shim layer between AS4 and Gateway (which creates an argument for the Gateway's executor which looks like AS3's GraphQLRequestContext) did not copy changes to response headers or HTTP status back to the real GraphQLRequestContext. This PR makes the shimmed HTTP response object use the real response objects as backing storage.

Fixes #7069.
