### PR TITLE
Remove an edge case where GET requests could be treated as batched

### DIFF
--- a/.changeset/shaggy-taxis-burn.md
+++ b/.changeset/shaggy-taxis-burn.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server': patch
+---
+
+Never interpret `GET` requests as batched. In previous versions of Apollo Server 4, a `GET` request whose body was a JSON array with N elements would be interpreted as a batch of the operation specified in the query string repeated N times. Now we just ignore the body for `GET` requests (like in Apollo Server 3), and never treat them as batched.

--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -620,6 +620,24 @@ export function defineIntegrationTestSuiteHttpServerTests(
         });
       });
 
+      it('GET request with array body is not interpreted as batch', async () => {
+        const app = await createApp({ schema, allowBatchedHttpRequests: true });
+        const res = await request(app)
+          .get('/')
+          .set('apollo-require-preflight', 't')
+          .set('content-type', 'application/json')
+          .query({ query: '{ testString }' })
+          .send('[1, 2]');
+        expect(res.status).toEqual(200);
+        expect(res.body).toMatchInlineSnapshot(`
+          {
+            "data": {
+              "testString": "it works",
+            },
+          }
+        `);
+      });
+
       it('can handle a basic implicit GET request', async () => {
         const app = await createApp();
         const expected = {

--- a/packages/server/src/httpBatching.ts
+++ b/packages/server/src/httpBatching.ts
@@ -71,7 +71,12 @@ export async function runPotentiallyBatchedHttpQuery<
   schemaDerivedData: SchemaDerivedData,
   internals: ApolloServerInternals<TContext>,
 ): Promise<HTTPGraphQLResponse> {
-  if (!Array.isArray(httpGraphQLRequest.body)) {
+  if (
+    !(
+      httpGraphQLRequest.method === 'POST' &&
+      Array.isArray(httpGraphQLRequest.body)
+    )
+  ) {
     return await runHttpQuery(
       server,
       httpGraphQLRequest,


### PR DESCRIPTION
Previously, a `GET` request whose body was a JSON array with N elements would be interpreted as a batch of the operation specified in the query string repeated N times. Now we just ignore the body for `GET` requests and never treat them as batched. This matches the Apollo Server 3 behavior.

(You can try to sneak arrays into Apollo Server 3 GETs by using search parameters like `query[]=`, because AS3 uses the `querystring` npm package instead of the simpler W3C-style `URLSearchParams`. But that won't give you "an array of objects with keys like `query`"; it'll give you "an object with a `query` key whose value is an array", which isn't enough to make it trigger the batch code.)

Note that Apollo Client Web's batched HTTP link explicitly refuses to send batched operations over GET.
