### PR TITLE
Add allowed error message to integration testsuite's malformed JSON test

### DIFF
--- a/.changeset/many-teachers-remain.md
+++ b/.changeset/many-teachers-remain.md
@@ -2,4 +2,4 @@
 '@apollo/server-integration-testsuite': patch
 ---
 
-Add allowed error message to integration testsuite's malformed JSON test
+Recognize malformed JSON error messages from Next.js.

--- a/.changeset/many-teachers-remain.md
+++ b/.changeset/many-teachers-remain.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-integration-testsuite': patch
+---
+
+Add allowed error message to integration testsuite's malformed JSON test

--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -379,8 +379,8 @@ export function defineIntegrationTestSuiteHttpServerTests(
         return req.then((res) => {
           expect(res.status).toEqual(400);
           expect(
-            ['Unexpected token f', 'Bad Request'].some((substring) =>
-              (res.error as HTTPError).text.includes(substring),
+            ['Unexpected token f', 'Bad Request', 'Invalid JSON'].some(
+              (substring) => (res.error as HTTPError).text.includes(substring),
             ),
           ).toBe(true);
         });


### PR DESCRIPTION
I'm currently building a Next.js integration for Apollo Server 4 over [here](https://github.com/apollo-server-integrations/apollo-server-integration-next).

To make sure the integration works properly with Next.js I'm reusing Next.js's [apiResolver](https://github.com/vercel/next.js/blob/canary/packages/next/server/api-utils/node.ts#L426), which handles parsing API route requests. I [managed to make every test](https://github.com/apollo-server-integrations/apollo-server-integration-next/pull/14) in `apollo-server-integrations-testsuite` pass except for one, `throws an error if POST JSON is malformed`. This test checks the error message in the server response when malformed JSON data is sent and matches it to two possible substrings, `Unexpected token f` and `Bad Request`.

Next.js's `apiResolver` uses the [parseBody](https://github.com/vercel/next.js/blob/canary/packages/next/server/api-utils/node.ts#L143) function to parse the request body, which in turn uses [parseJSON](https://github.com/vercel/next.js/blob/canary/packages/next/server/api-utils/node.ts#L126) to parse JSON. In the case of malformed JSON `parseJSON` throws an `ApiError` with the message `Invalid JSON`, which is then returned in the server response. Since it's not possible for me to change the message returned by Next.js I was hoping I could add it to the tests's allowed error messages, making the test pass.
