### PR TITLE
Corrected broken link to RESTDataSource Github

### DIFF
--- a/docs/source/data/data-sources.mdx
+++ b/docs/source/data/data-sources.mdx
@@ -34,7 +34,7 @@ Apollo and the larger community maintain the following open-source implementaton
 
 | Class            | Source    | For Use With          |
 |------------------|-----------|-----------------------|
-| [`RESTDataSource`](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-datasource-rest) | Apollo    | REST APIs ([see below](#restdatasource-reference)) |
+| [`RESTDataSource`](https://github.com/apollographql/datasource-rest) | Apollo    | REST APIs ([see below](#restdatasource-reference)) |
 | [`HTTPDataSource`](https://github.com/StarpTech/apollo-datasource-http)  | Community | HTTP/REST APIs (newer community alternative to `RESTDataSource`) |
 | [`SQLDataSource`](https://github.com/cvburgess/SQLDataSource)  | Community | SQL databases (via [Knex.js](http://knexjs.org/)) |
 | [`MongoDataSource`](https://github.com/GraphQLGuide/apollo-datasource-mongodb/) | Community | MongoDB |


### PR DESCRIPTION
Essentially, the link for RESTDataSource on [the Data Sources page](https://www.apollographql.com/docs/apollo-server/v2/data/data-sources) in the docs was **stale**. I've tracked down [the correct link](https://github.com/apollographql/datasource-rest) and updated the markdown. I hope that helps future visitors!