### PR TITLE
Update usage-reporting-protobuf to have main field

### DIFF
--- a/.changeset/metal-pigs-sleep.md
+++ b/.changeset/metal-pigs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@apollo/usage-reporting-protobuf': patch
+---
+
+Include `main` and `module` fields in package.json for build tools that look for them instead of `exports`.

--- a/packages/usage-reporting-protobuf/package.json
+++ b/packages/usage-reporting-protobuf/package.json
@@ -10,6 +10,8 @@
       "types": "./generated/protobuf.d.ts"
     }
   },
+  "main": "generated/protobuf.cjs",
+  "module": "generated/protobuf.mjs",
   "types": "generated/protobuf.d.ts",
   "scripts": {
     "generate": "rm -rf generated && mkdir generated && npm run pbjs-cjs && npm run pbjs-esm && npm run pbts",


### PR DESCRIPTION
@apollo/usage-reporting-protobuf should define a main/module field in package.json, same as @apollo/server does. The "exports" field doesn't work everywhere yet still (ex. jest, or at least old versions of jest, don't respect it).