### PR TITLE
Backport usage reporting improvements #7101 to AS3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
-## v3.11.0
+## v3.10.4
 
 - `apollo-server-core`: Manage memory more efficiently in the usage reporting plugin by allowing large objects to be garbage collected more quickly. [PR #FIXME](https://github.com/apollographql/apollo-server/pull/FIXME)
 - `apollo-server-core`: The usage reporting plugin now defaults to a 30 second timeout for each attempt to send reports to Apollo Server instead of no timeout; the timeout can be adjusted with the new `requestTimeoutMs` option to `ApolloServerPluginUsageReporting`. (Apollo's servers already enforced a 30 second timeout, so this is unlikely to break any existing use cases.) [PR #FIXME](https://github.com/apollographql/apollo-server/pull/FIXME)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## v3.10.4
 
-- `apollo-server-core`: Manage memory more efficiently in the usage reporting plugin by allowing large objects to be garbage collected more quickly. [PR #FIXME](https://github.com/apollographql/apollo-server/pull/FIXME)
-- `apollo-server-core`: The usage reporting plugin now defaults to a 30 second timeout for each attempt to send reports to Apollo Server instead of no timeout; the timeout can be adjusted with the new `requestTimeoutMs` option to `ApolloServerPluginUsageReporting`. (Apollo's servers already enforced a 30 second timeout, so this is unlikely to break any existing use cases.) [PR #FIXME](https://github.com/apollographql/apollo-server/pull/FIXME)
+- `apollo-server-core`: Manage memory more efficiently in the usage reporting plugin by allowing large objects to be garbage collected more quickly. [PR #7106](https://github.com/apollographql/apollo-server/pull/7106)
+- `apollo-server-core`: The usage reporting plugin now defaults to a 30 second timeout for each attempt to send reports to Apollo Server instead of no timeout; the timeout can be adjusted with the new `requestTimeoutMs` option to `ApolloServerPluginUsageReporting`. (Apollo's servers already enforced a 30 second timeout, so this is unlikely to break any existing use cases.) [PR #7106](https://github.com/apollographql/apollo-server/pull/7106)
 
 ## v3.10.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+## v3.11.0
+
+- `apollo-server-core`: Manage memory more efficiently in the usage reporting plugin by allowing large objects to be garbage collected more quickly. [PR #FIXME](https://github.com/apollographql/apollo-server/pull/FIXME)
+- `apollo-server-core`: The usage reporting plugin now defaults to a 30 second timeout for each attempt to send reports to Apollo Server instead of no timeout; the timeout can be adjusted with the new `requestTimeoutMs` option to `ApolloServerPluginUsageReporting`. (Apollo's servers already enforced a 30 second timeout, so this is unlikely to break any existing use cases.) [PR #FIXME](https://github.com/apollographql/apollo-server/pull/FIXME)
+
 ## v3.10.3
+
 - `apollo-server-core`: Fix memory leak in usage reporting plugin. [Issue #6983](https://github.com/apollographql/apollo-server/issues/6983) [PR #6999](https://github.com/apollographql/apollo-server/[Issue #6983](https://github.com/apollographql/apollo-server/issues/6983)pull/6999)
 
 ## v3.10.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -13091,6 +13091,7 @@
         "jest-runtime": "^28.1.3",
         "jest-snapshot": "^28.1.3",
         "jest-util": "^28.1.3",
+        "node-abort-controller": "^3.0.1",
         "p-limit": "^3.1.0",
         "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
@@ -16497,6 +16498,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -21026,6 +21032,7 @@
         "graphql-tag": "^2.11.0",
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
         "sha.js": "^2.4.11",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -27183,6 +27190,7 @@
         "graphql-tag": "^2.11.0",
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
         "sha.js": "^2.4.11",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -31247,6 +31255,7 @@
         "jest-runtime": "^28.1.3",
         "jest-snapshot": "^28.1.3",
         "jest-util": "^28.1.3",
+        "node-abort-controller": "^3.0.1",
         "p-limit": "^3.1.0",
         "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
@@ -33799,6 +33808,11 @@
           "dev": true
         }
       }
+    },
+    "node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/packages/apollo-server-core/package.json
+++ b/packages/apollo-server-core/package.json
@@ -44,6 +44,7 @@
     "graphql-tag": "^2.11.0",
     "loglevel": "^1.6.8",
     "lru-cache": "^6.0.0",
+    "node-abort-controller": "^3.0.1",
     "sha.js": "^2.4.11",
     "uuid": "^9.0.0",
     "whatwg-mimetype": "^3.0.0"

--- a/packages/apollo-server-core/src/plugin/usageReporting/options.ts
+++ b/packages/apollo-server-core/src/plugin/usageReporting/options.ts
@@ -259,6 +259,12 @@ export interface ApolloServerPluginUsageReportingOptions<TContext> {
    */
   minimumRetryDelayMs?: number;
   /**
+   * Default timeout for each individual attempt to send a report to Apollo.
+   * (This is for each HTTP POST, not for all potential retries.) Defaults to 30
+   * seconds (30000ms).
+   */
+  requestTimeoutMs?: number;
+  /**
    * A logger interface to be used for output and errors.  When not provided
    * it will default to the server's own `logger` implementation and use
    * `console` when that is not available.


### PR DESCRIPTION
We only require Node 12 here but that's still enough for the zlib API change.

We don't bother to add `signal` to the `apollo-server-env` RequestInit. The integration test does show that it works with the default fetcher (`node-fetch` via `apollo-server-env`).
