### PR TITLE
Remove dev dependency on `@graphql-tools/utils`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@graphql-codegen/typescript-operations": "2.5.5",
         "@graphql-tools/mock": "8.7.8",
         "@graphql-tools/schema": "9.0.6",
-        "@graphql-tools/utils": "8.13.1",
         "@josephg/resolvable": "1.0.1",
         "@rollup/plugin-commonjs": "23.0.2",
         "@types/async-retry": "1.4.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@graphql-codegen/typescript-operations": "2.5.5",
     "@graphql-tools/mock": "8.7.8",
     "@graphql-tools/schema": "9.0.6",
-    "@graphql-tools/utils": "8.13.1",
     "@josephg/resolvable": "1.0.1",
     "@rollup/plugin-commonjs": "23.0.2",
     "@types/async-retry": "1.4.5",


### PR DESCRIPTION
Looks like we removed the last direct reference in 30ba0e63f. (It has a major bump today, but why bother evaluating such a Renovate PR if we don't use it?)
