### PR TITLE
Integration testsuite direct dependency on Apollo Server

### DIFF
--- a/.changeset/mighty-points-film.md
+++ b/.changeset/mighty-points-film.md
@@ -1,5 +1,5 @@
 ---
-'@apollo/server-integration-testsuite': patch
+'@apollo/server-integration-testsuite': minor
 ---
 
 Directly depend on Apollo Server rather than as a peer

--- a/.changeset/mighty-points-film.md
+++ b/.changeset/mighty-points-film.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-integration-testsuite': patch
+---
+
+Directly depend on Apollo Server rather than as a peer

--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,7 +12951,7 @@
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
-        "@apollo/server": "^4.0.5",
+        "@apollo/server": "^4.1.0",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",
@@ -12991,7 +12991,7 @@
     },
     "packages/server": {
       "name": "@apollo/server",
-      "version": "4.0.5",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
@@ -13223,7 +13223,7 @@
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
-        "@apollo/server": "^4.0.5",
+        "@apollo/server": "^4.1.0",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,7 +12951,7 @@
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
-        "@apollo/server": "^4.0.5",
+        "@apollo/server": "4.0.5",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",
@@ -13223,7 +13223,7 @@
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
-        "@apollo/server": "^4.0.5",
+        "@apollo/server": "4.0.5",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,6 +12951,7 @@
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
+        "@apollo/server": "^4.0.5",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",
@@ -12967,7 +12968,6 @@
         "node": ">=14.16.0"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.5",
         "@jest/globals": "28.x || 29.x",
         "graphql": "^16.6.0",
         "jest": "28.x || 29.x"
@@ -13223,6 +13223,7 @@
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
+        "@apollo/server": "^4.0.5",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12951,7 +12951,7 @@
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
-        "@apollo/server": "^4.1.0",
+        "@apollo/server": "^4.0.5",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",
@@ -12991,7 +12991,7 @@
     },
     "packages/server": {
       "name": "@apollo/server",
-      "version": "4.1.0",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
@@ -13223,7 +13223,7 @@
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/client": "^3.6.9",
-        "@apollo/server": "^4.1.0",
+        "@apollo/server": "^4.0.5",
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^1.1.0",

--- a/packages/integration-testsuite/README.md
+++ b/packages/integration-testsuite/README.md
@@ -10,7 +10,27 @@ party Express integration.
 
 The version of this package will be published in lockstep with Apollo Server, so
 choose the same version of this package as the version of Apollo Server which
-you intend to support.
+you intend to support. The expected configuration for an integration should
+follow the pattern:
+
+```json
+{
+  "name": "my-server-integration",
+  "devDependencies": {
+    "@apollo/server": "4.1.0",
+    "@apollo/server-integration-testsuite": "4.1.0"
+  },
+  "peerDependencies": {
+    "@apollo/server": "^4.0.0"
+  }
+}
+```
+
+In the example above, the `peerDependencies` allow your configuration to be used
+with the full range of Apollo Server v4 packages. The `devDependencies` which
+your integration is built and tested against should stay up-to-date with the
+latest version of Apollo Server, and the server and testsuite packages should be
+in lockstep with each other.
 
 This package imposes dependency requirements on your project, however it should
 only require they be installed as `devDependencies`:

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",
     "@apollo/client": "^3.6.9",
-    "@apollo/server": "^4.0.5",
+    "@apollo/server": "^4.1.0",
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@apollo/utils.createhash": "^1.1.0",

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",
     "@apollo/client": "^3.6.9",
-    "@apollo/server": "^4.0.5",
+    "@apollo/server": "4.0.5",
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@apollo/utils.createhash": "^1.1.0",

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",
     "@apollo/client": "^3.6.9",
-    "@apollo/server": "^4.1.0",
+    "@apollo/server": "^4.0.5",
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@apollo/utils.createhash": "^1.1.0",

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",
     "@apollo/client": "^3.6.9",
+    "@apollo/server": "^4.0.5",
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "@apollo/utils.createhash": "^1.1.0",
@@ -41,7 +42,6 @@
     "supertest": "^6.2.3"
   },
   "peerDependencies": {
-    "@apollo/server": "^4.0.5",
     "@jest/globals": "28.x || 29.x",
     "graphql": "^16.6.0",
     "jest": "28.x || 29.x"

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -209,12 +209,17 @@ export function defineIntegrationTestSuiteApolloServerTests(
     }
     afterEach(stopServer);
 
-    // This test ensures that consumers of this testsuite are using the lockstep
-    // versioned packages of @apollo/server and
-    // @apollo/server-integration-testsuite. If these versions are out of sync,
-    // this test should fail.
+    // If this test fails, it means your `@apollo/server` and
+    // `@apollo/server-integration-testsuite` versions are out of sync. Please
+    // update both packages to the same version.
     it('lockstep versioning of @apollo/server and @apollo/server-integration-testsuite', async () => {
-      expect((await createServer({ schema })).server).toBeInstanceOf(
+      const server = (await createServer({ schema })).server;
+      if (!(server instanceof ApolloServer)) {
+        throw Error(
+          'Have you installed @apollo/server and @apollo/server-integration-testsuite with non-matching versions?',
+        );
+      }
+      expect(server).toBeInstanceOf(
         ApolloServer,
       );
     });

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -209,6 +209,16 @@ export function defineIntegrationTestSuiteApolloServerTests(
     }
     afterEach(stopServer);
 
+    // This test ensures that consumers of this testsuite are using the lockstep
+    // versioned packages of @apollo/server and
+    // @apollo/server-integration-testsuite. If these versions are out of sync,
+    // this test should fail.
+    it('lockstep versioning of @apollo/server and @apollo/server-integration-testsuite', async () => {
+      expect((await createServer({ schema })).server).toBeInstanceOf(
+        ApolloServer,
+      );
+    });
+
     describe('constructor', () => {
       describe('validation rules', () => {
         it('accepts additional rules', async () => {

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -219,9 +219,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
           'Have you installed @apollo/server and @apollo/server-integration-testsuite with non-matching versions?',
         );
       }
-      expect(server).toBeInstanceOf(
-        ApolloServer,
-      );
+      expect(server).toBeInstanceOf(ApolloServer);
     });
 
     describe('constructor', () => {

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -219,7 +219,6 @@ export function defineIntegrationTestSuiteApolloServerTests(
           'Have you installed @apollo/server and @apollo/server-integration-testsuite with non-matching versions?',
         );
       }
-      expect(server).toBeInstanceOf(ApolloServer);
     });
 
     describe('constructor', () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/server",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Core engine for Apollo GraphQL server",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/server",
-  "version": "4.1.0",
+  "version": "4.0.5",
   "description": "Core engine for Apollo GraphQL server",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,13 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupSlug": "all-minor-patch",
     },
+    // We want the testsuite to explicitly pin the version of @apollo/server
+    // since they are supposed to be in lockstep.
+    {
+      matchPackageNames: ["@apollo/server"],
+      matchPaths: ["packages/integration-testsuite/package.json"],
+      rangeStrategy: "pin",
+    },
     // We need to support Node v14, so we don't allow ourselves to use type definitions
     // that would let us write v16-specific code.
     {


### PR DESCRIPTION
The peer dependency arrangement of testsuite on server was problematic. In one sense, it seems reasonable since we want integration authors to bring their own AS package. However, bumping that peer dependency with every version update is technically a breaking change - and our release tooling (changeset) doesn't provide us a means to workaround the behavior where it major version bumps both packages.

For correctness and compliance with our tooling, a direct dependency addresses both concerns. We've also added an additional test which ensures that the versions match. The test really just validates that there's one install of @apollo/server (by using an instanceof check against the testsuite's ApolloServer constructor and the actual instance provided by the testsuite consumer).

Fixes #7109

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
