### PR TITLE
Provide new requestIsBatched field to gateway compatibility layer

### DIFF
--- a/.changeset/clever-camels-judge.md
+++ b/.changeset/clever-camels-judge.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-gateway-interface': patch
+'@apollo/server': patch
+---
+
+Provide new `GraphQLRequestContext.requestIsBatched` field to gateways, because we did add it in a backport to AS3 and the gateway interface is based on AS3.

--- a/packages/gateway-interface/src/index.ts
+++ b/packages/gateway-interface/src/index.ts
@@ -76,6 +76,9 @@ export interface GatewayGraphQLRequestContext<TContext = Record<string, any>> {
   // runtime before using it anyway, so let's just make everything build by
   // declaring this as `any`.
   readonly overallCachePolicy: any;
+  // This was only added in v3.11/v4.1, so we don't want to declare that it's
+  // required. (In fact, we made it optional in v3.11.1 for this very reason.)
+  readonly requestIsBatched?: boolean;
 }
 
 export interface GatewayGraphQLRequest {

--- a/packages/server/src/utils/makeGatewayGraphQLRequestContext.ts
+++ b/packages/server/src/utils/makeGatewayGraphQLRequestContext.ts
@@ -153,6 +153,7 @@ export function makeGatewayGraphQLRequestContext<TContext extends BaseContext>(
     metrics: as4RequestContext.metrics,
     debug: internals.includeStacktraceInErrorResponses,
     overallCachePolicy: as4RequestContext.overallCachePolicy,
+    requestIsBatched: as4RequestContext.requestIsBatched,
   };
 }
 


### PR DESCRIPTION
This field was added today in v3.11.0 and v4.1.0. That means that if you
installed an older version of Gateway that gets its types from AS3
rather than from `@apollo/server-gateway-interface` it would suddenly
start expecting this field on its GraphQLRequestContext.

We fixed that problem by releasing v3.11.1 which makes the field
optional. But it still seems reasonable to provide it if it's
available... but we keep the field optional in the compatibility
interface so that new Gateway doesn't end up requiring new Server.