### PR TITLE
Make newly-added GraphQLRequestContext.requestIsBatched field optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The version headers in this history reflect the versions of Apollo Server itself
 
 ## vNEXT
 
+## v3.11.1
+- `apollo-server-core`: Follow-up to v3.11.0: make `GraphQLRequestContext.requestIsBatched` optional for better compatibility with older versions of `@apollo/gateway`.
+
 ## v3.11.0
 - ⚠️ **SECURITY**: The cache control plugin no longer sets the `cache-control` HTTP response header if the operation is part of a batched HTTP request. Previously, it would set the header to a value describing the cache policy of only one of the operations in the request, which could lead to data being unintentionally cached by proxies or clients. This bug was introduced in v3.0.0 and this fix restores the behavior of Apollo Server 2. (In Apollo Server 4 (specifically, `@apollo/server@4.1.0` or newer), the features work properly together, setting the header based on the combined cache policy of all operations.) This could theoretically have led to data tagged as uncacheable being cached and potentially served to different users. More details are available at the [security advisory](https://github.com/apollographql/apollo-server/security/advisories/GHSA-8r69-3cvp-wxc3).
 - `apollo-server-core`: New field `GraphQLRequestContext.requestIsBatched` available to plugins.

--- a/packages/apollo-server-types/src/index.ts
+++ b/packages/apollo-server-types/src/index.ts
@@ -176,11 +176,16 @@ export interface GraphQLRequestContext<TContext = Record<string, any>> {
   /**
    * True if this request is part of a potentially multi-operation batch. Note
    * that if this is true, the headers and status code `response.http` will be
-   * be merged together; if two operations set the same header one will arbitrarily
-   * win. (In Apollo Server v4, `response.http` will be shared with the other
-   * operations in the batch.)
+   * be merged together; if two operations set the same header one will
+   * arbitrarily win. (In Apollo Server v4, `response.http` will be shared with
+   * the other operations in the batch.) This boolean is always set by Apollo
+   * Server v3.11.0+/v4.1.0+, but because this type is also part of the
+   * interface between older versions of `@apollo/gateway` and Apollo Server, we
+   * leave it optional here to avoid typechecking issues if the version of
+   * `apollo-server-types` transitively included by `@apollo/gateway` does not
+   * match the version of Apollo Server actually used.
    */
-  readonly requestIsBatched: boolean;
+  readonly requestIsBatched?: boolean;
 }
 
 export type ValidationRule = (context: ValidationContext) => ASTVisitor;


### PR DESCRIPTION
We ran into issues where AS4 + old Gateway + transitively included AS3.11.0 would be surprised that this field wasn't provided. So just make it optional.