### PR TITLE
Add Next.js integration to docs

### DIFF
--- a/docs/source/integrations/integration-index.mdx
+++ b/docs/source/integrations/integration-index.mdx
@@ -18,6 +18,7 @@ The larger community maintains the following open-source integrations for Apollo
 | [AWS Lambda](https://aws.amazon.com/lambda/) | [`@as-integrations/aws-lambda`](https://www.npmjs.com/package/@as-integrations/aws-lambda) |
 | [Fastify](https://fastify.io/) | [`@as-integrations/fastify`](https://www.npmjs.com/package/@as-integrations/fastify) |
 | [Koa](https://koajs.com/) | [`@as-integrations/koa`](https://www.npmjs.com/package/@as-integrations/koa) |
+| [Next.js](https://nextjs.org) | [`@as-integrations/next`](https://www.npmjs.com/package/@as-integrations/next) |
 | [Nuxt](https://v3.nuxtjs.org/) / [h3](https://github.com/unjs/h3) | [`@as-integrations/h3`](https://www.npmjs.com/package/@as-integrations/h3) |
 
 > Apollo does not provide official support for the above community-maintained libraries. We cannot guarantee that community-maintained libraries adhere to best practices or that they will continue to be maintained.


### PR DESCRIPTION
We just released version v1.0.0 of [@as-integrations/next](https://www.npmjs.com/package/@as-integrations/next) so I was hoping we could add the integration to the docs.