### PR TITLE
Fix 'broken' links

### DIFF
--- a/docs/source/api/express-middleware.mdx
+++ b/docs/source/api/express-middleware.mdx
@@ -15,7 +15,7 @@ The `expressMiddleware` function enables you to attach Apollo Server to an Expre
 
 The `expressMiddleware` function expects you to set up HTTP body parsing and CORS headers for your web framework. Specifically, you should install the [`body-parser`](https://www.npmjs.com/package/body-parser) and [`cors`](https://www.npmjs.com/package/cors) packages and use them to set up your Express app, as shown below.
 
-> See [Configuring CORS](../../security/cors#specifying-origins) for guidance on configuring the CORS behavior of your project.
+> See [Configuring CORS](../security/cors#specifying-origins) for guidance on configuring the CORS behavior of your project.
 
 The `expressMiddleware` function accepts two arguments. The first **required** argument is an instance of `ApolloServer` that has been `start`ed:
 

--- a/docs/source/api/plugin/landing-pages.mdx
+++ b/docs/source/api/plugin/landing-pages.mdx
@@ -55,13 +55,13 @@ Available configuration options are listed in each plugin's reference below.
 
 ## Default non-production landing page
 
-In non-production environments, Apollo Server 4's landing page is an embedded version of [Apollo Sandbox](/studio/explorer/sandbox) (served at `http://localhost:4000` by default):
+In non-production environments, Apollo Server 4's landing page is an embedded version of [Apollo Sandbox](/graphos/explorer/sandbox) (served at `http://localhost:4000` by default):
 
 <img class="screenshot" src="../../images/sandbox.jpeg" alt="Apollo Sandbox" />
 
 This landing page is designed for use in local development, where `NODE_ENV` is *not* set to `production`.
 
-[Apollo Sandbox](https://studio.apollographql.com/sandbox) is a special mode of Apollo Studio used for local development, which doesn't require an Apollo account. Sandbox includes the [Apollo Studio Explorer](/studio/explorer/explorer), a powerful web IDE that enables you to build and run operations against your server (or any other reachable server).
+[Apollo Sandbox](https://studio.apollographql.com/sandbox) is a special mode of Apollo Studio used for local development, which doesn't require an Apollo account. Sandbox includes the [Apollo Studio Explorer](/graphos/explorer/explorer), a powerful web IDE that enables you to build and run operations against your server (or any other reachable server).
 ### Options
 
 <table class="field-table">
@@ -177,7 +177,7 @@ If you omit this, the Explorer defaults `includeCookies` to `false` or the curre
 </td>
 <td>
 
-If `true`, the Apollo Server landing page renders an embedded version of [Apollo Sandbox](/studio/explorer/sandbox/) at its GraphQL endpoint URL. This is the default behavior.
+If `true`, the Apollo Server landing page renders an embedded version of [Apollo Sandbox](/graphos/explorer/sandbox/) at its GraphQL endpoint URL. This is the default behavior.
 
 If you set this option to `false`, your server's landing page is a splash page containing a copyable command-line snippet showing how to run operations via `curl` alongside a link to Apollo Sandbox.
 
@@ -194,7 +194,7 @@ The `ApolloServerPluginLandingPageProductionDefault` shows a minimalist landing 
 
 <img class="screenshot" src="../../images/as-landing-page-production.jpg" alt="Apollo Server default landing page" width="350"/>
 
-This landing page is designed for use in production. It provides a copyable command-line snippet showing how to run operations with your server. By default, the only visible reference to Apollo is a footer explaining how to customize the page. You can also configure it to add a link to query your graph with the [Apollo Explorer](https://www.apollographql.com/docs/studio/explorer). You can choose to embed the Apollo Explorer on your endpoint if you pass the `embed` [option](#embed-options).
+This landing page is designed for use in production. It provides a copyable command-line snippet showing how to run operations with your server. By default, the only visible reference to Apollo is a footer explaining how to customize the page. You can also configure it to add a link to query your graph with the [Apollo Explorer](/graphos/explorer/explorer/). You can choose to embed the Apollo Explorer on your endpoint if you pass the `embed` [option](#embed-options).
 
 ### Options
 
@@ -461,7 +461,7 @@ The default value is `dark`.
 
 ## GraphQL Playground landing page
 
-By default, Apollo Server 2 provided a GraphQL Playground landing page. For migration purposes, we've published the [`@apollo/server-plugin-landing-page-graphql-playground`](https://www.npmjs.com/package/@apollo/server-plugin-landing-page-graphql-playground) package, a GraphQL Playground plugin compatible with Apollo Server 4. However, we aren't supporting this plugin with documentation or security updates since the GraphQL Playground project is officially [retired](https://github.com/graphql/graphql-playground/issues/1143) and we do not recommend its continued use. Instead, we recommend migrating to the actively maintained [Apollo Sandbox](/studio/explorer/sandbox) (the default landing page in Apollo Server 4) at your earliest convenience.
+By default, Apollo Server 2 provided a GraphQL Playground landing page. For migration purposes, we've published the [`@apollo/server-plugin-landing-page-graphql-playground`](https://www.npmjs.com/package/@apollo/server-plugin-landing-page-graphql-playground) package, a GraphQL Playground plugin compatible with Apollo Server 4. However, we aren't supporting this plugin with documentation or security updates since the GraphQL Playground project is officially [retired](https://github.com/graphql/graphql-playground/issues/1143) and we do not recommend its continued use. Instead, we recommend migrating to the actively maintained [Apollo Sandbox](/graphos/explorer/sandbox) (the default landing page in Apollo Server 4) at your earliest convenience.
 
 ## Disabling the landing page
 

--- a/docs/source/api/plugin/usage-reporting.mdx
+++ b/docs/source/api/plugin/usage-reporting.mdx
@@ -191,7 +191,7 @@ By default, all requests are included in usage reports.
 </td>
 <td>
 
-Specify this function to provide Apollo Studio with client details for each processed request. Apollo Studio uses this information to [segment metrics by client](/studio/metrics/client-awareness/).
+Specify this function to provide Apollo Studio with client details for each processed request. Apollo Studio uses this information to [segment metrics by client](/graphos/metrics/client-awareness/).
 
 This function is passed a [`GraphQLRequestContext`](https://github.com/apollographql/apollo-server/blob/6b4945935a786d06e7ff904be94c0035fe27aeb1/packages/server/src/externalTypes/graphql.ts#L47) object containing all available information about the request. It should return an object with `clientName` and `clientVersion` fields that identify the associated client.
 

--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -205,7 +205,7 @@ httpServer.listen(PORT, () => {
 
 </ExpansionPanel>
 
-> ⚠️ **Running into an error?** If you're using the `graphql-ws` library, your specified subscription protocol must be consistent across your backend, frontend, and **every other tool** you use (including [Apollo Sandbox](/studio/explorer/additional-features/#subscription-support)). For more information, see [Switching from `subscriptions-transport-ws`](#switching-from-subscriptions-transport-ws).
+> ⚠️ **Running into an error?** If you're using the `graphql-ws` library, your specified subscription protocol must be consistent across your backend, frontend, and **every other tool** you use (including [Apollo Sandbox](/graphos/explorer/additional-features/#subscription-support)). For more information, see [Switching from `subscriptions-transport-ws`](#switching-from-subscriptions-transport-ws).
 
 ## Resolving a subscription
 
@@ -411,7 +411,7 @@ subscription IncrementingNumber {
 }
 ```
 
-> If you don't see the result of your subscription operation you might need to [adjust your Sandbox settings to use the `graphql-ws` protocol](/studio/explorer/additional-features/#subscription-support).
+> If you don't see the result of your subscription operation you might need to [adjust your Sandbox settings to use the `graphql-ws` protocol](/graphos/explorer/additional-features/#subscription-support).
 
 After you start up the server in CodeSandbox, follow the instructions in the browser to test running the `numberIncremented` subscription in Apollo Sandbox. You should see the subscription's value update every second.
 
@@ -611,19 +611,19 @@ If you intend to [switch from `subscriptions-transport-ws` to `graphql-ws`](/apo
 <tr>
 <td>
 
-[Apollo Studio Explorer](/studio/explorer/explorer/)
+[Apollo Studio Explorer](/graphos/explorer/explorer/)
 
 </td>
 
 <td>
 
-[`graphql-ws`](/studio/explorer/additional-features/#subscription-support)
+[`graphql-ws`](/graphos/explorer/additional-features/#subscription-support)
 
 </td>
 
 <td>
 
-[`subscriptions-transport-ws`](/studio/explorer/additional-features/#subscription-support)
+[`subscriptions-transport-ws`](/graphos/explorer/additional-features/#subscription-support)
 
 </td>
 

--- a/docs/source/deployment/heroku.md
+++ b/docs/source/deployment/heroku.md
@@ -123,7 +123,7 @@ Then from the app's detail page, select the **Deploy** tab. On that tab, you can
 
 To enable the production mode of Apollo Server, you need to set the `NODE_ENV` variable to `production`. To ensure you have visibility into your GraphQL performance in Apollo Studio, you'll want to add the `APOLLO_KEY` environment variable to Heroku. For the API key, log in to [Apollo Studio](https://studio.apollographql.com) and navigate to your graph or create a new one.
 
-Under your Heroku app's Settings tab, click **Reveal Config Vars**. Next, set `NODE_ENV` to `production` and [copy your graph API key](/studio/api-keys/#graph-api-keys) from Apollo Studio as the value for `APOLLO_KEY`.
+Under your Heroku app's Settings tab, click **Reveal Config Vars**. Next, set `NODE_ENV` to `production` and [copy your graph API key](/graphos/api-keys/#graph-api-keys) from Apollo Studio as the value for `APOLLO_KEY`.
 
 <img class="screenshot" src="../images/deployment/heroku/config-vars.jpg" alt="Adding config vars" />
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -282,7 +282,7 @@ We're up and running!
 
 ## Step 8: Execute your first query
 
-We can now execute GraphQL queries on our server. To execute our first query, we can use [**Apollo Sandbox**](/studio/explorer/sandbox/).
+We can now execute GraphQL queries on our server. To execute our first query, we can use [**Apollo Sandbox**](/graphos/explorer/sandbox/).
 
 Visit `http://localhost:4000` in your browser, which will open the Apollo Sandbox:
 

--- a/docs/source/monitoring/metrics.mdx
+++ b/docs/source/monitoring/metrics.mdx
@@ -3,19 +3,19 @@ title: Metrics and logging
 description: How to monitor Apollo Server's performance
 ---
 
-Apollo Server integrates seamlessly with [Apollo Studio](/studio) to help you monitor the execution of your GraphQL operations. Apollo Server additionally provides configurable mechanisms for logging each phase of a GraphQL operation.
+Apollo Server integrates seamlessly with [Apollo GraphOS](/graphos/) to help you monitor the execution of your GraphQL operations. Apollo Server additionally provides configurable mechanisms for logging each phase of a GraphQL operation.
 
 > Using Federation? Check out the documentation for [federated tracing](/federation/metrics/).
 
-## Sending metrics to Apollo Studio
+## Sending metrics to GraphOS
 
-[Apollo Studio](/studio/) provides an integrated hub for all of your GraphQL performance data. It [aggregates and displays information](/studio/metrics/usage-reporting/) for your schema, queries, requests, and errors. You can also configure alerts that support [Slack](/studio/notification-setup/#slack) and [Datadog](/studio/metrics/datadog-integration/) integrations.
+[Apollo GraphOS](/graphos/) provides an integrated hub for all of your GraphQL performance data, which you can view in Apollo Studio. Studio [aggregates and displays information](/graphos/metrics/usage-reporting/) for your schema, queries, requests, and errors. You can also configure alerts that support [Slack](/graphos/notifications/notification-setup/#slack) and [Datadog](/graphos/metrics/datadog-integration/) integrations.
 
-### Connecting to Apollo Studio
+### Connecting to GraphOS
 
-To connect Apollo Server to Apollo Studio, first [obtain a graph API key](/studio/metrics/usage-reporting/#pushing-metrics-from-apollo-server). To provide this key to Apollo Server, assign it to the `APOLLO_KEY` environment variable in your server's environment.
+To connect Apollo Server to GraphOS, first [obtain a graph API key](/graphos/api-keys#graph-api-keys). To provide this key to Apollo Server, assign it to the `APOLLO_KEY` environment variable in your server's environment.
 
-Then associate your server instance with a particular graph ID and [graph variant](/studio/org/graphs/#managing-variants) by setting the `APOLLO_GRAPH_REF` environment variable.
+Then associate your server instance with a particular graph ID and [graph variant](/graphos/graphs/overview/#variants) by setting the `APOLLO_GRAPH_REF` environment variable.
 
 You can set environment variable values on the command line as seen below, or with the [`dotenv` npm package](https://www.npmjs.com/package/dotenv) (or similar).
 
@@ -33,7 +33,7 @@ By default, Apollo Server aggregates your traces and sends them in batches to St
 
 ### Identifying distinct clients
 
-Apollo Studio's [client awareness feature](/studio/metrics/client-awareness/) enables you to view metrics for distinct versions
+Apollo Studio's [client awareness feature](/graphos/metrics/client-awareness/) enables you to view metrics for distinct versions
 of your clients. To enable this, your clients need to include some or all of the following identifying information in the headers of GraphQL requests they
 send to Apollo Server:
 

--- a/docs/source/security/cors.mdx
+++ b/docs/source/security/cors.mdx
@@ -62,7 +62,7 @@ If you don't, while your personal computer is on your private network, a script 
 
 #### Federated subgraphs
 
-If you're building a [federated graph](/federation/), we strongly recommend that _all_ of your production subgraph servers _disable_ CORS or limit your subgraph's origins to tools like the [Apollo Studio Explorer](/studio/explorer/embed-explorer/). Most subgraphs should _only_ allow communication from your gateways, and that communication doesn't involve a browser.
+If you're building a [federated graph](/federation/), we strongly recommend that _all_ of your production subgraph servers _disable_ CORS or limit your subgraph's origins to tools like the [Apollo Studio Explorer](/graphos/explorer/embed-explorer/). Most subgraphs should _only_ allow communication from your gateways, and that communication doesn't involve a browser.
 
 For more information, see [Securing your subgraphs](/federation/building-supergraphs/subgraphs-overview#securing-your-subgraphs).
 

--- a/docs/source/workflow/build-run-queries.mdx
+++ b/docs/source/workflow/build-run-queries.mdx
@@ -2,13 +2,13 @@
 title: Build and run queries against Apollo Server
 ---
 
-In non-production environments, Apollo Server 4's landing page is an embedded version of [Apollo Sandbox](/studio/explorer/sandbox) (served at `http://localhost:4000` by default):
+In non-production environments, Apollo Server 4's landing page is an embedded version of [Apollo Sandbox](/graphos/explorer/sandbox) (served at `http://localhost:4000` by default):
 
 <img class="screenshot" src="../images/sandbox.jpeg" alt="Apollo Sandbox" />
 
 > Apollo Server serves a different landing page [in production](#production-vs-non-production).
 
-[Apollo Sandbox](https://studio.apollographql.com/sandbox) is a special mode of Apollo Studio used for local development, which doesn't require an Apollo account. Sandbox includes the [Apollo Studio Explorer](/studio/explorer/explorer), a powerful web IDE that enables you to build and run operations against your server (or any other reachable server).
+[Apollo Sandbox](https://studio.apollographql.com/sandbox) is a special mode of Apollo Studio used for local development, which doesn't require an Apollo account. Sandbox includes the [Apollo Studio Explorer](/graphos/explorer/explorer), a powerful web IDE that enables you to build and run operations against your server (or any other reachable server).
 
 ## Production vs. non-production
 

--- a/docs/source/workflow/generate-types.mdx
+++ b/docs/source/workflow/generate-types.mdx
@@ -3,7 +3,7 @@ title: Generating types from a GraphQL schema
 description: How to ensure your resolvers are type safe
 ---
 
-> 👋 If you haven't set up a TypeScript project using Apollo Server yet, follow our [Getting Started](../../getting-started) guide before continuing.
+> 👋 If you haven't set up a TypeScript project using Apollo Server yet, follow our [Getting Started](../getting-started) guide before continuing.
 
 GraphQL uses a type system to clearly define the available data for each type and field in a [GraphQL schema](../schema/schema). Type generation libraries can take advantage of the strongly-typed nature of a GraphQL schema to automatically generate TypeScript types based on that schema.
 


### PR DESCRIPTION
Almost all of these are handled via redirects, but this gets them out of the broken link report