### PR TITLE
docs: add link to graphql-servicebus-queues

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -583,6 +583,7 @@ The following are community-created `PubSub` libraries for popular event-publish
 - [Google Firebase Realtime Database](https://github.com/swantzter/graphql-firebase-subscriptions)
 - [Azure SignalR Service](https://github.com/aaronpowell/graphql-azure-subscriptions)
 - [Azure ServiceBus](https://github.com/abdomohamed/graphql-azure-servicebus-subscriptions)
+- [Azure Service Bus Queues](https://github.com/photomoose/graphql-servicebus-queues)
 
 If none of these libraries fits your use case, you can also create your own `PubSubEngine` subclass. If you create a new open-source library, click **Edit on GitHub** to let us know about it!
 


### PR DESCRIPTION
Updated docs with link to graphql-servicebus-queues package, which provides an implementation of `PubSubEngine` for Azure Service Bus Queues.