### PR TITLE
Fix v4.2.0 regression in `variables: null` (et al)

### DIFF
--- a/.changeset/red-cats-clap.md
+++ b/.changeset/red-cats-clap.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server': patch
+---
+
+Fix v4.2.0 (#7171) regression where `"operationName": null`, `"variables": null`, and `"extensions": null` in POST bodies were improperly rejected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7914,9 +7914,9 @@
       }
     },
     "node_modules/graphql-http": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.8.0.tgz",
-      "integrity": "sha512-8nZJW5zybaKMa6pPXgZKW2Jy5pescyguhCwaF0eBLCmsErNbwT940ShHSZRTEseplAizXdea3CJEBsHUHYUlCw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.9.0.tgz",
+      "integrity": "sha512-MMwhHK24BRzf/AODYnT7eu3eCFHzoj1LBeB/8j+pFuhk539bnYQLP8Z/ey92PEgAbbL28lml7uZXbbCDYHVM1A==",
       "engines": {
         "node": ">=12"
       },
@@ -13088,7 +13088,7 @@
         "@josephg/resolvable": "^1.0.1",
         "body-parser": "^1.20.0",
         "express": "^4.18.1",
-        "graphql-http": "1.8.0",
+        "graphql-http": "1.9.0",
         "graphql-tag": "^2.12.6",
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
@@ -13364,7 +13364,7 @@
         "@josephg/resolvable": "^1.0.1",
         "body-parser": "^1.20.0",
         "express": "^4.18.1",
-        "graphql-http": "1.8.0",
+        "graphql-http": "1.9.0",
         "graphql-tag": "^2.12.6",
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
@@ -19240,9 +19240,9 @@
       }
     },
     "graphql-http": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.8.0.tgz",
-      "integrity": "sha512-8nZJW5zybaKMa6pPXgZKW2Jy5pescyguhCwaF0eBLCmsErNbwT940ShHSZRTEseplAizXdea3CJEBsHUHYUlCw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.9.0.tgz",
+      "integrity": "sha512-MMwhHK24BRzf/AODYnT7eu3eCFHzoj1LBeB/8j+pFuhk539bnYQLP8Z/ey92PEgAbbL28lml7uZXbbCDYHVM1A==",
       "requires": {}
     },
     "graphql-request": {

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -36,7 +36,7 @@
     "@josephg/resolvable": "^1.0.1",
     "body-parser": "^1.20.0",
     "express": "^4.18.1",
-    "graphql-http": "1.8.0",
+    "graphql-http": "1.9.0",
     "graphql-tag": "^2.12.6",
     "loglevel": "^1.8.0",
     "node-fetch": "^2.6.7",

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -155,6 +155,7 @@ export async function runHttpQuery<TContext extends BaseContext>({
 
       if (
         'extensions' in httpRequest.body &&
+        httpRequest.body.extensions !== null &&
         !isStringRecord(httpRequest.body.extensions)
       ) {
         throw new BadRequestError(
@@ -164,6 +165,7 @@ export async function runHttpQuery<TContext extends BaseContext>({
 
       if (
         'variables' in httpRequest.body &&
+        httpRequest.body.variables !== null &&
         !isStringRecord(httpRequest.body.variables)
       ) {
         throw new BadRequestError(
@@ -173,6 +175,7 @@ export async function runHttpQuery<TContext extends BaseContext>({
 
       if (
         'operationName' in httpRequest.body &&
+        httpRequest.body.operationName !== null &&
         typeof httpRequest.body.operationName !== 'string'
       ) {
         throw new BadRequestError(


### PR DESCRIPTION
In v4.2.0 (#7171) we changed POST handling to be stricter if `operationName`, `variables`, or `extensions` were provided with a surprising data type. This was intended to pass more of the optional recommendations of the GraphQL Over HTTP spec as tested by the graphql-http audit suite. However, we were overzealous and also banned providing these parameters as an explicit `null`, which is documented by the spec as legitimate. (And some clients, such as FIXME, actually send `variables: null` in practice.)

We added explicit tests for this to the `graphql-http` test suite (https://github.com/graphql/graphql-http/pull/28) and this commit allows these `null`s again.

Fixes #7200.