### PR TITLE
remove 'current user settings' on landing page docs

### DIFF
--- a/docs/source/api/plugin/landing-pages.mdx
+++ b/docs/source/api/plugin/landing-pages.mdx
@@ -163,7 +163,7 @@ If `true`, the embedded Apollo Studio Explorer includes cookies in its GraphQL r
 
 The default value is `false`, unless the user changes the setting in the Explorer UI.
 
-If you omit this, the Explorer defaults `includeCookies` to `false` or the current user setting.
+If you omit this, the Explorer defaults `includeCookies` to `false`.
 
 </td>
 </tr>
@@ -331,7 +331,7 @@ You can configure the Explorer embedded on your Apollo Server endpoint with disp
 
 A boolean used to set whether Studio Explorer should include cookies in its GraphQL requests to your server.
 
-If you omit this, the Explorer defaults `includeCookies` to `false` or the current user setting.
+If you omit this, the Explorer defaults `includeCookies` to `false`.
 
 </td>
 </tr>


### PR DESCRIPTION
there is no include cookies toggle exposed to the sandbox user
