### PR TITLE
De-flake `stoppable` tests

### DIFF
--- a/.changeset/fluffy-hats-guess.md
+++ b/.changeset/fluffy-hats-guess.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Refactor the implementation of `ApolloServerPluginDrainHttpServer`'s grace period. This is intended to be a no-op.

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -36,6 +36,7 @@ concat
 contravariance
 contravariantly
 createhash
+culted
 dataloaders
 datasource
 datasources
@@ -174,8 +175,8 @@ subpackage
 subqueries
 sumby
 supergraph
-supergraphs
 Supergraph
+supergraphs
 testful
 testonly
 testsuite

--- a/packages/server/src/__tests__/plugin/drainHttpServer/stoppable.test.ts
+++ b/packages/server/src/__tests__/plugin/drainHttpServer/stoppable.test.ts
@@ -224,7 +224,7 @@ Object.keys(schemes).forEach((schemeName) => {
           gracefully = stopReturn;
         });
 
-      // Wait a while. Stopping should not have happened yet,
+      // Wait a while (number chosen here is arbitrary). Stopping should not have happened yet.
       await a.delay(500);
       expect(closeCalled).toBe(false);
       expect(gracefully).toBeNull();

--- a/packages/server/src/__tests__/plugin/drainHttpServer/stoppable/server.js
+++ b/packages/server/src/__tests__/plugin/drainHttpServer/stoppable/server.js
@@ -1,14 +1,17 @@
+// This server is run by a test in stoppable.test.js. Its HTTP server should
+// only ever get one request. It will respond with a 200 and start writing its
+// body and then start the Stopper process with no hard-destroy grace period. It
+// will finish the request on SIGUSR1.
+
 import http from 'http';
 import { Stopper } from '../../../../../dist/esm/plugin/drainHttpServer/stoppable.js';
 
-const grace = Number(process.argv[2] || Infinity);
 let stopper;
 const server = http.createServer((req, res) => {
-  const delay = parseInt(req.url.slice(1), 10);
   res.writeHead(200);
   res.write('hello');
-  setTimeout(() => res.end('world'), delay);
-  stopper.stop(grace);
+  process.on('SIGUSR1', () => res.end('world'));
+  stopper.stop();
 });
 stopper = new Stopper(server);
 server.listen(0, () => console.log(server.address().port));


### PR DESCRIPTION
We've had a lot of issues where `stoppable` tests are flaky because they depend on measuring the time that something takes and hoping it's relatively close to a particular timeout that's supposed to be "controlling" the observed behavior.

This PR refactors the internal Stoppable object so that instead of taking a millisecond timeout value, it takes a DOM-style AbortSignal. This object is only used by ApolloServerPluginDrainHttpServer; we move the setTimeout from inside Stoppable into that plugin, which now creates an AbortController polyfilled from `node-abort-controller` (like we already are in the usage reporting plugin; note that once we drop Node v14 support we can switch to the built-in implementation).

Now the Stoppable test can control the grace period directly via AbortSignals rather than indirectly based on timeouts. This lets us drop all of the time measurements from the test. There still are some delays but they are just of the form "wait some time and double-check that nothing happened": the worst case scenario here is that a test passes that should fail because the thing would have happened if you'd waited slightly longer, but there shouldn't be any spurious failures.

Fixes #6963.
