### PR TITLE
Two unrelated small cache improvements

### DIFF
--- a/.changeset/fifty-eyes-chew.md
+++ b/.changeset/fifty-eyes-chew.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-plugin-response-cache': minor
+---
+
+If the cache you provide to the `cache` option is created with `PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation` (new in `@apollo/utils.keyvaluecache@2.1.0`), the `fqc:` prefix will not be added to cache keys.

--- a/.changeset/selfish-buckets-mate.md
+++ b/.changeset/selfish-buckets-mate.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+If the cache you provide to the `persistedQueries.cache` option is created with `PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation` (new in `@apollo/utils.keyvaluecache@2.1.0`), the `apq:` prefix will not be added to cache keys. Providing such a cache to `new ApolloServer()` throws an error.

--- a/.changeset/sour-kiwis-eat.md
+++ b/.changeset/sour-kiwis-eat.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+For ease of upgrade from the recommended configuration of Apollo Server v3.9+, you can now pass `new ApolloServer({ cache: 'bounded' })`, which is equivalent to not providing the `cache` option (as a bounded cache is now the default in AS4).

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -353,7 +353,7 @@ Controls whether to allow [Batching Queries](../workflow/requests/#batching) in 
 
 A [`KeyValueCache`](https://www.npmjs.com/package/@apollo/utils.keyvaluecache) which Apollo Server uses for several features, including APQs and full response caching. This cache is also available to Apollo Server's plugins.
 
-The default cache is an [`InMemoryLRUCache`](https://www.npmjs.com/package/@apollo/utils.keyvaluecache) with a default size of roughly 30MiB.
+The default cache is an [`InMemoryLRUCache`](https://www.npmjs.com/package/@apollo/utils.keyvaluecache) with a default size of roughly 30MiB. (For backwards-compatibility with Apollo Server 3, specifying `cache: 'bounded'` also selects this default bounded cache.)
 
 To learn more about configuring Apollo Server's cache, see [Configuring cache backends](../performance/cache-backends).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,32 +234,12 @@
         "node": ">=14"
       }
     },
-    "node_modules/@apollo/utils.keyvaluecache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.1.tgz",
-      "integrity": "sha512-F1v3m2pMXPD3rb2+F79qklBBFtNSWssV+8YJIAI0iLxRxoNdDAzfrBFUseUaBaeen/e5mR54QkeNCiq8EvQ/Eg==",
-      "dependencies": {
-        "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "^7.14.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@apollo/utils.keyvaluecache/node_modules/@apollo/utils.logger": {
+    "node_modules/@apollo/utils.logger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
       "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -13071,7 +13051,7 @@
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0"
       },
       "peerDependencies": {
@@ -13086,12 +13066,24 @@
         "node": ">=14"
       }
     },
-    "packages/gateway-interface/node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+    "packages/gateway-interface/node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/gateway-interface/node_modules/lru-cache": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/integration-testsuite": {
@@ -13105,7 +13097,7 @@
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@josephg/resolvable": "^1.0.1",
         "body-parser": "^1.20.0",
         "express": "^4.18.1",
@@ -13124,13 +13116,33 @@
         "jest": "28.x || 29.x"
       }
     },
+    "packages/integration-testsuite/node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/integration-testsuite/node_modules/lru-cache": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "packages/plugin-response-cache": {
       "name": "@apollo/server-plugin-response-cache",
       "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.createhash": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1"
+        "@apollo/utils.keyvaluecache": "^2.1.0"
       },
       "engines": {
         "node": ">=14.16.0"
@@ -13138,6 +13150,26 @@
       "peerDependencies": {
         "@apollo/server": "^4.0.1",
         "graphql": "^16.6.0"
+      }
+    },
+    "packages/plugin-response-cache/node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/plugin-response-cache/node_modules/lru-cache": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/server": {
@@ -13151,7 +13183,7 @@
         "@apollo/utils.createhash": "^2.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0",
         "@apollo/utils.usagereporting": "^2.0.0",
         "@apollo/utils.withrequired": "^2.0.0",
@@ -13205,18 +13237,22 @@
         "node": ">=14"
       }
     },
-    "packages/server/node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+    "packages/server/node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+      "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.0",
+        "lru-cache": "^7.14.1"
+      },
       "engines": {
         "node": ">=14"
       }
     },
     "packages/server/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
       "engines": {
         "node": ">=12"
       }
@@ -13307,7 +13343,7 @@
         "@apollo/utils.createhash": "^2.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0",
         "@apollo/utils.usagereporting": "^2.0.0",
         "@apollo/utils.withrequired": "^2.0.0",
@@ -13334,15 +13370,19 @@
           "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.0.tgz",
           "integrity": "sha512-RC0twEwwBKbhk/y4B2X4YEciRG1xoKMgiPy5xQqNMd3pG78sR+ybctG/m7c/8+NaaQOS22UPUCBd6yS6WihBIg=="
         },
-        "@apollo/utils.logger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-          "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
+        "@apollo/utils.keyvaluecache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+          "requires": {
+            "@apollo/utils.logger": "^2.0.0",
+            "lru-cache": "^7.14.1"
+          }
         },
         "lru-cache": {
-          "version": "7.13.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-          "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
         },
         "uuid": {
           "version": "9.0.0",
@@ -13356,7 +13396,7 @@
       "requires": {
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.fetcher": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0"
       },
       "dependencies": {
@@ -13365,10 +13405,19 @@
           "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.0.tgz",
           "integrity": "sha512-RC0twEwwBKbhk/y4B2X4YEciRG1xoKMgiPy5xQqNMd3pG78sR+ybctG/m7c/8+NaaQOS22UPUCBd6yS6WihBIg=="
         },
-        "@apollo/utils.logger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-          "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
+        "@apollo/utils.keyvaluecache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+          "requires": {
+            "@apollo/utils.logger": "^2.0.0",
+            "lru-cache": "^7.14.1"
+          }
+        },
+        "lru-cache": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
         }
       }
     },
@@ -13381,7 +13430,7 @@
         "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
         "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.createhash": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
         "@josephg/resolvable": "^1.0.1",
         "body-parser": "^1.20.0",
         "express": "^4.18.1",
@@ -13390,6 +13439,22 @@
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
         "supertest": "^6.2.3"
+      },
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+          "requires": {
+            "@apollo/utils.logger": "^2.0.0",
+            "lru-cache": "^7.14.1"
+          }
+        },
+        "lru-cache": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+        }
       }
     },
     "@apollo/server-plugin-landing-page-graphql-playground": {
@@ -13404,7 +13469,23 @@
       "version": "file:packages/plugin-response-cache",
       "requires": {
         "@apollo/utils.createhash": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.0.1"
+        "@apollo/utils.keyvaluecache": "^2.1.0"
+      },
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
+          "integrity": "sha512-WBNI4H1dGX2fHMk5j4cJo7mlXWn1X6DYCxQ50IvmI7Xv7Y4QKiA5EwbLOCITh9OIZQrVX7L0ASBSgTt6jYx/cg==",
+          "requires": {
+            "@apollo/utils.logger": "^2.0.0",
+            "lru-cache": "^7.14.1"
+          }
+        },
+        "lru-cache": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+        }
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -13433,26 +13514,10 @@
       "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.0.tgz",
       "integrity": "sha512-77CiAM2qDXn0haQYrgX0UgrboQykb+bOHaz5p3KKItMwUZ/EFphzuB2vqHvubneIc9dxJcTx2L7MFDswRw/JAQ=="
     },
-    "@apollo/utils.keyvaluecache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.1.tgz",
-      "integrity": "sha512-F1v3m2pMXPD3rb2+F79qklBBFtNSWssV+8YJIAI0iLxRxoNdDAzfrBFUseUaBaeen/e5mR54QkeNCiq8EvQ/Eg==",
-      "requires": {
-        "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "^7.14.1"
-      },
-      "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-          "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
-        },
-        "lru-cache": {
-          "version": "7.14.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
-        }
-      }
+    "@apollo/utils.logger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",

--- a/packages/gateway-interface/package.json
+++ b/packages/gateway-interface/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.logger": "^2.0.0",
-    "@apollo/utils.keyvaluecache": "^2.0.1",
+    "@apollo/utils.keyvaluecache": "^2.1.0",
     "@apollo/usage-reporting-protobuf": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -30,7 +30,7 @@
     "@apollo/client": "^3.6.9",
     "@apollo/server": "4.2.2",
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
-    "@apollo/utils.keyvaluecache": "^2.0.1",
+    "@apollo/utils.keyvaluecache": "^2.1.0",
     "@apollo/utils.createhash": "^2.0.0",
     "@apollo/usage-reporting-protobuf": "^4.0.0",
     "@josephg/resolvable": "^1.0.1",

--- a/packages/plugin-response-cache/package.json
+++ b/packages/plugin-response-cache/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@apollo/utils.createhash": "^2.0.0",
-    "@apollo/utils.keyvaluecache": "^2.0.1"
+    "@apollo/utils.keyvaluecache": "^2.1.0"
   },
   "peerDependencies": {
     "@apollo/server": "^4.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -90,7 +90,7 @@
     "@apollo/utils.createhash": "^2.0.0",
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.isnodelike": "^2.0.0",
-    "@apollo/utils.keyvaluecache": "^2.0.1",
+    "@apollo/utils.keyvaluecache": "^2.1.0",
     "@apollo/utils.logger": "^2.0.0",
     "@apollo/utils.usagereporting": "^2.0.0",
     "@apollo/utils.withrequired": "^2.0.0",

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -84,7 +84,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   rootValue?: ((parsedQuery: DocumentNode) => unknown) | unknown;
   validationRules?: Array<ValidationRule>;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
-  cache?: KeyValueCache<string>;
+  cache?: KeyValueCache<string> | 'bounded';
   includeStacktraceInErrorResponses?: boolean;
   logger?: Logger;
   allowBatchedHttpRequests?: boolean;

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -202,7 +202,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
   if (schemaDerivedData.documentStore) {
     try {
       requestContext.document = await schemaDerivedData.documentStore.get(
-        queryHash,
+        schemaDerivedData.documentStoreKeyPrefix + queryHash,
       );
     } catch (err: unknown) {
       server.logger.warn(
@@ -271,7 +271,10 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
       // `Promise.resolve` invocation, it seems that the underlying cache store
       // is returning a non-native `Promise` (e.g. Bluebird, etc.).
       Promise.resolve(
-        schemaDerivedData.documentStore.set(queryHash, requestContext.document),
+        schemaDerivedData.documentStore.set(
+          schemaDerivedData.documentStoreKeyPrefix + queryHash,
+          requestContext.document,
+        ),
       ).catch((err) =>
         server.logger.warn(
           'Could not store validated document. ' + err?.message || err,


### PR DESCRIPTION
- Explicitly allow people to pass `cache: 'bounded'`. Non-TS users upgrading from the recommended AS3.9+ configuration could do this by accident. Fixes #7240.

- Upgrade `@apollo/utils.keyvaluecache` so that the new `PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation` feature lets you disable prefixing for the APQ and full response caches. Throw if you try to pass such a cache to `ApolloServer` itself because that cache is designed to be shared across features. Migrate off of PrefixingKeyValueCache for `documentStore` so that its prefixing can't be disabled. Fixes #6742.
