### PR TITLE
Add BatchedSQLDataSource to Apollo Docs

### DIFF
--- a/docs/source/data/fetching-data.mdx
+++ b/docs/source/data/fetching-data.mdx
@@ -219,6 +219,8 @@ Apollo maintains the following open-source data source for Apollo Server 4:
 | [`RESTDataSource`](https://github.com/apollographql/datasource-rest) | [See Fetching Rest](./fetching-rest)|  HTTP/REST APIs |
 
 The community maintains the following open-source data source for Apollo Server 4:
+
+<!-- prettier-ignore -->
 | Class | Source | For Use With |
 | --- | --- | --- |
 | [`BatchedSQLDataSource`](https://github.com/nic-jennings/batched-sql-datasource) | Community | SQL databases (via [Knex.js](http://knexjs.org/)) & Batching (via [DataLoader](https://github.com/graphql/dataloader)) |

--- a/docs/source/data/fetching-data.mdx
+++ b/docs/source/data/fetching-data.mdx
@@ -218,6 +218,11 @@ Apollo maintains the following open-source data source for Apollo Server 4:
 | --- | --- | --- |
 | [`RESTDataSource`](https://github.com/apollographql/datasource-rest) | [See Fetching Rest](./fetching-rest)|  HTTP/REST APIs |
 
+The community maintains the following open-source data source for Apollo Server 4:
+| Class | Source | For Use With |
+| --- | --- | --- |
+| [`BatchedSQLDataSource`](https://github.com/nic-jennings/batched-sql-datasource) | Community | SQL databases (via [Knex.js](http://knexjs.org/)) & Batching (via [DataLoader](https://github.com/graphql/dataloader)) |
+
 ### Legacy data source classes
 
 > ⚠️ **Note**: The community built each data source package below for use with Apollo Server 3. [As shown below](#using-datasource-subclasses), you can still use these packages in Apollo Server 4 with a bit of extra setup.


### PR DESCRIPTION
A pull request to add a new package to the Open-source implementations. This is a typescript first Apollo Server 4 evolution of the SQLDataSource which allows developers to easily add DataLoaders to their Knex.js queries without bloating all the code.

The package can be seen here:
https://www.npmjs.com/package/@nic-jennings/sql-datasource

Github Repository is here:
https://github.com/nic-jennings/batched-sql-datasource

A write-up of the benefits can be seen here (Example was created  before the upgrade to Apollo Server 3):
https://betterprogramming.pub/batching-your-apollo-sql-datasources-is-invaluable-2d264a17df20