### PR TITLE
Docs: Update Create an instance of ApolloServer example in Get Started

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -252,11 +252,15 @@ const server = new ApolloServer({
 //  1. creates an Express app
 //  2. installs your ApolloServer instance as middleware
 //  3. prepares your app to handle incoming requests
-const { url } = await startStandaloneServer(server, {
+startStandaloneServer(server, {
   listen: { port: 4000 },
-});
-
-console.log(`🚀  Server ready at: ${url}`);
+})
+.then(({ url } ) => {
+  console.log(`🚀  Server ready at: ${url}`);
+})
+.catch(err => {
+  console.log(err)
+})
 ```
 
 </MultiCodeBlock>


### PR DESCRIPTION
I've changed the Create an instance of ApolloServer example in the get started section to promise base because the previous example was confusing for beginners.