### PR TITLE
Update `schemaIsSubgraph` to also support non nullable `_Service.sdl`

### DIFF
--- a/.changeset/quiet-pears-float.md
+++ b/.changeset/quiet-pears-float.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Update schemaIsSubgraph to also support non nullable \_Service.sdl

--- a/packages/server/src/__tests__/plugin/schemaIsSubgraph.test.ts
+++ b/packages/server/src/__tests__/plugin/schemaIsSubgraph.test.ts
@@ -1,0 +1,122 @@
+import { schemaIsSubgraph } from '../../plugin/schemaIsSubgraph';
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLNonNull,
+} from 'graphql';
+
+describe('end-to-end', () => {
+  it('returns false when there is no service field', async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'QueryType',
+        fields: {
+          hello: {
+            type: GraphQLString,
+          },
+        },
+      }),
+    });
+
+    expect(schemaIsSubgraph(schema)).toBe(false);
+  });
+
+  it('returns false when the sdl field is a not string', async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'QueryType',
+        fields: {
+          _service: {
+            type: new GraphQLObjectType({
+              name: '_Service',
+              fields: {
+                sdl: {
+                  type: GraphQLInt,
+                },
+              },
+            }),
+          },
+        },
+      }),
+    });
+
+    expect(schemaIsSubgraph(schema)).toBe(false);
+  });
+
+  it('returns false when the sdl field is a scalar', async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'QueryType',
+        fields: {
+          _service: {
+            type: new GraphQLObjectType({
+              name: '_Service',
+              fields: {
+                sdl: {
+                  type: new GraphQLObjectType({
+                    name: 'Scalar',
+                    fields: {
+                      value: {
+                        type: GraphQLString,
+                      },
+                    },
+                  }),
+                },
+              },
+            }),
+          },
+        },
+      }),
+    });
+
+    expect(schemaIsSubgraph(schema)).toBe(false);
+  });
+
+  it('returns true when the sdl field is a string', async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'QueryType',
+        fields: {
+          _service: {
+            type: new GraphQLObjectType({
+              name: '_Service',
+              fields: {
+                sdl: {
+                  type: GraphQLString,
+                },
+              },
+            }),
+          },
+        },
+      }),
+    });
+
+    expect(schemaIsSubgraph(schema)).toBe(true);
+  });
+
+  it('returns true when the sdl field is a non nullable string', async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'QueryType',
+        fields: {
+          _service: {
+            type: new GraphQLObjectType({
+              name: '_Service',
+              fields: {
+                sdl: {
+                  type: new GraphQLNonNull(GraphQLString),
+                },
+              },
+            }),
+          },
+        },
+      }),
+    });
+
+    expect(schemaIsSubgraph(schema)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/plugin/schemaIsSubgraph.test.ts
+++ b/packages/server/src/__tests__/plugin/schemaIsSubgraph.test.ts
@@ -9,7 +9,7 @@ import {
   GraphQLNonNull,
 } from 'graphql';
 
-describe('end-to-end', () => {
+describe('schemaIsSubgraph', () => {
   it('returns false when there is no service field', async () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({

--- a/packages/server/src/plugin/schemaIsSubgraph.ts
+++ b/packages/server/src/plugin/schemaIsSubgraph.ts
@@ -1,4 +1,9 @@
-import { GraphQLSchema, isObjectType, isScalarType } from 'graphql';
+import {
+  GraphQLSchema,
+  isObjectType,
+  isScalarType,
+  isNonNullType,
+} from 'graphql';
 
 // Returns true if it appears that the schema was appears to be of a subgraph
 // (eg, returned from @apollo/subgraph's buildSubgraphSchema). This strategy
@@ -24,7 +29,11 @@ export function schemaIsSubgraph(schema: GraphQLSchema): boolean {
   if (!sdlField) {
     return false;
   }
-  const sdlFieldType = sdlField.type;
+
+  let sdlFieldType = sdlField.type;
+  if (isNonNullType(sdlFieldType)) {
+    sdlFieldType = sdlFieldType.ofType;
+  }
   if (!isScalarType(sdlFieldType)) {
     return false;
   }


### PR DESCRIPTION
Related to https://github.com/apollographql/apollo-federation-subgraph-compatibility/pull/302

We found a discrepancy in how libraries implement the federation specification (`_Service.sdl` is `String` in Federation 1 and is `String` in Federation 2). 
I'm doing this PR mostly to check how easy it would be to support both specs at once, if I understood correctly the code `schemaIsSubgraph` might also be used outside Apollo Server 😊
