### PR TITLE
Add integration test for Rover's introspection command

### DIFF
--- a/.changeset/nine-shoes-train.md
+++ b/.changeset/nine-shoes-train.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-integration-testsuite': patch
+---
+
+Adds an integration test verifying that Rover's introspection query works. This should not break any integration that passes other tests.

--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -1365,6 +1365,25 @@ export function defineIntegrationTestSuiteHttpServerTests(
         });
       });
 
+      it('can handle Rover introspection request', async () => {
+        const app = await createApp();
+        const res = await request(app)
+          .post('/')
+          .set('content-type', 'application/json')
+          .set('user-agent', 'tool/0.0.0')
+          .set('accept', '*/*')
+          .set('accept-encoding', 'gzip, br')
+          .send(
+            String.raw`{
+          "variables": null,
+          "query": "query GraphIntrospectQuery {\n  __schema {\n    queryType {\n      name\n    }\n    mutationType {\n      name\n    }\n    subscriptionType {\n      name\n    }\n    types {\n      ...FullType\n    }\n    directives {\n      name\n      description\n      locations\n      args {\n        ...InputValue\n      }\n    }\n  }\n}\n\nfragment FullType on __Type {\n  kind\n  name\n  description\n  fields(includeDeprecated: true) {\n    name\n    description\n    args {\n      ...InputValue\n    }\n    type {\n      ...TypeRef\n    }\n    isDeprecated\n    deprecationReason\n  }\n  inputFields {\n    ...InputValue\n  }\n  interfaces {\n    ...TypeRef\n  }\n  enumValues(includeDeprecated: true) {\n    name\n    description\n    isDeprecated\n    deprecationReason\n  }\n  possibleTypes {\n    ...TypeRef\n  }\n}\n\nfragment InputValue on __InputValue {\n  name\n  description\n  type {\n    ...TypeRef\n  }\n  defaultValue\n}\n\nfragment TypeRef on __Type {\n  kind\n  name\n  ofType {\n    kind\n    name\n    ofType {\n      kind\n      name\n      ofType {\n        kind\n        name\n        ofType {\n          kind\n          name\n          ofType {\n            kind\n            name\n            ofType {\n              kind\n              name\n              ofType {\n                kind\n                name\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}",
+          "operationName": "GraphIntrospectQuery"
+        }`,
+          );
+        expect(res.status).toEqual(200);
+        expect(res.body.data.__schema.queryType.name).toEqual('QueryType');
+      });
+
       it('does not accept a query AST', async () => {
         const app = await createApp();
         const req = request(app)


### PR DESCRIPTION
We once broke this (by dropping support for `variables: null`). Let's be explicit.

Fixes #7202.
