### PR TITLE
Add queryStringParams to sample event

### DIFF
--- a/docs/source/deployment/lambda.mdx
+++ b/docs/source/deployment/lambda.mdx
@@ -207,7 +207,8 @@ You can store a mock HTTP requests locally by creating a `query.json` file, like
     "content-type": "application/json"
   },
   "requestContext": {},
-  "body": "{\"operationName\": null, \"variables\": null, \"query\": \"{ hello }\"}"
+  "body": "{\"operationName\": null, \"variables\": null, \"query\": \"{ hello }\"}",
+  "queryStringParameters": {}
 }
 ```
 


### PR DESCRIPTION
I was running into an error when trying to use the sample serverless event verbatim. Adding an empty object as query params fixed it for me.

Error:
```{
    "statusCode": 400,
    "body": "Search params not parsable from event"
}
``` 
Serverless version Framework Core: 3.22.0 (local) 3.26.0 (global)

<!--
First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
-->
