### PR TITLE
De-comment GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,8 +3,6 @@ name: 🚀 Feature Request
 about: Have a feature that you think is important? Help us understand it.
 ---
 
-<!--
-
 - Some features can be built as plugins.
 
   We encourage exploring the plugin API prior to opening a feature request:
@@ -34,4 +32,3 @@ about: Have a feature that you think is important? Help us understand it.
   necessitate a specific API design.  We also hope you'll be willing to engage
   in the on-going design discussion prior to opening a pull-request.
 
--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!--
 First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!
 
 Here are some important details to follow:
@@ -32,4 +31,3 @@ Here are some important details to follow:
           pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!
 
 We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
--->


### PR DESCRIPTION
I believe our intention is that people creating issues/PRs delete this
boilerplate text rather than keeping it in the description. However, if
they don't, it's basically invisible because it's interpreted as a
Markdown comment... but it still ends up in the actual merge commit
message if not explicitly deleted. By de-commenting it, it will be more
obvious if it is left in (and we can just delete it in the UI when we
look at the PR).

This is more relevant for PRs than feature request issues but I think
the point still stands.
