### PR TITLE
release-pr workflow: use Node version of project

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,7 +16,7 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           # setup-node knows how to read the `volta.node` field.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          # setup-node knows how to read the `volta.node` field.
+          node-version-file: package.json
       - name: Install Dependencies
         run: npm i
 


### PR DESCRIPTION
Just one fewer place to change when we upgrade Node. Note that right now this changes us from using Node v16 to v18 for release-pr workflows. Supported since v3.5 of the workflow:
https://github.com/actions/setup-node/releases/tag/v3.5.0
