### PR TITLE
Expand on non-nullability of `_Service.sdl` field

### DIFF
--- a/.changeset/quiet-pears-float.md
+++ b/.changeset/quiet-pears-float.md
@@ -2,4 +2,7 @@
 '@apollo/server': patch
 ---
 
-Update schemaIsSubgraph to also support non nullable \_Service.sdl
+The subgraph spec has evolved in Federation v2 such that the type of
+`_Service.sdl` (formerly nullable) is now non-nullable. Apollo Server now
+detects both cases correctly in order to determine whether to install / enable
+the `ApolloServerPluginInlineTrace` plugin.

--- a/.changeset/quiet-pears-float.md
+++ b/.changeset/quiet-pears-float.md
@@ -4,5 +4,7 @@
 
 The subgraph spec has evolved in Federation v2 such that the type of
 `_Service.sdl` (formerly nullable) is now non-nullable. Apollo Server now
-detects both cases correctly in order to determine whether to install / enable
-the `ApolloServerPluginInlineTrace` plugin.
+detects both cases correctly in order to determine whether to:
+1. install / enable the `ApolloServerPluginInlineTrace` plugin
+2. throw on startup if `ApolloServerPluginSchemaReporting` should not be installed
+3. warn when `ApolloServerPluginUsageReporting` is installed and configured with the `__onlyIfSchemaIsNotSubgraph` option

--- a/docs/source/api/plugin/inline-trace.mdx
+++ b/docs/source/api/plugin/inline-trace.mdx
@@ -11,7 +11,7 @@ This article documents the options for the `ApolloServerPluginInlineTrace` plugi
 
 This plugin enables your GraphQL server to include encoded performance and usage traces inside responses. This is primarily designed for use with [Apollo Federation](/federation/metrics/). Federated subgraphs use this plugin and include a trace in the `ftv1` GraphQL response extension if requested to do so by the Apollo gateway. The gateway requests this trace by passing the HTTP header `apollo-federation-include-trace: ftv1`.
 
-Apollo Server installs this plugin by default in all federated subgraphs, with its default configuration. Apollo Server inspects whether or not the schema it is serving includes a field `_Service.sdl: String` to determine if it is a federated subgraph. You typically do not have to install this plugin yourself; you only need to do so if you want to provide non-default configuration.
+Apollo Server installs this plugin by default in all federated subgraphs, with its default configuration. Apollo Server inspects whether or not the schema it is serving includes a field `_Service.sdl: String!` (as well as its former nullable version `_Service.sdl: String`) to determine if it is a federated subgraph. You typically do not have to install this plugin yourself; you only need to do so if you want to provide non-default configuration.
 
 If you want to configure the `ApolloServerPluginInlineTrace` plugin, import it and pass it to your `ApolloServer` constructor's `plugins` array:
 
@@ -34,7 +34,7 @@ const server = new ApolloServer({
 
 </MultiCodeBlock>
 
-If you don't want to use the inline trace plugin even though your schema defines `_Service.sdl: String`, you can explicitly disable it with the `ApolloServerPluginInlineTraceDisabled` plugin:
+If you don't want to use the inline trace plugin even though your schema defines `_Service.sdl: String!`, you can explicitly disable it with the `ApolloServerPluginInlineTraceDisabled` plugin:
 
 <MultiCodeBlock>
 

--- a/docs/source/api/plugin/inline-trace.mdx
+++ b/docs/source/api/plugin/inline-trace.mdx
@@ -11,7 +11,7 @@ This article documents the options for the `ApolloServerPluginInlineTrace` plugi
 
 This plugin enables your GraphQL server to include encoded performance and usage traces inside responses. This is primarily designed for use with [Apollo Federation](/federation/metrics/). Federated subgraphs use this plugin and include a trace in the `ftv1` GraphQL response extension if requested to do so by the Apollo gateway. The gateway requests this trace by passing the HTTP header `apollo-federation-include-trace: ftv1`.
 
-Apollo Server installs this plugin by default in all federated subgraphs, with its default configuration. Apollo Server inspects whether or not the schema it is serving includes a field `_Service.sdl: String!` (as well as its former nullable version `_Service.sdl: String`) to determine if it is a federated subgraph. You typically do not have to install this plugin yourself; you only need to do so if you want to provide non-default configuration.
+Apollo Server installs this plugin by default in all federated subgraphs, with its default configuration. Apollo Server inspects whether or not the schema it is serving includes a field `_Service.sdl: String!` (as well as its former, nullable version from Federation v1: `_Service.sdl: String`) to determine if it is a federated subgraph. You typically do not have to install this plugin yourself; you only need to do so if you want to provide non-default configuration.
 
 If you want to configure the `ApolloServerPluginInlineTrace` plugin, import it and pass it to your `ApolloServer` constructor's `plugins` array:
 


### PR DESCRIPTION
Fed v2 updated the subgraph spec to make `_Service.sdl` non-nullable. We should explain this thoroughly in our docs, test for both cases, and update a relevant recent changelog entry. Follow-up to #7274.

Addresses https://github.com/apollographql/apollo-server/pull/7274#discussion_r1061064648