### PR TITLE
docs: change String type to primitive in TS example

### DIFF
--- a/docs/source/api/express-middleware.mdx
+++ b/docs/source/api/express-middleware.mdx
@@ -107,7 +107,7 @@ import bodyParser from 'body-parser';
 import { typeDefs, resolvers } from './schema';
 
 interface MyContext {
-  token?: String;
+  token?: string;
 }
 
 // Required logic for integrating with Express


### PR DESCRIPTION
Changing the type to a primitive in the TS example.

[`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) is part of the [`@typescript-eslint/recommended`](https://typescript-eslint.io/docs/linting/configs#recommended) plugin.

TS example in the docs use the `String` type, but should probably be using the `string` primitive. 