### PR TITLE
expose ApolloServerOptions interfaces

### DIFF
--- a/.changeset/fluffy-rats-fail.md
+++ b/.changeset/fluffy-rats-fail.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Export intermediate ApolloServerOptions\* types

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -106,7 +106,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
 }
 
-interface ApolloServerOptionsWithGateway<TContext extends BaseContext>
+export interface ApolloServerOptionsWithGateway<TContext extends BaseContext>
   extends ApolloServerOptionsBase<TContext> {
   gateway: GatewayInterface;
   schema?: undefined;
@@ -114,7 +114,7 @@ interface ApolloServerOptionsWithGateway<TContext extends BaseContext>
   resolvers?: undefined;
 }
 
-interface ApolloServerOptionsWithSchema<TContext extends BaseContext>
+export interface ApolloServerOptionsWithSchema<TContext extends BaseContext>
   extends ApolloServerOptionsBase<TContext> {
   schema: GraphQLSchema;
   gateway?: undefined;
@@ -122,7 +122,7 @@ interface ApolloServerOptionsWithSchema<TContext extends BaseContext>
   resolvers?: undefined;
 }
 
-interface ApolloServerOptionsWithTypeDefs<TContext extends BaseContext>
+export interface ApolloServerOptionsWithTypeDefs<TContext extends BaseContext>
   extends ApolloServerOptionsBase<TContext> {
   // These two options are always only passed directly through to
   // makeExecutableSchema. (If you don't want to use makeExecutableSchema, pass

--- a/packages/server/src/externalTypes/index.ts
+++ b/packages/server/src/externalTypes/index.ts
@@ -43,6 +43,10 @@ export type {
   ApolloConfig,
   PersistedQueryOptions,
   CSRFPreventionOptions,
+  ApolloServerOptionsWithSchema,
+  ApolloServerOptionsWithTypeDefs,
+  ApolloServerOptionsWithStaticSchema,
+  ApolloServerOptionsWithGateway,
   ApolloServerOptions,
 } from './constructor.js';
 


### PR DESCRIPTION
Hi there,

I'm developing an in-house graphql framework wrapping around the apollo server. In the framework, I'm trying to create different types (gateway, subgraph or standalone) of apollo server based on some config. Thus the framework need access to all these interfaces.

Thanks for reviewing this PR.

Cheers.