### PR TITLE
Use HeaderMap instead of plain Map for headers

### DIFF
--- a/.changeset/blue-planets-juggle.md
+++ b/.changeset/blue-planets-juggle.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Allow case insensitive lookup on headers. Use HeaderMap instead of plain Map for headers in expressMiddleware.

--- a/packages/server/src/express4/index.ts
+++ b/packages/server/src/express4/index.ts
@@ -7,6 +7,7 @@ import type {
   HTTPGraphQLRequest,
 } from '../externalTypes/index.js';
 import { parse as urlParse } from 'url';
+import { HeaderMap } from '../utils/HeaderMap.js';
 
 export interface ExpressContextFunctionArgument {
   req: express.Request;
@@ -56,7 +57,7 @@ export function expressMiddleware<TContext extends BaseContext>(
       return;
     }
 
-    const headers = new Map<string, string>();
+    const headers = new HeaderMap();
     for (const [key, value] of Object.entries(req.headers)) {
       if (value !== undefined) {
         // Node/Express headers can be an array or a single value. We join


### PR DESCRIPTION
The `expressMiddleware` handler uses a plain `Map` for the headers that results in case sensitive lookup on the headers. This makes the header `Apollo-Query-Plan-Experimental` ineffective when the ApolloServer is used with `expressMiddleware` handler.

Resolves apollographql/federation#2337
