### PR TITLE
Update gateway metrics interface

### DIFF
--- a/.changeset/wicked-walls-jump.md
+++ b/.changeset/wicked-walls-jump.md
@@ -2,4 +2,6 @@
 '@apollo/server-gateway-interface': minor
 ---
 
-Add optional `nonFtv1ErrorPaths` to Gateway metrics data
+Add optional `nonFtv1ErrorPaths` to Gateway metrics data. This change is a prerequisite to:
+* https://github.com/apollographql/federation/pull/2242
+* https://github.com/apollographql/apollo-server/pull/7136

--- a/.changeset/wicked-walls-jump.md
+++ b/.changeset/wicked-walls-jump.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-gateway-interface': minor
+---
+
+Add optional `nonFtv1ErrorPaths` to Gateway metrics data

--- a/packages/gateway-interface/src/index.ts
+++ b/packages/gateway-interface/src/index.ts
@@ -118,7 +118,7 @@ export interface GatewayGraphQLRequestMetrics {
   registeredOperation?: boolean;
   startHrTime?: [number, number];
   queryPlanTrace?: Trace.QueryPlanNode;
-  nonFtv1Errors: NonFtv1ErrorPath[];
+  nonFtv1ErrorPaths?: NonFtv1ErrorPath[];
 }
 
 export interface GatewayCachePolicy extends GatewayCacheHint {

--- a/packages/gateway-interface/src/index.ts
+++ b/packages/gateway-interface/src/index.ts
@@ -1,8 +1,3 @@
-// NOTE: Once Apollo Server 4 is released, move this package into the
-// apollo-server repo. We're placing it in the apollo-utils repo for now to
-// enable us to make non-alpha releases that can be used on the apollo-server
-// version-4 branch.
-
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
 import type {
   DocumentNode,
@@ -109,6 +104,11 @@ export interface GatewayHTTPResponse {
 
 export type GatewaySchemaHash = string & { __fauxpaque: 'SchemaHash' };
 
+export interface NonFtv1ErrorPath {
+  subgraph: string;
+  path: GraphQLError['path'];
+}
+
 export interface GatewayGraphQLRequestMetrics {
   captureTraces?: boolean;
   persistedQueryHit?: boolean;
@@ -118,6 +118,7 @@ export interface GatewayGraphQLRequestMetrics {
   registeredOperation?: boolean;
   startHrTime?: [number, number];
   queryPlanTrace?: Trace.QueryPlanNode;
+  nonFtv1Errors: NonFtv1ErrorPath[];
 }
 
 export interface GatewayCachePolicy extends GatewayCacheHint {


### PR DESCRIPTION
Precursor to:
https://github.com/apollographql/apollo-server/pull/7136
https://github.com/apollographql/federation/pull/2242

This interface needs to be published in order to properly land and publish the required change to gateway, which the Apollo Server change depends on.