### PR TITLE
Pin `node-abort-controller`

### DIFF
--- a/.changeset/sharp-boxes-shave.md
+++ b/.changeset/sharp-boxes-shave.md
@@ -1,0 +1,7 @@
+---
+'@apollo/server': patch
+---
+
+Pin `node-abort-controller` version to avoid breaking change. Apollo Server users can enter a broken state if they update their package-lock.json due to a breaking change in a minor release of the mentioned package.
+
+Ref: https://github.com/southpolesteve/node-abort-controller/issues/39

--- a/package-lock.json
+++ b/package-lock.json
@@ -13605,7 +13605,7 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^7.10.1",
         "negotiator": "^0.6.3",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "3.0.1",
         "node-fetch": "^2.6.7",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -13765,7 +13765,7 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^7.10.1",
         "negotiator": "^0.6.3",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "3.0.1",
         "node-fetch": "^2.6.7",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -106,7 +106,7 @@
     "loglevel": "^1.6.8",
     "lru-cache": "^7.10.1",
     "negotiator": "^0.6.3",
-    "node-abort-controller": "^3.0.1",
+    "node-abort-controller": "3.0.1",
     "node-fetch": "^2.6.7",
     "uuid": "^9.0.0",
     "whatwg-mimetype": "^3.0.0"

--- a/renovate.json5
+++ b/renovate.json5
@@ -59,6 +59,10 @@
       matchSourceUrlPrefixes: ["https://github.com/rollup/"],
       matchUpdateTypes: ["major"],
       groupName: "rollup",
-    }
+    },
+    {
+      "matchPackageNames": ["node-abort-controller"],
+      "allowedVersions": "3.0.1"
+    },
   ]
 }


### PR DESCRIPTION
`node-abort-controller` just released `v3.1.0` with a breaking change that can be pulled in by current Apollo Server users (since the dependency is careted).

We should pin to the previous latest for now and see what comes of https://github.com/southpolesteve/node-abort-controller/issues/39