### PR TITLE
Use new audit IDs from `graphql-http` for filtering acceptable warnings

### DIFF
--- a/.changeset/tricky-camels-grin.md
+++ b/.changeset/tricky-camels-grin.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-integration-testsuite': patch
+---
+
+Update graphql-http to 1.13.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -8147,9 +8147,9 @@
       }
     },
     "node_modules/graphql-http": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.12.0.tgz",
-      "integrity": "sha512-si8S+MRlRBZlRiE3n5KOwTMRVLWjVH1cwD96mw85EA+ZKHLMijzelRntwITv8I4zTNS1w9DIhq3F9Igr32H6KQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.13.0.tgz",
+      "integrity": "sha512-3Ia3ql9k+i/GvjNucwRdqdbumLeyJ8Zame4IhniMy/974t+Dy2mDnF08fOCKwXJwd3ErmzhYS/ZyvcXiX4v8wg==",
       "engines": {
         "node": ">=12"
       },
@@ -13507,7 +13507,7 @@
         "@josephg/resolvable": "^1.0.1",
         "body-parser": "^1.20.0",
         "express": "^4.18.1",
-        "graphql-http": "1.12.0",
+        "graphql-http": "1.13.0",
         "graphql-tag": "^2.12.6",
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
@@ -13840,7 +13840,7 @@
         "@josephg/resolvable": "^1.0.1",
         "body-parser": "^1.20.0",
         "express": "^4.18.1",
-        "graphql-http": "1.12.0",
+        "graphql-http": "1.13.0",
         "graphql-tag": "^2.12.6",
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
@@ -19979,9 +19979,9 @@
       }
     },
     "graphql-http": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.12.0.tgz",
-      "integrity": "sha512-si8S+MRlRBZlRiE3n5KOwTMRVLWjVH1cwD96mw85EA+ZKHLMijzelRntwITv8I4zTNS1w9DIhq3F9Igr32H6KQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.13.0.tgz",
+      "integrity": "sha512-3Ia3ql9k+i/GvjNucwRdqdbumLeyJ8Zame4IhniMy/974t+Dy2mDnF08fOCKwXJwd3ErmzhYS/ZyvcXiX4v8wg==",
       "requires": {}
     },
     "graphql-request": {

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -36,7 +36,7 @@
     "@josephg/resolvable": "^1.0.1",
     "body-parser": "^1.20.0",
     "express": "^4.18.1",
-    "graphql-http": "1.12.0",
+    "graphql-http": "1.13.0",
     "graphql-tag": "^2.12.6",
     "loglevel": "^1.8.0",
     "node-fetch": "^2.6.7",

--- a/packages/integration-testsuite/src/httpSpecTests.ts
+++ b/packages/integration-testsuite/src/httpSpecTests.ts
@@ -59,7 +59,7 @@ export function defineIntegrationTestSuiteHttpSpecTests(
         // for a long time, and in fact a major reason these are merely SHOULDs
         // in the spec is so that AS can pass without backwards-incompatible
         // changes here. So we ignore these particular SHOULD failures.
-        const warning400InsteadOf200Ids = [
+        const expectedWarning400InsteadOf200Ids = [
           '3715',
           '9FE0',
           '9FE1',
@@ -84,7 +84,7 @@ export function defineIntegrationTestSuiteHttpSpecTests(
         ];
 
         if (
-          warning400InsteadOf200Ids.includes(audit.id) &&
+          expectedWarning400InsteadOf200Ids.includes(audit.id) &&
           result.response.status === 400
         ) {
           return;

--- a/packages/integration-testsuite/src/httpSpecTests.ts
+++ b/packages/integration-testsuite/src/httpSpecTests.ts
@@ -59,10 +59,32 @@ export function defineIntegrationTestSuiteHttpSpecTests(
         // for a long time, and in fact a major reason these are merely SHOULDs
         // in the spec is so that AS can pass without backwards-incompatible
         // changes here. So we ignore these particular SHOULD failures.
+        const warning400InsteadOf200Ids = [
+          '3715',
+          '9FE0',
+          '9FE1',
+          '9FE2',
+          '9FE3',
+          'FB90',
+          'FB91',
+          'FB92',
+          'FB93',
+          'F050',
+          'F051',
+          'F052',
+          'F053',
+          '3680',
+          '3681',
+          '3682',
+          '3683',
+          'D477',
+          'F5AF',
+          '572B',
+          'FDE2',
+        ];
+
         if (
-          audit.name.startsWith('SHOULD use 200 status code') &&
-          audit.name.endsWith('when accepting application/json') &&
-          result.reason === 'Response status code is not 200' &&
+          warning400InsteadOf200Ids.includes(audit.id) &&
           result.response.status === 400
         ) {
           return;


### PR DESCRIPTION
@enisdenjo kindly implemented an off-the-cuff feature request that I made via https://github.com/graphql/graphql-http/pull/49. Now we can filter our expected audit warnings in an explicit and stable way.