### PR TITLE
Show cookie toggle for embedded landing pages

### DIFF
--- a/.changeset/quick-teachers-tan.md
+++ b/.changeset/quick-teachers-tan.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+Show "Include Cookies" toggle in Embedded Sandbox landing page.

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -51,7 +51,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       </script>
       <script>
         var endpointUrl = window.location.href;
-        var embeddedExplorerConfig = {"includeCookies":true,"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"embed":{"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"},"persistExplorerState":true},"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"includeCookies":true,"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"embed":{"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"},"persistExplorerState":true},"graphRef":"graph@current","displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true};
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"includeCookies":true,"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"embed":{"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"},"persistExplorerState":true},"graphRef":"graph@current","displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true,"hideCookieToggle":false};
         new window.EmbeddedExplorer({
           ...embeddedExplorerConfig,
           endpointUrl,
@@ -89,7 +89,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       </script>
       <script>
         var endpointUrl = window.location.href;
-        var embeddedExplorerConfig = {"includeCookies":false,"embed":true,"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"includeCookies":false,"embed":true,"graphRef":"graph@current","displayOptions":{}},"persistExplorerState":false};
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"includeCookies":false,"embed":true,"graphRef":"graph@current","displayOptions":{}},"persistExplorerState":false,"hideCookieToggle":false};
         new window.EmbeddedExplorer({
           ...embeddedExplorerConfig,
           endpointUrl,

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -45,8 +45,8 @@ describe('Landing Page Config HTML', () => {
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
           initialEndpoint,
-          includeCookies: true,
-          initialState: {"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"}},
+          initialState: {"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"includeCookies":true},
+          hideCookieToggle: false,
         });
       </script>
     `);
@@ -82,8 +82,8 @@ describe('Landing Page Config HTML', () => {
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
           initialEndpoint,
-          includeCookies: false,
-          initialState: {},
+          initialState: {"includeCookies":false},
+          hideCookieToggle: false,
         });
       </script>
     `);

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -32,6 +32,7 @@ export const getEmbeddedExplorerHTML = (
       document?: string;
       variables?: Record<string, any>;
       headers?: Record<string, string>;
+      includeCookies?: boolean;
       displayOptions: {
         docsPanelState?: 'open' | 'closed'; // default to 'open',
         showHeadersAndEnvVars?: boolean; // default to `false`
@@ -116,11 +117,11 @@ id="embeddableSandbox"
   new window.EmbeddedSandbox({
     target: '#embeddableSandbox',
     initialEndpoint,
-    includeCookies: ${config.includeCookies ?? 'false'},
     initialState: ${getConfigStringForHtml({
       document: config.document ?? undefined,
       variables: config.variables ?? undefined,
       headers: config.headers ?? undefined,
+      includeCookies: config.includeCookies ?? undefined,
     })},
     hideCookieToggle: false,
   });

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -32,7 +32,6 @@ export const getEmbeddedExplorerHTML = (
       document?: string;
       variables?: Record<string, any>;
       headers?: Record<string, string>;
-      includeCookies?: boolean;
       displayOptions: {
         docsPanelState?: 'open' | 'closed'; // default to 'open',
         showHeadersAndEnvVars?: boolean; // default to `false`

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -42,7 +42,7 @@ export const getEmbeddedExplorerHTML = (
 
     endpointUrl: string;
 
-    includeCookies?: boolean; // defaults to 'false'
+    hideCookieToggle?: boolean; // defaults to 'true'
   }
   const productionLandingPageConfigOrDefault = {
     displayOptions: {},
@@ -61,6 +61,7 @@ export const getEmbeddedExplorerHTML = (
       },
       persistExplorerState:
         productionLandingPageConfigOrDefault.persistExplorerState,
+      hideCookieToggle: false,
     };
 
   return `
@@ -121,6 +122,7 @@ id="embeddableSandbox"
       variables: config.variables ?? undefined,
       headers: config.headers ?? undefined,
     })},
+    hideCookieToggle: false,
   });
 </script>
 `;

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -52,7 +52,7 @@ export const getEmbeddedExplorerHTML = (
   };
   const embeddedExplorerParams: Omit<EmbeddableExplorerOptions, 'endpointUrl'> =
     {
-      ...config,
+      graphRef: config.graphRef,
       target: '#embeddableExplorer',
       initialState: {
         ...config,


### PR DESCRIPTION
[JIRA](https://apollographql.atlassian.net/browse/NEBULA-2011)
[Related embed PR](https://github.com/apollographql/embeddable-explorer/pull/215)

This code relies on several other PRs to be approved/merged, so I will keep it as a draft until it is ready.

## Context
Users are getting confused because the embedded sandbox doesn't show the `includeCookies` toggle. This toggle should be visible for AS4 users when they are in embedded sandbox.

## What Changed
This adjusts the way the getEmbeddedHTML helpers use the landing page config options. These options should stay the same and the user shouldn't experience any changes to how they need to configure their Apollo Server configuration.

Instead, we use the `includeCookies` value as an initial value for the cookie toggle in explorer, pass it to `initialState`, and turn off a `hideCookieToggle` flag to expose this value to users in explorer.

## How to test

Use codesandbox link below