### PR TITLE
Update custom scalar docs

### DIFF
--- a/docs/source/schema/custom-scalars.mdx
+++ b/docs/source/schema/custom-scalars.mdx
@@ -45,11 +45,17 @@ import { GraphQLScalarType, Kind } from 'graphql';
 const dateScalar = new GraphQLScalarType({
   name: 'Date',
   description: 'Date custom scalar type',
-  serialize(value: Date) {
-    return value.getTime(); // Convert outgoing Date to integer for JSON
+  serialize(value) {
+    if (value instanceof Date) {
+      return value.getTime(); // Convert outgoing Date to integer for JSON
+    }
+    throw Error('GraphQL Date Scalar serializer expected a `Date` object');
   },
-  parseValue(value: number) {
-    return new Date(value); // Convert incoming integer to Date
+  parseValue(value) {
+    if (typeof value === 'number') {
+      return new Date(value); // Convert incoming integer to Date
+    }
+    throw new Error('GraphQL Date Scalar parser expected a `number`');
   },
   parseLiteral(ast) {
     if (ast.kind === Kind.INT) {


### PR DESCRIPTION
Fixes #7351

The values passed by `serialize` and `parseValue` are of `unknown` type, so we can't assert otherwise in the signature.