### PR TITLE
Add conditional to workflow so it doesn't run on forks

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: github.repository == 'apollographql/apollo-server'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Our release GH action currently runs in forks as well. This is made particularly obvious by the fact that the action itself opens a PR which references a bunch of other PRs (so we get additional noise per fork on all of our closed PRs).
Ref: https://github.com/SimenB/apollo-server/pull/298#issuecomment-1404237690

This conditional prevents the action from running anywhere but this repo. 