### PR TITLE
Update context doc

### DIFF
--- a/docs/source/data/context.mdx
+++ b/docs/source/data/context.mdx
@@ -163,7 +163,7 @@ Built-in and [custom plugins](../integrations/plugins/#the-anatomy-of-a-plugin) 
 
 ```ts
 interface MyContext {
-  token: String
+  token: string
 }
 
 const server = new ApolloServer<MyContext>({


### PR DESCRIPTION
This pr fixes a typo in which .graphql `String` syntax was used in a typescript file to define a typescript `string` type
