### PR TITLE
doc: Add Cloudflare Workers to the integration list

### DIFF
--- a/docs/source/shared/integration-table.mdx
+++ b/docs/source/shared/integration-table.mdx
@@ -6,3 +6,4 @@
 | [Koa](https://koajs.com/) | [`@as-integrations/koa`](https://www.npmjs.com/package/@as-integrations/koa) |
 | [Next.js](https://nextjs.org) | [`@as-integrations/next`](https://www.npmjs.com/package/@as-integrations/next) |
 | [Nuxt](https://v3.nuxtjs.org/) / [h3](https://github.com/unjs/h3) | [`@as-integrations/h3`](https://www.npmjs.com/package/@as-integrations/h3) |
+| [Cloudflare Workers](https://workers.cloudflare.com/) | [`@as-integrations/cloudflare-workers`](https://www.npmjs.com/package/@as-integrations/cloudflare-workers) |


### PR DESCRIPTION
The Cloudflare Workers integration released in NPM. Therefore, I think we should add these package to the documentation.