### PR TITLE
[docs] Add docs on how to set a REST timeout

### DIFF
--- a/docs/source/data/fetching-rest.mdx
+++ b/docs/source/data/fetching-rest.mdx
@@ -386,16 +386,19 @@ class MoviesAPI extends RESTDataSource {
 ```
 
 ## Setting fetch options
-The second parameter to each of the REST methods is the request options object. This object includes some of the common options you might typically pass to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax), including `method`, `headers`, `body`, and `signal`. If you are looking for other advanced options that you cannot find in the Apollo docs, you can set them here and refer to your Fetch API docs.
+The second parameter passed to each REST method is an object containing request options. These include options commonly passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax), including `method`, `headers`, `body`, and `signal`.
+
+> If you're looking for other advanced options that aren't covered in the Apollo docs, you can set them here and refer to your Fetch API docs.
 
 ```
 this.get('/movies/1', options);
 ```
 
 ### Setting timeouts
-To set a `fetch` timeout, you need to provide an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) via the `signal` option which will allow you to abort the request with custom logic.
+To set a `fetch` timeout, provide an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) via the `signal` option, which enables you to abort the request with custom logic.
 
-Here is an example of a simple timeout after a fixed time for every request:
+Here's an example of a simple timeout after a fixed time for every request:
+
 ```
 this.get('/movies/1', { signal: AbortSignal.timeout(myTimeoutMilliseconds) });
 ```

--- a/docs/source/data/fetching-rest.mdx
+++ b/docs/source/data/fetching-rest.mdx
@@ -246,7 +246,7 @@ class MoviesAPI extends RESTDataSource {
 
 </MultiCodeBlock>
 
-### Requests specifying TTL
+### Specifying cache TTL
 
 > 📣 **New in Apollo Server 4**: Apollo Server no longer automatically provides its cache to data sources. [See here for more details](../migration/#datasources).
 
@@ -383,6 +383,20 @@ class MoviesAPI extends RESTDataSource {
     );
   }
 }
+```
+
+## Setting fetch options
+When you make a call to one of the REST methods, the second parameter has some predefined TypeScript types provided by `@apollo/datasource-rest`, but ultimately it is the same `options` object that is passed to your [fetch implementation](https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax). If you are looking for other advanced options that you can not find in the Apollo docs, you can set them here and refer to your Fetch API docs.
+
+```
+this.get('/movies/1', options);
+```
+
+### Setting timeouts
+To set a timeout with a fetch implementation you need to set the `signal` option to a [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which will allow you to abort the request with custom logic.
+
+```
+this.get('/movies/1', {signal: AbortSignal.timeout(myTimeoutMilliseconds)});
 ```
 
 ## Intercepting fetches

--- a/docs/source/data/fetching-rest.mdx
+++ b/docs/source/data/fetching-rest.mdx
@@ -386,18 +386,18 @@ class MoviesAPI extends RESTDataSource {
 ```
 
 ## Setting fetch options
-When you make a call to one of the REST methods, the second parameter has some predefined TypeScript types provided by `@apollo/datasource-rest`, but ultimately it is the same `options` object that is passed to your [fetch implementation](https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax). If you are looking for other advanced options that you can not find in the Apollo docs, you can set them here and refer to your Fetch API docs.
+The second parameter to each of the REST methods is the request options object. This object includes some of the common options you might typically pass to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#syntax), including `method`, `headers`, `body`, and `signal`. If you are looking for other advanced options that you cannot find in the Apollo docs, you can set them here and refer to your Fetch API docs.
 
 ```
 this.get('/movies/1', options);
 ```
 
 ### Setting timeouts
-To set a timeout with a fetch implementation you need to set the `signal` option to an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which will allow you to abort the request with custom logic.
+To set a `fetch` timeout, you need to provide an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) via the `signal` option which will allow you to abort the request with custom logic.
 
 Here is an example of a simple timeout after a fixed time for every request:
 ```
-this.get('/movies/1', {signal: AbortSignal.timeout(myTimeoutMilliseconds)});
+this.get('/movies/1', { signal: AbortSignal.timeout(myTimeoutMilliseconds) });
 ```
 
 ## Intercepting fetches

--- a/docs/source/data/fetching-rest.mdx
+++ b/docs/source/data/fetching-rest.mdx
@@ -393,8 +393,9 @@ this.get('/movies/1', options);
 ```
 
 ### Setting timeouts
-To set a timeout with a fetch implementation you need to set the `signal` option to a [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which will allow you to abort the request with custom logic.
+To set a timeout with a fetch implementation you need to set the `signal` option to an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) which will allow you to abort the request with custom logic.
 
+Here is an example of a simple timeout after a fixed time for every request:
 ```
 this.get('/movies/1', {signal: AbortSignal.timeout(myTimeoutMilliseconds)});
 ```


### PR DESCRIPTION
The docs for `@apollo/datasource-rest` are missing info about how to set a timeout. While this feature is not directly handled by the Apollo package and instead is really information about how to use the `fetch()` API, we can add this common use case here and link off to MDN for more info.