### PR TITLE
Update protobuf

### DIFF
--- a/.changeset/violet-olives-doubt.md
+++ b/.changeset/violet-olives-doubt.md
@@ -1,0 +1,5 @@
+---
+'@apollo/usage-reporting-protobuf': minor
+---
+
+Update protobuf which includes updates for supporting (notably) ConditionNode in the gateway

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -19,6 +19,7 @@ dictionaries:
 useGitignore: true
 ignorePaths:
   - '**/generated/**'
+  - 'packages/usage-reporting-protobuf/src/reports.proto'
   - '**/*.sketch'
   - '**/*.svg'
   - cspell.yaml

--- a/packages/server/src/__tests__/plugin/usageReporting/plugin.test.ts
+++ b/packages/server/src/__tests__/plugin/usageReporting/plugin.test.ts
@@ -447,8 +447,6 @@ describe('sendHeaders makeHTTPRequestHeaders helper', () => {
   function makeTestHTTP(): Trace.HTTP {
     return new Trace.HTTP({
       method: Trace.HTTP.Method.UNKNOWN,
-      host: null,
-      path: null,
     });
   }
 

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -425,15 +425,6 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
               Trace.HTTP.Method[
                 http.method as keyof typeof Trace.HTTP.Method
               ] || Trace.HTTP.Method.UNKNOWN,
-            // Host and path are not used anywhere on the backend, so let's not bother
-            // trying to parse request.url to get them, which is a potential
-            // source of bugs because integrations have different behavior here.
-            // On Node's HTTP module, request.url only includes the path
-            // (see https://nodejs.org/api/http.html#http_message_url)
-            // The same is true on Lambda (where we pass event.path)
-            // But on environments like Cloudflare we do get a complete URL.
-            host: null,
-            path: null,
           });
 
           if (options.sendHeaders) {

--- a/packages/server/src/plugin/usageReporting/stats.ts
+++ b/packages/server/src/plugin/usageReporting/stats.ts
@@ -35,6 +35,10 @@ export class SizeEstimator {
   bytes = 0;
 }
 export class OurReport implements Required<IReport> {
+  // Apollo Server includes each operation either as aggregated stats or as a
+  // trace, but not both. Other reporting agents such as Apollo Router include
+  // all operations in stats (even those that are sent as traces), and they set
+  // this flag to true.
   tracesPreAggregated = false;
 
   constructor(readonly header: ReportHeader) {}

--- a/packages/server/src/plugin/usageReporting/stats.ts
+++ b/packages/server/src/plugin/usageReporting/stats.ts
@@ -35,6 +35,8 @@ export class SizeEstimator {
   bytes = 0;
 }
 export class OurReport implements Required<IReport> {
+  tracesPreAggregated = false;
+
   constructor(readonly header: ReportHeader) {}
   readonly tracesPerQuery: Record<string, OurTracesAndStats> =
     Object.create(null);

--- a/packages/usage-reporting-protobuf/generated/protobuf.cjs
+++ b/packages/usage-reporting-protobuf/generated/protobuf.cjs
@@ -19,6 +19,7 @@ $root.Trace = (function() {
      * @property {google.protobuf.ITimestamp|null} [endTime] Trace endTime
      * @property {number|null} [durationNs] Trace durationNs
      * @property {Trace.INode|null} [root] Trace root
+     * @property {boolean|null} [isIncomplete] Trace isIncomplete
      * @property {string|null} [signature] Trace signature
      * @property {string|null} [unexecutedOperationBody] Trace unexecutedOperationBody
      * @property {string|null} [unexecutedOperationName] Trace unexecutedOperationName
@@ -82,6 +83,14 @@ $root.Trace = (function() {
      * @instance
      */
     Trace.prototype.root = null;
+
+    /**
+     * Trace isIncomplete.
+     * @member {boolean} isIncomplete
+     * @memberof Trace
+     * @instance
+     */
+    Trace.prototype.isIncomplete = false;
 
     /**
      * Trace signature.
@@ -265,6 +274,8 @@ $root.Trace = (function() {
             writer.uint32(/* id 28, wireType 2 =*/226).string(message.unexecutedOperationName);
         if (message.fieldExecutionWeight != null && Object.hasOwnProperty.call(message, "fieldExecutionWeight"))
             writer.uint32(/* id 31, wireType 1 =*/249).double(message.fieldExecutionWeight);
+        if (message.isIncomplete != null && Object.hasOwnProperty.call(message, "isIncomplete"))
+            writer.uint32(/* id 33, wireType 0 =*/264).bool(message.isIncomplete);
         return writer;
     };
 
@@ -310,6 +321,9 @@ $root.Trace = (function() {
                 break;
             case 14:
                 message.root = $root.Trace.Node.decode(reader, reader.uint32());
+                break;
+            case 33:
+                message.isIncomplete = reader.bool();
                 break;
             case 19:
                 message.signature = reader.string();
@@ -409,6 +423,9 @@ $root.Trace = (function() {
             if (error)
                 return "root." + error;
         }
+        if (message.isIncomplete != null && message.hasOwnProperty("isIncomplete"))
+            if (typeof message.isIncomplete !== "boolean")
+                return "isIncomplete: boolean expected";
         if (message.signature != null && message.hasOwnProperty("signature"))
             if (!$util.isString(message.signature))
                 return "signature: string expected";
@@ -498,6 +515,7 @@ $root.Trace = (function() {
             object.unexecutedOperationBody = "";
             object.unexecutedOperationName = "";
             object.fieldExecutionWeight = 0;
+            object.isIncomplete = false;
         }
         if (message.endTime != null && message.hasOwnProperty("endTime"))
             object.endTime = $root.google.protobuf.Timestamp.toObject(message.endTime, options);
@@ -540,6 +558,8 @@ $root.Trace = (function() {
             object.unexecutedOperationName = message.unexecutedOperationName;
         if (message.fieldExecutionWeight != null && message.hasOwnProperty("fieldExecutionWeight"))
             object.fieldExecutionWeight = options.json && !isFinite(message.fieldExecutionWeight) ? String(message.fieldExecutionWeight) : message.fieldExecutionWeight;
+        if (message.isIncomplete != null && message.hasOwnProperty("isIncomplete"))
+            object.isIncomplete = message.isIncomplete;
         return object;
     };
 
@@ -1232,13 +1252,9 @@ $root.Trace = (function() {
          * @memberof Trace
          * @interface IHTTP
          * @property {Trace.HTTP.Method|null} [method] HTTP method
-         * @property {string|null} [host] HTTP host
-         * @property {string|null} [path] HTTP path
          * @property {Object.<string,Trace.HTTP.IValues>|null} [requestHeaders] HTTP requestHeaders
          * @property {Object.<string,Trace.HTTP.IValues>|null} [responseHeaders] HTTP responseHeaders
          * @property {number|null} [statusCode] HTTP statusCode
-         * @property {boolean|null} [secure] HTTP secure
-         * @property {string|null} [protocol] HTTP protocol
          */
 
         /**
@@ -1267,22 +1283,6 @@ $root.Trace = (function() {
         HTTP.prototype.method = 0;
 
         /**
-         * HTTP host.
-         * @member {string} host
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.host = "";
-
-        /**
-         * HTTP path.
-         * @member {string} path
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.path = "";
-
-        /**
          * HTTP requestHeaders.
          * @member {Object.<string,Trace.HTTP.IValues>} requestHeaders
          * @memberof Trace.HTTP
@@ -1305,22 +1305,6 @@ $root.Trace = (function() {
          * @instance
          */
         HTTP.prototype.statusCode = 0;
-
-        /**
-         * HTTP secure.
-         * @member {boolean} secure
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.secure = false;
-
-        /**
-         * HTTP protocol.
-         * @member {string} protocol
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.protocol = "";
 
         /**
          * Creates a new HTTP instance using the specified properties.
@@ -1348,10 +1332,6 @@ $root.Trace = (function() {
                 writer = $Writer.create();
             if (message.method != null && Object.hasOwnProperty.call(message, "method"))
                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.method);
-            if (message.host != null && Object.hasOwnProperty.call(message, "host"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.host);
-            if (message.path != null && Object.hasOwnProperty.call(message, "path"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.path);
             if (message.requestHeaders != null && Object.hasOwnProperty.call(message, "requestHeaders"))
                 for (var keys = Object.keys(message.requestHeaders), i = 0; i < keys.length; ++i) {
                     writer.uint32(/* id 4, wireType 2 =*/34).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
@@ -1364,10 +1344,6 @@ $root.Trace = (function() {
                 }
             if (message.statusCode != null && Object.hasOwnProperty.call(message, "statusCode"))
                 writer.uint32(/* id 6, wireType 0 =*/48).uint32(message.statusCode);
-            if (message.secure != null && Object.hasOwnProperty.call(message, "secure"))
-                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.secure);
-            if (message.protocol != null && Object.hasOwnProperty.call(message, "protocol"))
-                writer.uint32(/* id 9, wireType 2 =*/74).string(message.protocol);
             return writer;
         };
 
@@ -1405,12 +1381,6 @@ $root.Trace = (function() {
                 case 1:
                     message.method = reader.int32();
                     break;
-                case 2:
-                    message.host = reader.string();
-                    break;
-                case 3:
-                    message.path = reader.string();
-                    break;
                 case 4:
                     reader.skip().pos++;
                     if (message.requestHeaders === $util.emptyObject)
@@ -1429,12 +1399,6 @@ $root.Trace = (function() {
                     break;
                 case 6:
                     message.statusCode = reader.uint32();
-                    break;
-                case 8:
-                    message.secure = reader.bool();
-                    break;
-                case 9:
-                    message.protocol = reader.string();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -1487,12 +1451,6 @@ $root.Trace = (function() {
                 case 9:
                     break;
                 }
-            if (message.host != null && message.hasOwnProperty("host"))
-                if (!$util.isString(message.host))
-                    return "host: string expected";
-            if (message.path != null && message.hasOwnProperty("path"))
-                if (!$util.isString(message.path))
-                    return "path: string expected";
             if (message.requestHeaders != null && message.hasOwnProperty("requestHeaders")) {
                 if (!$util.isObject(message.requestHeaders))
                     return "requestHeaders: object expected";
@@ -1516,12 +1474,6 @@ $root.Trace = (function() {
             if (message.statusCode != null && message.hasOwnProperty("statusCode"))
                 if (!$util.isInteger(message.statusCode))
                     return "statusCode: integer expected";
-            if (message.secure != null && message.hasOwnProperty("secure"))
-                if (typeof message.secure !== "boolean")
-                    return "secure: boolean expected";
-            if (message.protocol != null && message.hasOwnProperty("protocol"))
-                if (!$util.isString(message.protocol))
-                    return "protocol: string expected";
             return null;
         };
 
@@ -1544,18 +1496,10 @@ $root.Trace = (function() {
             }
             if (options.defaults) {
                 object.method = options.enums === String ? "UNKNOWN" : 0;
-                object.host = "";
-                object.path = "";
                 object.statusCode = 0;
-                object.secure = false;
-                object.protocol = "";
             }
             if (message.method != null && message.hasOwnProperty("method"))
                 object.method = options.enums === String ? $root.Trace.HTTP.Method[message.method] : message.method;
-            if (message.host != null && message.hasOwnProperty("host"))
-                object.host = message.host;
-            if (message.path != null && message.hasOwnProperty("path"))
-                object.path = message.path;
             var keys2;
             if (message.requestHeaders && (keys2 = Object.keys(message.requestHeaders)).length) {
                 object.requestHeaders = {};
@@ -1569,10 +1513,6 @@ $root.Trace = (function() {
             }
             if (message.statusCode != null && message.hasOwnProperty("statusCode"))
                 object.statusCode = message.statusCode;
-            if (message.secure != null && message.hasOwnProperty("secure"))
-                object.secure = message.secure;
-            if (message.protocol != null && message.hasOwnProperty("protocol"))
-                object.protocol = message.protocol;
             return object;
         };
 
@@ -2414,6 +2354,8 @@ $root.Trace = (function() {
          * @property {Trace.QueryPlanNode.IParallelNode|null} [parallel] QueryPlanNode parallel
          * @property {Trace.QueryPlanNode.IFetchNode|null} [fetch] QueryPlanNode fetch
          * @property {Trace.QueryPlanNode.IFlattenNode|null} [flatten] QueryPlanNode flatten
+         * @property {Trace.QueryPlanNode.IDeferNode|null} [defer] QueryPlanNode defer
+         * @property {Trace.QueryPlanNode.IConditionNode|null} [condition] QueryPlanNode condition
          */
 
         /**
@@ -2463,17 +2405,33 @@ $root.Trace = (function() {
          */
         QueryPlanNode.prototype.flatten = null;
 
+        /**
+         * QueryPlanNode defer.
+         * @member {Trace.QueryPlanNode.IDeferNode|null|undefined} defer
+         * @memberof Trace.QueryPlanNode
+         * @instance
+         */
+        QueryPlanNode.prototype.defer = null;
+
+        /**
+         * QueryPlanNode condition.
+         * @member {Trace.QueryPlanNode.IConditionNode|null|undefined} condition
+         * @memberof Trace.QueryPlanNode
+         * @instance
+         */
+        QueryPlanNode.prototype.condition = null;
+
         // OneOf field names bound to virtual getters and setters
         var $oneOfFields;
 
         /**
          * QueryPlanNode node.
-         * @member {"sequence"|"parallel"|"fetch"|"flatten"|undefined} node
+         * @member {"sequence"|"parallel"|"fetch"|"flatten"|"defer"|"condition"|undefined} node
          * @memberof Trace.QueryPlanNode
          * @instance
          */
         Object.defineProperty(QueryPlanNode.prototype, "node", {
-            get: $util.oneOfGetter($oneOfFields = ["sequence", "parallel", "fetch", "flatten"]),
+            get: $util.oneOfGetter($oneOfFields = ["sequence", "parallel", "fetch", "flatten", "defer", "condition"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -2509,6 +2467,10 @@ $root.Trace = (function() {
                 $root.Trace.QueryPlanNode.FetchNode.encode(message.fetch, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
             if (message.flatten != null && Object.hasOwnProperty.call(message, "flatten"))
                 $root.Trace.QueryPlanNode.FlattenNode.encode(message.flatten, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            if (message.defer != null && Object.hasOwnProperty.call(message, "defer"))
+                $root.Trace.QueryPlanNode.DeferNode.encode(message.defer, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+            if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                $root.Trace.QueryPlanNode.ConditionNode.encode(message.condition, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
             return writer;
         };
 
@@ -2554,6 +2516,12 @@ $root.Trace = (function() {
                     break;
                 case 4:
                     message.flatten = $root.Trace.QueryPlanNode.FlattenNode.decode(reader, reader.uint32());
+                    break;
+                case 5:
+                    message.defer = $root.Trace.QueryPlanNode.DeferNode.decode(reader, reader.uint32());
+                    break;
+                case 6:
+                    message.condition = $root.Trace.QueryPlanNode.ConditionNode.decode(reader, reader.uint32());
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -2629,6 +2597,26 @@ $root.Trace = (function() {
                         return "flatten." + error;
                 }
             }
+            if (message.defer != null && message.hasOwnProperty("defer")) {
+                if (properties.node === 1)
+                    return "node: multiple values";
+                properties.node = 1;
+                {
+                    var error = $root.Trace.QueryPlanNode.DeferNode.verify(message.defer);
+                    if (error)
+                        return "defer." + error;
+                }
+            }
+            if (message.condition != null && message.hasOwnProperty("condition")) {
+                if (properties.node === 1)
+                    return "node: multiple values";
+                properties.node = 1;
+                {
+                    var error = $root.Trace.QueryPlanNode.ConditionNode.verify(message.condition);
+                    if (error)
+                        return "condition." + error;
+                }
+            }
             return null;
         };
 
@@ -2664,6 +2652,16 @@ $root.Trace = (function() {
                 object.flatten = $root.Trace.QueryPlanNode.FlattenNode.toObject(message.flatten, options);
                 if (options.oneofs)
                     object.node = "flatten";
+            }
+            if (message.defer != null && message.hasOwnProperty("defer")) {
+                object.defer = $root.Trace.QueryPlanNode.DeferNode.toObject(message.defer, options);
+                if (options.oneofs)
+                    object.node = "defer";
+            }
+            if (message.condition != null && message.hasOwnProperty("condition")) {
+                object.condition = $root.Trace.QueryPlanNode.ConditionNode.toObject(message.condition, options);
+                if (options.oneofs)
+                    object.node = "condition";
             }
             return object;
         };
@@ -3529,6 +3527,1051 @@ $root.Trace = (function() {
             };
 
             return FlattenNode;
+        })();
+
+        QueryPlanNode.DeferNode = (function() {
+
+            /**
+             * Properties of a DeferNode.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferNode
+             * @property {Trace.QueryPlanNode.IDeferNodePrimary|null} [primary] DeferNode primary
+             * @property {Array.<Trace.QueryPlanNode.IDeferredNode>|null} [deferred] DeferNode deferred
+             */
+
+            /**
+             * Constructs a new DeferNode.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferNode.
+             * @implements IDeferNode
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferNode=} [properties] Properties to set
+             */
+            function DeferNode(properties) {
+                this.deferred = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferNode primary.
+             * @member {Trace.QueryPlanNode.IDeferNodePrimary|null|undefined} primary
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @instance
+             */
+            DeferNode.prototype.primary = null;
+
+            /**
+             * DeferNode deferred.
+             * @member {Array.<Trace.QueryPlanNode.IDeferredNode>} deferred
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @instance
+             */
+            DeferNode.prototype.deferred = $util.emptyArray;
+
+            /**
+             * Creates a new DeferNode instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNode=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferNode} DeferNode instance
+             */
+            DeferNode.create = function create(properties) {
+                return new DeferNode(properties);
+            };
+
+            /**
+             * Encodes the specified DeferNode message. Does not implicitly {@link Trace.QueryPlanNode.DeferNode.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNode} message DeferNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNode.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.primary != null && Object.hasOwnProperty.call(message, "primary"))
+                    $root.Trace.QueryPlanNode.DeferNodePrimary.encode(message.primary, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.deferred != null && message.deferred.length)
+                    for (var i = 0; i < message.deferred.length; ++i)
+                        $root.Trace.QueryPlanNode.DeferredNode.encode(message.deferred[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferNode.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNode} message DeferNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNode.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferNode message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferNode} DeferNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNode.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferNode();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.primary = $root.Trace.QueryPlanNode.DeferNodePrimary.decode(reader, reader.uint32());
+                        break;
+                    case 2:
+                        if (!(message.deferred && message.deferred.length))
+                            message.deferred = [];
+                        message.deferred.push($root.Trace.QueryPlanNode.DeferredNode.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferNode message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferNode} DeferNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNode.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferNode message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferNode.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.primary != null && message.hasOwnProperty("primary")) {
+                    var error = $root.Trace.QueryPlanNode.DeferNodePrimary.verify(message.primary);
+                    if (error)
+                        return "primary." + error;
+                }
+                if (message.deferred != null && message.hasOwnProperty("deferred")) {
+                    if (!Array.isArray(message.deferred))
+                        return "deferred: array expected";
+                    for (var i = 0; i < message.deferred.length; ++i) {
+                        var error = $root.Trace.QueryPlanNode.DeferredNode.verify(message.deferred[i]);
+                        if (error)
+                            return "deferred." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferNode message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.DeferNode} message DeferNode
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferNode.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.deferred = [];
+                if (options.defaults)
+                    object.primary = null;
+                if (message.primary != null && message.hasOwnProperty("primary"))
+                    object.primary = $root.Trace.QueryPlanNode.DeferNodePrimary.toObject(message.primary, options);
+                if (message.deferred && message.deferred.length) {
+                    object.deferred = [];
+                    for (var j = 0; j < message.deferred.length; ++j)
+                        object.deferred[j] = $root.Trace.QueryPlanNode.DeferredNode.toObject(message.deferred[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this DeferNode to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferNode.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferNode;
+        })();
+
+        QueryPlanNode.ConditionNode = (function() {
+
+            /**
+             * Properties of a ConditionNode.
+             * @memberof Trace.QueryPlanNode
+             * @interface IConditionNode
+             * @property {string|null} [condition] ConditionNode condition
+             * @property {Trace.IQueryPlanNode|null} [ifClause] ConditionNode ifClause
+             * @property {Trace.IQueryPlanNode|null} [elseClause] ConditionNode elseClause
+             */
+
+            /**
+             * Constructs a new ConditionNode.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a ConditionNode.
+             * @implements IConditionNode
+             * @constructor
+             * @param {Trace.QueryPlanNode.IConditionNode=} [properties] Properties to set
+             */
+            function ConditionNode(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * ConditionNode condition.
+             * @member {string} condition
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             */
+            ConditionNode.prototype.condition = "";
+
+            /**
+             * ConditionNode ifClause.
+             * @member {Trace.IQueryPlanNode|null|undefined} ifClause
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             */
+            ConditionNode.prototype.ifClause = null;
+
+            /**
+             * ConditionNode elseClause.
+             * @member {Trace.IQueryPlanNode|null|undefined} elseClause
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             */
+            ConditionNode.prototype.elseClause = null;
+
+            /**
+             * Creates a new ConditionNode instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.IConditionNode=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.ConditionNode} ConditionNode instance
+             */
+            ConditionNode.create = function create(properties) {
+                return new ConditionNode(properties);
+            };
+
+            /**
+             * Encodes the specified ConditionNode message. Does not implicitly {@link Trace.QueryPlanNode.ConditionNode.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.IConditionNode} message ConditionNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ConditionNode.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.condition);
+                if (message.ifClause != null && Object.hasOwnProperty.call(message, "ifClause"))
+                    $root.Trace.QueryPlanNode.encode(message.ifClause, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.elseClause != null && Object.hasOwnProperty.call(message, "elseClause"))
+                    $root.Trace.QueryPlanNode.encode(message.elseClause, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified ConditionNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.ConditionNode.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.IConditionNode} message ConditionNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ConditionNode.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a ConditionNode message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.ConditionNode} ConditionNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ConditionNode.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.ConditionNode();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.condition = reader.string();
+                        break;
+                    case 2:
+                        message.ifClause = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    case 3:
+                        message.elseClause = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a ConditionNode message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.ConditionNode} ConditionNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ConditionNode.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a ConditionNode message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            ConditionNode.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.condition != null && message.hasOwnProperty("condition"))
+                    if (!$util.isString(message.condition))
+                        return "condition: string expected";
+                if (message.ifClause != null && message.hasOwnProperty("ifClause")) {
+                    var error = $root.Trace.QueryPlanNode.verify(message.ifClause);
+                    if (error)
+                        return "ifClause." + error;
+                }
+                if (message.elseClause != null && message.hasOwnProperty("elseClause")) {
+                    var error = $root.Trace.QueryPlanNode.verify(message.elseClause);
+                    if (error)
+                        return "elseClause." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a ConditionNode message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.ConditionNode} message ConditionNode
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            ConditionNode.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.condition = "";
+                    object.ifClause = null;
+                    object.elseClause = null;
+                }
+                if (message.condition != null && message.hasOwnProperty("condition"))
+                    object.condition = message.condition;
+                if (message.ifClause != null && message.hasOwnProperty("ifClause"))
+                    object.ifClause = $root.Trace.QueryPlanNode.toObject(message.ifClause, options);
+                if (message.elseClause != null && message.hasOwnProperty("elseClause"))
+                    object.elseClause = $root.Trace.QueryPlanNode.toObject(message.elseClause, options);
+                return object;
+            };
+
+            /**
+             * Converts this ConditionNode to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            ConditionNode.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return ConditionNode;
+        })();
+
+        QueryPlanNode.DeferNodePrimary = (function() {
+
+            /**
+             * Properties of a DeferNodePrimary.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferNodePrimary
+             * @property {Trace.IQueryPlanNode|null} [node] DeferNodePrimary node
+             */
+
+            /**
+             * Constructs a new DeferNodePrimary.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferNodePrimary.
+             * @implements IDeferNodePrimary
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary=} [properties] Properties to set
+             */
+            function DeferNodePrimary(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferNodePrimary node.
+             * @member {Trace.IQueryPlanNode|null|undefined} node
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @instance
+             */
+            DeferNodePrimary.prototype.node = null;
+
+            /**
+             * Creates a new DeferNodePrimary instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferNodePrimary} DeferNodePrimary instance
+             */
+            DeferNodePrimary.create = function create(properties) {
+                return new DeferNodePrimary(properties);
+            };
+
+            /**
+             * Encodes the specified DeferNodePrimary message. Does not implicitly {@link Trace.QueryPlanNode.DeferNodePrimary.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary} message DeferNodePrimary message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNodePrimary.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.node != null && Object.hasOwnProperty.call(message, "node"))
+                    $root.Trace.QueryPlanNode.encode(message.node, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferNodePrimary message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferNodePrimary.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary} message DeferNodePrimary message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNodePrimary.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferNodePrimary message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferNodePrimary} DeferNodePrimary
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNodePrimary.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferNodePrimary();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.node = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferNodePrimary message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferNodePrimary} DeferNodePrimary
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNodePrimary.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferNodePrimary message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferNodePrimary.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.node != null && message.hasOwnProperty("node")) {
+                    var error = $root.Trace.QueryPlanNode.verify(message.node);
+                    if (error)
+                        return "node." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferNodePrimary message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.DeferNodePrimary} message DeferNodePrimary
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferNodePrimary.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults)
+                    object.node = null;
+                if (message.node != null && message.hasOwnProperty("node"))
+                    object.node = $root.Trace.QueryPlanNode.toObject(message.node, options);
+                return object;
+            };
+
+            /**
+             * Converts this DeferNodePrimary to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferNodePrimary.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferNodePrimary;
+        })();
+
+        QueryPlanNode.DeferredNode = (function() {
+
+            /**
+             * Properties of a DeferredNode.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferredNode
+             * @property {Array.<Trace.QueryPlanNode.IDeferredNodeDepends>|null} [depends] DeferredNode depends
+             * @property {string|null} [label] DeferredNode label
+             * @property {Array.<Trace.QueryPlanNode.IResponsePathElement>|null} [path] DeferredNode path
+             * @property {Trace.IQueryPlanNode|null} [node] DeferredNode node
+             */
+
+            /**
+             * Constructs a new DeferredNode.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferredNode.
+             * @implements IDeferredNode
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferredNode=} [properties] Properties to set
+             */
+            function DeferredNode(properties) {
+                this.depends = [];
+                this.path = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferredNode depends.
+             * @member {Array.<Trace.QueryPlanNode.IDeferredNodeDepends>} depends
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.depends = $util.emptyArray;
+
+            /**
+             * DeferredNode label.
+             * @member {string} label
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.label = "";
+
+            /**
+             * DeferredNode path.
+             * @member {Array.<Trace.QueryPlanNode.IResponsePathElement>} path
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.path = $util.emptyArray;
+
+            /**
+             * DeferredNode node.
+             * @member {Trace.IQueryPlanNode|null|undefined} node
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.node = null;
+
+            /**
+             * Creates a new DeferredNode instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNode=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferredNode} DeferredNode instance
+             */
+            DeferredNode.create = function create(properties) {
+                return new DeferredNode(properties);
+            };
+
+            /**
+             * Encodes the specified DeferredNode message. Does not implicitly {@link Trace.QueryPlanNode.DeferredNode.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNode} message DeferredNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNode.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.depends != null && message.depends.length)
+                    for (var i = 0; i < message.depends.length; ++i)
+                        $root.Trace.QueryPlanNode.DeferredNodeDepends.encode(message.depends[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.label != null && Object.hasOwnProperty.call(message, "label"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.label);
+                if (message.path != null && message.path.length)
+                    for (var i = 0; i < message.path.length; ++i)
+                        $root.Trace.QueryPlanNode.ResponsePathElement.encode(message.path[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.node != null && Object.hasOwnProperty.call(message, "node"))
+                    $root.Trace.QueryPlanNode.encode(message.node, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferredNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferredNode.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNode} message DeferredNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNode.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferredNode message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferredNode} DeferredNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNode.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferredNode();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.depends && message.depends.length))
+                            message.depends = [];
+                        message.depends.push($root.Trace.QueryPlanNode.DeferredNodeDepends.decode(reader, reader.uint32()));
+                        break;
+                    case 2:
+                        message.label = reader.string();
+                        break;
+                    case 3:
+                        if (!(message.path && message.path.length))
+                            message.path = [];
+                        message.path.push($root.Trace.QueryPlanNode.ResponsePathElement.decode(reader, reader.uint32()));
+                        break;
+                    case 4:
+                        message.node = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferredNode message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferredNode} DeferredNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNode.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferredNode message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferredNode.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.depends != null && message.hasOwnProperty("depends")) {
+                    if (!Array.isArray(message.depends))
+                        return "depends: array expected";
+                    for (var i = 0; i < message.depends.length; ++i) {
+                        var error = $root.Trace.QueryPlanNode.DeferredNodeDepends.verify(message.depends[i]);
+                        if (error)
+                            return "depends." + error;
+                    }
+                }
+                if (message.label != null && message.hasOwnProperty("label"))
+                    if (!$util.isString(message.label))
+                        return "label: string expected";
+                if (message.path != null && message.hasOwnProperty("path")) {
+                    if (!Array.isArray(message.path))
+                        return "path: array expected";
+                    for (var i = 0; i < message.path.length; ++i) {
+                        var error = $root.Trace.QueryPlanNode.ResponsePathElement.verify(message.path[i]);
+                        if (error)
+                            return "path." + error;
+                    }
+                }
+                if (message.node != null && message.hasOwnProperty("node")) {
+                    var error = $root.Trace.QueryPlanNode.verify(message.node);
+                    if (error)
+                        return "node." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferredNode message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.DeferredNode} message DeferredNode
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferredNode.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults) {
+                    object.depends = [];
+                    object.path = [];
+                }
+                if (options.defaults) {
+                    object.label = "";
+                    object.node = null;
+                }
+                if (message.depends && message.depends.length) {
+                    object.depends = [];
+                    for (var j = 0; j < message.depends.length; ++j)
+                        object.depends[j] = $root.Trace.QueryPlanNode.DeferredNodeDepends.toObject(message.depends[j], options);
+                }
+                if (message.label != null && message.hasOwnProperty("label"))
+                    object.label = message.label;
+                if (message.path && message.path.length) {
+                    object.path = [];
+                    for (var j = 0; j < message.path.length; ++j)
+                        object.path[j] = $root.Trace.QueryPlanNode.ResponsePathElement.toObject(message.path[j], options);
+                }
+                if (message.node != null && message.hasOwnProperty("node"))
+                    object.node = $root.Trace.QueryPlanNode.toObject(message.node, options);
+                return object;
+            };
+
+            /**
+             * Converts this DeferredNode to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferredNode.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferredNode;
+        })();
+
+        QueryPlanNode.DeferredNodeDepends = (function() {
+
+            /**
+             * Properties of a DeferredNodeDepends.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferredNodeDepends
+             * @property {string|null} [id] DeferredNodeDepends id
+             * @property {string|null} [deferLabel] DeferredNodeDepends deferLabel
+             */
+
+            /**
+             * Constructs a new DeferredNodeDepends.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferredNodeDepends.
+             * @implements IDeferredNodeDepends
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends=} [properties] Properties to set
+             */
+            function DeferredNodeDepends(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferredNodeDepends id.
+             * @member {string} id
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @instance
+             */
+            DeferredNodeDepends.prototype.id = "";
+
+            /**
+             * DeferredNodeDepends deferLabel.
+             * @member {string} deferLabel
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @instance
+             */
+            DeferredNodeDepends.prototype.deferLabel = "";
+
+            /**
+             * Creates a new DeferredNodeDepends instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferredNodeDepends} DeferredNodeDepends instance
+             */
+            DeferredNodeDepends.create = function create(properties) {
+                return new DeferredNodeDepends(properties);
+            };
+
+            /**
+             * Encodes the specified DeferredNodeDepends message. Does not implicitly {@link Trace.QueryPlanNode.DeferredNodeDepends.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends} message DeferredNodeDepends message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNodeDepends.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.deferLabel != null && Object.hasOwnProperty.call(message, "deferLabel"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.deferLabel);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferredNodeDepends message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferredNodeDepends.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends} message DeferredNodeDepends message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNodeDepends.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferredNodeDepends message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferredNodeDepends} DeferredNodeDepends
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNodeDepends.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferredNodeDepends();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.deferLabel = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferredNodeDepends message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferredNodeDepends} DeferredNodeDepends
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNodeDepends.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferredNodeDepends message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferredNodeDepends.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.deferLabel != null && message.hasOwnProperty("deferLabel"))
+                    if (!$util.isString(message.deferLabel))
+                        return "deferLabel: string expected";
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferredNodeDepends message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.DeferredNodeDepends} message DeferredNodeDepends
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferredNodeDepends.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.deferLabel = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.deferLabel != null && message.hasOwnProperty("deferLabel"))
+                    object.deferLabel = message.deferLabel;
+                return object;
+            };
+
+            /**
+             * Converts this DeferredNodeDepends to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferredNodeDepends.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferredNodeDepends;
         })();
 
         QueryPlanNode.ResponsePathElement = (function() {
@@ -6164,6 +7207,7 @@ $root.Report = (function() {
      * @property {Object.<string,ITracesAndStats>|null} [tracesPerQuery] Report tracesPerQuery
      * @property {google.protobuf.ITimestamp|null} [endTime] Report endTime
      * @property {number|null} [operationCount] Report operationCount
+     * @property {boolean|null} [tracesPreAggregated] Report tracesPreAggregated
      */
 
     /**
@@ -6215,6 +7259,14 @@ $root.Report = (function() {
     Report.prototype.operationCount = 0;
 
     /**
+     * Report tracesPreAggregated.
+     * @member {boolean} tracesPreAggregated
+     * @memberof Report
+     * @instance
+     */
+    Report.prototype.tracesPreAggregated = false;
+
+    /**
      * Creates a new Report instance using the specified properties.
      * @function create
      * @memberof Report
@@ -6249,6 +7301,8 @@ $root.Report = (function() {
             }
         if (message.operationCount != null && Object.hasOwnProperty.call(message, "operationCount"))
             writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.operationCount);
+        if (message.tracesPreAggregated != null && Object.hasOwnProperty.call(message, "tracesPreAggregated"))
+            writer.uint32(/* id 7, wireType 0 =*/56).bool(message.tracesPreAggregated);
         return writer;
     };
 
@@ -6299,6 +7353,9 @@ $root.Report = (function() {
                 break;
             case 6:
                 message.operationCount = reader.uint64();
+                break;
+            case 7:
+                message.tracesPreAggregated = reader.bool();
                 break;
             default:
                 reader.skipType(tag & 7);
@@ -6358,6 +7415,9 @@ $root.Report = (function() {
         if (message.operationCount != null && message.hasOwnProperty("operationCount"))
             if (!$util.isInteger(message.operationCount) && !(message.operationCount && $util.isInteger(message.operationCount.low) && $util.isInteger(message.operationCount.high)))
                 return "operationCount: integer|Long expected";
+        if (message.tracesPreAggregated != null && message.hasOwnProperty("tracesPreAggregated"))
+            if (typeof message.tracesPreAggregated !== "boolean")
+                return "tracesPreAggregated: boolean expected";
         return null;
     };
 
@@ -6380,6 +7440,7 @@ $root.Report = (function() {
             object.header = null;
             object.endTime = null;
             object.operationCount = 0;
+            object.tracesPreAggregated = false;
         }
         if (message.header != null && message.hasOwnProperty("header"))
             object.header = $root.ReportHeader.toObject(message.header, options);
@@ -6396,6 +7457,8 @@ $root.Report = (function() {
                 object.operationCount = options.longs === String ? String(message.operationCount) : message.operationCount;
             else
                 object.operationCount = options.longs === String ? $util.Long.prototype.toString.call(message.operationCount) : options.longs === Number ? new $util.LongBits(message.operationCount.low >>> 0, message.operationCount.high >>> 0).toNumber(true) : message.operationCount;
+        if (message.tracesPreAggregated != null && message.hasOwnProperty("tracesPreAggregated"))
+            object.tracesPreAggregated = message.tracesPreAggregated;
         return object;
     };
 

--- a/packages/usage-reporting-protobuf/generated/protobuf.d.ts
+++ b/packages/usage-reporting-protobuf/generated/protobuf.d.ts
@@ -14,6 +14,9 @@ export interface ITrace {
     /** Trace root */
     root?: (Trace.INode|null);
 
+    /** Trace isIncomplete */
+    isIncomplete?: (boolean|null);
+
     /** Trace signature */
     signature?: (string|null);
 
@@ -80,6 +83,9 @@ export class Trace implements ITrace {
 
     /** Trace root. */
     public root?: (Trace.INode|null);
+
+    /** Trace isIncomplete. */
+    public isIncomplete: boolean;
 
     /** Trace signature. */
     public signature: string;
@@ -487,12 +493,6 @@ export namespace Trace {
         /** HTTP method */
         method?: (Trace.HTTP.Method|null);
 
-        /** HTTP host */
-        host?: (string|null);
-
-        /** HTTP path */
-        path?: (string|null);
-
         /** HTTP requestHeaders */
         requestHeaders?: ({ [k: string]: Trace.HTTP.IValues }|null);
 
@@ -501,12 +501,6 @@ export namespace Trace {
 
         /** HTTP statusCode */
         statusCode?: (number|null);
-
-        /** HTTP secure */
-        secure?: (boolean|null);
-
-        /** HTTP protocol */
-        protocol?: (string|null);
     }
 
     /** Represents a HTTP. */
@@ -521,12 +515,6 @@ export namespace Trace {
         /** HTTP method. */
         public method: Trace.HTTP.Method;
 
-        /** HTTP host. */
-        public host: string;
-
-        /** HTTP path. */
-        public path: string;
-
         /** HTTP requestHeaders. */
         public requestHeaders: { [k: string]: Trace.HTTP.IValues };
 
@@ -535,12 +523,6 @@ export namespace Trace {
 
         /** HTTP statusCode. */
         public statusCode: number;
-
-        /** HTTP secure. */
-        public secure: boolean;
-
-        /** HTTP protocol. */
-        public protocol: string;
 
         /**
          * Creates a new HTTP instance using the specified properties.
@@ -949,6 +931,12 @@ export namespace Trace {
 
         /** QueryPlanNode flatten */
         flatten?: (Trace.QueryPlanNode.IFlattenNode|null);
+
+        /** QueryPlanNode defer */
+        defer?: (Trace.QueryPlanNode.IDeferNode|null);
+
+        /** QueryPlanNode condition */
+        condition?: (Trace.QueryPlanNode.IConditionNode|null);
     }
 
     /** Represents a QueryPlanNode. */
@@ -972,8 +960,14 @@ export namespace Trace {
         /** QueryPlanNode flatten. */
         public flatten?: (Trace.QueryPlanNode.IFlattenNode|null);
 
+        /** QueryPlanNode defer. */
+        public defer?: (Trace.QueryPlanNode.IDeferNode|null);
+
+        /** QueryPlanNode condition. */
+        public condition?: (Trace.QueryPlanNode.IConditionNode|null);
+
         /** QueryPlanNode node. */
-        public node?: ("sequence"|"parallel"|"fetch"|"flatten");
+        public node?: ("sequence"|"parallel"|"fetch"|"flatten"|"defer"|"condition");
 
         /**
          * Creates a new QueryPlanNode instance using the specified properties.
@@ -1404,6 +1398,463 @@ export namespace Trace {
 
             /**
              * Converts this FlattenNode to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a DeferNode. */
+        interface IDeferNode {
+
+            /** DeferNode primary */
+            primary?: (Trace.QueryPlanNode.IDeferNodePrimary|null);
+
+            /** DeferNode deferred */
+            deferred?: (Trace.QueryPlanNode.IDeferredNode[]|null);
+        }
+
+        /** Represents a DeferNode. */
+        class DeferNode implements IDeferNode {
+
+            /**
+             * Constructs a new DeferNode.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: Trace.QueryPlanNode.IDeferNode);
+
+            /** DeferNode primary. */
+            public primary?: (Trace.QueryPlanNode.IDeferNodePrimary|null);
+
+            /** DeferNode deferred. */
+            public deferred: Trace.QueryPlanNode.IDeferredNode[];
+
+            /**
+             * Creates a new DeferNode instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns DeferNode instance
+             */
+            public static create(properties?: Trace.QueryPlanNode.IDeferNode): Trace.QueryPlanNode.DeferNode;
+
+            /**
+             * Encodes the specified DeferNode message. Does not implicitly {@link Trace.QueryPlanNode.DeferNode.verify|verify} messages.
+             * @param message DeferNode message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: Trace.QueryPlanNode.IDeferNode, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified DeferNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferNode.verify|verify} messages.
+             * @param message DeferNode message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: Trace.QueryPlanNode.IDeferNode, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a DeferNode message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns DeferNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Trace.QueryPlanNode.DeferNode;
+
+            /**
+             * Decodes a DeferNode message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns DeferNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Trace.QueryPlanNode.DeferNode;
+
+            /**
+             * Verifies a DeferNode message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a plain object from a DeferNode message. Also converts values to other types if specified.
+             * @param message DeferNode
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: Trace.QueryPlanNode.DeferNode, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this DeferNode to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a ConditionNode. */
+        interface IConditionNode {
+
+            /** ConditionNode condition */
+            condition?: (string|null);
+
+            /** ConditionNode ifClause */
+            ifClause?: (Trace.IQueryPlanNode|null);
+
+            /** ConditionNode elseClause */
+            elseClause?: (Trace.IQueryPlanNode|null);
+        }
+
+        /** Represents a ConditionNode. */
+        class ConditionNode implements IConditionNode {
+
+            /**
+             * Constructs a new ConditionNode.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: Trace.QueryPlanNode.IConditionNode);
+
+            /** ConditionNode condition. */
+            public condition: string;
+
+            /** ConditionNode ifClause. */
+            public ifClause?: (Trace.IQueryPlanNode|null);
+
+            /** ConditionNode elseClause. */
+            public elseClause?: (Trace.IQueryPlanNode|null);
+
+            /**
+             * Creates a new ConditionNode instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns ConditionNode instance
+             */
+            public static create(properties?: Trace.QueryPlanNode.IConditionNode): Trace.QueryPlanNode.ConditionNode;
+
+            /**
+             * Encodes the specified ConditionNode message. Does not implicitly {@link Trace.QueryPlanNode.ConditionNode.verify|verify} messages.
+             * @param message ConditionNode message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: Trace.QueryPlanNode.IConditionNode, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified ConditionNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.ConditionNode.verify|verify} messages.
+             * @param message ConditionNode message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: Trace.QueryPlanNode.IConditionNode, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a ConditionNode message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns ConditionNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Trace.QueryPlanNode.ConditionNode;
+
+            /**
+             * Decodes a ConditionNode message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns ConditionNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Trace.QueryPlanNode.ConditionNode;
+
+            /**
+             * Verifies a ConditionNode message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a plain object from a ConditionNode message. Also converts values to other types if specified.
+             * @param message ConditionNode
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: Trace.QueryPlanNode.ConditionNode, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this ConditionNode to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a DeferNodePrimary. */
+        interface IDeferNodePrimary {
+
+            /** DeferNodePrimary node */
+            node?: (Trace.IQueryPlanNode|null);
+        }
+
+        /** Represents a DeferNodePrimary. */
+        class DeferNodePrimary implements IDeferNodePrimary {
+
+            /**
+             * Constructs a new DeferNodePrimary.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: Trace.QueryPlanNode.IDeferNodePrimary);
+
+            /** DeferNodePrimary node. */
+            public node?: (Trace.IQueryPlanNode|null);
+
+            /**
+             * Creates a new DeferNodePrimary instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns DeferNodePrimary instance
+             */
+            public static create(properties?: Trace.QueryPlanNode.IDeferNodePrimary): Trace.QueryPlanNode.DeferNodePrimary;
+
+            /**
+             * Encodes the specified DeferNodePrimary message. Does not implicitly {@link Trace.QueryPlanNode.DeferNodePrimary.verify|verify} messages.
+             * @param message DeferNodePrimary message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: Trace.QueryPlanNode.IDeferNodePrimary, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified DeferNodePrimary message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferNodePrimary.verify|verify} messages.
+             * @param message DeferNodePrimary message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: Trace.QueryPlanNode.IDeferNodePrimary, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a DeferNodePrimary message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns DeferNodePrimary
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Trace.QueryPlanNode.DeferNodePrimary;
+
+            /**
+             * Decodes a DeferNodePrimary message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns DeferNodePrimary
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Trace.QueryPlanNode.DeferNodePrimary;
+
+            /**
+             * Verifies a DeferNodePrimary message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a plain object from a DeferNodePrimary message. Also converts values to other types if specified.
+             * @param message DeferNodePrimary
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: Trace.QueryPlanNode.DeferNodePrimary, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this DeferNodePrimary to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a DeferredNode. */
+        interface IDeferredNode {
+
+            /** DeferredNode depends */
+            depends?: (Trace.QueryPlanNode.IDeferredNodeDepends[]|null);
+
+            /** DeferredNode label */
+            label?: (string|null);
+
+            /** DeferredNode path */
+            path?: (Trace.QueryPlanNode.IResponsePathElement[]|null);
+
+            /** DeferredNode node */
+            node?: (Trace.IQueryPlanNode|null);
+        }
+
+        /** Represents a DeferredNode. */
+        class DeferredNode implements IDeferredNode {
+
+            /**
+             * Constructs a new DeferredNode.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: Trace.QueryPlanNode.IDeferredNode);
+
+            /** DeferredNode depends. */
+            public depends: Trace.QueryPlanNode.IDeferredNodeDepends[];
+
+            /** DeferredNode label. */
+            public label: string;
+
+            /** DeferredNode path. */
+            public path: Trace.QueryPlanNode.IResponsePathElement[];
+
+            /** DeferredNode node. */
+            public node?: (Trace.IQueryPlanNode|null);
+
+            /**
+             * Creates a new DeferredNode instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns DeferredNode instance
+             */
+            public static create(properties?: Trace.QueryPlanNode.IDeferredNode): Trace.QueryPlanNode.DeferredNode;
+
+            /**
+             * Encodes the specified DeferredNode message. Does not implicitly {@link Trace.QueryPlanNode.DeferredNode.verify|verify} messages.
+             * @param message DeferredNode message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: Trace.QueryPlanNode.IDeferredNode, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified DeferredNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferredNode.verify|verify} messages.
+             * @param message DeferredNode message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: Trace.QueryPlanNode.IDeferredNode, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a DeferredNode message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns DeferredNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Trace.QueryPlanNode.DeferredNode;
+
+            /**
+             * Decodes a DeferredNode message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns DeferredNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Trace.QueryPlanNode.DeferredNode;
+
+            /**
+             * Verifies a DeferredNode message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a plain object from a DeferredNode message. Also converts values to other types if specified.
+             * @param message DeferredNode
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: Trace.QueryPlanNode.DeferredNode, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this DeferredNode to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a DeferredNodeDepends. */
+        interface IDeferredNodeDepends {
+
+            /** DeferredNodeDepends id */
+            id?: (string|null);
+
+            /** DeferredNodeDepends deferLabel */
+            deferLabel?: (string|null);
+        }
+
+        /** Represents a DeferredNodeDepends. */
+        class DeferredNodeDepends implements IDeferredNodeDepends {
+
+            /**
+             * Constructs a new DeferredNodeDepends.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: Trace.QueryPlanNode.IDeferredNodeDepends);
+
+            /** DeferredNodeDepends id. */
+            public id: string;
+
+            /** DeferredNodeDepends deferLabel. */
+            public deferLabel: string;
+
+            /**
+             * Creates a new DeferredNodeDepends instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns DeferredNodeDepends instance
+             */
+            public static create(properties?: Trace.QueryPlanNode.IDeferredNodeDepends): Trace.QueryPlanNode.DeferredNodeDepends;
+
+            /**
+             * Encodes the specified DeferredNodeDepends message. Does not implicitly {@link Trace.QueryPlanNode.DeferredNodeDepends.verify|verify} messages.
+             * @param message DeferredNodeDepends message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: Trace.QueryPlanNode.IDeferredNodeDepends, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified DeferredNodeDepends message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferredNodeDepends.verify|verify} messages.
+             * @param message DeferredNodeDepends message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: Trace.QueryPlanNode.IDeferredNodeDepends, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a DeferredNodeDepends message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns DeferredNodeDepends
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): Trace.QueryPlanNode.DeferredNodeDepends;
+
+            /**
+             * Decodes a DeferredNodeDepends message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns DeferredNodeDepends
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): Trace.QueryPlanNode.DeferredNodeDepends;
+
+            /**
+             * Verifies a DeferredNodeDepends message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a plain object from a DeferredNodeDepends message. Also converts values to other types if specified.
+             * @param message DeferredNodeDepends
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: Trace.QueryPlanNode.DeferredNodeDepends, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this DeferredNodeDepends to JSON.
              * @returns JSON object
              */
             public toJSON(): { [k: string]: any };
@@ -2438,6 +2889,9 @@ export interface IReport {
 
     /** Report operationCount */
     operationCount?: (number|null);
+
+    /** Report tracesPreAggregated */
+    tracesPreAggregated?: (boolean|null);
 }
 
 /** Represents a Report. */
@@ -2460,6 +2914,9 @@ export class Report implements IReport {
 
     /** Report operationCount. */
     public operationCount: number;
+
+    /** Report tracesPreAggregated. */
+    public tracesPreAggregated: boolean;
 
     /**
      * Creates a new Report instance using the specified properties.

--- a/packages/usage-reporting-protobuf/generated/protobuf.mjs
+++ b/packages/usage-reporting-protobuf/generated/protobuf.mjs
@@ -17,6 +17,7 @@ export const Trace = $root.Trace = (() => {
      * @property {google.protobuf.ITimestamp|null} [endTime] Trace endTime
      * @property {number|null} [durationNs] Trace durationNs
      * @property {Trace.INode|null} [root] Trace root
+     * @property {boolean|null} [isIncomplete] Trace isIncomplete
      * @property {string|null} [signature] Trace signature
      * @property {string|null} [unexecutedOperationBody] Trace unexecutedOperationBody
      * @property {string|null} [unexecutedOperationName] Trace unexecutedOperationName
@@ -80,6 +81,14 @@ export const Trace = $root.Trace = (() => {
      * @instance
      */
     Trace.prototype.root = null;
+
+    /**
+     * Trace isIncomplete.
+     * @member {boolean} isIncomplete
+     * @memberof Trace
+     * @instance
+     */
+    Trace.prototype.isIncomplete = false;
 
     /**
      * Trace signature.
@@ -263,6 +272,8 @@ export const Trace = $root.Trace = (() => {
             writer.uint32(/* id 28, wireType 2 =*/226).string(message.unexecutedOperationName);
         if (message.fieldExecutionWeight != null && Object.hasOwnProperty.call(message, "fieldExecutionWeight"))
             writer.uint32(/* id 31, wireType 1 =*/249).double(message.fieldExecutionWeight);
+        if (message.isIncomplete != null && Object.hasOwnProperty.call(message, "isIncomplete"))
+            writer.uint32(/* id 33, wireType 0 =*/264).bool(message.isIncomplete);
         return writer;
     };
 
@@ -308,6 +319,9 @@ export const Trace = $root.Trace = (() => {
                 break;
             case 14:
                 message.root = $root.Trace.Node.decode(reader, reader.uint32());
+                break;
+            case 33:
+                message.isIncomplete = reader.bool();
                 break;
             case 19:
                 message.signature = reader.string();
@@ -407,6 +421,9 @@ export const Trace = $root.Trace = (() => {
             if (error)
                 return "root." + error;
         }
+        if (message.isIncomplete != null && message.hasOwnProperty("isIncomplete"))
+            if (typeof message.isIncomplete !== "boolean")
+                return "isIncomplete: boolean expected";
         if (message.signature != null && message.hasOwnProperty("signature"))
             if (!$util.isString(message.signature))
                 return "signature: string expected";
@@ -496,6 +513,7 @@ export const Trace = $root.Trace = (() => {
             object.unexecutedOperationBody = "";
             object.unexecutedOperationName = "";
             object.fieldExecutionWeight = 0;
+            object.isIncomplete = false;
         }
         if (message.endTime != null && message.hasOwnProperty("endTime"))
             object.endTime = $root.google.protobuf.Timestamp.toObject(message.endTime, options);
@@ -538,6 +556,8 @@ export const Trace = $root.Trace = (() => {
             object.unexecutedOperationName = message.unexecutedOperationName;
         if (message.fieldExecutionWeight != null && message.hasOwnProperty("fieldExecutionWeight"))
             object.fieldExecutionWeight = options.json && !isFinite(message.fieldExecutionWeight) ? String(message.fieldExecutionWeight) : message.fieldExecutionWeight;
+        if (message.isIncomplete != null && message.hasOwnProperty("isIncomplete"))
+            object.isIncomplete = message.isIncomplete;
         return object;
     };
 
@@ -1230,13 +1250,9 @@ export const Trace = $root.Trace = (() => {
          * @memberof Trace
          * @interface IHTTP
          * @property {Trace.HTTP.Method|null} [method] HTTP method
-         * @property {string|null} [host] HTTP host
-         * @property {string|null} [path] HTTP path
          * @property {Object.<string,Trace.HTTP.IValues>|null} [requestHeaders] HTTP requestHeaders
          * @property {Object.<string,Trace.HTTP.IValues>|null} [responseHeaders] HTTP responseHeaders
          * @property {number|null} [statusCode] HTTP statusCode
-         * @property {boolean|null} [secure] HTTP secure
-         * @property {string|null} [protocol] HTTP protocol
          */
 
         /**
@@ -1265,22 +1281,6 @@ export const Trace = $root.Trace = (() => {
         HTTP.prototype.method = 0;
 
         /**
-         * HTTP host.
-         * @member {string} host
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.host = "";
-
-        /**
-         * HTTP path.
-         * @member {string} path
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.path = "";
-
-        /**
          * HTTP requestHeaders.
          * @member {Object.<string,Trace.HTTP.IValues>} requestHeaders
          * @memberof Trace.HTTP
@@ -1303,22 +1303,6 @@ export const Trace = $root.Trace = (() => {
          * @instance
          */
         HTTP.prototype.statusCode = 0;
-
-        /**
-         * HTTP secure.
-         * @member {boolean} secure
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.secure = false;
-
-        /**
-         * HTTP protocol.
-         * @member {string} protocol
-         * @memberof Trace.HTTP
-         * @instance
-         */
-        HTTP.prototype.protocol = "";
 
         /**
          * Creates a new HTTP instance using the specified properties.
@@ -1346,10 +1330,6 @@ export const Trace = $root.Trace = (() => {
                 writer = $Writer.create();
             if (message.method != null && Object.hasOwnProperty.call(message, "method"))
                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.method);
-            if (message.host != null && Object.hasOwnProperty.call(message, "host"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.host);
-            if (message.path != null && Object.hasOwnProperty.call(message, "path"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.path);
             if (message.requestHeaders != null && Object.hasOwnProperty.call(message, "requestHeaders"))
                 for (let keys = Object.keys(message.requestHeaders), i = 0; i < keys.length; ++i) {
                     writer.uint32(/* id 4, wireType 2 =*/34).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
@@ -1362,10 +1342,6 @@ export const Trace = $root.Trace = (() => {
                 }
             if (message.statusCode != null && Object.hasOwnProperty.call(message, "statusCode"))
                 writer.uint32(/* id 6, wireType 0 =*/48).uint32(message.statusCode);
-            if (message.secure != null && Object.hasOwnProperty.call(message, "secure"))
-                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.secure);
-            if (message.protocol != null && Object.hasOwnProperty.call(message, "protocol"))
-                writer.uint32(/* id 9, wireType 2 =*/74).string(message.protocol);
             return writer;
         };
 
@@ -1403,12 +1379,6 @@ export const Trace = $root.Trace = (() => {
                 case 1:
                     message.method = reader.int32();
                     break;
-                case 2:
-                    message.host = reader.string();
-                    break;
-                case 3:
-                    message.path = reader.string();
-                    break;
                 case 4:
                     reader.skip().pos++;
                     if (message.requestHeaders === $util.emptyObject)
@@ -1427,12 +1397,6 @@ export const Trace = $root.Trace = (() => {
                     break;
                 case 6:
                     message.statusCode = reader.uint32();
-                    break;
-                case 8:
-                    message.secure = reader.bool();
-                    break;
-                case 9:
-                    message.protocol = reader.string();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -1485,12 +1449,6 @@ export const Trace = $root.Trace = (() => {
                 case 9:
                     break;
                 }
-            if (message.host != null && message.hasOwnProperty("host"))
-                if (!$util.isString(message.host))
-                    return "host: string expected";
-            if (message.path != null && message.hasOwnProperty("path"))
-                if (!$util.isString(message.path))
-                    return "path: string expected";
             if (message.requestHeaders != null && message.hasOwnProperty("requestHeaders")) {
                 if (!$util.isObject(message.requestHeaders))
                     return "requestHeaders: object expected";
@@ -1514,12 +1472,6 @@ export const Trace = $root.Trace = (() => {
             if (message.statusCode != null && message.hasOwnProperty("statusCode"))
                 if (!$util.isInteger(message.statusCode))
                     return "statusCode: integer expected";
-            if (message.secure != null && message.hasOwnProperty("secure"))
-                if (typeof message.secure !== "boolean")
-                    return "secure: boolean expected";
-            if (message.protocol != null && message.hasOwnProperty("protocol"))
-                if (!$util.isString(message.protocol))
-                    return "protocol: string expected";
             return null;
         };
 
@@ -1542,18 +1494,10 @@ export const Trace = $root.Trace = (() => {
             }
             if (options.defaults) {
                 object.method = options.enums === String ? "UNKNOWN" : 0;
-                object.host = "";
-                object.path = "";
                 object.statusCode = 0;
-                object.secure = false;
-                object.protocol = "";
             }
             if (message.method != null && message.hasOwnProperty("method"))
                 object.method = options.enums === String ? $root.Trace.HTTP.Method[message.method] : message.method;
-            if (message.host != null && message.hasOwnProperty("host"))
-                object.host = message.host;
-            if (message.path != null && message.hasOwnProperty("path"))
-                object.path = message.path;
             let keys2;
             if (message.requestHeaders && (keys2 = Object.keys(message.requestHeaders)).length) {
                 object.requestHeaders = {};
@@ -1567,10 +1511,6 @@ export const Trace = $root.Trace = (() => {
             }
             if (message.statusCode != null && message.hasOwnProperty("statusCode"))
                 object.statusCode = message.statusCode;
-            if (message.secure != null && message.hasOwnProperty("secure"))
-                object.secure = message.secure;
-            if (message.protocol != null && message.hasOwnProperty("protocol"))
-                object.protocol = message.protocol;
             return object;
         };
 
@@ -2412,6 +2352,8 @@ export const Trace = $root.Trace = (() => {
          * @property {Trace.QueryPlanNode.IParallelNode|null} [parallel] QueryPlanNode parallel
          * @property {Trace.QueryPlanNode.IFetchNode|null} [fetch] QueryPlanNode fetch
          * @property {Trace.QueryPlanNode.IFlattenNode|null} [flatten] QueryPlanNode flatten
+         * @property {Trace.QueryPlanNode.IDeferNode|null} [defer] QueryPlanNode defer
+         * @property {Trace.QueryPlanNode.IConditionNode|null} [condition] QueryPlanNode condition
          */
 
         /**
@@ -2461,17 +2403,33 @@ export const Trace = $root.Trace = (() => {
          */
         QueryPlanNode.prototype.flatten = null;
 
+        /**
+         * QueryPlanNode defer.
+         * @member {Trace.QueryPlanNode.IDeferNode|null|undefined} defer
+         * @memberof Trace.QueryPlanNode
+         * @instance
+         */
+        QueryPlanNode.prototype.defer = null;
+
+        /**
+         * QueryPlanNode condition.
+         * @member {Trace.QueryPlanNode.IConditionNode|null|undefined} condition
+         * @memberof Trace.QueryPlanNode
+         * @instance
+         */
+        QueryPlanNode.prototype.condition = null;
+
         // OneOf field names bound to virtual getters and setters
         let $oneOfFields;
 
         /**
          * QueryPlanNode node.
-         * @member {"sequence"|"parallel"|"fetch"|"flatten"|undefined} node
+         * @member {"sequence"|"parallel"|"fetch"|"flatten"|"defer"|"condition"|undefined} node
          * @memberof Trace.QueryPlanNode
          * @instance
          */
         Object.defineProperty(QueryPlanNode.prototype, "node", {
-            get: $util.oneOfGetter($oneOfFields = ["sequence", "parallel", "fetch", "flatten"]),
+            get: $util.oneOfGetter($oneOfFields = ["sequence", "parallel", "fetch", "flatten", "defer", "condition"]),
             set: $util.oneOfSetter($oneOfFields)
         });
 
@@ -2507,6 +2465,10 @@ export const Trace = $root.Trace = (() => {
                 $root.Trace.QueryPlanNode.FetchNode.encode(message.fetch, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
             if (message.flatten != null && Object.hasOwnProperty.call(message, "flatten"))
                 $root.Trace.QueryPlanNode.FlattenNode.encode(message.flatten, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            if (message.defer != null && Object.hasOwnProperty.call(message, "defer"))
+                $root.Trace.QueryPlanNode.DeferNode.encode(message.defer, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+            if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                $root.Trace.QueryPlanNode.ConditionNode.encode(message.condition, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
             return writer;
         };
 
@@ -2552,6 +2514,12 @@ export const Trace = $root.Trace = (() => {
                     break;
                 case 4:
                     message.flatten = $root.Trace.QueryPlanNode.FlattenNode.decode(reader, reader.uint32());
+                    break;
+                case 5:
+                    message.defer = $root.Trace.QueryPlanNode.DeferNode.decode(reader, reader.uint32());
+                    break;
+                case 6:
+                    message.condition = $root.Trace.QueryPlanNode.ConditionNode.decode(reader, reader.uint32());
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -2627,6 +2595,26 @@ export const Trace = $root.Trace = (() => {
                         return "flatten." + error;
                 }
             }
+            if (message.defer != null && message.hasOwnProperty("defer")) {
+                if (properties.node === 1)
+                    return "node: multiple values";
+                properties.node = 1;
+                {
+                    let error = $root.Trace.QueryPlanNode.DeferNode.verify(message.defer);
+                    if (error)
+                        return "defer." + error;
+                }
+            }
+            if (message.condition != null && message.hasOwnProperty("condition")) {
+                if (properties.node === 1)
+                    return "node: multiple values";
+                properties.node = 1;
+                {
+                    let error = $root.Trace.QueryPlanNode.ConditionNode.verify(message.condition);
+                    if (error)
+                        return "condition." + error;
+                }
+            }
             return null;
         };
 
@@ -2662,6 +2650,16 @@ export const Trace = $root.Trace = (() => {
                 object.flatten = $root.Trace.QueryPlanNode.FlattenNode.toObject(message.flatten, options);
                 if (options.oneofs)
                     object.node = "flatten";
+            }
+            if (message.defer != null && message.hasOwnProperty("defer")) {
+                object.defer = $root.Trace.QueryPlanNode.DeferNode.toObject(message.defer, options);
+                if (options.oneofs)
+                    object.node = "defer";
+            }
+            if (message.condition != null && message.hasOwnProperty("condition")) {
+                object.condition = $root.Trace.QueryPlanNode.ConditionNode.toObject(message.condition, options);
+                if (options.oneofs)
+                    object.node = "condition";
             }
             return object;
         };
@@ -3527,6 +3525,1051 @@ export const Trace = $root.Trace = (() => {
             };
 
             return FlattenNode;
+        })();
+
+        QueryPlanNode.DeferNode = (function() {
+
+            /**
+             * Properties of a DeferNode.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferNode
+             * @property {Trace.QueryPlanNode.IDeferNodePrimary|null} [primary] DeferNode primary
+             * @property {Array.<Trace.QueryPlanNode.IDeferredNode>|null} [deferred] DeferNode deferred
+             */
+
+            /**
+             * Constructs a new DeferNode.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferNode.
+             * @implements IDeferNode
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferNode=} [properties] Properties to set
+             */
+            function DeferNode(properties) {
+                this.deferred = [];
+                if (properties)
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferNode primary.
+             * @member {Trace.QueryPlanNode.IDeferNodePrimary|null|undefined} primary
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @instance
+             */
+            DeferNode.prototype.primary = null;
+
+            /**
+             * DeferNode deferred.
+             * @member {Array.<Trace.QueryPlanNode.IDeferredNode>} deferred
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @instance
+             */
+            DeferNode.prototype.deferred = $util.emptyArray;
+
+            /**
+             * Creates a new DeferNode instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNode=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferNode} DeferNode instance
+             */
+            DeferNode.create = function create(properties) {
+                return new DeferNode(properties);
+            };
+
+            /**
+             * Encodes the specified DeferNode message. Does not implicitly {@link Trace.QueryPlanNode.DeferNode.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNode} message DeferNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNode.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.primary != null && Object.hasOwnProperty.call(message, "primary"))
+                    $root.Trace.QueryPlanNode.DeferNodePrimary.encode(message.primary, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.deferred != null && message.deferred.length)
+                    for (let i = 0; i < message.deferred.length; ++i)
+                        $root.Trace.QueryPlanNode.DeferredNode.encode(message.deferred[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferNode.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNode} message DeferNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNode.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferNode message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferNode} DeferNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNode.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                let end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferNode();
+                while (reader.pos < end) {
+                    let tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.primary = $root.Trace.QueryPlanNode.DeferNodePrimary.decode(reader, reader.uint32());
+                        break;
+                    case 2:
+                        if (!(message.deferred && message.deferred.length))
+                            message.deferred = [];
+                        message.deferred.push($root.Trace.QueryPlanNode.DeferredNode.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferNode message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferNode} DeferNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNode.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferNode message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferNode.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.primary != null && message.hasOwnProperty("primary")) {
+                    let error = $root.Trace.QueryPlanNode.DeferNodePrimary.verify(message.primary);
+                    if (error)
+                        return "primary." + error;
+                }
+                if (message.deferred != null && message.hasOwnProperty("deferred")) {
+                    if (!Array.isArray(message.deferred))
+                        return "deferred: array expected";
+                    for (let i = 0; i < message.deferred.length; ++i) {
+                        let error = $root.Trace.QueryPlanNode.DeferredNode.verify(message.deferred[i]);
+                        if (error)
+                            return "deferred." + error;
+                    }
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferNode message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @static
+             * @param {Trace.QueryPlanNode.DeferNode} message DeferNode
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferNode.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                let object = {};
+                if (options.arrays || options.defaults)
+                    object.deferred = [];
+                if (options.defaults)
+                    object.primary = null;
+                if (message.primary != null && message.hasOwnProperty("primary"))
+                    object.primary = $root.Trace.QueryPlanNode.DeferNodePrimary.toObject(message.primary, options);
+                if (message.deferred && message.deferred.length) {
+                    object.deferred = [];
+                    for (let j = 0; j < message.deferred.length; ++j)
+                        object.deferred[j] = $root.Trace.QueryPlanNode.DeferredNode.toObject(message.deferred[j], options);
+                }
+                return object;
+            };
+
+            /**
+             * Converts this DeferNode to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferNode
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferNode.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferNode;
+        })();
+
+        QueryPlanNode.ConditionNode = (function() {
+
+            /**
+             * Properties of a ConditionNode.
+             * @memberof Trace.QueryPlanNode
+             * @interface IConditionNode
+             * @property {string|null} [condition] ConditionNode condition
+             * @property {Trace.IQueryPlanNode|null} [ifClause] ConditionNode ifClause
+             * @property {Trace.IQueryPlanNode|null} [elseClause] ConditionNode elseClause
+             */
+
+            /**
+             * Constructs a new ConditionNode.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a ConditionNode.
+             * @implements IConditionNode
+             * @constructor
+             * @param {Trace.QueryPlanNode.IConditionNode=} [properties] Properties to set
+             */
+            function ConditionNode(properties) {
+                if (properties)
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * ConditionNode condition.
+             * @member {string} condition
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             */
+            ConditionNode.prototype.condition = "";
+
+            /**
+             * ConditionNode ifClause.
+             * @member {Trace.IQueryPlanNode|null|undefined} ifClause
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             */
+            ConditionNode.prototype.ifClause = null;
+
+            /**
+             * ConditionNode elseClause.
+             * @member {Trace.IQueryPlanNode|null|undefined} elseClause
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             */
+            ConditionNode.prototype.elseClause = null;
+
+            /**
+             * Creates a new ConditionNode instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.IConditionNode=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.ConditionNode} ConditionNode instance
+             */
+            ConditionNode.create = function create(properties) {
+                return new ConditionNode(properties);
+            };
+
+            /**
+             * Encodes the specified ConditionNode message. Does not implicitly {@link Trace.QueryPlanNode.ConditionNode.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.IConditionNode} message ConditionNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ConditionNode.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.condition != null && Object.hasOwnProperty.call(message, "condition"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.condition);
+                if (message.ifClause != null && Object.hasOwnProperty.call(message, "ifClause"))
+                    $root.Trace.QueryPlanNode.encode(message.ifClause, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.elseClause != null && Object.hasOwnProperty.call(message, "elseClause"))
+                    $root.Trace.QueryPlanNode.encode(message.elseClause, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified ConditionNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.ConditionNode.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.IConditionNode} message ConditionNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            ConditionNode.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a ConditionNode message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.ConditionNode} ConditionNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ConditionNode.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                let end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.ConditionNode();
+                while (reader.pos < end) {
+                    let tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.condition = reader.string();
+                        break;
+                    case 2:
+                        message.ifClause = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    case 3:
+                        message.elseClause = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a ConditionNode message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.ConditionNode} ConditionNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            ConditionNode.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a ConditionNode message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            ConditionNode.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.condition != null && message.hasOwnProperty("condition"))
+                    if (!$util.isString(message.condition))
+                        return "condition: string expected";
+                if (message.ifClause != null && message.hasOwnProperty("ifClause")) {
+                    let error = $root.Trace.QueryPlanNode.verify(message.ifClause);
+                    if (error)
+                        return "ifClause." + error;
+                }
+                if (message.elseClause != null && message.hasOwnProperty("elseClause")) {
+                    let error = $root.Trace.QueryPlanNode.verify(message.elseClause);
+                    if (error)
+                        return "elseClause." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a ConditionNode message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @static
+             * @param {Trace.QueryPlanNode.ConditionNode} message ConditionNode
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            ConditionNode.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                let object = {};
+                if (options.defaults) {
+                    object.condition = "";
+                    object.ifClause = null;
+                    object.elseClause = null;
+                }
+                if (message.condition != null && message.hasOwnProperty("condition"))
+                    object.condition = message.condition;
+                if (message.ifClause != null && message.hasOwnProperty("ifClause"))
+                    object.ifClause = $root.Trace.QueryPlanNode.toObject(message.ifClause, options);
+                if (message.elseClause != null && message.hasOwnProperty("elseClause"))
+                    object.elseClause = $root.Trace.QueryPlanNode.toObject(message.elseClause, options);
+                return object;
+            };
+
+            /**
+             * Converts this ConditionNode to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.ConditionNode
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            ConditionNode.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return ConditionNode;
+        })();
+
+        QueryPlanNode.DeferNodePrimary = (function() {
+
+            /**
+             * Properties of a DeferNodePrimary.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferNodePrimary
+             * @property {Trace.IQueryPlanNode|null} [node] DeferNodePrimary node
+             */
+
+            /**
+             * Constructs a new DeferNodePrimary.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferNodePrimary.
+             * @implements IDeferNodePrimary
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary=} [properties] Properties to set
+             */
+            function DeferNodePrimary(properties) {
+                if (properties)
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferNodePrimary node.
+             * @member {Trace.IQueryPlanNode|null|undefined} node
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @instance
+             */
+            DeferNodePrimary.prototype.node = null;
+
+            /**
+             * Creates a new DeferNodePrimary instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferNodePrimary} DeferNodePrimary instance
+             */
+            DeferNodePrimary.create = function create(properties) {
+                return new DeferNodePrimary(properties);
+            };
+
+            /**
+             * Encodes the specified DeferNodePrimary message. Does not implicitly {@link Trace.QueryPlanNode.DeferNodePrimary.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary} message DeferNodePrimary message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNodePrimary.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.node != null && Object.hasOwnProperty.call(message, "node"))
+                    $root.Trace.QueryPlanNode.encode(message.node, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferNodePrimary message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferNodePrimary.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferNodePrimary} message DeferNodePrimary message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferNodePrimary.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferNodePrimary message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferNodePrimary} DeferNodePrimary
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNodePrimary.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                let end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferNodePrimary();
+                while (reader.pos < end) {
+                    let tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.node = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferNodePrimary message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferNodePrimary} DeferNodePrimary
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferNodePrimary.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferNodePrimary message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferNodePrimary.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.node != null && message.hasOwnProperty("node")) {
+                    let error = $root.Trace.QueryPlanNode.verify(message.node);
+                    if (error)
+                        return "node." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferNodePrimary message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @static
+             * @param {Trace.QueryPlanNode.DeferNodePrimary} message DeferNodePrimary
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferNodePrimary.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                let object = {};
+                if (options.defaults)
+                    object.node = null;
+                if (message.node != null && message.hasOwnProperty("node"))
+                    object.node = $root.Trace.QueryPlanNode.toObject(message.node, options);
+                return object;
+            };
+
+            /**
+             * Converts this DeferNodePrimary to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferNodePrimary
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferNodePrimary.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferNodePrimary;
+        })();
+
+        QueryPlanNode.DeferredNode = (function() {
+
+            /**
+             * Properties of a DeferredNode.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferredNode
+             * @property {Array.<Trace.QueryPlanNode.IDeferredNodeDepends>|null} [depends] DeferredNode depends
+             * @property {string|null} [label] DeferredNode label
+             * @property {Array.<Trace.QueryPlanNode.IResponsePathElement>|null} [path] DeferredNode path
+             * @property {Trace.IQueryPlanNode|null} [node] DeferredNode node
+             */
+
+            /**
+             * Constructs a new DeferredNode.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferredNode.
+             * @implements IDeferredNode
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferredNode=} [properties] Properties to set
+             */
+            function DeferredNode(properties) {
+                this.depends = [];
+                this.path = [];
+                if (properties)
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferredNode depends.
+             * @member {Array.<Trace.QueryPlanNode.IDeferredNodeDepends>} depends
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.depends = $util.emptyArray;
+
+            /**
+             * DeferredNode label.
+             * @member {string} label
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.label = "";
+
+            /**
+             * DeferredNode path.
+             * @member {Array.<Trace.QueryPlanNode.IResponsePathElement>} path
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.path = $util.emptyArray;
+
+            /**
+             * DeferredNode node.
+             * @member {Trace.IQueryPlanNode|null|undefined} node
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             */
+            DeferredNode.prototype.node = null;
+
+            /**
+             * Creates a new DeferredNode instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNode=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferredNode} DeferredNode instance
+             */
+            DeferredNode.create = function create(properties) {
+                return new DeferredNode(properties);
+            };
+
+            /**
+             * Encodes the specified DeferredNode message. Does not implicitly {@link Trace.QueryPlanNode.DeferredNode.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNode} message DeferredNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNode.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.depends != null && message.depends.length)
+                    for (let i = 0; i < message.depends.length; ++i)
+                        $root.Trace.QueryPlanNode.DeferredNodeDepends.encode(message.depends[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.label != null && Object.hasOwnProperty.call(message, "label"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.label);
+                if (message.path != null && message.path.length)
+                    for (let i = 0; i < message.path.length; ++i)
+                        $root.Trace.QueryPlanNode.ResponsePathElement.encode(message.path[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.node != null && Object.hasOwnProperty.call(message, "node"))
+                    $root.Trace.QueryPlanNode.encode(message.node, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferredNode message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferredNode.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNode} message DeferredNode message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNode.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferredNode message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferredNode} DeferredNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNode.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                let end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferredNode();
+                while (reader.pos < end) {
+                    let tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        if (!(message.depends && message.depends.length))
+                            message.depends = [];
+                        message.depends.push($root.Trace.QueryPlanNode.DeferredNodeDepends.decode(reader, reader.uint32()));
+                        break;
+                    case 2:
+                        message.label = reader.string();
+                        break;
+                    case 3:
+                        if (!(message.path && message.path.length))
+                            message.path = [];
+                        message.path.push($root.Trace.QueryPlanNode.ResponsePathElement.decode(reader, reader.uint32()));
+                        break;
+                    case 4:
+                        message.node = $root.Trace.QueryPlanNode.decode(reader, reader.uint32());
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferredNode message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferredNode} DeferredNode
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNode.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferredNode message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferredNode.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.depends != null && message.hasOwnProperty("depends")) {
+                    if (!Array.isArray(message.depends))
+                        return "depends: array expected";
+                    for (let i = 0; i < message.depends.length; ++i) {
+                        let error = $root.Trace.QueryPlanNode.DeferredNodeDepends.verify(message.depends[i]);
+                        if (error)
+                            return "depends." + error;
+                    }
+                }
+                if (message.label != null && message.hasOwnProperty("label"))
+                    if (!$util.isString(message.label))
+                        return "label: string expected";
+                if (message.path != null && message.hasOwnProperty("path")) {
+                    if (!Array.isArray(message.path))
+                        return "path: array expected";
+                    for (let i = 0; i < message.path.length; ++i) {
+                        let error = $root.Trace.QueryPlanNode.ResponsePathElement.verify(message.path[i]);
+                        if (error)
+                            return "path." + error;
+                    }
+                }
+                if (message.node != null && message.hasOwnProperty("node")) {
+                    let error = $root.Trace.QueryPlanNode.verify(message.node);
+                    if (error)
+                        return "node." + error;
+                }
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferredNode message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @static
+             * @param {Trace.QueryPlanNode.DeferredNode} message DeferredNode
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferredNode.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                let object = {};
+                if (options.arrays || options.defaults) {
+                    object.depends = [];
+                    object.path = [];
+                }
+                if (options.defaults) {
+                    object.label = "";
+                    object.node = null;
+                }
+                if (message.depends && message.depends.length) {
+                    object.depends = [];
+                    for (let j = 0; j < message.depends.length; ++j)
+                        object.depends[j] = $root.Trace.QueryPlanNode.DeferredNodeDepends.toObject(message.depends[j], options);
+                }
+                if (message.label != null && message.hasOwnProperty("label"))
+                    object.label = message.label;
+                if (message.path && message.path.length) {
+                    object.path = [];
+                    for (let j = 0; j < message.path.length; ++j)
+                        object.path[j] = $root.Trace.QueryPlanNode.ResponsePathElement.toObject(message.path[j], options);
+                }
+                if (message.node != null && message.hasOwnProperty("node"))
+                    object.node = $root.Trace.QueryPlanNode.toObject(message.node, options);
+                return object;
+            };
+
+            /**
+             * Converts this DeferredNode to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferredNode
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferredNode.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferredNode;
+        })();
+
+        QueryPlanNode.DeferredNodeDepends = (function() {
+
+            /**
+             * Properties of a DeferredNodeDepends.
+             * @memberof Trace.QueryPlanNode
+             * @interface IDeferredNodeDepends
+             * @property {string|null} [id] DeferredNodeDepends id
+             * @property {string|null} [deferLabel] DeferredNodeDepends deferLabel
+             */
+
+            /**
+             * Constructs a new DeferredNodeDepends.
+             * @memberof Trace.QueryPlanNode
+             * @classdesc Represents a DeferredNodeDepends.
+             * @implements IDeferredNodeDepends
+             * @constructor
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends=} [properties] Properties to set
+             */
+            function DeferredNodeDepends(properties) {
+                if (properties)
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+
+            /**
+             * DeferredNodeDepends id.
+             * @member {string} id
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @instance
+             */
+            DeferredNodeDepends.prototype.id = "";
+
+            /**
+             * DeferredNodeDepends deferLabel.
+             * @member {string} deferLabel
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @instance
+             */
+            DeferredNodeDepends.prototype.deferLabel = "";
+
+            /**
+             * Creates a new DeferredNodeDepends instance using the specified properties.
+             * @function create
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends=} [properties] Properties to set
+             * @returns {Trace.QueryPlanNode.DeferredNodeDepends} DeferredNodeDepends instance
+             */
+            DeferredNodeDepends.create = function create(properties) {
+                return new DeferredNodeDepends(properties);
+            };
+
+            /**
+             * Encodes the specified DeferredNodeDepends message. Does not implicitly {@link Trace.QueryPlanNode.DeferredNodeDepends.verify|verify} messages.
+             * @function encode
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends} message DeferredNodeDepends message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNodeDepends.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.deferLabel != null && Object.hasOwnProperty.call(message, "deferLabel"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.deferLabel);
+                return writer;
+            };
+
+            /**
+             * Encodes the specified DeferredNodeDepends message, length delimited. Does not implicitly {@link Trace.QueryPlanNode.DeferredNodeDepends.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.IDeferredNodeDepends} message DeferredNodeDepends message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DeferredNodeDepends.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+
+            /**
+             * Decodes a DeferredNodeDepends message from the specified reader or buffer.
+             * @function decode
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {Trace.QueryPlanNode.DeferredNodeDepends} DeferredNodeDepends
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNodeDepends.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                let end = length === undefined ? reader.len : reader.pos + length, message = new $root.Trace.QueryPlanNode.DeferredNodeDepends();
+                while (reader.pos < end) {
+                    let tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.deferLabel = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+
+            /**
+             * Decodes a DeferredNodeDepends message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {Trace.QueryPlanNode.DeferredNodeDepends} DeferredNodeDepends
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DeferredNodeDepends.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+
+            /**
+             * Verifies a DeferredNodeDepends message.
+             * @function verify
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DeferredNodeDepends.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.deferLabel != null && message.hasOwnProperty("deferLabel"))
+                    if (!$util.isString(message.deferLabel))
+                        return "deferLabel: string expected";
+                return null;
+            };
+
+            /**
+             * Creates a plain object from a DeferredNodeDepends message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @static
+             * @param {Trace.QueryPlanNode.DeferredNodeDepends} message DeferredNodeDepends
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DeferredNodeDepends.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                let object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.deferLabel = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.deferLabel != null && message.hasOwnProperty("deferLabel"))
+                    object.deferLabel = message.deferLabel;
+                return object;
+            };
+
+            /**
+             * Converts this DeferredNodeDepends to JSON.
+             * @function toJSON
+             * @memberof Trace.QueryPlanNode.DeferredNodeDepends
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DeferredNodeDepends.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+
+            return DeferredNodeDepends;
         })();
 
         QueryPlanNode.ResponsePathElement = (function() {
@@ -6162,6 +7205,7 @@ export const Report = $root.Report = (() => {
      * @property {Object.<string,ITracesAndStats>|null} [tracesPerQuery] Report tracesPerQuery
      * @property {google.protobuf.ITimestamp|null} [endTime] Report endTime
      * @property {number|null} [operationCount] Report operationCount
+     * @property {boolean|null} [tracesPreAggregated] Report tracesPreAggregated
      */
 
     /**
@@ -6213,6 +7257,14 @@ export const Report = $root.Report = (() => {
     Report.prototype.operationCount = 0;
 
     /**
+     * Report tracesPreAggregated.
+     * @member {boolean} tracesPreAggregated
+     * @memberof Report
+     * @instance
+     */
+    Report.prototype.tracesPreAggregated = false;
+
+    /**
      * Creates a new Report instance using the specified properties.
      * @function create
      * @memberof Report
@@ -6247,6 +7299,8 @@ export const Report = $root.Report = (() => {
             }
         if (message.operationCount != null && Object.hasOwnProperty.call(message, "operationCount"))
             writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.operationCount);
+        if (message.tracesPreAggregated != null && Object.hasOwnProperty.call(message, "tracesPreAggregated"))
+            writer.uint32(/* id 7, wireType 0 =*/56).bool(message.tracesPreAggregated);
         return writer;
     };
 
@@ -6297,6 +7351,9 @@ export const Report = $root.Report = (() => {
                 break;
             case 6:
                 message.operationCount = reader.uint64();
+                break;
+            case 7:
+                message.tracesPreAggregated = reader.bool();
                 break;
             default:
                 reader.skipType(tag & 7);
@@ -6356,6 +7413,9 @@ export const Report = $root.Report = (() => {
         if (message.operationCount != null && message.hasOwnProperty("operationCount"))
             if (!$util.isInteger(message.operationCount) && !(message.operationCount && $util.isInteger(message.operationCount.low) && $util.isInteger(message.operationCount.high)))
                 return "operationCount: integer|Long expected";
+        if (message.tracesPreAggregated != null && message.hasOwnProperty("tracesPreAggregated"))
+            if (typeof message.tracesPreAggregated !== "boolean")
+                return "tracesPreAggregated: boolean expected";
         return null;
     };
 
@@ -6378,6 +7438,7 @@ export const Report = $root.Report = (() => {
             object.header = null;
             object.endTime = null;
             object.operationCount = 0;
+            object.tracesPreAggregated = false;
         }
         if (message.header != null && message.hasOwnProperty("header"))
             object.header = $root.ReportHeader.toObject(message.header, options);
@@ -6394,6 +7455,8 @@ export const Report = $root.Report = (() => {
                 object.operationCount = options.longs === String ? String(message.operationCount) : message.operationCount;
             else
                 object.operationCount = options.longs === String ? $util.Long.prototype.toString.call(message.operationCount) : options.longs === Number ? new $util.LongBits(message.operationCount.low >>> 0, message.operationCount.high >>> 0).toNumber(true) : message.operationCount;
+        if (message.tracesPreAggregated != null && message.hasOwnProperty("tracesPreAggregated"))
+            object.tracesPreAggregated = message.tracesPreAggregated;
         return object;
     };
 

--- a/packages/usage-reporting-protobuf/src/reports.proto
+++ b/packages/usage-reporting-protobuf/src/reports.proto
@@ -54,8 +54,6 @@ message Trace {
       PATCH = 9;
     }
     Method method = 1;
-    string host = 2;
-    string path = 3;
 
     // Should exclude manual blacklist ("Auth" by default)
     map<string, Values> request_headers = 4;
@@ -63,8 +61,7 @@ message Trace {
 
     uint32 status_code = 6;
 
-    bool secure = 8; // TLS was used
-    string protocol = 9; // by convention "HTTP/1.0", "HTTP/1.1", "HTTP/2" or "h2"
+    reserved 2, 3, 8, 9;
   }
 
   message Location {
@@ -113,14 +110,14 @@ message Trace {
 
   // represents a node in the query plan, under which there is a trace tree for that service fetch.
   // In particular, each fetch node represents a call to an implementing service, and calls to implementing
-  // services may not be unique. See https://github.com/apollographql/apollo-server/blob/main/packages/apollo-gateway/src/QueryPlan.ts
+  // services may not be unique. See https://github.com/apollographql/federation/blob/main/query-planner-js/src/QueryPlan.ts
   // for more information and details.
   message QueryPlanNode {
-    // This represents a set of nodes to be executed sequentially by the Gateway executor
+    // This represents a set of nodes to be executed sequentially by the Router/Gateway executor
     message SequenceNode {
       repeated QueryPlanNode nodes = 1;
     }
-    // This represents a set of nodes to be executed in parallel by the Gateway executor
+    // This represents a set of nodes to be executed in parallel by the Router/Gateway executor
     message ParallelNode {
       repeated QueryPlanNode nodes = 1;
     }
@@ -134,14 +131,14 @@ message Trace {
       bool trace_parsing_failed = 2;
 
       // This Trace only contains start_time, end_time, duration_ns, and root;
-      // all timings were calculated **on the federated service**, and clock skew
+      // all timings were calculated **on the subgraph**, and clock skew
       // will be handled by the ingress server.
       Trace trace = 3;
 
-      // relative to the outer trace's start_time, in ns, measured in the gateway.
+      // relative to the outer trace's start_time, in ns, measured in the Router/Gateway.
       uint64 sent_time_offset = 4;
 
-      // Wallclock times measured in the gateway for when this operation was
+      // Wallclock times measured in the Router/Gateway for when this operation was
       // sent and received.
       google.protobuf.Timestamp sent_time = 5;
       google.protobuf.Timestamp received_time = 6;
@@ -153,6 +150,33 @@ message Trace {
       repeated ResponsePathElement response_path = 1;
       QueryPlanNode node = 2;
     }
+
+    // A `DeferNode` corresponds to one or more @defer at the same level of "nestedness" in the planned query.
+    message DeferNode {
+      DeferNodePrimary primary = 1;
+      repeated DeferredNode deferred = 2;
+    }
+
+    message ConditionNode {
+      string condition = 1;
+      QueryPlanNode if_clause = 2;
+      QueryPlanNode else_clause = 3;
+    }
+
+    message DeferNodePrimary {
+      QueryPlanNode node = 1;
+    }
+    message DeferredNode {
+      repeated DeferredNodeDepends depends = 1;
+      string label = 2;
+      repeated ResponsePathElement path = 3;
+      QueryPlanNode node = 4;
+    }
+    message DeferredNodeDepends {
+      string id = 1;
+      string defer_label = 2;
+    }
+
     message ResponsePathElement {
       oneof id {
         string field_name = 1;
@@ -164,6 +188,8 @@ message Trace {
       ParallelNode parallel = 2;
       FetchNode fetch = 3;
       FlattenNode flatten = 4;
+      DeferNode defer = 5;
+      ConditionNode condition = 6;
     }
   }
 
@@ -178,9 +204,18 @@ message Trace {
   // service, including errors.
   Node root = 14;
 
+  // If this is true, the trace is potentially missing some nodes that were
+  // present on the query plan. This can happen if the trace span buffer used
+  // in the Router fills up and some spans have to be dropped. In these cases
+  // the overall trace timing will still be correct, but the trace data could
+  // be missing some referenced or executed fields, and some nodes may be
+  // missing. If this is true we should display a warning to the user when they
+  // view the trace in Explorer.
+  bool is_incomplete = 33;
+
   // -------------------------------------------------------------------------
-  // Fields below this line are *not* included in federated traces (the traces
-  // sent from federated services to the gateway).
+  // Fields below this line are *not* included in inline traces (the traces
+  // sent from subgraphs to the Router/Gateway).
 
   // In addition to details.raw_query, we include a "signature" of the query,
   // which can be normalized: for example, you may want to discard aliases, drop
@@ -209,10 +244,10 @@ message Trace {
 
   CachePolicy cache_policy = 18;
 
-  // If this Trace was created by a gateway, this is the query plan, including
-  // sub-Traces for federated services. Note that the 'root' tree on the
+  // If this Trace was created by a Router/Gateway, this is the query plan, including
+  // sub-Traces for subgraphs. Note that the 'root' tree on the
   // top-level Trace won't contain any resolvers (though it could contain errors
-  // that occurred in the gateway itself).
+  // that occurred in the Router/Gateway itself).
   QueryPlanNode query_plan = 26;
 
   // Was this response served from a full query response cache?  (In that case
@@ -401,6 +436,13 @@ message Report {
 
   // Total number of operations processed during this period.
   uint64 operation_count = 6;
+
+  // If this is set to true, the stats in TracesWithStats.stats_with_context
+  // represent all of the operations described from this report, and the
+  // traces in TracesWithStats.trace are a sampling of some of the same
+  // operations. If this is false, each operation is described in precisely
+  // one of those two fields.
+  bool traces_pre_aggregated = 7;
 }
 
 message ContextualizedStats {
@@ -412,8 +454,11 @@ message ContextualizedStats {
 
 }
 
-// A sequence of traces and stats. An individual operation should either be described as a trace
-// or as part of stats, but not both.
+// A sequence of traces and stats. If Report.traces_pre_aggregated (at the top
+// level of the report) is false, an individual operation should either be
+// described as a trace or as part of stats, but not both. If that flag
+// is true, then all operations are described as stats and some are also
+// described as traces.
 message TracesAndStats {
   repeated Trace trace = 1 [(js_preEncoded)=true];
   repeated ContextualizedStats stats_with_context = 2 [(js_use_toArray)=true];


### PR DESCRIPTION
Update protobuf to latest, which notably introduces a `ConditionNode` needed to reintroduce support for `@skip`/`@include` in gateway traces.

These changes were produced by running the following:
```sh
npm run update-proto -w @apollo/usage-reporting-protobuf
npm run generate -w @apollo/usage-reporting-protobuf
```