### PR TITLE
docs: Add max-width to wide table cell to prevent overflow

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -409,7 +409,7 @@ You can also manually call `stop()` in other contexts. Note that `stop()` is asy
 </tr>
 
 <tr>
-<td>
+<td style="max-width: 200px;">
 
 ##### `includeStacktraceInErrorResponses`
 


### PR DESCRIPTION
This long config option is causing the table's width to exceed its limits, resulting in a really unpleasant hiding of all the useful content in a horizontal scroll window. This limits the width of the cell and forces the word to break to new line instead.