### PR TITLE
Add required plugin to allow cache backend to work

### DIFF
--- a/docs/source/performance/cache-backends.mdx
+++ b/docs/source/performance/cache-backends.mdx
@@ -11,7 +11,7 @@ There are many cache backend implementations to choose from, including several i
 
 ## Configuring in-memory caching
 
-> ⚠️ If you are using Apollo Server 3, see the [previous version of this article](/apollo-server/v3/performance/cache-backends#ensuring-a-bounded-cache) to learn how to protect your cache from denial of service attacks by using a bounded cache. By default, Apollo Server 4's default cache is a _bounded_ in-memory cache backend.
+> ⚠️ If you are using Apollo Server 3, see the [previous version of this article](/apollo-server/v3/performance/cache-backends#ensuring-a-bounded-cache) to learn how to protect your cache from denial of service attacks by using a bounded cache. By default, Apollo Server default cache is a _bounded_ in-memory cache backend.
 
 You can configure your server to use a different backend (such as Redis or Memcached) using the `cache` constructor option.
 
@@ -27,7 +27,7 @@ const server = new ApolloServer({
 });
 ```
 
-> Apollo Server 4 provides the equivalent of the above code snippet out-of-the-box and doesn't require you to install the `@apollo/utils.keyvaluecache` package.
+> Apollo Server provides the equivalent of the above code snippet out-of-the-box and doesn't require you to install the `@apollo/utils.keyvaluecache` package.
 
 In this example, we've increased the default size and provided a default TTL. For more information on these configuration options, see the [`lru-cache` documentation](https://www.npmjs.com/package/lru-cache).
 
@@ -102,8 +102,11 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   cache: new KeyvAdapter(new Keyv("redis://user:pass@localhost:6379")), // highlight-line
+  plugins: [responseCachePlugin()],
 });
 ```
+
+> Not that when using an external caching plugin, you must include an execution of the `responseCachePlugin` method in the associated plugins array.
 
 ### Redis Sentinel
 ```ts


### PR DESCRIPTION
I believe that the code in the "Single instance" that calls for redis will not work without the plugin being defined. I've added that along with an appropriate note. Please check me if my assumption is correct. That is, the current code will never work as is.

Also, removed in two places a specific reference to Apollo Server 4 since this should only show up in the Apollo Server 4 doc tree. I assume that when Apollo Server 5 comes out, you do not want to have to go back and change that note (and so on and so forth for every version change)

Note: I assume this change should also be required for the Redis Sential and the Redis Cluster examples, but as this behavior is opaque to me, I really don't know if that is necessary. I would suggest also adding a comment regarding what is really happening and when the responseCachePlugin is needed. I had thoroughly read these doc pages before suggestion this and only know about because of thishttps://github.com/apollographql/apollo-server/issues/7416 discussed with @trevor-scheer.

Another point of confusion for me is that it seems that this section "Cache backends" requires that you have read thoroughly the previous section "Caching" where responseCachePlugin is discussed.  I had read that several times.

It currently says:

You can cache Apollo Server query responses in stores like Redis, Memcached, or Apollo Server's default in-memory cache. For more information, see Configuring cache backends.

And I believe it should say something like

The `responseCachePlugin()` is required to be passed as a plugin along with any KeyvAdapter instantiation. That is, in order to cache Apollo Server query responses in stores like Redis, Memcached, or Apollo Server's default in-memory cache. For more information, see Configuring cache backends.

If this is correct, I'd be happy to update that text, but I feel a little bit like I'm must making stuff up now.

First, 🌠 thank you 🌠 for taking the time to consider a contribution to Apollo!

Here are some important details to follow:

* ⏰ Your time is important
          To save your precious time, if the contribution you are making will take more
          than an hour, please make sure it has been discussed in an issue first.
          This is especially true for feature requests!
* 💡 Features
          Feature requests can be created and discussed within a GitHub Issue.  Be
          sure to search for existing feature requests (and related issues!) prior to
          opening a new request.  If an existing issue covers the need, please upvote
          that issue by using the 👍 emote, rather than opening a new issue.
* 🔌 Integrations
          Apollo Server has many web-framework integrations including Express, Koa,
          Hapi and more.  When adding a new feature, or fixing a bug, please take a
          peak and see if other integrations are also affected.  In most cases, the
          fix can be applied to the other frameworks as well.  Please note that,
          since new web-frameworks have a high maintenance cost, pull-requests for
          new web-frameworks should be discussed with a project maintainer first.
* 🕷 Bug fixes
          These can be created and discussed in this repository. When fixing a bug,
          please _try_ to add a test which verifies the fix.  If you cannot, you should
          still submit the PR but we may still ask you (and help you!) to create a test.
* 📖 Contribution guidelines
          Follow https://github.com/apollographql/apollo-server/blob/main/CONTRIBUTING.md
          when submitting a pull request.  Make sure existing tests still pass, and add
          tests for all new behavior.
* ✏️ Explain your pull request
          Describe the big picture of your changes here to communicate to what your
          pull request is meant to accomplish.  Provide 🔗 links 🔗 to associated issues!

We hope you will find this to be a positive experience!  Open source contribution can be intimidating and we hope to alleviate that pain as much as possible.  Without following these guidelines, you may be missing context that can help you succeed with your contribution, which is why we encourage discussion first.  Ultimately, there is no guarantee that we will be able to merge your pull-request, but by following these guidelines we can try to avoid disappointment.
