### PR TITLE
Update vscode launch task to be friendly to non-bash users

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "label": "Shell",
       "type": "shell",
-      "command": "bash",
+      "command": "${SHELL}",
       "args": ["-l"],
       "isBackground": true,
       "presentation": {


### PR DESCRIPTION
Use the user's default via `$SHELL`