### PR TITLE
NEBULA-2161: send package version to embeds

### DIFF
--- a/.changeset/polite-poets-teach.md
+++ b/.changeset/polite-poets-teach.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+We now send your @apollo/server version to the embedded Explorer & Sandbox used in the landing pages for analytics.

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -2,8 +2,9 @@ import { getEmbeddedExplorerHTML } from '../../../plugin/landingPage/default/get
 import type { ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
-const version = '_latest';
+const cdnVersion = '_latest';
 expect.addSnapshotSerializer(require('jest-serializer-html'));
+const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Embedded Explorer Landing Page Config HTML', () => {
   it('with document, variables, headers and displayOptions provided', () => {
@@ -29,7 +30,8 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         },
         graphRef: 'graph@current',
       };
-    expect(getEmbeddedExplorerHTML(version, config)).toMatchInlineSnapshot(`
+    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -47,7 +49,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?referrer=@apollo/server@4.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;
@@ -67,7 +69,8 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         embed: true as true,
         graphRef: 'graph@current',
       };
-    expect(getEmbeddedExplorerHTML(version, config)).toMatchInlineSnapshot(`
+    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -85,7 +88,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?referrer=@apollo/server@4.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -8,28 +8,30 @@ const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Embedded Explorer Landing Page Config HTML', () => {
   it('with document, variables, headers and displayOptions provided', () => {
-    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
-      {
-        includeCookies: true,
-        document: 'query Test { id }',
-        variables: {
-          option: {
-            a: 'val',
-            b: 1,
-            c: true,
-          },
+    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions & {
+      runtime: string;
+    } = {
+      includeCookies: true,
+      document: 'query Test { id }',
+      variables: {
+        option: {
+          a: 'val',
+          b: 1,
+          c: true,
         },
-        headers: { authorization: 'true' },
-        embed: {
-          displayOptions: {
-            showHeadersAndEnvVars: true,
-            docsPanelState: 'open',
-            theme: 'light',
-          },
-          persistExplorerState: true,
+      },
+      headers: { authorization: 'true' },
+      embed: {
+        displayOptions: {
+          showHeadersAndEnvVars: true,
+          docsPanelState: 'open',
+          theme: 'light',
         },
-        graphRef: 'graph@current',
-      };
+        persistExplorerState: true,
+      },
+      graphRef: 'graph@current',
+      runtime: '@apollo/server@4.0.0',
+    };
     expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
       <div class="fallback">
@@ -49,11 +51,11 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?referrer=@apollo/server@4.0.0">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=@apollo/server@4.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;
-        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"document":"query Test { id }","headers":{"authorization":"true"},"variables":{"option":{"a":"val","b":1,"c":true}},"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true,"includeCookies":true};
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"document":"query Test { id }","headers":{"authorization":"true"},"variables":{"option":{"a":"val","b":1,"c":true}},"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true,"includeCookies":true,"runtime":"@apollo/server@4.0.0"};
         new window.EmbeddedExplorer({
           ...embeddedExplorerConfig,
           endpointUrl,
@@ -63,12 +65,14 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
   });
 
   it('for embedded explorer with document, variables, headers and displayOptions excluded', () => {
-    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
-      {
-        includeCookies: false,
-        embed: true as true,
-        graphRef: 'graph@current',
-      };
+    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions & {
+      runtime: string;
+    } = {
+      includeCookies: false,
+      embed: true as true,
+      graphRef: 'graph@current',
+      runtime: '@apollo/server@4.0.0',
+    };
     expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
       <div class="fallback">
@@ -88,11 +92,11 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?referrer=@apollo/server@4.0.0">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=@apollo/server@4.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;
-        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"displayOptions":{}},"persistExplorerState":false,"includeCookies":false};
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"displayOptions":{}},"persistExplorerState":false,"includeCookies":false,"runtime":"@apollo/server@4.0.0"};
         new window.EmbeddedExplorer({
           ...embeddedExplorerConfig,
           endpointUrl,

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -49,7 +49,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;
@@ -88,7 +88,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -8,30 +8,28 @@ const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Embedded Explorer Landing Page Config HTML', () => {
   it('with document, variables, headers and displayOptions provided', () => {
-    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions & {
-      runtime: string;
-    } = {
-      includeCookies: true,
-      document: 'query Test { id }',
-      variables: {
-        option: {
-          a: 'val',
-          b: 1,
-          c: true,
+    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
+      {
+        includeCookies: true,
+        document: 'query Test { id }',
+        variables: {
+          option: {
+            a: 'val',
+            b: 1,
+            c: true,
+          },
         },
-      },
-      headers: { authorization: 'true' },
-      embed: {
-        displayOptions: {
-          showHeadersAndEnvVars: true,
-          docsPanelState: 'open',
-          theme: 'light',
+        headers: { authorization: 'true' },
+        embed: {
+          displayOptions: {
+            showHeadersAndEnvVars: true,
+            docsPanelState: 'open',
+            theme: 'light',
+          },
+          persistExplorerState: true,
         },
-        persistExplorerState: true,
-      },
-      graphRef: 'graph@current',
-      runtime: '@apollo/server@4.0.0',
-    };
+        graphRef: 'graph@current',
+      };
     expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
       <div class="fallback">
@@ -65,14 +63,12 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
   });
 
   it('for embedded explorer with document, variables, headers and displayOptions excluded', () => {
-    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions & {
-      runtime: string;
-    } = {
-      includeCookies: false,
-      embed: true as true,
-      graphRef: 'graph@current',
-      runtime: '@apollo/server@4.0.0',
-    };
+    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
+      {
+        includeCookies: false,
+        embed: true as true,
+        graphRef: 'graph@current',
+      };
     expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
       <div class="fallback">

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -8,7 +8,7 @@ const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Landing Page Config HTML', () => {
   it('for embedded sandbox with document, variables and headers provided', () => {
-    const config: LandingPageConfig & { runtime: string } = {
+    const config: LandingPageConfig = {
       includeCookies: true,
       document: 'query Test { id }',
       variables: {
@@ -20,7 +20,6 @@ describe('Landing Page Config HTML', () => {
       },
       headers: { authorization: 'true' },
       embed: true,
-      runtime: '@apollo/server@4.0.0',
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
@@ -57,10 +56,9 @@ describe('Landing Page Config HTML', () => {
   });
 
   it('for embedded sandbox with document, variables and headers excluded', () => {
-    const config: LandingPageConfig & { runtime: string } = {
+    const config: LandingPageConfig = {
       includeCookies: false,
       embed: true,
-      runtime: '@apollo/server@4.0.0',
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -2,8 +2,9 @@ import { getEmbeddedSandboxHTML } from '../../../plugin/landingPage/default/getE
 import type { LandingPageConfig } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
-const version = '_latest';
+const cdnVersion = '_latest';
 expect.addSnapshotSerializer(require('jest-serializer-html'));
+const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Landing Page Config HTML', () => {
   it('for embedded sandbox with document, variables and headers provided', () => {
@@ -20,7 +21,8 @@ describe('Landing Page Config HTML', () => {
       headers: { authorization: 'true' },
       embed: true,
     };
-    expect(getEmbeddedSandboxHTML(version, config)).toMatchInlineSnapshot(`
+    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -38,7 +40,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?referrer=@apollo/server@4.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;
@@ -57,7 +59,8 @@ describe('Landing Page Config HTML', () => {
       includeCookies: false,
       embed: true,
     };
-    expect(getEmbeddedSandboxHTML(version, config)).toMatchInlineSnapshot(`
+    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -75,7 +78,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?referrer=@apollo/server@4.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -40,7 +40,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;
@@ -79,7 +79,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -8,7 +8,7 @@ const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Landing Page Config HTML', () => {
   it('for embedded sandbox with document, variables and headers provided', () => {
-    const config: LandingPageConfig = {
+    const config: LandingPageConfig & { runtime: string } = {
       includeCookies: true,
       document: 'query Test { id }',
       variables: {
@@ -20,6 +20,7 @@ describe('Landing Page Config HTML', () => {
       },
       headers: { authorization: 'true' },
       embed: true,
+      runtime: '@apollo/server@4.0.0',
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
@@ -40,7 +41,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?referrer=@apollo/server@4.0.0">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;
@@ -49,15 +50,17 @@ describe('Landing Page Config HTML', () => {
           initialEndpoint,
           initialState: {"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"includeCookies":true},
           hideCookieToggle: false,
+          runtime: '@apollo/server@4.0.0'
         });
       </script>
     `);
   });
 
   it('for embedded sandbox with document, variables and headers excluded', () => {
-    const config: LandingPageConfig = {
+    const config: LandingPageConfig & { runtime: string } = {
       includeCookies: false,
       embed: true,
+      runtime: '@apollo/server@4.0.0',
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
@@ -78,7 +81,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?referrer=@apollo/server@4.0.0">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;
@@ -87,6 +90,7 @@ describe('Landing Page Config HTML', () => {
           initialEndpoint,
           initialState: {"includeCookies":false},
           hideCookieToggle: false,
+          runtime: '@apollo/server@4.0.0'
         });
       </script>
     `);

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -84,7 +84,9 @@ export const getEmbeddedExplorerHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableExplorer"
 ></div>
-<script src="https://embeddable-explorer.cdn.apollographql.com/${explorerCdnVersion}/embeddable-explorer.umd.production.min.js?runtime=${apolloServerVersion}"></script>
+<script src="https://embeddable-explorer.cdn.apollographql.com/${encodeURIComponent(
+    explorerCdnVersion,
+  )}/embeddable-explorer.umd.production.min.js?runtime=${apolloServerVersion}"></script>
 <script>
   var endpointUrl = window.location.href;
   var embeddedExplorerConfig = ${getConfigStringForHtml(
@@ -117,7 +119,9 @@ export const getEmbeddedSandboxHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"
 ></div>
-<script src="https://embeddable-sandbox.cdn.apollographql.com/${sandboxCdnVersion}/embeddable-sandbox.umd.production.min.js?runtime=${apolloServerVersion}"></script>
+<script src="https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
+    sandboxCdnVersion,
+  )}/embeddable-sandbox.umd.production.min.js?runtime=${apolloServerVersion}"></script>
 <script>
   var initialEndpoint = window.location.href;
   new window.EmbeddedSandbox({

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -22,7 +22,9 @@ function getConfigStringForHtml(config: LandingPageConfig) {
 
 export const getEmbeddedExplorerHTML = (
   explorerCdnVersion: string,
-  config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions,
+  config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions & {
+    runtime: string;
+  },
   apolloServerVersion: string,
 ) => {
   interface EmbeddableExplorerOptions {
@@ -50,22 +52,25 @@ export const getEmbeddedExplorerHTML = (
     persistExplorerState: false,
     ...(typeof config.embed === 'boolean' ? {} : config.embed),
   };
-  const embeddedExplorerParams: Omit<EmbeddableExplorerOptions, 'endpointUrl'> =
-    {
-      graphRef: config.graphRef,
-      target: '#embeddableExplorer',
-      initialState: {
-        document: config.document,
-        headers: config.headers,
-        variables: config.variables,
-        displayOptions: {
-          ...productionLandingPageConfigOrDefault.displayOptions,
-        },
+  const embeddedExplorerParams: Omit<
+    EmbeddableExplorerOptions,
+    'endpointUrl'
+  > & { runtime: string } = {
+    graphRef: config.graphRef,
+    target: '#embeddableExplorer',
+    initialState: {
+      document: config.document,
+      headers: config.headers,
+      variables: config.variables,
+      displayOptions: {
+        ...productionLandingPageConfigOrDefault.displayOptions,
       },
-      persistExplorerState:
-        productionLandingPageConfigOrDefault.persistExplorerState,
-      includeCookies: config.includeCookies,
-    };
+    },
+    persistExplorerState:
+      productionLandingPageConfigOrDefault.persistExplorerState,
+    includeCookies: config.includeCookies,
+    runtime: config.runtime,
+  };
 
   return `
 <div class="fallback">
@@ -81,7 +86,7 @@ export const getEmbeddedExplorerHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableExplorer"
 ></div>
-<script src="https://embeddable-explorer.cdn.apollographql.com/${explorerCdnVersion}/embeddable-explorer.umd.production.min.js?referrer=${apolloServerVersion}"></script>
+<script src="https://embeddable-explorer.cdn.apollographql.com/${explorerCdnVersion}/embeddable-explorer.umd.production.min.js?runtime=${apolloServerVersion}"></script>
 <script>
   var endpointUrl = window.location.href;
   var embeddedExplorerConfig = ${getConfigStringForHtml(
@@ -97,7 +102,7 @@ id="embeddableExplorer"
 
 export const getEmbeddedSandboxHTML = (
   sandboxCdnVersion: string,
-  config: LandingPageConfig,
+  config: LandingPageConfig & { runtime: string },
   apolloServerVersion: string,
 ) => {
   return `
@@ -114,7 +119,7 @@ export const getEmbeddedSandboxHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"
 ></div>
-<script src="https://embeddable-sandbox.cdn.apollographql.com/${sandboxCdnVersion}/embeddable-sandbox.umd.production.min.js?referrer=${apolloServerVersion}"></script>
+<script src="https://embeddable-sandbox.cdn.apollographql.com/${sandboxCdnVersion}/embeddable-sandbox.umd.production.min.js?runtime=${apolloServerVersion}"></script>
 <script>
   var initialEndpoint = window.location.href;
   new window.EmbeddedSandbox({
@@ -127,6 +132,7 @@ id="embeddableSandbox"
       includeCookies: config.includeCookies,
     })},
     hideCookieToggle: false,
+    runtime: '${config.runtime}'
   });
 </script>
 `;

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -22,9 +22,7 @@ function getConfigStringForHtml(config: LandingPageConfig) {
 
 export const getEmbeddedExplorerHTML = (
   explorerCdnVersion: string,
-  config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions & {
-    runtime: string;
-  },
+  config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions,
   apolloServerVersion: string,
 ) => {
   interface EmbeddableExplorerOptions {
@@ -69,7 +67,7 @@ export const getEmbeddedExplorerHTML = (
     persistExplorerState:
       productionLandingPageConfigOrDefault.persistExplorerState,
     includeCookies: config.includeCookies,
-    runtime: config.runtime,
+    runtime: apolloServerVersion,
   };
 
   return `
@@ -102,7 +100,7 @@ id="embeddableExplorer"
 
 export const getEmbeddedSandboxHTML = (
   sandboxCdnVersion: string,
-  config: LandingPageConfig & { runtime: string },
+  config: LandingPageConfig,
   apolloServerVersion: string,
 ) => {
   return `
@@ -132,7 +130,7 @@ id="embeddableSandbox"
       includeCookies: config.includeCookies,
     })},
     hideCookieToggle: false,
-    runtime: '${config.runtime}'
+    runtime: '${apolloServerVersion}'
   });
 </script>
 `;

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -86,7 +86,9 @@ id="embeddableExplorer"
 ></div>
 <script src="https://embeddable-explorer.cdn.apollographql.com/${encodeURIComponent(
     explorerCdnVersion,
-  )}/embeddable-explorer.umd.production.min.js?runtime=${apolloServerVersion}"></script>
+  )}/embeddable-explorer.umd.production.min.js?runtime=${encodeURIComponent(
+    apolloServerVersion,
+  )}"></script>
 <script>
   var endpointUrl = window.location.href;
   var embeddedExplorerConfig = ${getConfigStringForHtml(
@@ -121,7 +123,9 @@ id="embeddableSandbox"
 ></div>
 <script src="https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
     sandboxCdnVersion,
-  )}/embeddable-sandbox.umd.production.min.js?runtime=${apolloServerVersion}"></script>
+  )}/embeddable-sandbox.umd.production.min.js?runtime=${encodeURIComponent(
+    apolloServerVersion,
+  )}"></script>
 <script>
   var initialEndpoint = window.location.href;
   new window.EmbeddedSandbox({

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -21,8 +21,9 @@ function getConfigStringForHtml(config: LandingPageConfig) {
 }
 
 export const getEmbeddedExplorerHTML = (
-  version: string,
+  explorerCdnVersion: string,
   config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions,
+  apolloServerVersion: string,
 ) => {
   interface EmbeddableExplorerOptions {
     graphRef: string;
@@ -80,7 +81,7 @@ export const getEmbeddedExplorerHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableExplorer"
 ></div>
-<script src="https://embeddable-explorer.cdn.apollographql.com/${version}/embeddable-explorer.umd.production.min.js"></script>
+<script src="https://embeddable-explorer.cdn.apollographql.com/${explorerCdnVersion}/embeddable-explorer.umd.production.min.js?referrer=${apolloServerVersion}"></script>
 <script>
   var endpointUrl = window.location.href;
   var embeddedExplorerConfig = ${getConfigStringForHtml(
@@ -95,8 +96,9 @@ id="embeddableExplorer"
 };
 
 export const getEmbeddedSandboxHTML = (
-  version: string,
+  sandboxCdnVersion: string,
   config: LandingPageConfig,
+  apolloServerVersion: string,
 ) => {
   return `
 <div class="fallback">
@@ -112,7 +114,7 @@ export const getEmbeddedSandboxHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"
 ></div>
-<script src="https://embeddable-sandbox.cdn.apollographql.com/${version}/embeddable-sandbox.umd.production.min.js"></script>
+<script src="https://embeddable-sandbox.cdn.apollographql.com/${sandboxCdnVersion}/embeddable-sandbox.umd.production.min.js?referrer=${apolloServerVersion}"></script>
 <script>
   var initialEndpoint = window.location.href;
   new window.EmbeddedSandbox({

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -70,7 +70,7 @@ const getNonEmbeddedLandingPageHTML = (
   <p>The full landing page cannot be loaded; it appears that you might be offline.</p>
 </div>
 <script>window.landingPage = ${encodedConfig};</script>
-<script src="https://apollo-server-landing-page.cdn.apollographql.com/${cdnVersion}/static/js/main.js?referrer=${apolloServerVersion}"></script>`;
+<script src="https://apollo-server-landing-page.cdn.apollographql.com/${cdnVersion}/static/js/main.js?runtime=${apolloServerVersion}"></script>`;
 };
 
 // Helper for the two actual plugin functions.
@@ -85,7 +85,7 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
   const configWithVersion = {
     ...config,
-    referrer: apolloServerVersion,
+    runtime: apolloServerVersion,
   };
 
   return {

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -83,10 +83,6 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
 ): ImplicitlyInstallablePlugin<TContext> {
   const version = maybeVersion ?? '_latest';
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
-  const configWithVersion = {
-    ...config,
-    runtime: apolloServerVersion,
-  };
 
   return {
     __internal_installed_implicitly__: false,
@@ -137,23 +133,11 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
         }
       </style>
     ${
-      configWithVersion.embed
-        ? 'graphRef' in configWithVersion && configWithVersion.graphRef
-          ? getEmbeddedExplorerHTML(
-              version,
-              configWithVersion,
-              apolloServerVersion,
-            )
-          : getEmbeddedSandboxHTML(
-              version,
-              configWithVersion,
-              apolloServerVersion,
-            )
-        : getNonEmbeddedLandingPageHTML(
-            version,
-            configWithVersion,
-            apolloServerVersion,
-          )
+      config.embed
+        ? 'graphRef' in config && config.graphRef
+          ? getEmbeddedExplorerHTML(version, config, apolloServerVersion)
+          : getEmbeddedSandboxHTML(version, config, apolloServerVersion)
+        : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
     }
     </div>
   </body>

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -83,6 +83,10 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
 ): ImplicitlyInstallablePlugin<TContext> {
   const version = maybeVersion ?? '_latest';
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
+  const configWithVersion = {
+    ...config,
+    referrer: apolloServerVersion,
+  };
 
   return {
     __internal_installed_implicitly__: false,
@@ -133,11 +137,23 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
         }
       </style>
     ${
-      config.embed
-        ? 'graphRef' in config && config.graphRef
-          ? getEmbeddedExplorerHTML(version, config, apolloServerVersion)
-          : getEmbeddedSandboxHTML(version, config, apolloServerVersion)
-        : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
+      configWithVersion.embed
+        ? 'graphRef' in configWithVersion && configWithVersion.graphRef
+          ? getEmbeddedExplorerHTML(
+              version,
+              configWithVersion,
+              apolloServerVersion,
+            )
+          : getEmbeddedSandboxHTML(
+              version,
+              configWithVersion,
+              apolloServerVersion,
+            )
+        : getNonEmbeddedLandingPageHTML(
+            version,
+            configWithVersion,
+            apolloServerVersion,
+          )
     }
     </div>
   </body>

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -12,6 +12,7 @@ import {
   getEmbeddedExplorerHTML,
   getEmbeddedSandboxHTML,
 } from './getEmbeddedHTML.js';
+import { packageVersion } from '../../../generated/packageVersion.js';
 
 export type {
   ApolloServerPluginLandingPageLocalDefaultOptions,
@@ -57,8 +58,9 @@ function encodeConfig(config: LandingPageConfig): string {
 }
 
 const getNonEmbeddedLandingPageHTML = (
-  version: string,
+  cdnVersion: string,
   config: LandingPageConfig,
+  apolloServerVersion: string,
 ) => {
   const encodedConfig = encodeConfig(config);
 
@@ -68,7 +70,7 @@ const getNonEmbeddedLandingPageHTML = (
   <p>The full landing page cannot be loaded; it appears that you might be offline.</p>
 </div>
 <script>window.landingPage = ${encodedConfig};</script>
-<script src="https://apollo-server-landing-page.cdn.apollographql.com/${version}/static/js/main.js"></script>`;
+<script src="https://apollo-server-landing-page.cdn.apollographql.com/${cdnVersion}/static/js/main.js?referrer=${apolloServerVersion}"></script>`;
 };
 
 // Helper for the two actual plugin functions.
@@ -80,6 +82,7 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
   },
 ): ImplicitlyInstallablePlugin<TContext> {
   const version = maybeVersion ?? '_latest';
+  const apolloServerVersion = `@apollo/server@${packageVersion}`;
 
   return {
     __internal_installed_implicitly__: false,
@@ -132,9 +135,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     ${
       config.embed
         ? 'graphRef' in config && config.graphRef
-          ? getEmbeddedExplorerHTML(version, config)
-          : getEmbeddedSandboxHTML(version, config)
-        : getNonEmbeddedLandingPageHTML(version, config)
+          ? getEmbeddedExplorerHTML(version, config, apolloServerVersion)
+          : getEmbeddedSandboxHTML(version, config, apolloServerVersion)
+        : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
     }
     </div>
   </body>


### PR DESCRIPTION
This pr should be rebased off of https://github.com/apollographql/apollo-server/pull/7432

## Context

[JIRA](https://apollographql.atlassian.net/browse/NEBULA-2161?atlOrigin=eyJpIjoiNjRiNTc1ZWIyNTE0NDU3ZWE4ZDZlN2FiOWNlMzI1OTUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
[Slack](https://apollograph.slack.com/archives/C025ENJA19Q/p1678288648578999)

## What Changed?

This PR does 2 things
1. passes the packageVersion as query params in the <script tag that requests the embedded Explorer / Sandbox CDN bundle.
2. sends the packageVersion to the embedded Explorer & Sandbox, which are [set up to send these as query params to Studio](https://github.com/apollographql/embeddable-explorer/pull/221). This is redundant data capture just in case.

## How to test

erm, run the landing pages locally, check the console & see that the version shows up correctly in the cdn script url

there are already tests for the html functions