### PR TITLE
NEBULA-2126: Add new config options to Sandbox & Explorer landing pages

### DIFF
--- a/.changeset/angry-weeks-flash.md
+++ b/.changeset/angry-weeks-flash.md
@@ -14,18 +14,14 @@ const server = new ApolloServer({
     process.env.NODE_ENV === 'production'
       ? ApolloServerPluginLandingPageProductionDefault({
           graphRef: 'my-graph-id@my-graph-variant',
-          defaultOperation: {
-            collectionId: 'abcdef',
-            operationId: '12345'
-          },
+          collectionId: 'abcdef',
+          operationId: '12345'
           embed: true,
           footer: false,
         })
       : ApolloServerPluginLandingPageLocalDefault({
-          defaultOperation: {
-            collectionId: 'abcdef',
-            operationId: '12345'
-          },
+          collectionId: 'abcdef',
+          operationId: '12345'
           embed: {
             initialState: {
               pollForSchemaUpdates: false,

--- a/.changeset/angry-weeks-flash.md
+++ b/.changeset/angry-weeks-flash.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+In the Apollo Server Landing Page Local config, you can now automatically turn off autopolling on your endpoints as well as pass headers used to introspect your schema, embed an operation from a collection, and configure whether the endpoint input box is editable. In the Apollo Server Landing Page Prod config, you can embed an operation from a collection & we fixed a bug introduced in release 4.4.0

--- a/.changeset/angry-weeks-flash.md
+++ b/.changeset/angry-weeks-flash.md
@@ -3,3 +3,41 @@
 ---
 
 In the Apollo Server Landing Page Local config, you can now automatically turn off autopolling on your endpoints as well as pass headers used to introspect your schema, embed an operation from a collection, and configure whether the endpoint input box is editable. In the Apollo Server Landing Page Prod config, you can embed an operation from a collection & we fixed a bug introduced in release 4.4.0
+
+Example of all new config options: 
+
+```
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  plugins: [
+    process.env.NODE_ENV === 'production'
+      ? ApolloServerPluginLandingPageProductionDefault({
+          graphRef: 'my-graph-id@my-graph-variant',
+          defaultOperation: {
+            collectionId: 'abcdef',
+            operationId: '12345'
+          },
+          embed: true,
+          footer: false,
+        })
+      : ApolloServerPluginLandingPageLocalDefault({
+          defaultOperation: {
+            collectionId: 'abcdef',
+            operationId: '12345'
+          },
+          embed: {
+            initialState: {
+              pollForSchemaUpdates: false,
+              sharedHeaders: {
+                "HeaderNeededForIntrospection": "ValueForIntrospection"
+              },
+            },
+            endpointIsEditable: true,
+          },
+          footer: false,
+        }),
+  ],
+});
+
+```

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -66,8 +66,10 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
     const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
       {
         includeCookies: true,
-        collectionId: '12345',
-        operationId: 'abcdef',
+        defaultOperation: {
+          collectionId: '12345',
+          operationId: 'abcdef',
+        },
         embed: true,
         graphRef: 'graph@current',
       };
@@ -90,7 +92,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var endpointUrl = window.location.href;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -62,6 +62,46 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
     `);
   });
 
+  it('with only headers provided', () => {
+    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
+      {
+        includeCookies: true,
+        headers: { authorization: 'true' },
+        embed: true,
+        graphRef: 'graph@current',
+      };
+    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Explorer cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
+      <style>
+        iframe {
+          background-color: white;
+        }
+      </style>
+      <div style="width: 100vw; height: 100vh; position: absolute; top: 0;"
+           id="embeddableExplorer"
+      >
+      </div>
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      </script>
+      <script>
+        var endpointUrl = window.location.href;
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"headers":{"authorization":"true"},"displayOptions":{}},"persistExplorerState":false,"includeCookies":true,"runtime":"@apollo/server@4.0.0"};
+        new window.EmbeddedExplorer({
+          ...embeddedExplorerConfig,
+          endpointUrl,
+        });
+      </script>
+    `);
+  });
+
   it('with operationId, collectionId provided', () => {
     const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
       {

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -66,10 +66,8 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
     const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
       {
         includeCookies: true,
-        defaultOperation: {
-          collectionId: '12345',
-          operationId: 'abcdef',
-        },
+        collectionId: '12345',
+        operationId: 'abcdef',
         embed: true,
         graphRef: 'graph@current',
       };

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -62,11 +62,52 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
     `);
   });
 
+  it('with operationId, collectionId provided', () => {
+    const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
+      {
+        includeCookies: true,
+        collectionId: '12345',
+        operationId: 'abcdef',
+        embed: true,
+        graphRef: 'graph@current',
+      };
+    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Explorer cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
+      <style>
+        iframe {
+          background-color: white;
+        }
+      </style>
+      <div style="width: 100vw; height: 100vh; position: absolute; top: 0;"
+           id="embeddableExplorer"
+      >
+      </div>
+      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      </script>
+      <script>
+        var endpointUrl = window.location.href;
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"collectionId":"12345","operationId":"abcdef","displayOptions":{}},"persistExplorerState":false,"includeCookies":true,"runtime":"@apollo/server@4.0.0"};
+        new window.EmbeddedExplorer({
+          ...embeddedExplorerConfig,
+          endpointUrl,
+        });
+      </script>
+    `);
+  });
+
   it('for embedded explorer with document, variables, headers and displayOptions excluded', () => {
     const config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
       {
         includeCookies: false,
-        embed: true as true,
+        embed: true,
         graphRef: 'graph@current',
       };
     expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -79,7 +79,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;
@@ -97,8 +97,10 @@ describe('Landing Page Config HTML', () => {
 
   it('for embedded sandbox with operationId & collectionId provided', () => {
     const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
-      collectionId: '12345',
-      operationId: 'abcdef',
+      defaultOperation: {
+        collectionId: '12345',
+        operationId: 'abcdef',
+      },
       embed: true,
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
@@ -137,9 +139,7 @@ describe('Landing Page Config HTML', () => {
   });
 
   it('for embedded sandbox with endpointIsEditable, pollForSchemaUpdates, sharedHeaders provided', () => {
-    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions & {
-      runtime: string;
-    } = {
+    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
       includeCookies: false,
       embed: {
         endpointIsEditable: true,
@@ -148,7 +148,6 @@ describe('Landing Page Config HTML', () => {
           sharedHeaders: { SharedHeaderKey: 'SharedHeaderValue' },
         },
       },
-      runtime: '@apollo/server@4.0.0',
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
       .toMatchInlineSnapshot(`
@@ -169,7 +168,7 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
       </script>
       <script>
         var initialEndpoint = window.location.href;

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -56,6 +56,47 @@ describe('Landing Page Config HTML', () => {
     `);
   });
 
+  it('for embedded sandbox with only headers provided', () => {
+    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
+      includeCookies: true,
+      headers: { authorization: 'true' },
+      embed: true,
+    };
+    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Sandbox cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
+      <style>
+        iframe {
+          background-color: white;
+        }
+      </style>
+      <div style="width: 100vw; height: 100vh; position: absolute; top: 0;"
+           id="embeddableSandbox"
+      >
+      </div>
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      </script>
+      <script>
+        var initialEndpoint = window.location.href;
+        new window.EmbeddedSandbox({
+          target: '#embeddableSandbox',
+          initialEndpoint,
+          initialState: {"headers":{"authorization":"true"},"includeCookies":true},
+          hideCookieToggle: false,
+          endpointIsEditable: false,
+          runtime: '@apollo/server@4.0.0'
+        });
+      </script>
+    `);
+  });
+
   it('for embedded sandbox with all config excluded', () => {
     const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
       embed: true,

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -97,10 +97,8 @@ describe('Landing Page Config HTML', () => {
 
   it('for embedded sandbox with operationId & collectionId provided', () => {
     const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
-      defaultOperation: {
-        collectionId: '12345',
-        operationId: 'abcdef',
-      },
+      collectionId: '12345',
+      operationId: 'abcdef',
       embed: true,
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -1,5 +1,5 @@
 import { getEmbeddedSandboxHTML } from '../../../plugin/landingPage/default/getEmbeddedHTML';
-import type { LandingPageConfig } from '../../../plugin/landingPage/default/types';
+import type { ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
 const cdnVersion = '_latest';
@@ -8,7 +8,7 @@ const apolloServerVersion = '@apollo/server@4.0.0';
 
 describe('Landing Page Config HTML', () => {
   it('for embedded sandbox with document, variables and headers provided', () => {
-    const config: LandingPageConfig = {
+    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
       includeCookies: true,
       document: 'query Test { id }',
       variables: {
@@ -49,15 +49,56 @@ describe('Landing Page Config HTML', () => {
           initialEndpoint,
           initialState: {"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"includeCookies":true},
           hideCookieToggle: false,
+          endpointIsEditable: false,
           runtime: '@apollo/server@4.0.0'
         });
       </script>
     `);
   });
 
-  it('for embedded sandbox with document, variables and headers excluded', () => {
-    const config: LandingPageConfig = {
-      includeCookies: false,
+  it('for embedded sandbox with all config excluded', () => {
+    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
+      embed: true,
+    };
+    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Sandbox cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
+      <style>
+        iframe {
+          background-color: white;
+        }
+      </style>
+      <div style="width: 100vw; height: 100vh; position: absolute; top: 0;"
+           id="embeddableSandbox"
+      >
+      </div>
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      </script>
+      <script>
+        var initialEndpoint = window.location.href;
+        new window.EmbeddedSandbox({
+          target: '#embeddableSandbox',
+          initialEndpoint,
+          initialState: {},
+          hideCookieToggle: false,
+          endpointIsEditable: false,
+          runtime: '@apollo/server@4.0.0'
+        });
+      </script>
+    `);
+  });
+
+  it('for embedded sandbox with operationId & collectionId provided', () => {
+    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
+      collectionId: '12345',
+      operationId: 'abcdef',
       embed: true,
     };
     expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
@@ -86,8 +127,58 @@ describe('Landing Page Config HTML', () => {
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
           initialEndpoint,
-          initialState: {"includeCookies":false},
+          initialState: {"collectionId":"12345","operationId":"abcdef"},
           hideCookieToggle: false,
+          endpointIsEditable: false,
+          runtime: '@apollo/server@4.0.0'
+        });
+      </script>
+    `);
+  });
+
+  it('for embedded sandbox with endpointIsEditable, pollForSchemaUpdates, sharedHeaders provided', () => {
+    const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions & {
+      runtime: string;
+    } = {
+      includeCookies: false,
+      embed: {
+        endpointIsEditable: true,
+        initialState: {
+          pollForSchemaUpdates: false,
+          sharedHeaders: { SharedHeaderKey: 'SharedHeaderValue' },
+        },
+      },
+      runtime: '@apollo/server@4.0.0',
+    };
+    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
+      .toMatchInlineSnapshot(`
+      <div class="fallback">
+        <h1>
+          Welcome to Apollo Server
+        </h1>
+        <p>
+          Apollo Sandbox cannot be loaded; it appears that you might be offline.
+        </p>
+      </div>
+      <style>
+        iframe {
+          background-color: white;
+        }
+      </style>
+      <div style="width: 100vw; height: 100vh; position: absolute; top: 0;"
+           id="embeddableSandbox"
+      >
+      </div>
+      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=@apollo/server@4.0.0">
+      </script>
+      <script>
+        var initialEndpoint = window.location.href;
+        new window.EmbeddedSandbox({
+          target: '#embeddableSandbox',
+          initialEndpoint,
+          initialState: {"includeCookies":false,"pollForSchemaUpdates":false,"sharedHeaders":{"SharedHeaderKey":"SharedHeaderValue"}},
+          hideCookieToggle: false,
+          endpointIsEditable: true,
           runtime: '@apollo/server@4.0.0'
         });
       </script>

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -59,11 +59,19 @@ export const getEmbeddedExplorerHTML = (
     graphRef: config.graphRef,
     target: '#embeddableExplorer',
     initialState: {
-      document: config.document,
-      headers: config.headers,
-      variables: config.variables,
-      collectionId: config.defaultOperation?.collectionId,
-      operationId: config.defaultOperation?.operationId,
+      ...('document' in config
+        ? {
+            document: config.document,
+            headers: config.headers,
+            variables: config.variables,
+          }
+        : {}),
+      ...('collectionId' in config
+        ? {
+            collectionId: config.collectionId,
+            operationId: config.operationId,
+          }
+        : {}),
       displayOptions: {
         ...productionLandingPageConfigOrDefault.displayOptions,
       },
@@ -142,12 +150,20 @@ id="embeddableSandbox"
     target: '#embeddableSandbox',
     initialEndpoint,
     initialState: ${getConfigStringForHtml({
-      document: config.document,
-      variables: config.variables,
-      headers: config.headers,
+      ...('document' in config
+        ? {
+            document: config.document,
+            variables: config.variables,
+            headers: config.headers,
+          }
+        : {}),
+      ...('collectionId' in config
+        ? {
+            collectionId: config.collectionId,
+            operationId: config.operationId,
+          }
+        : {}),
       includeCookies: config.includeCookies,
-      collectionId: config.defaultOperation?.collectionId,
-      operationId: config.defaultOperation?.operationId,
       ...(typeof config.embed !== 'boolean' &&
       config.embed?.initialState?.pollForSchemaUpdates !== undefined
         ? {

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -62,8 +62,8 @@ export const getEmbeddedExplorerHTML = (
       document: config.document,
       headers: config.headers,
       variables: config.variables,
-      collectionId: config.collectionId,
-      operationId: config.operationId,
+      collectionId: config.defaultOperation?.collectionId,
+      operationId: config.defaultOperation?.operationId,
       displayOptions: {
         ...productionLandingPageConfigOrDefault.displayOptions,
       },
@@ -146,8 +146,8 @@ id="embeddableSandbox"
       variables: config.variables,
       headers: config.headers,
       includeCookies: config.includeCookies,
-      collectionId: config.collectionId,
-      operationId: config.operationId,
+      collectionId: config.defaultOperation?.collectionId,
+      operationId: config.defaultOperation?.operationId,
       ...(typeof config.embed !== 'boolean' &&
       config.embed?.initialState?.pollForSchemaUpdates !== undefined
         ? {

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -59,7 +59,7 @@ export const getEmbeddedExplorerHTML = (
     graphRef: config.graphRef,
     target: '#embeddableExplorer',
     initialState: {
-      ...('document' in config
+      ...('document' in config || 'headers' in config || 'variables' in config
         ? {
             document: config.document,
             headers: config.headers,
@@ -150,7 +150,7 @@ id="embeddableSandbox"
     target: '#embeddableSandbox',
     initialEndpoint,
     initialState: ${getConfigStringForHtml({
-      ...('document' in config
+      ...('document' in config || 'headers' in config || 'variables' in config
         ? {
             document: config.document,
             variables: config.variables,

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -136,7 +136,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
       config.embed
         ? 'graphRef' in config && config.graphRef
           ? getEmbeddedExplorerHTML(version, config, apolloServerVersion)
-          : getEmbeddedSandboxHTML(version, config, apolloServerVersion)
+          : !('graphRef' in config)
+          ? getEmbeddedSandboxHTML(version, config, apolloServerVersion)
+          : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
         : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
     }
     </div>

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -24,17 +24,6 @@ export interface ApolloServerPluginLandingPageDefaultBaseOptions {
   variables?: Record<string, any>;
 
   /**
-   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
-   *
-   * You can find these values from a registered graph in Studio by
-   * clicking the ... menu next to an operation in the Explorer of that graph and
-   * selecting View operation details.
-   */
-  defaultOperation?: {
-    collectionId?: string;
-    operationId?: string;
-  };
-  /**
    * Users can configure their landing page to link to Studio Explorer with
    * headers loaded in the UI.
    */
@@ -77,6 +66,17 @@ export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
   embed?: true | EmbeddableSandboxOptions;
+  /**
+   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
+   *
+   * You can find these values from a registered graph in Studio by
+   * clicking the ... menu next to an operation in the Explorer of that graph and
+   * selecting View operation details.
+   */
+  defaultOperation?: {
+    collectionId?: string;
+    operationId?: string;
+  };
 }
 
 export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
@@ -90,6 +90,17 @@ export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
    * Users can configure their landing page to render an embedded Explorer.
    */
   embed: true | EmbeddableExplorerOptions;
+  /**
+   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
+   *
+   * You can find these values from a registered graph in Studio by
+   * clicking the ... menu next to an operation in the Explorer of that graph and
+   * selecting View operation details.
+   */
+  defaultOperation?: {
+    collectionId?: string;
+    operationId?: string;
+  };
 }
 
 type EmbeddableSandboxOptions = {

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -22,6 +22,16 @@ export interface ApolloServerPluginLandingPageDefaultBaseOptions {
    * variables loaded in the UI.
    */
   variables?: Record<string, any>;
+
+  /**
+   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load. 
+   *
+   * You can find these values from a registered graph in Studio by
+   * clicking the ... menu next to an operation in the Explorer of that graph and
+   * selecting View operation details.
+   */
+  collectionId?: string;
+  operationId?: string;
   /**
    * Users can configure their landing page to link to Studio Explorer with
    * headers loaded in the UI.
@@ -64,7 +74,7 @@ export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
    * Users can configure their landing page to render an embedded Explorer if
    * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
    */
-  embed?: true;
+  embed?: true | EmbeddableSandboxOptions;
 }
 
 export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
@@ -79,6 +89,32 @@ export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
    */
   embed: true | EmbeddableExplorerOptions;
 }
+
+type EmbeddableSandboxOptions = {
+  initialState?:{
+    /**
+     * If true, the embedded Sandbox periodically polls your initialEndpoint for schema updates.
+     *
+     * The default value is true.
+     */
+    pollForSchemaUpdates?: boolean;
+    /**
+     * Headers that are applied by default to every operation executed by the landing page's Sandbox.
+     * Users can disable the application of these headers, but they can't modify their values.
+     *
+     * The landing page's Sandbox always includes these headers in its introspection queries
+     * to your endpoint.
+     */
+    sharedHeaders?: Record<string, string>
+  }
+  /**
+   * By default, the Apollo Server embedded Sandbox has a url input box that is not editable by users.
+   *
+   * Set `endpointIsEditable` to `true` to enable users of your
+   * Apollo Server landing page to change the endpoint url.
+   */
+  endpointIsEditable?: boolean
+};
 
 type EmbeddableExplorerOptions = {
   /**

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -74,8 +74,8 @@ export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
    * selecting View operation details.
    */
   defaultOperation?: {
-    collectionId?: string;
-    operationId?: string;
+    collectionId: string;
+    operationId: string;
   };
 }
 
@@ -98,8 +98,8 @@ export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
    * selecting View operation details.
    */
   defaultOperation?: {
-    collectionId?: string;
-    operationId?: string;
+    collectionId: string;
+    operationId: string;
   };
 }
 

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -1,17 +1,4 @@
-export interface ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * By default, the landing page plugin uses the latest version of the landing
-   * page published to Apollo's CDN. If you'd like to pin the current version,
-   * pass the SHA served at
-   * https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt
-   * here.
-   */
-  version?: string;
-  /**
-   * Set to false to suppress the footer which explains how to configure the
-   * landing page.
-   */
-  footer?: boolean;
+type InitialDocumentVariablesHeaders = {
   /**
    * Users can configure their landing page to link to Studio Explorer with a
    * document loaded in the UI.
@@ -28,80 +15,92 @@ export interface ApolloServerPluginLandingPageDefaultBaseOptions {
    * headers loaded in the UI.
    */
   headers?: Record<string, string>;
+  collectionId?: never;
+  operationId?: never;
+};
+
+type InitialStateForEmbeds =
+  | {
+      /**
+       * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
+       *
+       * You can find these values from a registered graph in Studio by
+       * clicking the ... menu next to an operation in the Explorer of that graph and
+       * selecting View operation details.
+       */
+      collectionId: string;
+      operationId: string;
+    }
+  | InitialDocumentVariablesHeaders;
+
+export type ApolloServerPluginLandingPageDefaultBaseOptions = {
+  /**
+   * By default, the landing page plugin uses the latest version of the landing
+   * page published to Apollo's CDN. If you'd like to pin the current version,
+   * pass the SHA served at
+   * https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt
+   * here.
+   */
+  version?: string;
+  /**
+   * Set to false to suppress the footer which explains how to configure the
+   * landing page.
+   */
+  footer?: boolean;
 
   includeCookies?: boolean;
   // For Apollo use only.
   __internal_apolloStudioEnv__?: 'staging' | 'prod';
-}
+};
 
-export interface ApolloServerPluginNonEmbeddedLandingPageLocalDefaultOptions
-  extends ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * Users can configure their landing page to render an embedded Explorer if
-   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
-   */
-  embed: false;
-}
+export type ApolloServerPluginNonEmbeddedLandingPageLocalDefaultOptions =
+  ApolloServerPluginLandingPageDefaultBaseOptions &
+    InitialDocumentVariablesHeaders & {
+      /**
+       * Users can configure their landing page to render an embedded Explorer if
+       * given a graphRef, or an embedded Sandbox if there is no graphRef provided.
+       */
+      embed: false;
+    };
 
-export interface ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOptions
-  extends ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * If specified, provide a link (with opt-in auto-redirect) to the Studio page
-   * for the given graphRef. (You need to explicitly pass this here rather than
-   * relying on the server's ApolloConfig, because if your server is publicly
-   * accessible you may not want to display the graph ref publicly.)
-   */
-  graphRef?: string;
-  /**
-   * Users can configure their landing page to render an embedded Explorer if
-   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
-   */
-  embed?: false;
-}
+export type ApolloServerPluginNonEmbeddedLandingPageProductionDefaultOptions =
+  ApolloServerPluginLandingPageDefaultBaseOptions &
+    InitialDocumentVariablesHeaders & {
+      /**
+       * If specified, provide a link (with opt-in auto-redirect) to the Studio page
+       * for the given graphRef. (You need to explicitly pass this here rather than
+       * relying on the server's ApolloConfig, because if your server is publicly
+       * accessible you may not want to display the graph ref publicly.)
+       */
+      graphRef?: string;
+      /**
+       * Users can configure their landing page to render an embedded Explorer if
+       * given a graphRef, or an embedded Sandbox if there is no graphRef provided.
+       */
+      embed?: false;
+    };
 
-export interface ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions
-  extends ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * Users can configure their landing page to render an embedded Explorer if
-   * given a graphRef, or an embedded Sandbox if there is not graphRef provided.
-   */
-  embed?: true | EmbeddableSandboxOptions;
-  /**
-   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
-   *
-   * You can find these values from a registered graph in Studio by
-   * clicking the ... menu next to an operation in the Explorer of that graph and
-   * selecting View operation details.
-   */
-  defaultOperation?: {
-    collectionId: string;
-    operationId: string;
-  };
-}
+export type ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions =
+  ApolloServerPluginLandingPageDefaultBaseOptions & {
+    /**
+     * Users can configure their landing page to render an embedded Explorer if
+     * given a graphRef, or an embedded Sandbox if there is no graphRef provided.
+     */
+    embed?: true | EmbeddableSandboxOptions;
+  } & (InitialDocumentVariablesHeaders | InitialStateForEmbeds);
 
-export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
-  extends ApolloServerPluginLandingPageDefaultBaseOptions {
-  /**
-   * Use this registered's graphs schema to populate the embedded Explorer.
-   * Required if passing `embed: true`
-   */
-  graphRef: string;
-  /**
-   * Users can configure their landing page to render an embedded Explorer.
-   */
-  embed: true | EmbeddableExplorerOptions;
-  /**
-   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
-   *
-   * You can find these values from a registered graph in Studio by
-   * clicking the ... menu next to an operation in the Explorer of that graph and
-   * selecting View operation details.
-   */
-  defaultOperation?: {
-    collectionId: string;
-    operationId: string;
-  };
-}
+export type ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions =
+  ApolloServerPluginLandingPageDefaultBaseOptions & {
+    /**
+     * Use this registered's graphs schema to populate the embedded Explorer.
+     * Required if passing `embed: true`
+     */
+    graphRef: string;
+    /**
+     * Users can configure their landing page to render an embedded Explorer.
+     */
+    embed: true | EmbeddableExplorerOptions;
+  } & InitialStateForEmbeds;
 
 type EmbeddableSandboxOptions = {
   initialState?: {

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -24,14 +24,16 @@ export interface ApolloServerPluginLandingPageDefaultBaseOptions {
   variables?: Record<string, any>;
 
   /**
-   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load. 
+   * The ID of a collection, paired with an operation ID to populate in the Sandbox on load.
    *
    * You can find these values from a registered graph in Studio by
    * clicking the ... menu next to an operation in the Explorer of that graph and
    * selecting View operation details.
    */
-  collectionId?: string;
-  operationId?: string;
+  defaultOperation?: {
+    collectionId?: string;
+    operationId?: string;
+  };
   /**
    * Users can configure their landing page to link to Studio Explorer with
    * headers loaded in the UI.
@@ -91,7 +93,7 @@ export interface ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions
 }
 
 type EmbeddableSandboxOptions = {
-  initialState?:{
+  initialState?: {
     /**
      * If true, the embedded Sandbox periodically polls your initialEndpoint for schema updates.
      *
@@ -105,15 +107,15 @@ type EmbeddableSandboxOptions = {
      * The landing page's Sandbox always includes these headers in its introspection queries
      * to your endpoint.
      */
-    sharedHeaders?: Record<string, string>
-  }
+    sharedHeaders?: Record<string, string>;
+  };
   /**
    * By default, the Apollo Server embedded Sandbox has a url input box that is not editable by users.
    *
    * Set `endpointIsEditable` to `true` to enable users of your
    * Apollo Server landing page to change the endpoint url.
    */
-  endpointIsEditable?: boolean
+  endpointIsEditable?: boolean;
 };
 
 type EmbeddableExplorerOptions = {

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -117,6 +117,10 @@ type EmbeddableSandboxOptions = {
      * The landing page's Sandbox always includes these headers in its introspection queries
      * to your endpoint.
      */
+    // TODO(as5): We currently have `headers` at the top level and `embed.initialState.sharedHeaders`
+    // at this level. Shared headers populate introspection headers in Sandbox, while `headers` just
+    // adds headers to your default tab. We should consider changing the behavior such that `headers`
+    // at the base level populates shared headers as well.
     sharedHeaders?: Record<string, string>;
   };
   /**


### PR DESCRIPTION
This should be rebased off of [this PR](https://github.com/apollographql/apollo-server/pull/7430), can you do that with forks?

## Context

[JIRA](https://apollographql.atlassian.net/browse/NEBULA-2126)

## What Changed?

We recently added the ability to 

1. make the embedded Sandbox endpoint static
2. [pass through shared headers](https://apollographql.atlassian.net/browse/NEBULA-2069) https://github.com/apollographql/embeddable-explorer/issues/214
3. [Allow users to embed an operation from a collection](https://apollographql.atlassian.net/browse/NEBULA-2125)
4. [Allow users to decide not to poll for updates initially](https://github.com/apollographql/embeddable-explorer/issues/185)

[in the embeddable-explorer repo](https://github.com/apollographql/embeddable-explorer/pull/220)

So this PR allows users to set the above configuration in their Sandbox. This PR also allows folks to pass operation ids to the Explorer, but no other changes are made the the Explorer.

## How to test

erm, run the landing pages locally!

there are already tests for the html functions