### PR TITLE
🐛 Align apollo-server config with state of embeds

### DIFF
--- a/.changeset/kind-yaks-sneeze.md
+++ b/.changeset/kind-yaks-sneeze.md
@@ -1,0 +1,13 @@
+---
+'@apollo/server': patch
+---
+
+Bug fix: tldr revert a previous change that stops passing includeCookies from the prod landing page config.
+
+Who was affected? 
+
+Any Apollo Server instance that passes a `graphRef` to a production landing page with a non-default `includeCookies` value that does not match the `Include cookies` setting on your registered variant on studio.apollographql.com.
+
+How were they affected?
+
+From release 4.4.0 to this patch release, folks affected would have seen their Explorer requests being sent with cookies included only if they had set `Include cookies` on their variant. Cookies would not havhe been included by default.

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -51,7 +51,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       </script>
       <script>
         var endpointUrl = window.location.href;
-        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"includeCookies":true,"document":"query Test { id }","variables":{"option":{"a":"val","b":1,"c":true}},"headers":{"authorization":"true"},"embed":{"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"},"persistExplorerState":true},"graphRef":"graph@current","displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true,"hideCookieToggle":false};
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"document":"query Test { id }","headers":{"authorization":"true"},"variables":{"option":{"a":"val","b":1,"c":true}},"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true,"includeCookies":true};
         new window.EmbeddedExplorer({
           ...embeddedExplorerConfig,
           endpointUrl,
@@ -89,7 +89,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       </script>
       <script>
         var endpointUrl = window.location.href;
-        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"includeCookies":false,"embed":true,"graphRef":"graph@current","displayOptions":{}},"persistExplorerState":false,"hideCookieToggle":false};
+        var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"displayOptions":{}},"persistExplorerState":false,"includeCookies":false};
         new window.EmbeddedExplorer({
           ...embeddedExplorerConfig,
           endpointUrl,

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -42,7 +42,7 @@ export const getEmbeddedExplorerHTML = (
 
     endpointUrl: string;
 
-    hideCookieToggle?: boolean; // defaults to 'true'
+    includeCookies?: boolean; // defaults to 'false'
   }
   const productionLandingPageConfigOrDefault = {
     displayOptions: {},
@@ -54,14 +54,15 @@ export const getEmbeddedExplorerHTML = (
       graphRef: config.graphRef,
       target: '#embeddableExplorer',
       initialState: {
-        ...config,
+        document: config.document,
+        headers: config.headers,
+        variables: config.variables,
         displayOptions: {
           ...productionLandingPageConfigOrDefault.displayOptions,
         },
       },
       persistExplorerState:
         productionLandingPageConfigOrDefault.persistExplorerState,
-      hideCookieToggle: false,
     };
 
   return `

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -118,10 +118,10 @@ id="embeddableSandbox"
     target: '#embeddableSandbox',
     initialEndpoint,
     initialState: ${getConfigStringForHtml({
-      document: config.document ?? undefined,
-      variables: config.variables ?? undefined,
-      headers: config.headers ?? undefined,
-      includeCookies: config.includeCookies ?? undefined,
+      document: config.document,
+      variables: config.variables,
+      headers: config.headers,
+      includeCookies: config.includeCookies,
     })},
     hideCookieToggle: false,
   });

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -63,6 +63,7 @@ export const getEmbeddedExplorerHTML = (
       },
       persistExplorerState:
         productionLandingPageConfigOrDefault.persistExplorerState,
+      includeCookies: config.includeCookies,
     };
 
   return `


### PR DESCRIPTION
We added `hideCookieToggle` and `initialState.includeCookies` in the embedded Sandbox config. We then accidentally added `hideCookieToggle` to the embedded Explorer, and we should have only added it to the embedded Sandbox in this repo. 

This PR 
1. puts `includeCookies` back in the embedded Explorer
2. removes `hideCookieToggle` in the embedded Explorer
3. don't spread the entire config into the explorer config, name the arguments
4. remove redundant `?? undefined`s

```
Bug fix: tldr revert a previous change that stops passing includeCookies from the prod landing page config.

Who was affected? 

Any Apollo Server instance that passes a `graphRef` to a production landing page with a non-default `includeCookies` value that does not match the `Include cookies` setting on your registered variant on studio.apollographql.com.

How were they affected?

From release 4.4.0 to this patch release, folks affected would have seen their Explorer requests being sent with cookies included only if they had set `Include cookies` on their variant. Cookies would not havhe been included by default.
```