### PR TITLE
fix: export types form response cache plugin

### DIFF
--- a/.changeset/angry-dogs-tease.md
+++ b/.changeset/angry-dogs-tease.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-plugin-response-cache': patch
+---
+
+Export types from response cache plugin

--- a/packages/plugin-response-cache/src/index.ts
+++ b/packages/plugin-response-cache/src/index.ts
@@ -1,3 +1,2 @@
-import plugin from './ApolloServerPluginResponseCache.js';
-
-export default plugin;
+export { default } from './ApolloServerPluginResponseCache.js';
+export * from './ApolloServerPluginResponseCache.js';


### PR DESCRIPTION
This small change exposes all types used by the response cache plugin, and alow developers to use
```ts
import type { ApolloServerPluginResponseCacheOptions } from "@apollo/server-plugin-response-cache"
```
instead of
```ts
import type { ApolloServerPluginResponseCacheOptions } from "@apollo/server-plugin-response-cache/dist/esm/ApolloServerPluginResponseCache"
```
which is hard to use with ESM imports.

Additionally, it aligns nicer with the style of other packages in this, since it seems to be a pattern to keep everything in `index.ts`

# Alternative approach
Adjust the import/export in `index.ts`
```ts
export * from './ApolloServerPluginResponseCache.js';
```