### PR TITLE
docs(format-error): add an explanation that the original error wrapped in GraphQLError

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -293,7 +293,7 @@ You can disable this recommended security feature by passing `false` to `csrfPre
 
 Provide this function to transform the structure of error objects before they're sent to a client.
 
-The `formatError` hook receives two arguments: the first is a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) (to be spent with the response), and the second is the original error. This function should return a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) object.
+The `formatError` hook receives two arguments: the first is a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) (to be spent with the response), and the second is the original error [(wrapped in GraphQLError if thrown by a resolver)](/docs/source/data/errors.mdx#for-client-responses). This function should return a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) object.
 
 </td>
 </tr>

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -345,7 +345,7 @@ You can edit Apollo Server error details before they're passed to a client or re
 
 The `ApolloServer` constructor accepts a `formatError` hook that is run on each error before it's passed back to the client. You can use this function to log or mask particular errors.
 
-The `formatError` hook receives two arguments: the first is the error formatted as a JSON object (to be sent with the response), and the second is the original error (wrapped in GraphQLError if thrown by a resolver).
+The `formatError` hook receives two arguments: the first is the error formatted as a JSON object (to be sent with the response), and the second is the original error (wrapped in `GraphQLError` if thrown by a resolver).
 
 > The `formatError` function does _not_ modify errors that are sent to Apollo Studio as part of usage reporting. See [For Apollo Studio reporting](#for-apollo-studio-reporting).
 

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -345,7 +345,7 @@ You can edit Apollo Server error details before they're passed to a client or re
 
 The `ApolloServer` constructor accepts a `formatError` hook that is run on each error before it's passed back to the client. You can use this function to log or mask particular errors.
 
-The `formatError` hook receives two arguments: the first is the error formatted as a JSON object (to be sent with the response), and the second is the original error.
+The `formatError` hook receives two arguments: the first is the error formatted as a JSON object (to be sent with the response), and the second is the original error (wrapped in GraphQLError if thrown by a resolver).
 
 > The `formatError` function does _not_ modify errors that are sent to Apollo Studio as part of usage reporting. See [For Apollo Studio reporting](#for-apollo-studio-reporting).
 


### PR DESCRIPTION
Hi all! I was working with error handling in my project and wasted a lot of time because I couldn't figure out why I can identify my original error with "instanceof". It wasn't until after some research on StackOverflow that I realized that the original error was wrapped in a GraphQLError. Can we add this detail to the documentation? Thanks, everyone in advance