### PR TITLE
docs(api): replace the markdown relative link with the website relative link

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -293,7 +293,7 @@ You can disable this recommended security feature by passing `false` to `csrfPre
 
 Provide this function to transform the structure of error objects before they're sent to a client.
 
-The `formatError` hook receives two arguments: the first is a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) (to be spent with the response), and the second is the original error [(wrapped in GraphQLError if thrown by a resolver)](/docs/source/data/errors.mdx#for-client-responses). This function should return a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) object.
+The `formatError` hook receives two arguments: the first is a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) (to be spent with the response), and the second is the original error [(wrapped in GraphQLError if thrown by a resolver)](/apollo-server/data/errors/#for-client-responses). This function should return a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) object.
 
 </td>
 </tr>

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -293,7 +293,7 @@ You can disable this recommended security feature by passing `false` to `csrfPre
 
 Provide this function to transform the structure of error objects before they're sent to a client.
 
-The `formatError` hook receives two arguments: the first is a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) (to be spent with the response), and the second is the original error [(wrapped in GraphQLError if thrown by a resolver)](/apollo-server/data/errors/#for-client-responses). This function should return a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) object.
+The `formatError` hook receives two arguments: the first is a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) (to be spent with the response), and the second is the original error [(wrapped in GraphQLError if thrown by a resolver)](../data/errors/#for-client-responses). This function should return a [`GraphQLFormattedError`](https://github.com/graphql/graphql-js/blob/29bf39faa670effd3c1561a1512ec7767658a63b/src/error/GraphQLError.ts#L215) object.
 
 </td>
 </tr>


### PR DESCRIPTION
Hi all! After merging my previous PR #7443, I noticed that the links on the site are different from the markdown. I updated the link to the actual website page to fix the 404 Page Not Found error. I believe this should work now, but if you can double-check that this link is correct, that would be great! Thank you in advance