### PR TITLE
Add lock workflow to lock closed and stale issues/PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,34 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions: {}
+jobs:
+  lock:
+    permissions:
+      issues: write # to lock issues (dessant/lock-threads)
+      pull-requests: write # to lock PRs (dessant/lock-threads)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          issue-inactive-days: '30'
+          exclude-any-issue-labels: '💬 discussion'
+          # issue-comment: >
+          #   This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+
+          #   Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-server) or our [discord server](https://discord.gg/graphos) for questions.
+
+          pr-inactive-days: '30'
+          exclude-any-pr-labels: '💬 discussion'
+          # pr-comment: >
+          #   This pull request has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+
+          #   Please note this issue tracker is not a help forum. We recommend
+          #   using
+          #   [StackOverflow](https://stackoverflow.com/questions/tagged/apollo-server)
+          #   or our [discord server](https://discord.gg/graphos) for questions.


### PR DESCRIPTION
Copied from https://github.com/apollographql/apollo-client/pull/10500 (thanks @alessbell!)

Note: this only _locks_ PRs and issues which have already been closed. This does not autoclose anything.