### PR TITLE
Align on 6# for API table row cells

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -49,7 +49,7 @@ const server = new ApolloServer({
 <tr class="required">
 <td>
 
-##### `typeDefs`
+###### `typeDefs`
 
 `string`, `DocumentNode`, or `Array<DocumentNode>`
 
@@ -68,7 +68,7 @@ For an example, see [Define your GraphQL schema](../getting-started/#step-3-defi
 <tr class="required">
 <td>
 
-##### `resolvers`
+###### `resolvers`
 
 `Object` or `Array`
 
@@ -87,7 +87,7 @@ For details, see [Resolvers](../data/resolvers/).
 <tr>
 <td>
 
-##### `schema`
+###### `schema`
 
 `Object`
 
@@ -109,7 +109,7 @@ This field is helpful if:
 <tr>
 <td>
 
-##### `gateway`
+###### `gateway`
 
 `Object`
 
@@ -133,7 +133,7 @@ You can use this field to integrate your server with [Apollo Gateway](/federatio
 <tr>
 <td>
 
-##### `introspection`
+###### `introspection`
 
 `boolean`
 
@@ -151,7 +151,7 @@ The default value is `true`, **unless** the `NODE_ENV` environment variable is s
 <tr>
 <td>
 
-##### `fieldResolver`
+###### `fieldResolver`
 
 `GraphQLFieldResolver`
 
@@ -167,7 +167,7 @@ A custom resolver that will replace Apollo Server's [default field resolvers](..
 <tr>
 <td>
 
-##### `rootValue`
+###### `rootValue`
 
 `Any` or `Function`
 
@@ -184,7 +184,7 @@ Providing a function is useful if you want to use a different root value dependi
 <tr>
 <td>
 
-##### `validationRules`
+###### `validationRules`
 
 `Array<Function>`
 
@@ -199,7 +199,7 @@ An array containing custom functions to use as additional [validation rules](htt
 <tr>
 <td>
 
-##### `documentStore`
+###### `documentStore`
 
 `KeyValueCache<DocumentNode>` or `null`
 
@@ -247,7 +247,7 @@ Pass `null` to disable this cache entirely.
 <tr>
 <td>
 
-##### `persistedQueries`
+###### `persistedQueries`
 
 `Object` or `false`
 
@@ -263,7 +263,7 @@ If you're using [automated persisted queries (APQ)](../performance/apq/), you ca
 <tr>
 <td>
 
-##### `csrfPrevention`
+###### `csrfPrevention`
 
 `boolean` or `Object`
 
@@ -284,7 +284,7 @@ You can disable this recommended security feature by passing `false` to `csrfPre
 <tr>
 <td>
 
-##### `formatError`
+###### `formatError`
 
 `Function`
 
@@ -301,7 +301,7 @@ The `formatError` hook receives two arguments: the first is a [`GraphQLFormatted
 <tr>
 <td>
 
-##### `apollo`
+###### `apollo`
 
 `Object`
 
@@ -321,7 +321,7 @@ An object containing configuration options for connecting Apollo Server to [Apol
 <tr>
 <td>
 
-##### `allowBatchedHttpRequests`
+###### `allowBatchedHttpRequests`
 
 `boolean`
 
@@ -344,7 +344,7 @@ Controls whether to allow [Batching Queries](../workflow/requests/#batching) in 
 <tr>
 <td>
 
-##### `cache`
+###### `cache`
 
 `KeyValueCache`
 
@@ -363,7 +363,7 @@ To learn more about configuring Apollo Server's cache, see [Configuring cache ba
 <tr>
 <td>
 
-##### `plugins`
+###### `plugins`
 
 `Array`
 
@@ -382,7 +382,7 @@ Apollo Server comes with several plugins that it installs automatically in their
 <tr>
 <td>
 
-##### `stopOnTerminationSignals`
+###### `stopOnTerminationSignals`
 
 `boolean`
 
@@ -411,7 +411,7 @@ You can also manually call `stop()` in other contexts. Note that `stop()` is asy
 <tr>
 <td style="max-width: 200px;">
 
-##### `includeStacktraceInErrorResponses`
+###### `includeStacktraceInErrorResponses`
 
 `boolean`
 
@@ -429,7 +429,7 @@ Defaults to `true` unless the `NODE_ENV` environment variable is `production` or
 <tr>
 <td>
 
-##### `logger`
+###### `logger`
 
 [`Logger`](https://www.npmjs.com/package/@apollo/utils.logger)
 
@@ -448,7 +448,7 @@ This logger is automatically added to the `GraphQLRequestContext` object that's 
 <tr>
 <td>
 
-##### `parseOptions`
+###### `parseOptions`
 
 `Object`
 
@@ -463,7 +463,7 @@ An object that specifies how your server parses GraphQL operations. [See `graphq
 <tr>
 <td>
 
-##### `nodeEnv`
+###### `nodeEnv`
 
 `string`
 
@@ -613,7 +613,7 @@ Below are the available fields for the first argument of `executeOperation`:
 <tr class="required">
 <td>
 
-##### `query`
+###### `query`
 
 `string` or `DocumentNode`
 
@@ -629,7 +629,7 @@ Below are the available fields for the first argument of `executeOperation`:
 <tr>
 <td>
 
-##### `variables`
+###### `variables`
 
 `object`
 
@@ -642,7 +642,7 @@ An object containing any GraphQL variables to use as argument values for the exe
 <tr>
 <td>
 
-##### `operationName`
+###### `operationName`
 
 `string`
 
@@ -657,7 +657,7 @@ If `query` contains more than one operation definition, you must provide this op
 <tr>
 <td>
 
-##### `extensions`
+###### `extensions`
 
 `object`
 
@@ -672,7 +672,7 @@ The `extensions` object is usually used to pass request metadata within your ser
 <tr>
 <td>
 
-##### `http`
+###### `http`
 
 `HTTPGraphQLRequest`
 

--- a/docs/source/api/express-middleware.mdx
+++ b/docs/source/api/express-middleware.mdx
@@ -68,7 +68,7 @@ The `expressMiddleware` function's second optional argument is an _object_ for c
 
 <td>
 
-##### `context`
+###### `context`
 
 `Function`
 

--- a/docs/source/api/plugin/landing-pages.mdx
+++ b/docs/source/api/plugin/landing-pages.mdx
@@ -356,7 +356,7 @@ These are the fields you can include in the `embed` option you pass to the `Apol
 <tr>
 <td>
 
-##### `displayOptions`
+###### `displayOptions`
 
 `Object`
 
@@ -409,7 +409,7 @@ These are the fields you can include in the `displayOptions` option you pass to 
 <tr>
 <td>
 
-##### `docsPanelState`
+###### `docsPanelState`
 
 `"open" | "closed"`
 
@@ -426,7 +426,7 @@ The default value is `open`.
 <tr>
 <td>
 
-##### `showHeadersAndEnvVars`
+###### `showHeadersAndEnvVars`
 
 `true | false`
 
@@ -443,7 +443,7 @@ The default value is `true`.
 <tr>
 <td>
 
-##### `theme`
+###### `theme`
 
 `"dark" | "light"`
 

--- a/docs/source/testing/mocking.mdx
+++ b/docs/source/testing/mocking.mdx
@@ -59,7 +59,7 @@ The table below covers the default scalar types and the default mocked values re
 <tr >
 <td>
 
-##### `Int`
+###### `Int`
 
 </td>
 <td>
@@ -72,7 +72,7 @@ Returns a random positive or negative integer.
 <tr>
 <td>
 
-##### `String`
+###### `String`
 
 </td>
 <td>
@@ -85,7 +85,7 @@ Returns `Hello world`.
 <tr>
 <td>
 
-##### `Float`
+###### `Float`
 
 </td>
 <td>
@@ -98,7 +98,7 @@ Returns a random positive or negative double-precision floating-point value.
 <tr>
 <td>
 
-##### `Boolean`
+###### `Boolean`
 
 </td>
 <td>
@@ -111,7 +111,7 @@ Randomly returns either `true` or `false`.
 <tr>
 <td>
 
-##### `ID`
+###### `ID`
 
 </td>
 <td>
@@ -185,7 +185,7 @@ You can also use `mocks` to define object types and the fields belonging to thos
 
 <MultiCodeBlock>
 
-```ts 
+```ts
 // importing the casual library
 const casual = require('casual');
 


### PR DESCRIPTION
We have a mix of 5# and 6# row cells in our docs. Aligning on 6# at @StephenBarlow's recommendation.