### PR TITLE
fix: Introduce status code regression mitigation

### DIFF
--- a/.changeset/purple-paws-yell.md
+++ b/.changeset/purple-paws-yell.md
@@ -13,6 +13,6 @@ new ApolloServer({
 });
 ```
 
-Specifically, this regression affects cases where _input variable coercion_ fails. Variables of an incorrect type (i.e. `String` instead of `Int`) or unexpectedly `null` are examples that fail variable coercion. Additionally, missing or incorrect types on input objects as well as custom scalars that throw during validation will also fail variable coercion. For more specifics on variable coercion, see the "Input Coercion" sections in the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Scalars).
+Specifically, this regression affects cases where _input variable coercion_ fails. Variables of an incorrect type (i.e. `String` instead of `Int`) or unexpectedly `null` are examples that fail variable coercion. Additionally, missing or incorrect fields on input objects as well as custom scalars that throw during validation will also fail variable coercion. For more specifics on variable coercion, see the "Input Coercion" sections in the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Scalars).
 
 This will become the default behavior in Apollo Server v5 and the configuration option will be ignored / no longer needed.

--- a/.changeset/purple-paws-yell.md
+++ b/.changeset/purple-paws-yell.md
@@ -1,0 +1,16 @@
+---
+'@apollo/server': minor
+---
+
+Introduce new opt-in configuration option to mitigate v4 status code regression
+
+Apollo Server v4 accidentally started responding to requests with an invalid `variables` object with a 200 status code, where v3 previously responded with a 400. In order to not break current behavior (potentially breaking users who have creatively worked around this issue) and offer a mitigation, we've added the following configuration option which we recommend for all users.
+
+```ts
+new ApolloServer({
+  // ...
+  status400WithErrorsAndNoData: true,
+});
+```
+
+This will become the default behavior in Apollo Server v5 and the configuration option will be ignored / no longer needed.

--- a/.changeset/purple-paws-yell.md
+++ b/.changeset/purple-paws-yell.md
@@ -9,8 +9,10 @@ Apollo Server v4 accidentally started responding to requests with an invalid `va
 ```ts
 new ApolloServer({
   // ...
-  status400WithErrorsAndNoData: true,
+  status400ForVariableCoercionErrors: true,
 });
 ```
+
+Specifically, this regression affects cases where _input variable coercion_ fails. Variables of an incorrect type (i.e. `String` instead of `Int`) or unexpectedly `null` are examples that fail variable coercion. Additionally, missing or incorrect types on input objects as well as custom scalars that throw during validation will also fail variable coercion. For more specifics on variable coercion, see the "Input Coercion" sections in the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Scalars).
 
 This will become the default behavior in Apollo Server v5 and the configuration option will be ignored / no longer needed.

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -478,7 +478,7 @@ If this is set to any string value, use that value instead of the environment va
 <tr>
 <td>
 
-###### `status400WithErrorsAndNoData`
+###### `status400ForVariableCoercionErrors`
 
 `boolean`
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -475,6 +475,21 @@ If this is set to any string value, use that value instead of the environment va
 </td>
 </tr>
 
+<tr>
+<td>
+
+###### `status400WithErrorsAndNoData`
+
+`boolean`
+
+</td>
+<td>
+
+This option is a v4 regression mitigation that we recommend users set to `true`. This option will be ignored in Apollo Server v5 and its `true` behavior will become the default. Visit the [migration guide](../migration/#known-regressions) for more details on the regression.
+
+</td>
+</tr>
+
 </tbody>
 </table>
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -485,7 +485,9 @@ If this is set to any string value, use that value instead of the environment va
 </td>
 <td>
 
-This option is a v4 regression mitigation that we recommend users set to `true`. This option will be ignored in Apollo Server v5 and its `true` behavior will become the default. Visit the [migration guide](../migration/#known-regressions) for more details on the regression.
+**Set this option to `true`.** It mitigates a regression introduced in Apollo Server v4 where the server returns a 200 status code (instead of 400) when a client query provides invalid variables. [Learn more.](../migration/#known-regressions)
+
+Apollo Server v5 will _always_ behave as if this option is `true` (and will ignore any provided value).
 
 </td>
 </tr>

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -5,7 +5,7 @@ description: Making errors actionable on the client and server
 
 import TopLevelAwait from "../shared/top-level-await.mdx"
 
-> Apollo Server v4 introduced a regression where providing invalid variables yields a 200 status code instead of 400. To mitigate this regression, provide the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor. For more information, see the [migration guide](../migration/#known-regressions).
+> Apollo Server v4 introduced a regression where providing invalid variables yields a 200 status code instead of 400. To mitigate this regression, provide the `status400ForVariableCoercionErrors: true` option to your `ApolloServer` constructor. For more information, see the [migration guide](../migration/#known-regressions).
 
 <!-- cSpell:ignore typenam -->
 

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -5,6 +5,8 @@ description: Making errors actionable on the client and server
 
 import TopLevelAwait from "../shared/top-level-await.mdx"
 
+> Apollo Server v4 introduced a regression where providing invalid variables incorrectly yields a 200 status code. The mitigation for this regression is to provide the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor. More details can be found [in the migration guide](../migration/#known-regressions).
+
 <!-- cSpell:ignore typenam -->
 
 Whenever Apollo Server encounters errors while processing a GraphQL operation, its response to the client includes an `errors` array containing each error that occurred. Each error in the array has an `extensions` field that provides additional useful information, including an error `code` and (while in development mode) a `stacktrace`.

--- a/docs/source/data/errors.mdx
+++ b/docs/source/data/errors.mdx
@@ -5,7 +5,7 @@ description: Making errors actionable on the client and server
 
 import TopLevelAwait from "../shared/top-level-await.mdx"
 
-> Apollo Server v4 introduced a regression where providing invalid variables incorrectly yields a 200 status code. The mitigation for this regression is to provide the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor. More details can be found [in the migration guide](../migration/#known-regressions).
+> Apollo Server v4 introduced a regression where providing invalid variables yields a 200 status code instead of 400. To mitigate this regression, provide the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor. For more information, see the [migration guide](../migration/#known-regressions).
 
 <!-- cSpell:ignore typenam -->
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -344,6 +344,25 @@ You can also import each plugin's associated TypeScript types (e.g., `ApolloServ
 
 Once you've updated your imports, you can remove your project's dependency on `apollo-server-core`.
 
+## Known regressions
+
+### Appropriate 400 status codes
+
+Apollo Server v4 will respond to an invalid `variables` object with a _200_ status code, where v3 would correctly respond with a 400 status code. This regression was introduced in [PR #6502]https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
+
+The mitigation for this regression is an opt-in configuration option that we recommend for all users who have not already worked around this regression. Simply add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor like so:
+
+<MultiCodeBlock>
+```ts
+new ApolloServer({
+  // ...
+  status400WithErrorsAndNoData: true,
+})
+```
+</MultiCodeBlock>
+
+This option will no longer be needed (and be ignored) in Apollo Server v5.
+
 ## Bumped dependencies
 
 ### Node.js

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -352,14 +352,12 @@ Apollo Server v4 will respond to an invalid `variables` object with a _200_ stat
 
 The mitigation for this regression is an opt-in configuration option that we recommend for all users who have not already worked around this regression. Simply add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor like so:
 
-<MultiCodeBlock>
 ```ts
 new ApolloServer({
   // ...
   status400WithErrorsAndNoData: true,
 })
 ```
-</MultiCodeBlock>
 
 This option will no longer be needed (and be ignored) in Apollo Server v5.
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -348,9 +348,9 @@ Once you've updated your imports, you can remove your project's dependency on `a
 
 ### Appropriate 400 status codes
 
-Apollo Server v4 will respond to an invalid `variables` object with a _200_ status code, where v3 would correctly respond with a 400 status code. This regression was introduced in [PR #6502](https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
+Apollo Server v4 responds to an invalid `variables` object with a 200 status code, whereas v3 responds appropriately with a 400 status code. This regression was introduced in [PR #6502](https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
 
-The mitigation for this regression is an opt-in configuration option that we recommend for all users who have not already worked around this regression. Simply add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor like so:
+We recommend mitigating this regression unless you've already modified your application to work around it. To do so, add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor:
 
 ```ts
 new ApolloServer({
@@ -359,7 +359,7 @@ new ApolloServer({
 })
 ```
 
-This option will no longer be needed (and be ignored) in Apollo Server v5.
+This option will no longer be needed (and will be ignored) in Apollo Server v5.
 
 ## Bumped dependencies
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -350,14 +350,16 @@ Once you've updated your imports, you can remove your project's dependency on `a
 
 Apollo Server v4 responds to an invalid `variables` object with a 200 status code, whereas v3 responds appropriately with a 400 status code. This regression was introduced in [PR #6502](https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
 
-We recommend mitigating this regression unless you've already modified your application to work around it. To do so, add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor:
+Specifically, this regression affects cases where _input variable coercion_ fails. Variables of an incorrect type (i.e. `String` instead of `Int`) or unexpectedly `null` are examples that fail variable coercion. Additionally, missing or incorrect types on input objects as well as custom scalars that throw during validation will also fail variable coercion. For additional specifics on variable coercion, see the "Input Coercion" sections in the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Scalars).
+
+We recommend mitigating this regression unless you've already modified your application to work around it. To do so, add the `status400ForVariableCoercionErrors: true` option to your `ApolloServer` constructor:
 
 <MultiCodeBlock>
 
 ```ts
 new ApolloServer({
   // ...
-  status400WithErrorsAndNoData: true,
+  status400ForVariableCoercionErrors: true,
 })
 ```
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -350,7 +350,7 @@ Once you've updated your imports, you can remove your project's dependency on `a
 
 Apollo Server v4 responds to an invalid `variables` object with a 200 status code, whereas v3 responds appropriately with a 400 status code. This regression was introduced in [PR #6502](https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
 
-Specifically, this regression affects cases where _input variable coercion_ fails. Variables of an incorrect type (i.e. `String` instead of `Int`) or unexpectedly `null` are examples that fail variable coercion. Additionally, missing or incorrect types on input objects as well as custom scalars that throw during validation will also fail variable coercion. For additional specifics on variable coercion, see the "Input Coercion" sections in the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Scalars).
+Specifically, this regression affects cases where _input variable coercion_ fails. Variables of an incorrect type (i.e. `String` instead of `Int`) or unexpectedly `null` are examples that fail variable coercion. Additionally, missing or incorrect fields on input objects as well as custom scalars that throw during validation will also fail variable coercion. For additional specifics on variable coercion, see the "Input Coercion" sections in the [GraphQL spec](https://spec.graphql.org/June2018/#sec-Scalars).
 
 We recommend mitigating this regression unless you've already modified your application to work around it. To do so, add the `status400ForVariableCoercionErrors: true` option to your `ApolloServer` constructor:
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -352,12 +352,16 @@ Apollo Server v4 responds to an invalid `variables` object with a 200 status cod
 
 We recommend mitigating this regression unless you've already modified your application to work around it. To do so, add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor:
 
+<MultiCodeBlock>
+
 ```ts
 new ApolloServer({
   // ...
   status400WithErrorsAndNoData: true,
 })
 ```
+
+</MultiCodeBlock>
 
 This option will no longer be needed (and will be ignored) in Apollo Server v5.
 

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -348,7 +348,7 @@ Once you've updated your imports, you can remove your project's dependency on `a
 
 ### Appropriate 400 status codes
 
-Apollo Server v4 will respond to an invalid `variables` object with a _200_ status code, where v3 would correctly respond with a 400 status code. This regression was introduced in [PR #6502]https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
+Apollo Server v4 will respond to an invalid `variables` object with a _200_ status code, where v3 would correctly respond with a 400 status code. This regression was introduced in [PR #6502](https://github.com/apollographql/apollo-server/pull/6502) and brought to our attention in [Issue #7462](https://github.com/apollographql/apollo-server/issues/7462).
 
 The mitigation for this regression is an opt-in configuration option that we recommend for all users who have not already worked around this regression. Simply add the `status400WithErrorsAndNoData: true` option to your `ApolloServer` constructor like so:
 

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -327,7 +327,8 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           ? null
           : config.csrfPrevention.requestHeaders ??
             recommendedCsrfPreventionRequestHeaders,
-      status400WithErrorsAndNoData: config.status400WithErrorsAndNoData ?? false,
+      status400WithErrorsAndNoData:
+        config.status400WithErrorsAndNoData ?? false,
       __testing_incrementalExecutionResults:
         config.__testing_incrementalExecutionResults,
     };

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -174,7 +174,9 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   rootValue?: ((parsedQuery: DocumentNode) => unknown) | unknown;
   validationRules: Array<ValidationRule>;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
-
+  // TODO(AS5): remove OR warn + ignore with this option set, ignore option and
+  // flip default behavior.
+  status400WithErrorsAndNoData?: boolean;
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
 }
 
@@ -325,6 +327,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           ? null
           : config.csrfPrevention.requestHeaders ??
             recommendedCsrfPreventionRequestHeaders,
+      status400WithErrorsAndNoData: config.status400WithErrorsAndNoData ?? false,
       __testing_incrementalExecutionResults:
         config.__testing_incrementalExecutionResults,
     };

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -176,7 +176,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   // TODO(AS5): remove OR warn + ignore with this option set, ignore option and
   // flip default behavior.
-  status400WithErrorsAndNoData?: boolean;
+  status400ForVariableCoercionErrors?: boolean;
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
 }
 
@@ -327,8 +327,8 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           ? null
           : config.csrfPrevention.requestHeaders ??
             recommendedCsrfPreventionRequestHeaders,
-      status400WithErrorsAndNoData:
-        config.status400WithErrorsAndNoData ?? false,
+      status400ForVariableCoercionErrors:
+        config.status400ForVariableCoercionErrors ?? false,
       __testing_incrementalExecutionResults:
         config.__testing_incrementalExecutionResults,
     };

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -109,7 +109,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   // with a 200 status code by default. We recommend setting this to `true`
   // unless you've explicitly worked around this regression already (and maybe
   // consider undoing the workaround).
-  status400WithErrorsAndNoData?: boolean;
+  status400ForVariableCoercionErrors?: boolean;
 
   // For testing only.
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -102,6 +102,11 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   // parsing the schema.
   parseOptions?: ParseOptions;
 
+  // TODO(AS5): remove OR warn + ignore with this option set, ignore option and
+  // flip default behavior.
+  // Default false. This opt-in configuration fixes a regression caused by (FIXME)
+  status400WithErrorsAndNoData?: boolean;
+
   // For testing only.
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
 }

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -103,8 +103,12 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   parseOptions?: ParseOptions;
 
   // TODO(AS5): remove OR warn + ignore with this option set, ignore option and
-  // flip default behavior.
-  // Default false. This opt-in configuration fixes a regression caused by (FIXME)
+  // flip default behavior. Default false. This opt-in configuration fixes a
+  // regression introduced in v4. In v3, Apollo Server would correctly respond
+  // to a request with invalid `variables` with a 400 status code. AS4 responds
+  // with a 200 status code by default. We recommend setting this to `true`
+  // unless you've explicitly worked around this regression already (and maybe
+  // consider undoing the workaround).
   status400WithErrorsAndNoData?: boolean;
 
   // For testing only.

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -476,14 +476,15 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         : { formattedErrors: undefined, httpFromErrors: newHTTPGraphQLHead() };
 
       // TODO(AS5) This becomes the default behavior and the
-      // `status400WithErrorsAndNoData` configuration option is removed /
+      // `status400ForVariableCoercionErrors` configuration option is removed /
       // ignored.
       if (
-        internals.status400WithErrorsAndNoData &&
+        internals.status400ForVariableCoercionErrors &&
         resultErrors?.length &&
-        result.data === undefined
+        result.data === undefined &&
+        !httpFromErrors.status
       ) {
-        httpFromErrors.status = httpFromErrors.status ?? 400;
+        httpFromErrors.status = 400;
       }
 
       mergeHTTPGraphQLHead(requestContext.response.http, httpFromErrors);

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -474,6 +474,18 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
       const { formattedErrors, httpFromErrors } = resultErrors
         ? formatErrors(resultErrors)
         : { formattedErrors: undefined, httpFromErrors: newHTTPGraphQLHead() };
+
+      // TODO(AS5) This becomes the default behavior and the
+      // `status400WithErrorsAndNoData` configuration option is removed /
+      // ignored.
+      if (
+        internals.status400WithErrorsAndNoData &&
+        resultErrors?.length &&
+        result.data === undefined
+      ) {
+        httpFromErrors.status = httpFromErrors.status ?? 400;
+      }
+
       mergeHTTPGraphQLHead(requestContext.response.http, httpFromErrors);
 
       if ('singleResult' in fullResult) {


### PR DESCRIPTION
Apollo Server v4 introduced a regression with respect to invalid `variables` and http status codes. AS4 incorrectly started responding with a 200 status code, where AS3 would respond with a 400 when the provided variables object failed variable coercion (during `graphql-js` `execute`).

Providing the following config to your AS4 constructor options will opt-in to the regression mitigation:
```ts
new ApolloServer({
  // ...
  status400WithErrorsAndNoData: true,
})
```

Fixes #7462
Related discussion #7460

TODO:
- [x] check docs pages / links