### PR TITLE
Set package.json type to module

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -25,7 +25,7 @@ cd graphql-server-example
    prefer, such as Yarn):
 
 ```bash
-  npm init --yes
+  npm init --yes && npm pkg set type="module"
 ```
 
 Your project directory now contains a `package.json` file.

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -27,7 +27,7 @@ cd graphql-server-example
 ```bash
   npm init --yes && npm pkg set type="module"
 ```
-
+> This getting started guide sets up a project using ES Modules, which simplifies our examples and allows us to use top-level `await`.
 Your project directory now contains a `package.json` file.
 
 ## Step 2: Install dependencies

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -27,7 +27,9 @@ cd graphql-server-example
 ```bash
   npm init --yes && npm pkg set type="module"
 ```
+
 > This getting started guide sets up a project using ES Modules, which simplifies our examples and allows us to use top-level `await`.
+
 Your project directory now contains a `package.json` file.
 
 ## Step 2: Install dependencies


### PR DESCRIPTION
`npm init` doesn't set the type to module and walking through the quickstart for typescript ends with a typescript compile error

@StephenBarlow I'm curious if you think we should add a little note of why modules has to be set (cc @trevor-scheer)