### PR TITLE
Improve invalid `accept` header error message

### DIFF
--- a/.changeset/gentle-shirts-relate.md
+++ b/.changeset/gentle-shirts-relate.md
@@ -4,8 +4,4 @@
 
 Improve bad 'accept' header error message
 
-It's not obvious that users can bypass content-type negotiation
-within Apollo Server if they want to use a content-type that
-isn't exactly one of the two we prescribe. This improves the
-error message so that users understand how to skip AS's
-negotiation step if they choose to use a custom content-type.
+It's not obvious that users can bypass content-type negotiation within Apollo Server if they want to use a content-type that isn't exactly one of the two we prescribe. This improves the error message so that users understand how to skip AS's negotiation step if they choose to use a custom content-type.

--- a/.changeset/gentle-shirts-relate.md
+++ b/.changeset/gentle-shirts-relate.md
@@ -1,0 +1,11 @@
+---
+'@apollo/server': patch
+---
+
+Improve bad 'accept' header error message
+
+It's not obvious that users can bypass content-type negotiation
+within Apollo Server if they want to use a content-type that
+isn't exactly one of the two we prescribe. This improves the
+error message so that users understand how to skip AS's
+negotiation step if they choose to use a custom content-type.

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -710,17 +710,15 @@ describe('content-type negotiation', () => {
     });
     assert(body.kind === 'complete');
     const result = JSON.parse(body.string);
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "errors": [
-          {
-            "extensions": {
-              "code": "BAD_REQUEST",
-            },
-            "message": "An 'accept' header was provided for this request which does not accept application/json; charset=utf-8 or application/graphql-response+json; charset=utf-8. If you'd like to use a custom content-type and bypass content-type negotiation altogether, set the \`content-type\` response header in a plugin.",
+    expect(result.errors).toMatchInlineSnapshot(`
+      [
+        {
+          "extensions": {
+            "code": "BAD_REQUEST",
           },
-        ],
-      }
+          "message": "An 'accept' header was provided for this request which does not accept application/json; charset=utf-8 or application/graphql-response+json; charset=utf-8. If you'd like to use a custom content-type and bypass content-type negotiation altogether, set the \`content-type\` response header in a plugin.",
+        },
+      ]
     `);
     await server.stop();
   });
@@ -753,7 +751,7 @@ describe('content-type negotiation', () => {
     });
     assert(body.kind === 'complete');
     const result = JSON.parse(body.string);
-    expect(result.error).toBeUndefined();
+    expect(result.errors).toBeUndefined();
     expect(result.data?.hello).toBe('world');
     await server.stop();
   });

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -248,7 +248,9 @@ export async function runHttpQuery<TContext extends BaseContext>({
       if (contentType === null) {
         throw new BadRequestError(
           `An 'accept' header was provided for this request which does not accept ` +
-            `${MEDIA_TYPES.APPLICATION_JSON} or ${MEDIA_TYPES.APPLICATION_GRAPHQL_RESPONSE_JSON}`,
+            `${MEDIA_TYPES.APPLICATION_JSON} or ${MEDIA_TYPES.APPLICATION_GRAPHQL_RESPONSE_JSON}. ` +
+            `If you'd like to use a custom content-type and bypass content-type ` +
+            `negotiation altogether, set the \`content-type\` response header in a plugin.`,
           // Use 406 Not Accepted
           { extensions: { http: { status: 406 } } },
         );


### PR DESCRIPTION
It's not obvious that users can bypass `content-type` negotiation within Apollo Server if they want to use a `content-type` that isn't exactly one of the two we prescribe. This improves the error message so that users understand how to skip AS's negotiation step if they choose to use a custom `content-type`.