### PR TITLE
Declare array type to prevent TypeScript compilation error

### DIFF
--- a/packages/server/src/plugin/usageReporting/iterateOverTrace.ts
+++ b/packages/server/src/plugin/usageReporting/iterateOverTrace.ts
@@ -126,7 +126,7 @@ class ChildCollectingPathsResponseNamePath implements ResponseNamePath {
     readonly prev: CollectingPathsResponseNamePath,
   ) {}
   toArray() {
-    const out = [];
+    const out: string[] = [];
     let curr: CollectingPathsResponseNamePath = this;
     while (curr instanceof ChildCollectingPathsResponseNamePath) {
       out.push(curr.responseName);


### PR DESCRIPTION
In my application using `@apollo/server`, tsc shows an error with `Argument of type 'string' is not assignable to parameter of type 'never'.` during compilation.

While other code has declaration for array, this code does not have. I thinks it's consistent in terms of codebase.