### PR TITLE
🔓 🐛 safelist cdn scripts in meta tag in landing page

### DIFF
--- a/.changeset/sweet-planets-hang.md
+++ b/.changeset/sweet-planets-hang.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+🐛 Bug Fix for Apollo Server Landing Pages on Safari. A Content Security Policy was added to our landing page html so that Safari can run the inline scripts we use to call the Embedded Sandbox & Explorer

--- a/.changeset/sweet-planets-hang.md
+++ b/.changeset/sweet-planets-hang.md
@@ -2,4 +2,4 @@
 '@apollo/server': patch
 ---
 
-🐛 Bug Fix for Apollo Server Landing Pages on Safari. A Content Security Policy was added to our landing page html so that Safari can run the inline scripts we use to call the Embedded Sandbox & Explorer
+🐛 Bug Fix for Apollo Server Landing Pages on Safari. A Content Security Policy was added to our landing page html so that Safari can run the inline scripts we use to call the Embedded Sandbox & Explorer.

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -30,8 +30,9 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         },
         graphRef: 'graph@current',
       };
-    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -49,9 +50,11 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var endpointUrl = window.location.href;
         var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"document":"query Test { id }","headers":{"authorization":"true"},"variables":{"option":{"a":"val","b":1,"c":true}},"displayOptions":{"showHeadersAndEnvVars":true,"docsPanelState":"open","theme":"light"}},"persistExplorerState":true,"includeCookies":true,"runtime":"@apollo/server@4.0.0"};
         new window.EmbeddedExplorer({
@@ -70,8 +73,9 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         embed: true,
         graphRef: 'graph@current',
       };
-    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -89,9 +93,11 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var endpointUrl = window.location.href;
         var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"headers":{"authorization":"true"},"displayOptions":{}},"persistExplorerState":false,"includeCookies":true,"runtime":"@apollo/server@4.0.0"};
         new window.EmbeddedExplorer({
@@ -111,8 +117,9 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         embed: true,
         graphRef: 'graph@current',
       };
-    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -130,9 +137,11 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var endpointUrl = window.location.href;
         var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"collectionId":"12345","operationId":"abcdef","displayOptions":{}},"persistExplorerState":false,"includeCookies":true,"runtime":"@apollo/server@4.0.0"};
         new window.EmbeddedExplorer({
@@ -150,8 +159,9 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
         embed: true,
         graphRef: 'graph@current',
       };
-    expect(getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedExplorerHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -169,9 +179,11 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
            id="embeddableExplorer"
       >
       </div>
-      <script src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var endpointUrl = window.location.href;
         var embeddedExplorerConfig = {"graphRef":"graph@current","target":"#embeddableExplorer","initialState":{"displayOptions":{}},"persistExplorerState":false,"includeCookies":false,"runtime":"@apollo/server@4.0.0"};
         new window.EmbeddedExplorer({

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -21,8 +21,9 @@ describe('Landing Page Config HTML', () => {
       headers: { authorization: 'true' },
       embed: true,
     };
-    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -40,9 +41,11 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var initialEndpoint = window.location.href;
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
@@ -62,8 +65,9 @@ describe('Landing Page Config HTML', () => {
       headers: { authorization: 'true' },
       embed: true,
     };
-    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -81,9 +85,11 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var initialEndpoint = window.location.href;
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
@@ -101,8 +107,9 @@ describe('Landing Page Config HTML', () => {
     const config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions = {
       embed: true,
     };
-    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -120,9 +127,11 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var initialEndpoint = window.location.href;
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
@@ -142,8 +151,9 @@ describe('Landing Page Config HTML', () => {
       operationId: 'abcdef',
       embed: true,
     };
-    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -161,9 +171,11 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var initialEndpoint = window.location.href;
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',
@@ -188,8 +200,9 @@ describe('Landing Page Config HTML', () => {
         },
       },
     };
-    expect(getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion))
-      .toMatchInlineSnapshot(`
+    expect(
+      getEmbeddedSandboxHTML(cdnVersion, config, apolloServerVersion, 'nonce'),
+    ).toMatchInlineSnapshot(`
       <div class="fallback">
         <h1>
           Welcome to Apollo Server
@@ -207,9 +220,11 @@ describe('Landing Page Config HTML', () => {
            id="embeddableSandbox"
       >
       </div>
-      <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0">
+      <script nonce="nonce"
+              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+      >
       </script>
-      <script>
+      <script nonce="nonce">
         var initialEndpoint = window.location.href;
         new window.EmbeddedSandbox({
           target: '#embeddableSandbox',

--- a/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
+++ b/packages/server/src/plugin/landingPage/default/getEmbeddedHTML.ts
@@ -24,6 +24,7 @@ export const getEmbeddedExplorerHTML = (
   explorerCdnVersion: string,
   config: ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions,
   apolloServerVersion: string,
+  nonce: string,
 ) => {
   interface EmbeddableExplorerOptions {
     graphRef: string;
@@ -96,12 +97,12 @@ export const getEmbeddedExplorerHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableExplorer"
 ></div>
-<script src="https://embeddable-explorer.cdn.apollographql.com/${encodeURIComponent(
+<script nonce="${nonce}" src="https://embeddable-explorer.cdn.apollographql.com/${encodeURIComponent(
     explorerCdnVersion,
   )}/embeddable-explorer.umd.production.min.js?runtime=${encodeURIComponent(
     apolloServerVersion,
   )}"></script>
-<script>
+<script nonce="${nonce}">
   var endpointUrl = window.location.href;
   var embeddedExplorerConfig = ${getConfigStringForHtml(
     embeddedExplorerParams,
@@ -118,6 +119,7 @@ export const getEmbeddedSandboxHTML = (
   sandboxCdnVersion: string,
   config: ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions,
   apolloServerVersion: string,
+  nonce: string,
 ) => {
   const endpointIsEditable =
     typeof config.embed === 'boolean'
@@ -139,12 +141,12 @@ export const getEmbeddedSandboxHTML = (
 style="width: 100vw; height: 100vh; position: absolute; top: 0;"
 id="embeddableSandbox"
 ></div>
-<script src="https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
+<script nonce="${nonce}" src="https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
     sandboxCdnVersion,
   )}/embeddable-sandbox.umd.production.min.js?runtime=${encodeURIComponent(
     apolloServerVersion,
   )}"></script>
-<script>
+<script nonce="${nonce}">
   var initialEndpoint = window.location.href;
   new window.EmbeddedSandbox({
     target: '#embeddableSandbox',

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -101,7 +101,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-${nonce}' https://apollo-server-landing-page.cdn.apollographql.com/${version}/static/js/main.js https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-${nonce}' https://apollo-server-landing-page.cdn.apollographql.com/${encodeURIComponent(
+            version,
+          )}/static/js/main.js https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
             version,
           )}/embeddable-sandbox.umd.production.min.js https://embeddable-explorer.cdn.apollographql.com/${encodeURIComponent(
             version,

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -13,6 +13,8 @@ import {
   getEmbeddedSandboxHTML,
 } from './getEmbeddedHTML.js';
 import { packageVersion } from '../../../generated/packageVersion.js';
+import { createHash } from '@apollo/utils.createhash';
+import { v4 as uuidv4 } from 'uuid';
 
 export type {
   ApolloServerPluginLandingPageLocalDefaultOptions,
@@ -61,6 +63,7 @@ const getNonEmbeddedLandingPageHTML = (
   cdnVersion: string,
   config: LandingPageConfig,
   apolloServerVersion: string,
+  nonce: string,
 ) => {
   const encodedConfig = encodeConfig(config);
 
@@ -70,7 +73,9 @@ const getNonEmbeddedLandingPageHTML = (
   <p>The full landing page cannot be loaded; it appears that you might be offline.</p>
 </div>
 <script>window.landingPage = ${encodedConfig};</script>
-<script src="https://apollo-server-landing-page.cdn.apollographql.com/${cdnVersion}/static/js/main.js?runtime=${apolloServerVersion}"></script>`;
+<script nonce="${nonce}" src="https://apollo-server-landing-page.cdn.apollographql.com/${encodeURIComponent(
+    cdnVersion,
+  )}/static/js/main.js?runtime=${apolloServerVersion}"></script>`;
 };
 
 // Helper for the two actual plugin functions.
@@ -84,6 +89,8 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
   const version = maybeVersion ?? '_latest';
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
 
+  const nonce = createHash('sha256').update(uuidv4()).digest('hex');
+
   return {
     __internal_installed_implicitly__: false,
     async serverWillStart() {
@@ -94,9 +101,16 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-${nonce}' https://apollo-server-landing-page.cdn.apollographql.com/${version}/static/js/main.js https://embeddable-sandbox.cdn.apollographql.com/${encodeURIComponent(
+            version,
+          )}/embeddable-sandbox.umd.production.min.js https://embeddable-explorer.cdn.apollographql.com/${encodeURIComponent(
+            version,
+          )}/embeddable-explorer.umd.production.min.js" />
     <link
       rel="icon"
-      href="https://apollo-server-landing-page.cdn.apollographql.com/${version}/assets/favicon.png"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodeURIComponent(
+        version,
+      )}/assets/favicon.png"
     />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
@@ -108,11 +122,15 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     <meta name="description" content="Apollo server landing page" />
     <link
       rel="apple-touch-icon"
-      href="https://apollo-server-landing-page.cdn.apollographql.com/${version}/assets/favicon.png"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodeURIComponent(
+        version,
+      )}/assets/favicon.png"
     />
     <link
       rel="manifest"
-      href="https://apollo-server-landing-page.cdn.apollographql.com/${version}/manifest.json"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodeURIComponent(
+        version,
+      )}/manifest.json"
     />
     <title>Apollo Server</title>
   </head>
@@ -135,11 +153,21 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     ${
       config.embed
         ? 'graphRef' in config && config.graphRef
-          ? getEmbeddedExplorerHTML(version, config, apolloServerVersion)
+          ? getEmbeddedExplorerHTML(version, config, apolloServerVersion, nonce)
           : !('graphRef' in config)
-          ? getEmbeddedSandboxHTML(version, config, apolloServerVersion)
-          : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
-        : getNonEmbeddedLandingPageHTML(version, config, apolloServerVersion)
+          ? getEmbeddedSandboxHTML(version, config, apolloServerVersion, nonce)
+          : getNonEmbeddedLandingPageHTML(
+              version,
+              config,
+              apolloServerVersion,
+              nonce,
+            )
+        : getNonEmbeddedLandingPageHTML(
+            version,
+            config,
+            apolloServerVersion,
+            nonce,
+          )
     }
     </div>
   </body>


### PR DESCRIPTION
[Slack context](https://apollograph.slack.com/archives/CR62ZA5E0/p1682974036307769)

Pierre found that in Safari the AS embedded Sandbo str8 up doesn't work ?! How long has this been going on without us knowing? Shocked. 

Anyways, we needed to add a [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) for Safari to take these scripts seriously, and I did so via[ `<meta` tag.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta) using the `nonce` option. 

**To test**

Download the `apollo-server-typescript` code sandbox example & install & run on Safari.