### PR TITLE
docs: LRU cache ttl from ms to seconds

### DIFF
--- a/docs/source/performance/cache-backends.mdx
+++ b/docs/source/performance/cache-backends.mdx
@@ -39,8 +39,8 @@ const server = new ApolloServer({
   cache: new InMemoryLRUCache({
     // ~100MiB
     maxSize: Math.pow(2, 20) * 100,
-    // 5 minutes (in milliseconds)
-    ttl: 300_000,
+    // 5 minutes (in seconds)
+    ttl: 300,
   }),
 });
 ```


### PR DESCRIPTION
Looks like in the docs, `InMemoryLRUCache` is written that it takes in ms for the ttl. This doesn't seem to be correct within the code itself:

[KeyValueCache takes in seconds](https://github.com/apollographql/apollo-utils/blob/main/packages/keyValueCache/src/KeyValueCache.ts#L9)

[InMemoryLRUCache converts the input into seconds](https://github.com/apollographql/apollo-utils/blob/main/packages/keyValueCache/src/InMemoryLRUCache.ts#L37) 