### PR TITLE
docs: fix internal link to heading in fetching-rest.mdx

### DIFF
--- a/docs/source/data/fetching-rest.mdx
+++ b/docs/source/data/fetching-rest.mdx
@@ -112,7 +112,7 @@ console.log(`🚀  Server ready at ${url}`);
 Apollo Server calls [the `context` initialization](./context/#the-context-function) function for _every incoming operation_. This means:
 
 - For every operation, `context` returns an _object_ containing new instances of your `RESTDataSource` subclasses (in this case, `MoviesAPI` and `PersonalizationAPI`).
-- The **`context` function should create a new instance of each `RESTDataSource` subclass for each operation**. [More details on why below.](#get-requests-and-responses)
+- The **`context` function should create a new instance of each `RESTDataSource` subclass for each operation**. [More details on why below.](#get-and-head-requests-and-responses)
 
 Your resolvers can then access your data sources from the shared `contextValue` object and use them to fetch data:
 


### PR DESCRIPTION
The heading in the `fetching-rest.mdx` documentation Page was changed in this commit https://github.com/apollographql/apollo-server/commit/191c877aa71e3712c202adfd9757d85c8949ead4#diff-1b1e79b6e6a5fbc493fc168c6dbbdeca02d2ed996086f7b8608234458d3a2e82R147 but an internal link in the same document wasn't updated.