### PR TITLE
Docs: Improve documentation example from O(n²) to O(n)

### DIFF
--- a/docs/source/data/fetching-data.mdx
+++ b/docs/source/data/fetching-data.mdx
@@ -102,7 +102,11 @@ class ProductsDataSource {
 
   private batchProducts = new DataLoader(async (ids) => {
     const productList = await this.dbConnection.fetchAllKeys(ids);
-    return ids.map((id) => productList.find((product) => product.id === id));
+    const productIdToProductMap = productList.reduce((mapping, product) => {
+        mapping[product.id] = product
+        return mapping
+    }, {});
+    return ids.map((id) => (productIdToProductMap[id]))
   });
 
   async getProductFor(id) {


### PR DESCRIPTION
I was reading the docs looking for examples on how to use dataloader and I found this example that makes nested loop iterations with a find inside a map.

Changing it to something like this would optimize the example, specially for large datasets