### PR TITLE
Update errorNormalize.ts

### DIFF
--- a/.changeset/nervous-terms-drop.md
+++ b/.changeset/nervous-terms-drop.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+Bugfix: when error does not initially contain extensions this ensures the default INTERNAL_SERVER_ERROR is applied

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -30,9 +30,13 @@ describe('Errors', () => {
       expect(error.extensions?.stacktrace).toBeDefined();
     });
     it('error without extension gives INTERNAL_SERVER_ERROR code', () => {
-      const [error] = normalizeAndFormatErrors([new Error()], {
+      const myBrokenGraphqlError = new GraphQLError('broken');
+      //@ts-ignore
+      delete myBrokenGraphqlError.extensions;
+      const [error] = normalizeAndFormatErrors([myBrokenGraphqlError], {
         includeStacktraceInErrorResponses: true,
       }).formattedErrors;
+      expect(error.message).toEqual('broken');
       expect(error.extensions?.code).toEqual('INTERNAL_SERVER_ERROR');
     });
     it('hides stacktrace by default', () => {

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -29,7 +29,7 @@ describe('Errors', () => {
       // stacktrace should exist
       expect(error.extensions?.stacktrace).toBeDefined();
     });
-    it('error without extension gives INTERAL_SERVER_ERROR code', () => {
+    it('error without extension gives INTERNAL_SERVER_ERROR code', () => {
       const [error] = normalizeAndFormatErrors(
         [
           new Error(),

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -29,6 +29,15 @@ describe('Errors', () => {
       // stacktrace should exist
       expect(error.extensions?.stacktrace).toBeDefined();
     });
+    it('error without extension gives INTERAL_SERVER_ERROR code', () => {
+      const [error] = normalizeAndFormatErrors(
+        [
+          new Error(),
+        ],
+        { includeStacktraceInErrorResponses: true },
+      ).formattedErrors;
+      expect(error.extensions?.code).toEqual('INTERNAL_SERVER_ERROR');
+    });
     it('hides stacktrace by default', () => {
       const thrown = new Error(message);
       (thrown as any).key = key;

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -30,12 +30,9 @@ describe('Errors', () => {
       expect(error.extensions?.stacktrace).toBeDefined();
     });
     it('error without extension gives INTERNAL_SERVER_ERROR code', () => {
-      const [error] = normalizeAndFormatErrors(
-        [
-          new Error(),
-        ],
-        { includeStacktraceInErrorResponses: true },
-      ).formattedErrors;
+      const [error] = normalizeAndFormatErrors([new Error()], {
+        includeStacktraceInErrorResponses: true,
+      }).formattedErrors;
       expect(error.extensions?.code).toEqual('INTERNAL_SERVER_ERROR');
     });
     it('hides stacktrace by default', () => {

--- a/packages/server/src/errorNormalize.ts
+++ b/packages/server/src/errorNormalize.ts
@@ -61,7 +61,7 @@ export function normalizeAndFormatErrors(
     const extensions: GraphQLErrorExtensions = {
       ...graphqlError.extensions,
       code:
-        graphqlError.extensions.code ??
+        graphqlError.extensions?.code ??
         ApolloServerErrorCode.INTERNAL_SERVER_ERROR,
     };
 


### PR DESCRIPTION
* 🕷 Bug fixes

* ✏️ Explain your pull request


I am receiving 

TypeError: Cannot read property 'code' of undefined
    at enrichError (/Users/skitchen/Library/CloudStorage/OneDrive/Desktop/git/graphql/node_modules/@apollo/server/dist/cjs/errorNormalize.js:34:43)
    at /Users/skitchen/Library/CloudStorage/OneDrive/Desktop/git/graphql/node_modules/@apollo/server/dist/cjs/errorNormalize.js:19:28
    at Array.map (<anonymous>)
    at normalizeAndFormatErrors (/Users/skitchen/Library/CloudStorage/Desktop/git/graphql/node_modules/@apollo/server/dist/cjs/errorNormalize.js:13:33)
    at ApolloServer.errorResponse (/Users/skitchen/Library/CloudStorage/OneDrive/Desktop/git/graphql/node_modules/@apollo/server/dist/cjs/ApolloServer.js:545:102)
    at ApolloServer.executeHTTPGraphQLRequest (/Users/skitchen/Library/CloudStorage/OneDrive/Desktop/git/graphql/node_modules/@apollo/server/dist/cjs/ApolloServer.js:541:25)
    
 Because my error does not have an "extensions" attribute --- this ensures even without an extensions attribute the code can be defaulted to INTERNAL_SERVER_ERROR

