### PR TITLE
Allow landing page to be configured with a precomputed nonce (fix for CF workers)

### DIFF
--- a/.changeset/pink-mugs-pump.md
+++ b/.changeset/pink-mugs-pump.md
@@ -2,14 +2,9 @@
 '@apollo/server': patch
 ---
 
-Provide a new configuration option for landing page plugins `precomputedNonce`
-which allows users to provide a nonce and avoid calling into `uuid` functions on
-startup. This is useful for Cloudflare Workers where random number generation is
-not available on startup (only during requests). Unless you are using Cloudflare Workers,
-you can ignore this change.
+Provide a new configuration option for landing page plugins `precomputedNonce` which allows users to provide a nonce and avoid calling into `uuid` functions on startup. This is useful for Cloudflare Workers where random number generation is not available on startup (only during requests). Unless you are using Cloudflare Workers, you can ignore this change.
 
-The example below assumes you've provided a `PRECOMPUTED_NONCE` variable in your
-`wrangler.toml` file.
+The example below assumes you've provided a `PRECOMPUTED_NONCE` variable in your `wrangler.toml` file.
 
 Example usage:
 ```ts

--- a/.changeset/pink-mugs-pump.md
+++ b/.changeset/pink-mugs-pump.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Use Web Crypto API for UUID generation when it's available (in Node 20+ and web workers)

--- a/.changeset/pink-mugs-pump.md
+++ b/.changeset/pink-mugs-pump.md
@@ -2,4 +2,23 @@
 '@apollo/server': patch
 ---
 
-Use Web Crypto API for UUID generation when it's available (in Node 20+ and web workers)
+Provide a new configuration option for landing page plugins `precomputedNonce`
+which allows users to provide a nonce and avoid calling into `uuid` functions on
+startup. This is useful for Cloudflare Workers where random number generation is
+not available on startup (only during requests). Unless you are using Cloudflare Workers,
+you can ignore this change.
+
+The example below assumes you've provided a `PRECOMPUTED_NONCE` variable in your
+`wrangler.toml` file.
+
+Example usage:
+```ts
+const server = new ApolloServer({
+  // ...
+  plugins: [
+    ApolloServerPluginLandingPageLocalDefault({
+      precomputedNonce: PRECOMPUTED_NONCE
+    })
+  ],
+});
+```

--- a/docs/source/api/plugin/landing-pages.mdx
+++ b/docs/source/api/plugin/landing-pages.mdx
@@ -448,8 +448,7 @@ An object containing initial HTTP header values to populate in the Explorer on l
 
 ###### `embed`
 
-`boolean | ApolloServerPluginEmbedded`
-`LandingPageProductionConfigOptions`
+`boolean | EmbeddableSandboxOptions`
 </td>
 <td>
 
@@ -460,6 +459,19 @@ To embed the Apollo Sandbox, you must _also_ provide Apollo Server with the **gr
 The default value is `false`, in which case the landing page displays a basic `curl` command.
 
 You can configure the Explorer embedded on your Apollo Server endpoint with display and functional options. For supported options, see [`embed` options](#embed-options).
+
+</td>
+</tr>
+<tr>
+<td>
+
+###### `precomputedNonce`
+
+`string`
+</td>
+<td>
+
+The landing page renders with a randomly generated nonce for security purposes. If you'd like to provide your own nonce, you can do so here. This is useful for Cloudflare Workers which can't perform random number generation on startup.
 
 </td>
 </tr>

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -89,7 +89,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
   const version = maybeVersion ?? '_latest';
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
 
-  const nonce = createHash('sha256').update(uuidv4()).digest('hex');
+  const nonce =
+    config.precomputedNonce ??
+    createHash('sha256').update(uuidv4()).digest('hex');
 
   return {
     __internal_installed_implicitly__: false,

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -53,6 +53,11 @@ export type ApolloServerPluginLandingPageDefaultBaseOptions = {
 
   includeCookies?: boolean;
 
+  /**
+   * If specified, the landing page will use the provided nonce rather than
+   * compute its own. This is useful for Cloudflare Workers, which do not allow
+   * number generation on startup.
+   */
   precomputedNonce?: string;
 
   // For Apollo use only.

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -53,6 +53,8 @@ export type ApolloServerPluginLandingPageDefaultBaseOptions = {
 
   includeCookies?: boolean;
 
+  precomputedNonce?: string;
+
   // For Apollo use only.
   __internal_apolloStudioEnv__?: 'staging' | 'prod';
 };


### PR DESCRIPTION
#7539 introduced a `v4()` call from the `uuid` package which broke CF workers (https://github.com/apollo-server-integrations/apollo-server-integration-cloudflare-workers/issues/37). This change allows users to configure / precompute the `nonce` in advance to avoid making crypto-y calls on startup (which CF workers throws errors about).