### PR TITLE
Move apollo-datasource-firestore to modern datasources

### DIFF
--- a/docs/source/data/fetching-data.mdx
+++ b/docs/source/data/fetching-data.mdx
@@ -230,6 +230,7 @@ The community maintains the following open-source data source for Apollo Server 
 | Class | Source | For Use With |
 | --- | --- | --- |
 | [`BatchedSQLDataSource`](https://github.com/nic-jennings/batched-sql-datasource) | Community | SQL databases (via [Knex.js](http://knexjs.org/)) & Batching (via [DataLoader](https://github.com/graphql/dataloader)) |
+| [`FirestoreDataSource`](https://github.com/swantzter/apollo-datasource-firestore) | Community | Cloud Firestore |
 
 ### Legacy data source classes
 
@@ -246,7 +247,6 @@ The larger community maintains the following open-source implementations:
 | [`SQLDataSource`](https://github.com/cvburgess/SQLDataSource) | Community | SQL databases (via [Knex.js](http://knexjs.org/)) |
 | [`MongoDataSource`](https://github.com/GraphQLGuide/apollo-datasource-mongodb/) | Community | MongoDB |
 | [`CosmosDataSource`](https://github.com/andrejpk/apollo-datasource-cosmosdb) | Community | Azure Cosmos DB |
-| [`FirestoreDataSource`](https://github.com/swantzter/apollo-datasource-firestore) | Community | Cloud Firestore |
 
 > Apollo does not provide official support for community-maintained libraries. We cannot guarantee that community-maintained libraries adhere to best practices, or that they will continue to be maintained.
 


### PR DESCRIPTION
With version 6.0.0 I've reworked the datasource to use the modern format
