### PR TITLE
fix: undefined MyContext

### DIFF
--- a/docs/source/workflow/generate-types.mdx
+++ b/docs/source/workflow/generate-types.mdx
@@ -50,6 +50,12 @@ import { readFileSync } from 'fs';
 // if the server is executed using `npm run`.
 const typeDefs = readFileSync('./schema.graphql', { encoding: 'utf-8' });
 
+interface MyContext {
+  dataSources: {
+    books: Book[];
+  };
+}
+
 const server = new ApolloServer<MyContext>({
   typeDefs,
   resolvers,


### PR DESCRIPTION
Fix undefined `MyContext` type in docs