### PR TITLE
Docs - More clearly point to special web client case

### DIFF
--- a/docs/source/schema/unions-interfaces.md
+++ b/docs/source/schema/unions-interfaces.md
@@ -260,7 +260,6 @@ Here's a valid result for the above query:
 }
 ```
 
-
 ### Resolving an interface
 
 > Before reading this section, [learn about resolvers](../data/resolvers/).

--- a/docs/source/schema/unions-interfaces.md
+++ b/docs/source/schema/unions-interfaces.md
@@ -70,7 +70,7 @@ query GetSearchResults {
 
 > [What is the `__typename` field?](./schema/#the-__typename-field)
 
-This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Result`'s `title` (if it's a `Book`) or its `name` (if it's an `Author`).
+This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Result`'s `title` (if it's a `Book`) or its `name` (if it's an `Author`). The React client can be informed about this polymorphic relationship by [passing the possibleTypes option](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
 
 Here's a valid result for the above query:
 
@@ -91,7 +91,6 @@ Here's a valid result for the above query:
 }
 ```
 
-For more information, see [Using fragments with unions and interfaces](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
 
 ### Resolving a union
 
@@ -234,7 +233,7 @@ query GetBooks {
 
 > [What is the `__typename` field?](./schema/#the-__typename-field)
 
-This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Book`'s `courses` (if it's a `Textbook`) or its `colors` (if it's a `ColoringBook`).
+This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Book`'s `courses` (if it's a `Textbook`) or its `colors` (if it's a `ColoringBook`). The React client can be informed about this polymorphic relationship by [passing the possibleTypes option](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
 
 Here's a valid result for the above query:
 
@@ -261,7 +260,6 @@ Here's a valid result for the above query:
 }
 ```
 
-For more information, see [Using fragments with unions and interfaces](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
 
 ### Resolving an interface
 

--- a/docs/source/schema/unions-interfaces.md
+++ b/docs/source/schema/unions-interfaces.md
@@ -70,7 +70,7 @@ query GetSearchResults {
 
 > [What is the `__typename` field?](./schema/#the-__typename-field)
 
-This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Result`'s `title` (if it's a `Book`) or its `name` (if it's an `Author`). The React client can be informed about this polymorphic relationship by [passing the possibleTypes option](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
+This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Result`'s `title` (if it's a `Book`) or its `name` (if it's an `Author`). The web client can be informed about this polymorphic relationship by [passing the possibleTypes option](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
 
 Here's a valid result for the above query:
 
@@ -233,7 +233,7 @@ query GetBooks {
 
 > [What is the `__typename` field?](./schema/#the-__typename-field)
 
-This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Book`'s `courses` (if it's a `Textbook`) or its `colors` (if it's a `ColoringBook`). The React client can be informed about this polymorphic relationship by [passing the possibleTypes option](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
+This query uses [inline fragments](https://graphql.org/learn/queries/#inline-fragments) to fetch a `Book`'s `courses` (if it's a `Textbook`) or its `colors` (if it's a `ColoringBook`). The web client can be informed about this polymorphic relationship by [passing the possibleTypes option](https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces).
 
 Here's a valid result for the above query:
 


### PR DESCRIPTION
Would solve [this issue](https://github.com/apollographql/apollo-client/issues/9904). I only mention the React case, since the other clients appear to infer this.