### PR TITLE
chore: small security fix to update superagent

### DIFF
--- a/.changeset/lucky-experts-cheat.md
+++ b/.changeset/lucky-experts-cheat.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server-integration-testsuite': patch
+---
+
+Add missing `supertest` dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "qs-middleware": "1.0.3",
         "requisition": "1.7.0",
         "rollup": "3.26.3",
+        "superagent": "8.0.7",
         "supertest": "6.3.3",
         "test-listen": "1.1.0",
         "ts-jest": "29.1.1",
@@ -6333,9 +6334,9 @@
       "license": "MIT"
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -8158,9 +8159,9 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
-      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -13065,16 +13066,16 @@
       "license": "MIT"
     },
     "node_modules/superagent": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.6.tgz",
-      "integrity": "sha512-HqSe6DSIh3hEn6cJvCkaM1BLi466f1LHi4yubR0tpewlMpk4RUFFy35bKz8SsPBwYfIIJy5eclp+3tCYAuX0bw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.7.tgz",
+      "integrity": "sha512-lffxSyqkswW7kzDFkLNyX1GMIfR5TyCKBF4Vdvzn/6d0Q1s+YX1EbbwhyEGx2xzThnwDFmfsIVymZZ2Tk4Nubw==",
       "dependencies": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.3",
+        "cookiejar": "^2.1.4",
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.1",
+        "formidable": "^2.1.2",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0",
@@ -19308,9 +19309,9 @@
       "version": "1.0.6"
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -20684,9 +20685,9 @@
       }
     },
     "formidable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
-      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
       "requires": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -24109,16 +24110,16 @@
       "dev": true
     },
     "superagent": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.6.tgz",
-      "integrity": "sha512-HqSe6DSIh3hEn6cJvCkaM1BLi466f1LHi4yubR0tpewlMpk4RUFFy35bKz8SsPBwYfIIJy5eclp+3tCYAuX0bw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.7.tgz",
+      "integrity": "sha512-lffxSyqkswW7kzDFkLNyX1GMIfR5TyCKBF4Vdvzn/6d0Q1s+YX1EbbwhyEGx2xzThnwDFmfsIVymZZ2Tk4Nubw==",
       "requires": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.3",
+        "cookiejar": "^2.1.4",
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.1",
+        "formidable": "^2.1.2",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
         "qs-middleware": "1.0.3",
         "requisition": "1.7.0",
         "rollup": "3.26.3",
-        "superagent": "8.0.7",
         "supertest": "6.3.3",
         "test-listen": "1.1.0",
         "ts-jest": "29.1.1",
@@ -14252,6 +14251,7 @@
         "graphql-tag": "^2.12.6",
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
+        "superagent": "^8.0.9",
         "supertest": "^6.2.3"
       },
       "engines": {
@@ -14261,6 +14261,50 @@
         "@jest/globals": "28.x || 29.x",
         "graphql": "^16.6.0",
         "jest": "28.x || 29.x"
+      }
+    },
+    "packages/integration-testsuite/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/integration-testsuite/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "packages/integration-testsuite/node_modules/superagent": {
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
+      "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
       }
     },
     "packages/plugin-response-cache": {
@@ -14585,7 +14629,42 @@
         "graphql-tag": "^2.12.6",
         "loglevel": "^1.8.0",
         "node-fetch": "^2.6.7",
+        "superagent": "^8.0.9",
         "supertest": "^6.2.3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+        },
+        "superagent": {
+          "version": "8.0.9",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
+          "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+          "requires": {
+            "component-emitter": "^1.3.0",
+            "cookiejar": "^2.1.4",
+            "debug": "^4.3.4",
+            "fast-safe-stringify": "^2.1.1",
+            "form-data": "^4.0.0",
+            "formidable": "^2.1.2",
+            "methods": "^1.1.2",
+            "mime": "2.6.0",
+            "qs": "^6.11.0",
+            "semver": "^7.3.8"
+          }
+        }
       }
     },
     "@apollo/server-plugin-response-cache": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "requisition": "1.7.0",
     "rollup": "3.26.3",
     "supertest": "6.3.3",
-    "superagent": "8.0.7",
     "test-listen": "1.1.0",
     "ts-jest": "29.1.1",
     "typescript": "5.1.6"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "requisition": "1.7.0",
     "rollup": "3.26.3",
     "supertest": "6.3.3",
+    "superagent": "8.0.7",
     "test-listen": "1.1.0",
     "ts-jest": "29.1.1",
     "typescript": "5.1.6"

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -39,6 +39,7 @@
     "graphql-tag": "^2.12.6",
     "loglevel": "^1.8.0",
     "node-fetch": "^2.6.7",
+    "superagent": "^8.0.9",
     "supertest": "^6.2.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Problem Super Agent is a package used but implicitly installed in node_module due to other packages importing it : 

<img width="534" alt="image" src="https://github.com/apollographql/apollo-server/assets/37447884/7c53075d-10ac-46cd-b743-92f8214fdabd">

## Solution

specify it in the main package.json so to alleviate surprises in the future.


## Problem "CookieJar" is a dependency used by Super Agent which currently has a security bulletin : 

```
cookiejar  <2.1.4
Severity: moderate
cookiejar Regular Expression Denial of Service via Cookie.parse function - https://github.com/advisories/GHSA-h452-7996-h45h
fix available via `npm audit fix`
node_modules/cookiejar
```

## Solution , perform a minor bump of `SuperAgent` which has a fix for the CookieJar issue

## Does it all work?

`formidable` and `cookiejar` are only used by `superAgent` so we can just verify the current tests using `superAgent`

So Let's run every test!

<img width="729" alt="image" src="https://github.com/apollographql/apollo-server/assets/37447884/69a1546f-4593-47af-b7b3-fdee0cd45421">

