### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # The renovate-approve bot is allowed to merge its own PRs.  As it's not
 # a regular GitHub user (but rather, an app!), its username is indicated
 # as such, using the `app/` prefix. https://github.com/apps/renovate-approve
-/docs/ app/renovate-approve @apollographql/docs @glasser
+/docs/ app/renovate-approve @apollographql/docs @glasser @trevor-scheer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-# The renovate-approve bot is allowed to merge its own PRs.  As it's not
-# a regular GitHub user (but rather, an app!), its username is indicated
-# as such, using the `app/` prefix. https://github.com/apps/renovate-approve
-/docs/ app/renovate-approve @apollographql/docs @glasser @trevor-scheer
+/docs/ @apollographql/docs @glasser @trevor-scheer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # The renovate-approve bot is allowed to merge its own PRs.  As it's not
 # a regular GitHub user (but rather, an app!), its username is indicated
 # as such, using the `app/` prefix. https://github.com/apps/renovate-approve
-/docs/ app/renovate-approve @stephenbarlow @glasser
+/docs/ app/renovate-approve @apollographql/docs @glasser


### PR DESCRIPTION
This PR updates to the codeowners for `/docs` to the [docs team](https://github.com/orgs/apollographql/teams/docs).