### PR TITLE
chore: Enforcing no extraneous dependencies in package.json

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
       files: ['**/*.ts'],
       excludedFiles: '**/__tests__/**/*.ts',
       rules: {
+        "import/no-extraneous-dependencies": "error",
         'import/extensions': ['error', 'ignorePackages'],
         '@typescript-eslint/consistent-type-imports': [
           'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,8 +11,8 @@ module.exports = {
       files: ['**/*.ts'],
       excludedFiles: '**/__tests__/**/*.ts',
       rules: {
-        // Dissallow importing a node module without it being specified in package.json
-        "import/no-extraneous-dependencies": "error",
+        // Disallow importing a node module without it being specified in package.json
+        'import/no-extraneous-dependencies': 'error',
         'import/extensions': ['error', 'ignorePackages'],
         '@typescript-eslint/consistent-type-imports': [
           'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
       files: ['**/*.ts'],
       excludedFiles: '**/__tests__/**/*.ts',
       rules: {
+        // Dissallow importing a node module without it being specified in package.json
         "import/no-extraneous-dependencies": "error",
         'import/extensions': ['error', 'ignorePackages'],
         '@typescript-eslint/consistent-type-imports': [


### PR DESCRIPTION
Follow up of this PR -> https://github.com/apollographql/apollo-server/pull/7655

Here we are enabling a eslint rule to disallow this pattern in the future.

Does it work?:

<img width="836" alt="image" src="https://github.com/apollographql/apollo-server/assets/37447884/da73e841-60a6-48fa-ac73-0d0b70645383">
