### PR TITLE
Add missing `nonce` to `script` tag

### DIFF
--- a/.changeset/rude-monkeys-pay.md
+++ b/.changeset/rude-monkeys-pay.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Add missing `nonce` on `script` tag for non-embedded landing page

--- a/packages/server/src/__tests__/plugin/landingPage/plugin.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/plugin.test.ts
@@ -1,5 +1,8 @@
 import { ApolloServer, HeaderMap } from '@apollo/server';
-import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default';
+import {
+  ApolloServerPluginLandingPageLocalDefault,
+  ApolloServerPluginLandingPageProductionDefault,
+} from '@apollo/server/plugin/landingPage/default';
 import { describe, expect, test } from '@jest/globals';
 import assert from 'assert';
 import { mockLogger } from '../../mockLogger';
@@ -60,5 +63,17 @@ describe('ApolloServerPluginLandingPageDefault', () => {
       "The `precomputedNonce` landing page configuration option is deprecated. Removing this option is strictly an improvement to Apollo Server's landing page Content Security Policy (CSP) implementation for preventing XSS attacks.",
     );
     await server.stop();
+  });
+
+  test(`nonce exists in non-embedded landing page`, async () => {
+    const plugin = ApolloServerPluginLandingPageProductionDefault({
+      embed: false,
+    });
+
+    // @ts-ignore not passing things to `serverWillStart`
+    const { renderLandingPage } = await plugin.serverWillStart?.({});
+    const landingPageHtml = await (await renderLandingPage?.()).html();
+
+    expect(landingPageHtml).toMatch(/<script nonce=".*">window\.landingPage/);
   });
 });

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -72,7 +72,7 @@ const getNonEmbeddedLandingPageHTML = (
   <h1>Welcome to Apollo Server</h1>
   <p>The full landing page cannot be loaded; it appears that you might be offline.</p>
 </div>
-<script>window.landingPage = ${encodedConfig};</script>
+<script nonce="${nonce}">window.landingPage = ${encodedConfig};</script>
 <script nonce="${nonce}" src="https://apollo-server-landing-page.cdn.apollographql.com/${encodeURIComponent(
     cdnVersion,
   )}/static/js/main.js?runtime=${apolloServerVersion}"></script>`;


### PR DESCRIPTION
Follow-up to https://github.com/apollographql/apollo-server/security/advisories/GHSA-68jh-rf6x-836f