### PR TITLE
chore: update documentation to include install commands for typescript

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -92,6 +92,12 @@ First, install Apollo Server, the JavaScript implementation of the core GraphQL 
 npm install @apollo/server graphql express cors body-parser
 ```
 
+If using Typescript you may also need to install additional type declaration packages as development dependencies to avoid common errors when importing the above packages (i.e. Could not find a declaration file for module '`cors`'):
+
+```
+npm install --save-dev @types/cors @types/express @types/body-parser
+```
+
 Then, write the following to `server.mjs`. (By using the `.mjs` extension, Node lets you use the `await` keyword at the top level.)
 
 ```js


### PR DESCRIPTION
# Proposed Changes
* Update the documentation to include npm install commands for needed Typescript declaration files to prevent errors.

In the process of migrating from apollo-server-express to just using apollo-server v4 I was following the migration guide here: https://www.apollographql.com/docs/apollo-server/migration/#migrate-from-apollo-server-express and when I installed the `cors` package and imported it into my `index.ts` file I got the error shown in the readme.md file below. I believe it is important to include the corresponding Typescript commands to use for other users who will migrate to v4. 

Thanks!
