### PR TITLE
Use requestContext.response.body instead of requestContext.errors in ApolloServerPluginUsageReporting

### DIFF
--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -584,8 +584,14 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
             // Search above for a comment about "didResolveSource" to see which
             // of the pre-source-resolution errors we are intentionally avoiding.
             if (!didResolveSource) return;
-            if (requestContext.errors) {
-              treeBuilder.didEncounterErrors(requestContext.errors);
+            if ('singleResult' in requestContext.response.body) {
+              treeBuilder.didEncounterErrors(
+                requestContext.response.body.singleResult.errors,
+              );
+            } else {
+              treeBuilder.didEncounterErrors(
+                requestContext.response.body.initialResult.errors,
+              );
             }
 
             // If there isn't any defer/stream coming later, we're done.


### PR DESCRIPTION
Even though [the documentation](https://www.apollographql.com/docs/apollo-server/data/errors#for-apollo-studio-reporting) states that developers can use the `extensions` field in the function assigned to the `sendErrors->transform` option of ApolloServerPluginUsageReporting, `requestContext.errors` used to build the tree does not contain formatted errors.

This PR is intended to fix the problem by using `requestContext.response.body.(singleResult|initialResult).errors` instead of `requestContext.errors` as suggested in [#4351](https://github.com/apollographql/apollo-server/issues/4351#issuecomment-1286466645)