### PR TITLE
Update subscriptions.mdx to document support for Solace 

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -573,6 +573,7 @@ Instead, you should use a subclass of the [`PubSubEngine` abstract class](https:
 
 The following are community-created `PubSub` libraries for popular event-publishing systems:
 
+- [Solace](https://github.com/solacecommunity/graphql-solace-subscriptions)
 - [Redis](https://github.com/davidyaha/graphql-redis-subscriptions)
 - [Google PubSub](https://github.com/axelspringer/graphql-google-pubsub)
 - [MQTT enabled broker](https://github.com/davidyaha/graphql-mqtt-subscriptions)


### PR DESCRIPTION
Updating the docs to add Solace PubSub+ as a supported integration for GraphQL subscriptions.
