### PR TITLE
Fix trace placement for errors occurring in lists

### DIFF
--- a/.changeset/gentle-cycles-look.md
+++ b/.changeset/gentle-cycles-look.md
@@ -1,0 +1,11 @@
+---
+'@apollo/server': patch
+---
+
+Fix error path attachment for list items
+
+Previously, when errors occurred while resolving a list item, the trace builder would fail to place the error at the correct path and just default to the root node with a warning message:
+
+> `Could not find node with path x.y.1, defaulting to put errors on root node.`
+
+This change places these errors at their correct paths and removes the log.

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -189,6 +189,7 @@ tsconfig
 tsconfigs
 typecheck
 typeis
+typenames
 typeof
 typesafe
 unawaited

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,4 +1,5 @@
 import { defaults } from 'jest-config';
+import { createRequire } from 'node:module';
 
 export default {
   testEnvironment: 'node',
@@ -22,6 +23,5 @@ export default {
     // Ignore '.js' at the end of imports; part of ESM support.
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  // this can be removed with jest v29
-  snapshotFormat: { escapeString: false, printBasicPrototype: false },
+  prettierPath: createRequire(import.meta.url).resolve('prettier-2'),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "nock": "13.3.2",
         "node-fetch": "2.6.12",
         "prettier": "3.0.1",
+        "prettier-2": "npm:prettier@^2",
         "qs-middleware": "1.0.3",
         "requisition": "1.7.0",
         "rollup": "3.28.0",
@@ -11880,6 +11881,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-2": {
+      "name": "prettier",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
@@ -23539,6 +23556,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
       "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "dev": true
+    },
+    "prettier-2": {
+      "version": "npm:prettier@2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "nock": "13.3.2",
     "node-fetch": "2.6.12",
     "prettier": "3.0.1",
+    "prettier-2": "npm:prettier@^2",
     "qs-middleware": "1.0.3",
     "requisition": "1.7.0",
     "rollup": "3.28.0",

--- a/packages/server/src/__tests__/plugin/inlineTrace/inlineTracePlugin.test.ts
+++ b/packages/server/src/__tests__/plugin/inlineTrace/inlineTracePlugin.test.ts
@@ -1,0 +1,66 @@
+import { ApolloServer, HeaderMap } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { describe, it, expect } from '@jest/globals';
+import assert from 'assert';
+import { Trace } from '@apollo/usage-reporting-protobuf';
+
+describe('ApolloServerPluginInlineTrace', () => {
+  it('Adds errors within lists to the correct path rather than the root', async () => {
+    const server = new ApolloServer({
+      schema: buildSubgraphSchema({
+        typeDefs: gql`
+          type Query {
+            a: A!
+          }
+          type A {
+            brokenList: [String!]!
+          }
+        `,
+        resolvers: {
+          Query: {
+            a: () => ({}),
+          },
+          A: {
+            brokenList() {
+              return ['hello world!', null];
+            },
+          },
+        },
+      }),
+    });
+    await server.start();
+    const result = await server.executeHTTPGraphQLRequest({
+      httpGraphQLRequest: {
+        body: { query: '{a{brokenList}}' },
+        headers: new HeaderMap([
+          ['content-type', 'application/json'],
+          ['apollo-federation-include-trace', 'ftv1'],
+        ]),
+        method: 'POST',
+        search: '',
+      },
+      context: async () => ({}),
+    });
+    assert(result.body.kind === 'complete');
+    const trace = Trace.decode(
+      Buffer.from(JSON.parse(result.body.string).extensions?.ftv1, 'base64'),
+    );
+    expect(trace.root?.error).toMatchInlineSnapshot(`
+      [
+        {
+          "json": "{"message":"<masked>","locations":[{"line":1,"column":4}],"path":["a","brokenList",1],"extensions":{"maskedBy":"ApolloServerPluginInlineTrace"}}",
+          "location": [
+            {
+              "column": 4,
+              "line": 1,
+            },
+          ],
+          "message": "<masked>",
+        },
+      ]
+    `);
+
+    await server.stop();
+  });
+});

--- a/packages/server/src/plugin/inlineTrace/index.ts
+++ b/packages/server/src/plugin/inlineTrace/index.ts
@@ -66,7 +66,7 @@ export function ApolloServerPluginInlineTrace(
         }
       }
     },
-    async requestDidStart({ request: { http }, metrics, logger }) {
+    async requestDidStart({ request: { http }, metrics }) {
       if (!enabled) {
         return;
       }
@@ -74,7 +74,6 @@ export function ApolloServerPluginInlineTrace(
       const treeBuilder = new TraceTreeBuilder({
         maskedBy: 'ApolloServerPluginInlineTrace',
         sendErrors: options.includeErrors,
-        logger,
       });
 
       // XXX Provide a mechanism to customize this logic.

--- a/packages/server/src/plugin/traceTreeBuilder.ts
+++ b/packages/server/src/plugin/traceTreeBuilder.ts
@@ -8,7 +8,7 @@ import {
 import { Trace, google } from '@apollo/usage-reporting-protobuf';
 import type { SendErrorsOptions } from './usageReporting';
 import { UnreachableCaseError } from '../utils/UnreachableCaseError.js';
-import { addPath } from 'graphql/jsutils/Path';
+import { addPath } from 'graphql/jsutils/Path.js';
 
 function internalError(message: string) {
   return new Error(`[internal apollo-server error] ${message}`);

--- a/packages/server/src/plugin/traceTreeBuilder.ts
+++ b/packages/server/src/plugin/traceTreeBuilder.ts
@@ -8,7 +8,6 @@ import {
 import { Trace, google } from '@apollo/usage-reporting-protobuf';
 import type { SendErrorsOptions } from './usageReporting';
 import { UnreachableCaseError } from '../utils/UnreachableCaseError.js';
-import { addPath } from 'graphql/jsutils/Path.js';
 
 function internalError(message: string) {
   return new Error(`[internal apollo-server error] ${message}`);
@@ -285,7 +284,11 @@ function responsePathFromArray(
   let nodePtr: Trace.INode | undefined = node;
   for (const key of path) {
     nodePtr = nodePtr?.child?.find((child) => child.responseName === key);
-    responsePath = addPath(responsePath, key, nodePtr?.parentType ?? undefined);
+    responsePath = {
+      key,
+      prev: responsePath,
+      typename: nodePtr?.type ?? undefined,
+    };
   }
   return responsePath;
 }

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -411,7 +411,6 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
         const treeBuilder: TraceTreeBuilder = new TraceTreeBuilder({
           maskedBy: 'ApolloServerPluginUsageReporting',
           sendErrors: options.sendErrors,
-          logger,
         });
         treeBuilder.startTiming();
         metrics.startHrTime = treeBuilder.startHrTime;


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-server/issues/4476

Currently, when errors occur while resolving a list item, the trace builder fails to place the error at the correct path and just defaults to the root node with a warning message:
> `Could not find node with path x.y.1, defaulting to put errors on root node.`

This change places these errors at their correct paths and removes the log.