### PR TITLE
Add enterprise callout

### DIFF
--- a/docs/source/api/plugin/usage-reporting.mdx
+++ b/docs/source/api/plugin/usage-reporting.mdx
@@ -3,6 +3,9 @@ title: "API Reference: Usage reporting plugin"
 api_reference: true
 ---
 
+> Sending metrics from Apollo Server to GraphOS requires an [enterprise plan](../org/plans/).
+> If your organization _doesn't_ currently have an Enterprise plan, you can test out this functionality by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
+
 Apollo Server's built-in usage reporting plugin gathers data on how your clients use the operations and fields in your GraphQL schema. The plugin also handles pushing this usage data to [GraphOS](/graphos/), as described in [Metrics and logging](../../monitoring/metrics/).
 
 This plugin is designed to be used in an Apollo Gateway or in a monolithic server; it is not designed to be used from a subgraph. In a supergraph running Apollo Federation, the Apollo Gateway or Apollo Router will send usage reports to Apollo's cloud. Subgraphs don't need to also send usage reports to Apollo's cloud; instead, they send it to the Router via [inline traces](./inline-trace/) and the Router combines execution information across all subgraphs and sends summarized reports to the cloud.

--- a/docs/source/monitoring/metrics.mdx
+++ b/docs/source/monitoring/metrics.mdx
@@ -3,6 +3,9 @@ title: Metrics and logging
 description: How to monitor Apollo Server's performance
 ---
 
+> Sending metrics from Apollo Server to GraphOS requires an [enterprise plan](../org/plans/).
+> If your organization _doesn't_ currently have an Enterprise plan, you can test out this functionality by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
+
 Apollo Server integrates seamlessly with [Apollo GraphOS](/graphos/) to help you monitor the execution of your GraphQL operations. Apollo Server additionally provides configurable mechanisms for logging each phase of a GraphQL operation.
 
 > Using Federation? Check out the documentation for [federated tracing](/federation/metrics/).


### PR DESCRIPTION
This PR calls out than an enterprise plan is necessary to report metrics from Apollo Server to GraphOS.