### PR TITLE
Update list of benign-positive secret detections

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,13 +1,13 @@
-# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs. 
+# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs.
 # This is an Apollo-Internal link, but more information about these scans is available here:
 # https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing#Scheduled-Scans.1
-# 
+#
 # Apollo is using Gitleaks (https://github.com/gitleaks/gitleaks) to run these scans.
 # However, this file is not something that Gitleaks natively consumes. This file is an
 # Apollo-convention. Prior to scanning a repo, Apollo merges
 # our standard Gitleaks configuration (which is largely just the Gitleaks-default config) with
 # this file if it exists in a repo. The combined config is then used to scan a repo.
-# 
+#
 # We did this because the natively-supported allowlisting functionality in Gitleaks didn't do everything we wanted
 # or wasn't as robust as we needed. For example, one of the allowlisting options offered by Gitleaks depends on the line number
 # on which a false positive secret exists to allowlist it. (https://github.com/gitleaks/gitleaks#gitleaksignore).
@@ -25,7 +25,7 @@
             # Allowlist https://github.com/apollographql/apollo-server/blob/213acbba32829c83f99f12d81ed9e88f3fe1c8cb/docs/_config.yml#L36
             # This is a segment key that Apollo SecOps was unable to utilize with Segment
             "213acbba32829c83f99f12d81ed9e88f3fe1c8cb",
-            
+
         ]
 
 [[ rules ]]
@@ -35,7 +35,17 @@
             # Allowlist https://github.com/apollographql/apollo-server/blob/89da132450677ae69aef156ade4c3a11e3885a33/test/testApolloServer.js#L56
             # Code comments indicate the value being identified is not a secret
             "89da132450677ae69aef156ade4c3a11e3885a33",
-            
+
+            # Allowlist https://github.com/apollographql/apollo-server/blob/213acbba32829c83f99f12d81ed9e88f3fe1c8cb/docs/_config.yml#L38
+            # Confirmed that the DocSearch value is not a secret
+            "213acbba32829c83f99f12d81ed9e88f3fe1c8cb",
+
+            # Allowlist https://github.com/apollographql/apollo-server/blob/4155e73ff8541b12944947236cb854d258e08746/packages/apollo-gateway/src/__tests__/integration/nockMocks.ts#L19
+            # Allowlist https://github.com/apollographql/apollo-server/blob/efa9427dcca848eafc1fd37463bcb4ac1ceeca7d/packages/apollo-gateway/src/__tests__/integration/nockMocks.ts#L5
+            # Based on file path, the detected value is part of a test and not actually in-use
+            "4155e73ff8541b12944947236cb854d258e08746",
+            "efa9427dcca848eafc1fd37463bcb4ac1ceeca7d",
+
         ]
 
 [[ rules ]]
@@ -45,5 +55,5 @@
             # Allowlist https://github.com/apollographql/apollo-server/blob/aadbeb647485207b408f620a10d8c385ce4ee25f/packages/apollo-server/src/__tests__/stoppable/fixture.key#L1
             # Based on file path, the private key is part of a test and not actually in-use
             "aadbeb647485207b408f620a10d8c385ce4ee25f",
-            
+
         ]


### PR DESCRIPTION
This PR updates the Apollo-custom Gitleaks allowlist file at the root of the repo. 

Specifically, this PR allowlists 3 detected values which are linked in comments in the modified TOML file. 

A recent update to the version of Gitleaks the Apollo Security team is using caused additional values to be detected. We have confirmed that these values are not actually secrets. We would like to ignore these detections in the future to prevent noise. 