### PR TITLE
Added support for new incremental delivery format

### DIFF
--- a/packages/server/src/externalTypes/incrementalDeliveryPolyfill.ts
+++ b/packages/server/src/externalTypes/incrementalDeliveryPolyfill.ts
@@ -19,7 +19,16 @@ export interface GraphQLExperimentalFormattedInitialIncrementalExecutionResult<
   incremental?: ReadonlyArray<
     GraphQLExperimentalFormattedIncrementalResult<TData, TExtensions>
   >;
+  pending?: ReadonlyArray<GraphQLExperimentalFormattedPendingIncrementalResult>;
   extensions?: TExtensions;
+}
+
+// This was introduced in a revision of the incremental delivery format:
+// https://github.com/graphql/defer-stream-wg/discussions/69
+export interface GraphQLExperimentalFormattedPendingIncrementalResult {
+  path?: ReadonlyArray<string | number>;
+  id?: string;
+  label?: string;
 }
 
 export interface GraphQLExperimentalFormattedSubsequentIncrementalExecutionResult<
@@ -45,6 +54,8 @@ export interface GraphQLExperimentalFormattedIncrementalDeferResult<
   TExtensions = ObjMap<unknown>,
 > extends FormattedExecutionResult<TData, TExtensions> {
   path?: ReadonlyArray<string | number>;
+  subPath?: ReadonlyArray<string | number>;
+  id?: string;
   label?: string;
 }
 
@@ -55,6 +66,7 @@ export interface GraphQLExperimentalFormattedIncrementalStreamResult<
   errors?: ReadonlyArray<GraphQLFormattedError>;
   items?: TData | null;
   path?: ReadonlyArray<string | number>;
+  id?: string;
   label?: string;
   extensions?: TExtensions;
 }

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -357,6 +357,7 @@ function orderInitialIncrementalExecutionResultFields(
     hasNext: result.hasNext,
     errors: result.errors,
     data: result.data,
+    pending: result.pending,
     incremental: orderIncrementalResultFields(result.incremental),
     extensions: result.extensions,
   };
@@ -378,6 +379,8 @@ function orderIncrementalResultFields(
     hasNext: i.hasNext,
     errors: i.errors,
     path: i.path,
+    id: i.id,
+    subPath: i.subPath,
     label: i.label,
     data: i.data,
     items: i.items,


### PR DESCRIPTION
The format for incremental delivery has been updated: https://github.com/graphql/defer-stream-wg/discussions/69

I have added the new fields and ensured they get transmitted if they are present. It should still work with the previous format.

It is released in graphql@17.0.0-alpha.3, but I didn't want to disturb the existing integration test that uses it so I haven't added anything for it. In order to maintain the two in parallel the CI test would need to be duplicated to run with this version.