### PR TITLE
Update plugins-event-reference.mdx

### DIFF
--- a/docs/source/integrations/plugins-event-reference.mdx
+++ b/docs/source/integrations/plugins-event-reference.mdx
@@ -558,7 +558,7 @@ const server = new ApolloServer({
 
 The `unexpectedErrorProcessingRequest` event fires whenever an "unexpected" error is thrown during request execution. "Unexpected" errors don't include common client data errors such as validation, parsing, or GraphQL execution errors. Instead, an unexpected error indicates a _programming_ error, such as a plugin hook throwing unexpectedly or Apollo Server encountering a bug. No matter the cause, Apollo Server masks this type of error from a client.
 
-Note this hook is on the top level of the plugin rather than on the object returned from `requestWillStart`, because this hook triggers if `requestWillStart` throws.
+Note this hook is on the top level of the plugin rather than on the object returned from `requestDidStart`, because this hook triggers if `requestDidStart` throws.
 
 #### Example
 


### PR DESCRIPTION
We do not have `requestWillStart` that throws `unexpectedErrorProcessingRequest`, but I have tested it that `requestDidStart` throws a `unexpectedErrorProcessingRequest` error.