### PR TITLE
Landing Pages: switch from `_latest` to `v*` cdn buckets to pin major versions of landing pages

### DIFF
--- a/.changeset/cool-dancers-tickle.md
+++ b/.changeset/cool-dancers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Pin major releases of embeddable Explorer & Sandbox code.

--- a/docs/source/api/plugin/landing-pages.mdx
+++ b/docs/source/api/plugin/landing-pages.mdx
@@ -85,7 +85,7 @@ This landing page is designed for use in local development, where `NODE_ENV` is 
 
 By default, this plugin uses the latest version of the landing page published to Apollo's CDN. If you'd like to pin the current version, you can specify it here.
 
-The current latest version is available at [this link](https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt).
+The current latest version is available at [this link](https://apollo-server-landing-page.cdn.apollographql.com/latest/version.txt).
 
 </td>
 </tr>
@@ -363,7 +363,7 @@ This landing page is designed for use in production. It provides a copyable comm
 
 By default, this plugin uses the latest version of the landing page published to Apollo's CDN. If you'd like to pin the current version, you can specify it here.
 
-The current latest version is available at [this link](https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt).
+The current latest version is available at [this link](https://apollo-server-landing-page.cdn.apollographql.com/latest/version.txt).
 
 </td>
 </tr>

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -2912,7 +2912,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
         url = (await createServer(makeServerConfig([]))).url;
         await get().expect(
           200,
-          /embeddable-sandbox.cdn.apollographql.com\/_latest\/embeddable-sandbox.umd.production.min.js/s,
+          /embeddable-sandbox.cdn.apollographql.com\/v2\/embeddable-sandbox.umd.production.min.js/s,
         );
       });
 

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -2,7 +2,7 @@ import { getEmbeddedExplorerHTML } from '../../../plugin/landingPage/default/get
 import type { ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
-const cdnVersion = '_latest';
+const cdnVersion = 'v3';
 expect.addSnapshotSerializer(require('jest-serializer-html'));
 const apolloServerVersion = '@apollo/server@4.0.0';
 

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -1,8 +1,9 @@
+import { DEFAULT_EMBEDDED_EXPLORER_VERSION } from 'packages/server/src/plugin/landingPage/default';
 import { getEmbeddedExplorerHTML } from '../../../plugin/landingPage/default/getEmbeddedHTML';
 import type { ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
-const cdnVersion = 'v3';
+const cdnVersion = DEFAULT_EMBEDDED_EXPLORER_VERSION;
 expect.addSnapshotSerializer(require('jest-serializer-html'));
 const apolloServerVersion = '@apollo/server@4.0.0';
 

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -58,7 +58,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       <div id="embeddableExplorer">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-explorer.cdn.apollographql.com/v3/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -108,7 +108,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       <div id="embeddableExplorer">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-explorer.cdn.apollographql.com/v3/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -159,7 +159,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       <div id="embeddableExplorer">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-explorer.cdn.apollographql.com/v3/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -208,7 +208,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       <div id="embeddableExplorer">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-explorer.cdn.apollographql.com/v3/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -260,7 +260,7 @@ describe('Embedded Explorer Landing Page Config HTML', () => {
       <div id="embeddableExplorer">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-explorer.cdn.apollographql.com/_latest/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-explorer.cdn.apollographql.com/v3/embeddable-explorer.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedExplorerHTML.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_EMBEDDED_EXPLORER_VERSION } from 'packages/server/src/plugin/landingPage/default';
+import { DEFAULT_EMBEDDED_EXPLORER_VERSION } from '../../../plugin/landingPage/default';
 import { getEmbeddedExplorerHTML } from '../../../plugin/landingPage/default/getEmbeddedHTML';
 import type { ApolloServerPluginEmbeddedLandingPageProductionDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_EMBEDDED_SANDBOX_VERSION } from 'packages/server/src/plugin/landingPage/default';
+import { DEFAULT_EMBEDDED_SANDBOX_VERSION } from '../../../plugin/landingPage/default';
 import { getEmbeddedSandboxHTML } from '../../../plugin/landingPage/default/getEmbeddedHTML';
 import type { ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -49,7 +49,7 @@ describe('Landing Page Config HTML', () => {
       <div id="embeddableSandbox">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-sandbox.cdn.apollographql.com/v2/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -99,7 +99,7 @@ describe('Landing Page Config HTML', () => {
       <div id="embeddableSandbox">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-sandbox.cdn.apollographql.com/v2/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -147,7 +147,7 @@ describe('Landing Page Config HTML', () => {
       <div id="embeddableSandbox">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-sandbox.cdn.apollographql.com/v2/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -197,7 +197,7 @@ describe('Landing Page Config HTML', () => {
       <div id="embeddableSandbox">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-sandbox.cdn.apollographql.com/v2/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">
@@ -252,7 +252,7 @@ describe('Landing Page Config HTML', () => {
       <div id="embeddableSandbox">
       </div>
       <script nonce="nonce"
-              src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
+              src="https://embeddable-sandbox.cdn.apollographql.com/v2/embeddable-sandbox.umd.production.min.js?runtime=%40apollo%2Fserver%404.0.0"
       >
       </script>
       <script nonce="nonce">

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -2,7 +2,7 @@ import { getEmbeddedSandboxHTML } from '../../../plugin/landingPage/default/getE
 import type { ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
-const cdnVersion = '_latest';
+const cdnVersion = 'v2';
 expect.addSnapshotSerializer(require('jest-serializer-html'));
 const apolloServerVersion = '@apollo/server@4.0.0';
 

--- a/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
+++ b/packages/server/src/__tests__/plugin/landingPage/getEmbeddedSandboxHTML.test.ts
@@ -1,8 +1,9 @@
+import { DEFAULT_EMBEDDED_SANDBOX_VERSION } from 'packages/server/src/plugin/landingPage/default';
 import { getEmbeddedSandboxHTML } from '../../../plugin/landingPage/default/getEmbeddedHTML';
 import type { ApolloServerPluginEmbeddedLandingPageLocalDefaultOptions } from '../../../plugin/landingPage/default/types';
 import { describe, it, expect } from '@jest/globals';
 
-const cdnVersion = 'v2';
+const cdnVersion = DEFAULT_EMBEDDED_SANDBOX_VERSION;
 expect.addSnapshotSerializer(require('jest-serializer-html'));
 const apolloServerVersion = '@apollo/server@4.0.0';
 

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -86,7 +86,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     apolloStudioEnv: 'staging' | 'prod' | undefined;
   },
 ): ImplicitlyInstallablePlugin<TContext> {
-  const version = maybeVersion ?? '_latest';
+  const explorerVersion = maybeVersion ?? 'v3';
+  const sandboxVersion = maybeVersion ?? 'v2';
+  const apolloServerLandingPageVersion = maybeVersion ?? '_latest';
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
 
   const scriptSafeList = [
@@ -116,7 +118,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
       }
       return {
         async renderLandingPage() {
-          const encodedVersion = encodeURIComponent(version);
+          const encodedASLandingPageVersion = encodeURIComponent(
+            apolloServerLandingPageVersion,
+          );
           async function html() {
             const nonce =
               config.precomputedNonce ??
@@ -134,7 +138,7 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     <meta http-equiv="Content-Security-Policy" content="${scriptCsp}; ${styleCsp}; ${imageCsp}; ${manifestCsp}; ${frameCsp}" />
     <link
       rel="icon"
-      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodedVersion}/assets/favicon.png"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodedASLandingPageVersion}/assets/favicon.png"
     />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
@@ -146,11 +150,11 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     <meta name="description" content="Apollo server landing page" />
     <link
       rel="apple-touch-icon"
-      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodedVersion}/assets/favicon.png"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodedASLandingPageVersion}/assets/favicon.png"
     />
     <link
       rel="manifest"
-      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodedVersion}/manifest.json"
+      href="https://apollo-server-landing-page.cdn.apollographql.com/${encodedASLandingPageVersion}/manifest.json"
     />
     <title>Apollo Server</title>
   </head>
@@ -178,17 +182,27 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     ${
       config.embed
         ? 'graphRef' in config && config.graphRef
-          ? getEmbeddedExplorerHTML(version, config, apolloServerVersion, nonce)
+          ? getEmbeddedExplorerHTML(
+              explorerVersion,
+              config,
+              apolloServerVersion,
+              nonce,
+            )
           : !('graphRef' in config)
-          ? getEmbeddedSandboxHTML(version, config, apolloServerVersion, nonce)
+          ? getEmbeddedSandboxHTML(
+              sandboxVersion,
+              config,
+              apolloServerVersion,
+              nonce,
+            )
           : getNonEmbeddedLandingPageHTML(
-              version,
+              apolloServerLandingPageVersion,
               config,
               apolloServerVersion,
               nonce,
             )
         : getNonEmbeddedLandingPageHTML(
-            version,
+            apolloServerLandingPageVersion,
             config,
             apolloServerVersion,
             nonce,

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -88,7 +88,7 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
 ): ImplicitlyInstallablePlugin<TContext> {
   const explorerVersion = maybeVersion ?? 'v3';
   const sandboxVersion = maybeVersion ?? 'v2';
-  const apolloServerLandingPageVersion = maybeVersion ?? '_latest';
+  const apolloServerLandingPageVersion = maybeVersion ?? '_latest'; // note _latest is frozen is time as of this PR https://github.com/apollographql/embeddable-explorer/pull/280
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
 
   const scriptSafeList = [

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -78,6 +78,10 @@ const getNonEmbeddedLandingPageHTML = (
   )}/static/js/main.js?runtime=${apolloServerVersion}"></script>`;
 };
 
+export const DEFAULT_EMBEDDED_EXPLORER_VERSION = 'v3';
+export const DEFAULT_EMBEDDED_SANDBOX_VERSION = 'v2';
+export const DEFAULT_APOLLO_SERVER_LANDING_PAGE_VERSION = '_latest';
+
 // Helper for the two actual plugin functions.
 function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
   maybeVersion: string | undefined,
@@ -86,9 +90,10 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
     apolloStudioEnv: 'staging' | 'prod' | undefined;
   },
 ): ImplicitlyInstallablePlugin<TContext> {
-  const explorerVersion = maybeVersion ?? 'v3';
-  const sandboxVersion = maybeVersion ?? 'v2';
-  const apolloServerLandingPageVersion = maybeVersion ?? '_latest'; // note _latest is frozen is time as of this PR https://github.com/apollographql/embeddable-explorer/pull/280
+  const explorerVersion = maybeVersion ?? DEFAULT_EMBEDDED_EXPLORER_VERSION;
+  const sandboxVersion = maybeVersion ?? DEFAULT_EMBEDDED_SANDBOX_VERSION;
+  const apolloServerLandingPageVersion =
+    maybeVersion ?? DEFAULT_APOLLO_SERVER_LANDING_PAGE_VERSION;
   const apolloServerVersion = `@apollo/server@${packageVersion}`;
 
   const scriptSafeList = [

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -38,10 +38,10 @@ type InitialStateForEmbeds =
 
 export type ApolloServerPluginLandingPageDefaultBaseOptions = {
   /**
-   * By default, the landing page plugin uses the latest version of the landing
-   * page published to Apollo's CDN. If you'd like to pin the current version,
-   * pass the SHA served at
-   * https://apollo-server-landing-page.cdn.apollographql.com/_latest/version.txt
+   * By default, the landing page plugin uses the version of the landing
+   * page published to Apollo's CDN from https://github.com/apollographql/embeddable-explorer/commit/73baf89f5308d263425bbafe21a842a26123cfac.
+   * If you'd like to pin the current version, pass the SHA served at
+   * https://apollo-server-landing-page.cdn.apollographql.com/latest/version.txt
    * here.
    */
   version?: string;

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -38,10 +38,9 @@ type InitialStateForEmbeds =
 
 export type ApolloServerPluginLandingPageDefaultBaseOptions = {
   /**
-   * By default, the landing page plugin uses the version of the landing
-   * page published to Apollo's CDN from https://github.com/apollographql/embeddable-explorer/commit/73baf89f5308d263425bbafe21a842a26123cfac.
-   * If you'd like to pin the current version, pass the SHA served at
-   * https://apollo-server-landing-page.cdn.apollographql.com/latest/version.txt
+   * Specify the major version of the landing page to use, i.e v2 or 
+   * provide a specific commit from the [embeddable explorer](https://github.com/apollographql/embeddable-explorer) repo. 
+   * We also support a `_latest` tag but don't recommend using it as it's subject to major version updates.
    * here.
    */
   version?: string;

--- a/packages/server/src/plugin/landingPage/default/types.ts
+++ b/packages/server/src/plugin/landingPage/default/types.ts
@@ -38,10 +38,12 @@ type InitialStateForEmbeds =
 
 export type ApolloServerPluginLandingPageDefaultBaseOptions = {
   /**
-   * Specify the major version of the landing page to use, i.e v2 or 
-   * provide a specific commit from the [embeddable explorer](https://github.com/apollographql/embeddable-explorer) repo. 
-   * We also support a `_latest` tag but don't recommend using it as it's subject to major version updates.
-   * here.
+   * Specify the major version of the landing page to use, i.e v2 or
+   * provide a specific commit from the
+   * [embeddable explorer](https://github.com/apollographql/embeddable-explorer)
+   * repo.
+   * We also support a `latest` tag but don't recommend using it
+   * as it's subject to major version updates.
    */
   version?: string;
   /**


### PR DESCRIPTION
I published these buckets once already. Circle CI changes [here](https://github.com/apollographql/embeddable-explorer/pull/280)

in AS5 we want to pin embeddable code versions. Question - should we pin up to patch decimal, not just major? Just in case?