### PR TITLE
Fix type of `SchemaReporter.pollTimer`

### DIFF
--- a/.changeset/late-donuts-think.md
+++ b/.changeset/late-donuts-think.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Change SchemaReporter.pollTimer from being a NodeJS.Timer to a NodeJS.Timeout

--- a/packages/server/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/server/src/plugin/schemaReporting/schemaReporter.ts
@@ -40,7 +40,7 @@ export class SchemaReporter {
   private readonly fetcher: Fetcher;
 
   private isStopped: boolean;
-  private pollTimer?: NodeJS.Timer;
+  private pollTimer?: ReturnType<typeof setTimeout>;
   private readonly headers: Record<string, string>;
 
   constructor(options: {

--- a/packages/server/src/plugin/schemaReporting/schemaReporter.ts
+++ b/packages/server/src/plugin/schemaReporting/schemaReporter.ts
@@ -40,7 +40,7 @@ export class SchemaReporter {
   private readonly fetcher: Fetcher;
 
   private isStopped: boolean;
-  private pollTimer?: ReturnType<typeof setTimeout>;
+  private pollTimer?: NodeJS.Timeout;
   private readonly headers: Record<string, string>;
 
   constructor(options: {


### PR DESCRIPTION
Fixes #7768

In `packages/server/src/plugin/schemaReporting/schemaReporter.ts`, `SchemaReporter.pollTimer` is typed as `NodeJS.Timer`, it is actually a `NodeJS.Timeout`, so using node 18> types it is incompatible
with `clearTimeout()`.