### PR TITLE
Add dangerouslyDisableValidation option to apollo-server-core

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -201,7 +201,7 @@ An array containing custom functions to use as additional [validation rules](htt
 <tr>
 <td>
 
-##### `disableValidation`
+##### `dangerouslyDisableValidation`
 
 `Boolean`
 </td>

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -201,6 +201,20 @@ An array containing custom functions to use as additional [validation rules](htt
 <tr>
 <td>
 
+##### `disableValidation`
+
+`Boolean`
+</td>
+<td>
+
+Option to disable validation of graphql operations entirely.
+</td>
+</tr>
+
+
+<tr>
+<td>
+
 ##### `documentStore`
 
 `KeyValueCache<DocumentNode>` or `null`

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -959,6 +959,7 @@ export class ApolloServerBase<
       logger: this.logger,
       plugins: this.plugins,
       documentStore,
+      disableValidation: this.config.disableValidation,
       context,
       parseOptions: this.parseOptions,
       ...this.requestOptions,

--- a/packages/apollo-server-core/src/ApolloServer.ts
+++ b/packages/apollo-server-core/src/ApolloServer.ts
@@ -959,7 +959,7 @@ export class ApolloServerBase<
       logger: this.logger,
       plugins: this.plugins,
       documentStore,
-      disableValidation: this.config.disableValidation,
+      dangerouslyDisableValidation: this.config.dangerouslyDisableValidation,
       context,
       parseOptions: this.parseOptions,
       ...this.requestOptions,

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -62,6 +62,7 @@ export interface GraphQLServerOptions<
   persistedQueries?: PersistedQueryOptions;
   plugins?: ApolloServerPlugin[];
   documentStore?: DocumentStore | null;
+  disableValidation?: boolean;
   parseOptions?: ParseOptions;
   nodeEnv?: string;
   allowBatchedHttpRequests?: boolean;

--- a/packages/apollo-server-core/src/graphqlOptions.ts
+++ b/packages/apollo-server-core/src/graphqlOptions.ts
@@ -62,7 +62,7 @@ export interface GraphQLServerOptions<
   persistedQueries?: PersistedQueryOptions;
   plugins?: ApolloServerPlugin[];
   documentStore?: DocumentStore | null;
-  disableValidation?: boolean;
+  dangerouslyDisableValidation?: boolean;
   parseOptions?: ParseOptions;
   nodeEnv?: string;
   allowBatchedHttpRequests?: boolean;

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -91,7 +91,7 @@ export interface GraphQLRequestPipelineConfig<TContext> {
   ) => GraphQLResponse | null;
 
   plugins?: ApolloServerPlugin[];
-  disableValidation?: boolean;
+  dangerouslyDisableValidation?: boolean;
   documentStore?: DocumentStore | null;
 
   parseOptions?: ParseOptions;
@@ -258,7 +258,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
       return await sendErrorResponse(syntaxError as GraphQLError, SyntaxError);
     }
 
-    if (config.disableValidation !== true) {
+    if (config.dangerouslyDisableValidation !== true) {
       const validationDidEnd = await dispatcher.invokeDidStartHook(
         'validationDidStart',
         requestContext as GraphQLRequestContextValidationDidStart<TContext>,

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -274,7 +274,7 @@ export async function runHttpQuery(
     // passed in.
     cache: options.cache!,
     dataSources: options.dataSources,
-    disableValidation: options.disableValidation,
+    dangerouslyDisableValidation: options.dangerouslyDisableValidation,
     documentStore: options.documentStore,
 
     persistedQueries: options.persistedQueries,

--- a/packages/apollo-server-core/src/runHttpQuery.ts
+++ b/packages/apollo-server-core/src/runHttpQuery.ts
@@ -274,6 +274,7 @@ export async function runHttpQuery(
     // passed in.
     cache: options.cache!,
     dataSources: options.dataSources,
+    disableValidation: options.disableValidation,
     documentStore: options.documentStore,
 
     persistedQueries: options.persistedQueries,

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -107,6 +107,7 @@ export interface Config<ContextFunctionParams = any> extends BaseConfig {
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
+  disableValidation?: boolean;
   documentStore?: DocumentStore | null;
   csrfPrevention?: CSRFPreventionOptions | boolean;
   cache?: KeyValueCache | 'bounded';

--- a/packages/apollo-server-core/src/types.ts
+++ b/packages/apollo-server-core/src/types.ts
@@ -107,7 +107,7 @@ export interface Config<ContextFunctionParams = any> extends BaseConfig {
   stopOnTerminationSignals?: boolean;
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
-  disableValidation?: boolean;
+  dangerouslyDisableValidation?: boolean;
   documentStore?: DocumentStore | null;
   csrfPrevention?: CSRFPreventionOptions | boolean;
   cache?: KeyValueCache | 'bounded';

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -288,7 +288,7 @@ export function testApolloServer<AS extends ApolloServerBase>(
             stopOnTerminationSignals: false,
             nodeEnv: 'production',
             cache: 'bounded',
-            disableValidation: true,
+            dangerouslyDisableValidation: true,
           });
 
           const apolloFetch = createApolloFetch({ uri });

--- a/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
+++ b/packages/apollo-server-integration-testsuite/src/ApolloServer.ts
@@ -282,6 +282,22 @@ export function testApolloServer<AS extends ApolloServerBase>(
           );
         });
 
+        it('Allows disabling query validation', async () => {
+          const { url: uri } = await createApolloServer({
+            schema,
+            stopOnTerminationSignals: false,
+            nodeEnv: 'production',
+            cache: 'bounded',
+            disableValidation: true,
+          });
+
+          const apolloFetch = createApolloFetch({ uri });
+
+          const result = await apolloFetch({ query: INTROSPECTION_QUERY });
+          expect(result.errors).toBeUndefined();
+          expect(result.data).toBeDefined();
+        });
+
         it('allows introspection to be enabled explicitly', async () => {
           const { url: uri } = await createApolloServer({
             schema,


### PR DESCRIPTION
This adds a `disableValidation` option to apollo-server-core which will skip the validation step for graphql operations.