### PR TITLE
Add dangerouslyDisableValidation option to @apollo/server

### DIFF
--- a/.changeset/blue-laws-grab.md
+++ b/.changeset/blue-laws-grab.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-integration-testsuite': minor
+'@apollo/server': minor
+---
+
+Restore missing v1 `skipValidation` option as `dangerouslyDisableValidation`. Note that enabling this option exposes your server to potential security and unexpected runtime issues. Apollo will not support issues that arise as a result of using this option.

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -199,7 +199,7 @@ An array containing custom functions to use as additional [validation rules](htt
 <tr>
 <td>
 
-###### `disableValidation`
+###### `dangerouslyDisableValidation`
 
 `Boolean`
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -196,20 +196,6 @@ An array containing custom functions to use as additional [validation rules](htt
 </td>
 </tr>
 
-<tr>
-<td>
-
-###### `dangerouslyDisableValidation`
-
-`Boolean`
-
-</td>
-<td>
-
-Option to disable validation of graphql operations entirely.
-
-</td>
-</tr>
 
 <tr>
 <td>
@@ -504,6 +490,21 @@ If this is set to any string value, use that value instead of the environment va
 
 Apollo Server v5 will _always_ behave as if this option is `true` (and will ignore any provided value).
 
+</td>
+</tr>
+
+<tr>
+<td>
+
+##### `dangerouslyDisableValidation`
+
+`Boolean`
+</td>
+<td>
+
+⚠️ Caution: this option can lead to security vulnerabilities and unexpected behavior. Use of this option in production is not supported by Apollo.
+
+When set to `true`, disable validation of graphql operations entirely.
 </td>
 </tr>
 

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -199,6 +199,21 @@ An array containing custom functions to use as additional [validation rules](htt
 <tr>
 <td>
 
+###### `disableValidation`
+
+`Boolean`
+
+</td>
+<td>
+
+Option to disable validation of graphql operations entirely.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 ###### `documentStore`
 
 `KeyValueCache<DocumentNode>` or `null`

--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -196,7 +196,6 @@ An array containing custom functions to use as additional [validation rules](htt
 </td>
 </tr>
 
-
 <tr>
 <td>
 

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -317,7 +317,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
             schema,
             stopOnTerminationSignals: false,
             nodeEnv: 'production',
-            disableValidation: true,
+            dangerouslyDisableValidation: true,
           });
 
           const apolloFetch = createApolloFetch({ uri });

--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -312,6 +312,21 @@ export function defineIntegrationTestSuiteApolloServerTests(
           );
         });
 
+        it('allows disabling validation rules', async () => {
+          const uri = await createServerAndGetUrl({
+            schema,
+            stopOnTerminationSignals: false,
+            nodeEnv: 'production',
+            disableValidation: true,
+          });
+
+          const apolloFetch = createApolloFetch({ uri });
+
+          const result = await apolloFetch({ query: INTROSPECTION_QUERY });
+          expect(result.data).toBeDefined();
+          expect(result.errors).toBeUndefined();
+        });
+
         it('allows introspection to be enabled explicitly', async () => {
           const uri = await createServerAndGetUrl({
             schema,

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -155,7 +155,7 @@ type ServerState =
 export interface ApolloServerInternals<TContext extends BaseContext> {
   state: ServerState;
   gatewayExecutor: GatewayExecutor | null;
-  disableValidation?: boolean;
+  dangerouslyDisableValidation?: boolean;
   formatError?: (
     formattedError: GraphQLFormattedError,
     error: unknown,
@@ -296,7 +296,8 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         ...(config.validationRules ?? []),
         ...(introspectionEnabled ? [] : [NoIntrospection]),
       ],
-      disableValidation: config.disableValidation ?? false,
+      dangerouslyDisableValidation:
+        config.dangerouslyDisableValidation ?? false,
       fieldResolver: config.fieldResolver,
       includeStacktraceInErrorResponses:
         config.includeStacktraceInErrorResponses ??

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -155,7 +155,7 @@ type ServerState =
 export interface ApolloServerInternals<TContext extends BaseContext> {
   state: ServerState;
   gatewayExecutor: GatewayExecutor | null;
-
+  disableValidation?: boolean;
   formatError?: (
     formattedError: GraphQLFormattedError,
     error: unknown,
@@ -296,6 +296,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         ...(config.validationRules ?? []),
         ...(introspectionEnabled ? [] : [NoIntrospection]),
       ],
+      disableValidation: config.disableValidation ?? false,
       fieldResolver: config.fieldResolver,
       includeStacktraceInErrorResponses:
         config.includeStacktraceInErrorResponses ??

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -97,7 +97,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
   documentStore?: DocumentStore | null;
-  disableValidation?: boolean;
+  dangerouslyDisableValidation?: boolean;
   csrfPrevention?: CSRFPreventionOptions | boolean;
 
   // Used for parsing operations; unlike in AS3, this is not also used for

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -97,6 +97,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   apollo?: ApolloConfigInput;
   nodeEnv?: string;
   documentStore?: DocumentStore | null;
+  disableValidation?: boolean;
   csrfPrevention?: CSRFPreventionOptions | boolean;
 
   // Used for parsing operations; unlike in AS3, this is not also used for

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -235,7 +235,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
     }
     await parsingDidEnd();
 
-    if (internals.disableValidation !== true) {
+    if (internals.dangerouslyDisableValidation !== true) {
       const validationDidEnd = await invokeDidStartHook(
         requestListeners,
         async (l) =>

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -235,27 +235,29 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
     }
     await parsingDidEnd();
 
-    const validationDidEnd = await invokeDidStartHook(
-      requestListeners,
-      async (l) =>
-        l.validationDidStart?.(
-          requestContext as GraphQLRequestContextValidationDidStart<TContext>,
-        ),
-    );
-
-    const validationErrors = validate(
-      schemaDerivedData.schema,
-      requestContext.document,
-      [...specifiedRules, ...internals.validationRules],
-    );
-
-    if (validationErrors.length === 0) {
-      await validationDidEnd();
-    } else {
-      await validationDidEnd(validationErrors);
-      return await sendErrorResponse(
-        validationErrors.map((error) => new ValidationError(error)),
+    if (internals.disableValidation !== true) {
+      const validationDidEnd = await invokeDidStartHook(
+        requestListeners,
+        async (l) =>
+          l.validationDidStart?.(
+            requestContext as GraphQLRequestContextValidationDidStart<TContext>,
+          ),
       );
+
+      const validationErrors = validate(
+        schemaDerivedData.schema,
+        requestContext.document,
+        [...specifiedRules, ...internals.validationRules],
+      );
+
+      if (validationErrors.length === 0) {
+        await validationDidEnd();
+      } else {
+        await validationDidEnd(validationErrors);
+        return await sendErrorResponse(
+          validationErrors.map((error) => new ValidationError(error)),
+        );
+      }
     }
 
     if (schemaDerivedData.documentStore) {


### PR DESCRIPTION
This adds a `disableValidation` option to @apollo/server which will skip the validation step for graphql operations.