### PR TITLE
Fix type of ApolloServerPluginUsageReporting reportTimer

### DIFF
--- a/.changeset/fair-squids-unite.md
+++ b/.changeset/fair-squids-unite.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Fix type of ApolloServerPluginUsageReporting reportTimer

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -206,7 +206,7 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
           }
         | undefined;
 
-      let reportTimer: NodeJS.Timer | undefined;
+      let reportTimer: NodeJS.Timeout | undefined;
       if (!sendReportsImmediately) {
         reportTimer = setInterval(
           () => sendAllReportsAndReportErrors(),


### PR DESCRIPTION
Fixes #7798 
In src/plugin/usageReporting/plugin.ts reportTimer is typed as NodeJS.Timer, it is actually a timeout, so using node 18> types it is incompatible with clearInterval()