### PR TITLE
feat: allow `stringifyResult` to return a `Promise<string>`

### DIFF
--- a/.changeset/thirty-hairs-change.md
+++ b/.changeset/thirty-hairs-change.md
@@ -3,3 +3,5 @@
 ---
 
 allow `stringifyResult` to return a `Promise<string>`
+
+Users who implemented the `stringifyResult` hook can now expect error responses to be formatted with the hook as well. Please take care when updating to this version to ensure this is the desired behaviour, or implement the desired behaviour accordingly in your `stringifyResult` hook. This was considered a non-breaking change as we consider that it was an oversight in the original PR that introduced `stringifyResult` hook.

--- a/.changeset/thirty-hairs-change.md
+++ b/.changeset/thirty-hairs-change.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": minor
+---
+
+allow `stringifyResult` to return a `Promise<string>`

--- a/.changeset/thirty-hairs-change.md
+++ b/.changeset/thirty-hairs-change.md
@@ -4,4 +4,4 @@
 
 allow `stringifyResult` to return a `Promise<string>`
 
-Users who implemented the `stringifyResult` hook can now expect error responses to be formatted with the hook as well. Please take care when updating to this version to ensure this is the desired behaviour, or implement the desired behaviour accordingly in your `stringifyResult` hook. This was considered a non-breaking change as we consider that it was an oversight in the original PR that introduced `stringifyResult` hook.
+Users who implemented the `stringifyResult` hook can now expect error responses to be formatted with the hook as well. Please take care when updating to this version to ensure this is the desired behavior, or implement the desired behavior accordingly in your `stringifyResult` hook. This was considered a non-breaking change as we consider that it was an oversight in the original PR that introduced `stringifyResult` hook.

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -1017,7 +1017,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         // This is typically either the masked error from when background startup
         // failed, or related to invoking this function before startup or
         // during/after shutdown (due to lack of draining).
-        return this.errorResponse(error, httpGraphQLRequest);
+        return await this.errorResponse(error, httpGraphQLRequest);
       }
 
       if (
@@ -1033,7 +1033,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           } catch (maybeError: unknown) {
             const error = ensureError(maybeError);
             this.logger.error(`Landing page \`html\` function threw: ${error}`);
-            return this.errorResponse(error, httpGraphQLRequest);
+            return await this.errorResponse(error, httpGraphQLRequest);
           }
         }
 
@@ -1078,7 +1078,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         // If some random function threw, add a helpful prefix when converting
         // to GraphQLError. If it was already a GraphQLError, trust that the
         // message was chosen thoughtfully and leave off the prefix.
-        return this.errorResponse(
+        return await this.errorResponse(
           ensureGraphQLError(error, 'Context creation failed: '),
           httpGraphQLRequest,
         );
@@ -1110,7 +1110,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           );
         }
       }
-      return this.errorResponse(maybeError, httpGraphQLRequest);
+      return await this.errorResponse(maybeError, httpGraphQLRequest);
     }
   }
 

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -1115,7 +1115,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
   private async errorResponse(
     error: unknown,
     requestHead: HTTPGraphQLHead,
-  ): HTTPGraphQLResponse {
+  ): Promise<HTTPGraphQLResponse> {
     const { formattedErrors, httpFromErrors } = normalizeAndFormatErrors(
       [error],
       {

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -180,7 +180,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   // flip default behavior.
   status400ForVariableCoercionErrors?: boolean;
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
-  stringifyResult: (value: FormattedExecutionResult) => string;
+  stringifyResult: (value: FormattedExecutionResult) => string | Promise<string>;
 }
 
 function defaultLogger(): Logger {

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -1112,7 +1112,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
     }
   }
 
-  private errorResponse(
+  private async errorResponse(
     error: unknown,
     requestHead: HTTPGraphQLHead,
   ): HTTPGraphQLResponse {
@@ -1144,7 +1144,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       ]),
       body: {
         kind: 'complete',
-        string: prettyJSONStringify({
+        string: await this.internals.stringifyResult({
           errors: formattedErrors,
         }),
       },

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -180,7 +180,9 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   // flip default behavior.
   status400ForVariableCoercionErrors?: boolean;
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
-  stringifyResult: (value: FormattedExecutionResult) => string | Promise<string>;
+  stringifyResult: (
+    value: FormattedExecutionResult,
+  ) => string | Promise<string>;
 }
 
 function defaultLogger(): Logger {

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -182,7 +182,9 @@ describe('ApolloServer construction', () => {
         typeDefs,
         resolvers,
         stringifyResult: async (value: FormattedExecutionResult) => {
-          let result = await Promise.resolve(JSON.stringify(value, null, 10000));
+          let result = await Promise.resolve(
+            JSON.stringify(value, null, 10000),
+          );
           result = result.replace('world', 'stringifyResults works!'); // replace text with something custom
           return result;
         },

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -89,7 +89,9 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   includeStacktraceInErrorResponses?: boolean;
   logger?: Logger;
   allowBatchedHttpRequests?: boolean;
-  stringifyResult?: (value: FormattedExecutionResult) => string | Promise<string>;
+  stringifyResult?: (
+    value: FormattedExecutionResult,
+  ) => string | Promise<string>;
   introspection?: boolean;
   plugins?: ApolloServerPlugin<TContext>[];
   persistedQueries?: PersistedQueryOptions | false;

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -89,7 +89,7 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   includeStacktraceInErrorResponses?: boolean;
   logger?: Logger;
   allowBatchedHttpRequests?: boolean;
-  stringifyResult?: (value: FormattedExecutionResult) => string;
+  stringifyResult?: (value: FormattedExecutionResult) => string | Promise<string>;
   introspection?: boolean;
   plugins?: ApolloServerPlugin<TContext>[];
   persistedQueries?: PersistedQueryOptions | false;

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -260,7 +260,7 @@ export async function runHttpQuery<TContext extends BaseContext>({
       ...graphQLResponse.http,
       body: {
         kind: 'complete',
-        string: internals.stringifyResult(
+        string: await internals.stringifyResult(
           orderExecutionResultFields(graphQLResponse.body.singleResult),
         ),
       },


### PR DESCRIPTION
Previously `stringifyResult` had to be synchronous, despite only ever being called from the async context of `runHttpQuery`. This is an issue when the custom stringification function provided by the user through the constructor has to be async, for example when working with very large POJOs one could use [json-stream-stringify](https://github.com/Faleij/json-stream-stringify) because `JSON.stringify` would throw a `RangeError` with `Invalid string length`, the implementation using this library would be:

```ts
    stringifyResult: async (value) => {
      const stringifyStream = new JsonStreamStringify(value);
      let stringified = '';

      for await (const chunk of stringifyStream) {
        stringified += chunk;
      }

      return `${stringified}\n`;
    }
```

As can be seen here, this requires an async context within the callback function. @apollo/server can easily support this by awaiting the result of `internals.stringifyResult`.

Furthermore I also changed `errorResponse` to use the same `internals.stringifyResult` for consistency of how the JSON that will be sent to the requester is stringified.