### PR TITLE
Add graphql-amqp-subscriptions to docs

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -577,6 +577,7 @@ The following are community-created `PubSub` libraries for popular event-publish
 - [Google PubSub](https://github.com/axelspringer/graphql-google-pubsub)
 - [MQTT enabled broker](https://github.com/davidyaha/graphql-mqtt-subscriptions)
 - [RabbitMQ](https://github.com/cdmbase/graphql-rabbitmq-subscriptions)
+- [AMQP (RabbitMQ)](https://github.com/Surnet/graphql-amqp-subscriptions)
 - [Kafka](https://github.com/ancashoria/graphql-kafka-subscriptions)
 - [Postgres](https://github.com/GraphQLCollege/graphql-postgres-subscriptions)
 - [Google Cloud Firestore](https://github.com/MrBoolean/graphql-firestore-subscriptions)


### PR DESCRIPTION
`graphql-amqp-subscriptions` has already been linked for quite a while on https://github.com/apollographql/graphql-subscriptions
