### PR TITLE
[docs] Update authentication docs with link to Router

### DIFF
--- a/docs/source/security/authentication.mdx
+++ b/docs/source/security/authentication.mdx
@@ -10,6 +10,14 @@ Your GraphQL API probably needs to control which users can see and interact with
 - **Authentication** is determining whether a given user is logged in, and subsequently determining _which_ user someone is.
 - **Authorization** is then determining what a given user has permission to do or see.
 
+<Tip>
+
+Apollo Router can now provide authentication and authorization for your entire supergraph. While it may make sense to re-apply auth checks at a subgraph level or in a monolith graph, the Apollo Router has built and provided standard JWT checks that can be setup with a simple YAML configuration and enforce this in a central location for all subgraphs:
+
+https://www.apollographql.com/blog/centrally-enforce-policy-as-code-for-graphql-apis
+
+</Tip>
+
 ## Putting authenticated user info in your `contextValue`
 
 <TopLevelAwait />


### PR DESCRIPTION
Add links to Router docs for those who may land on the page from external or internal direct links