### PR TITLE
Docs: Fix generate-types syntax

### DIFF
--- a/docs/source/workflow/generate-types.mdx
+++ b/docs/source/workflow/generate-types.mdx
@@ -163,9 +163,7 @@ import { QueryResolvers } from '__generated__/resolvers-types';
 // Use the generated `QueryResolvers`
 // type to type check our queries!
 const queries: QueryResolvers = {
-  Query: {
   // ...queries
-  },
 };
 
 export default queries;
@@ -177,9 +175,7 @@ import { MutationResolvers } from '__generated__/resolvers-types';
 // Use the generated `MutationResolvers` type
 // to type check our mutations!
 const mutations: MutationResolvers = {
-  Mutation: {
-    // ...mutations
-  },
+  // ...mutations
 };
 
 export default mutations;


### PR DESCRIPTION
This change fixes the typescript error in the example of splitting resolvers in multiple files. The `books` and `addBooks` must no be wrapped with a `Queries` or `Mutation` object.

Wrong (screenshot taken from the official docs)
![image](https://github.com/apollographql/apollo-server/assets/17274950/8b002200-0c72-4556-b696-3b5956cc730a)


Correct without `Queries` parent key (extracted from the working exampled linked at the end of the markdown file)
![image](https://github.com/apollographql/apollo-server/assets/17274950/6e9d167f-9215-4baf-8821-ceda407680e4)

