### PR TITLE
docs: Standardize Edit in CodeSandbox button

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -325,14 +325,14 @@ One of the most important concepts of GraphQL is that clients can choose to quer
 
 ## Complete example
 
-You can view and fork the complete example on Code Sandbox:
+You can view and fork the complete example on CodeSandbox:
 
-<a href="https://codesandbox.io/s/github/apollographql/docs-examples/tree/main/apollo-server/v4/getting-started?fontsize=14&hidenavigation=1&theme=dark">
-  <img
-    alt="Edit server-getting-started"
-    src="https://codesandbox.io/static/img/play-codesandbox.svg"
-  />
-</a>
+<ButtonLink
+  href="https://codesandbox.io/s/github/apollographql/docs-examples/tree/main/apollo-server/v4/getting-started?fontsize=14&hidenavigation=1&theme=dark"
+  size="lg"
+>
+  Edit in CodeSandbox
+</ButtonLink>
 
 ## Next steps
 


### PR DESCRIPTION
Standardizes button used for CodeSandbox external link, from [this](https://www.apollographql.com/docs/apollo-server/getting-started#complete-example) to [this](https://deploy-preview-7838--apollo-server-docs.netlify.app/getting-started#complete-example)

<img width="615" alt="image" src="https://github.com/apollographql/apollo-server/assets/23219998/c27adc2c-f775-42c6-a342-2e3f03e31cab">

<img width="603" alt="image" src="https://github.com/apollographql/apollo-server/assets/23219998/43029103-33f2-451b-937f-5be724878cd4">


