### PR TITLE
Fix client delay when subscription is terminated

### DIFF
--- a/.changeset/bright-needles-suffer.md
+++ b/.changeset/bright-needles-suffer.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+In the subscription callback server plugin, terminating a subscription now immediately closes the internal async generator. This avoids that generator existing after termination and until the next message is received.

--- a/packages/server/src/plugin/subscriptionCallback/index.ts
+++ b/packages/server/src/plugin/subscriptionCallback/index.ts
@@ -197,6 +197,7 @@ function isAsyncIterable<T>(value: any): value is AsyncIterable<T> {
 
 interface SubscriptionObject {
   cancelled: boolean;
+  asyncIter: AsyncGenerator<ExecutionResult, void, void>;
   startConsumingSubscription: () => Promise<void>;
   completeSubscription: () => Promise<void>;
 }
@@ -523,6 +524,7 @@ class SubscriptionManager {
     const { subscription, heartbeat } = subscriptionInfo;
     if (subscription) {
       subscription.cancelled = true;
+      subscription.asyncIter?.return();
     }
     // cleanup heartbeat for subscription
     if (heartbeat) {
@@ -551,6 +553,7 @@ class SubscriptionManager {
     // allows us to break out of the `for await` and ignore future payloads.
     const self = this;
     const subscriptionObject = {
+      asyncIter: subscription,
       cancelled: false,
       async startConsumingSubscription() {
         self.logger?.debug(`Listening to graphql-js subscription`, id);


### PR DESCRIPTION
This PR addresses #7842 .

When configured with an HTTP callback, a terminated subscription does not fully clean up its resources immediately. Namely, the async generator that the subscription object uses is not closed (i.e. `return()` is not called). This means anything that is await-ing that promise will be waiting until the next message comes through the subscription.

The desired behavior is that calling `terminateSubscription` will also end the async generator.

To do this, the async generator is stored as a field in the subscription object, and its `return()` method is called in the `terminateSubscription` method.