### PR TITLE
fix: Undefined 'code' TypeError within errorNormalize #7850

### DIFF
--- a/.changeset/breezy-forks-develop.md
+++ b/.changeset/breezy-forks-develop.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": minor
+---
+
+Fixes an undefined error when normalizing errors

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -88,7 +88,7 @@ describe('Errors', () => {
         normalizeAndFormatErrors([error], {
           includeStacktraceInErrorResponses: true,
         });
-      }).rejects.not.toThrow();
+      }).toThrowError();
     });
 
     describe('formatError can be used to provide AS3-compatible extensions', () => {

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -79,6 +79,17 @@ describe('Errors', () => {
       ]).formattedErrors;
       expect(JSON.parse(JSON.stringify(formattedError)).message).toBe('Hello');
     });
+    it('does not throw for undefined extensions', () => {
+      const error = new GraphQLError('Hello', {
+        extensions: undefined,
+      });
+
+      expect(() => {
+        normalizeAndFormatErrors([error], {
+          includeStacktraceInErrorResponses: true,
+        });
+      }).rejects.not.toThrow();
+    });
 
     describe('formatError can be used to provide AS3-compatible extensions', () => {
       function formatError(

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -88,7 +88,7 @@ describe('Errors', () => {
         normalizeAndFormatErrors([error], {
           includeStacktraceInErrorResponses: true,
         });
-      }).toThrowError();
+      }).not.toThrowError();
     });
 
     describe('formatError can be used to provide AS3-compatible extensions', () => {

--- a/packages/server/src/errorNormalize.ts
+++ b/packages/server/src/errorNormalize.ts
@@ -58,8 +58,9 @@ export function normalizeAndFormatErrors(
   function enrichError(maybeError: unknown): GraphQLFormattedError {
     const graphqlError = ensureGraphQLError(maybeError);
 
-    const code = graphqlError.extensions?.code
-      ?? ApolloServerErrorCode.INTERNAL_SERVER_ERROR;
+    const code =
+      graphqlError.extensions?.code ??
+      ApolloServerErrorCode.INTERNAL_SERVER_ERROR;
 
     const extensions: GraphQLErrorExtensions = {
       ...graphqlError.extensions,

--- a/packages/server/src/errorNormalize.ts
+++ b/packages/server/src/errorNormalize.ts
@@ -58,11 +58,12 @@ export function normalizeAndFormatErrors(
   function enrichError(maybeError: unknown): GraphQLFormattedError {
     const graphqlError = ensureGraphQLError(maybeError);
 
+    const code = graphqlError.extensions?.code
+      ?? ApolloServerErrorCode.INTERNAL_SERVER_ERROR;
+
     const extensions: GraphQLErrorExtensions = {
       ...graphqlError.extensions,
-      code:
-        graphqlError.extensions.code ??
-        ApolloServerErrorCode.INTERNAL_SERVER_ERROR,
+      code: code,
     };
 
     if (isPartialHTTPGraphQLHead(extensions.http)) {


### PR DESCRIPTION
This PR fixes the issue reported #7850 

When running Apollo Server 4.10.1, I am running into an unhandled TypeError where extensions is undefined, so the error code cannot be retrieved from the object.

For context, this adds backwards compatibility with older versions of graphql (`^14.3.0`) as we upgrade to newer versions.