### PR TITLE
Export package.json from exports list in package.json to support introspection by build tools

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,6 +7,7 @@
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": {
         "require": "./dist/cjs/index.d.ts",

--- a/smoke-test/smoke-test.cjs
+++ b/smoke-test/smoke-test.cjs
@@ -13,6 +13,7 @@ async function validateAllImports() {
   require('@apollo/server/plugin/schemaReporting');
   require('@apollo/server/plugin/usageReporting');
   require('@apollo/server/standalone');
+  require('@apollo/server/package.json');
 }
 
 async function smokeTest() {


### PR DESCRIPTION
A common pattern in build tooling such as bundlers is to introspect the `package.json` file for dependencies. By providing an exports field in the package.json, external tools are prevented from being able to access `package.json` via `require()`, resulting in an error `Package subpath './package.json' is not defined by "exports"`. 

This change would add `package.json` to the list of exports, allowing it to be required in this manner.

This does appear to be some debate around this issue, and whether it's best solved by packages adding `package.json` to their exports list, by build tools being more robust against this scenario and falling back to e.g. `fs` APIs to read `package.json`, or even the suggestion that node itself should allow requiring of `package.json` without an explicit export. However, the pattern of adding `package.json` to the exports appears to be fairly commonly accepted. 

Further context can be found here:
https://github.com/nodejs/node/issues/33460
https://github.com/uuidjs/uuid/issues/444
https://github.com/uuidjs/uuid/pull/449

(In my specific case, I'm encountering this issue when trying to package a service that uses Apollo server for AWS Lambda, using esbuild with the [Datadog esbuild plugin](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/#esbuild-support)


