### PR TITLE
Handle failed subscription payloads

### DIFF
--- a/.changeset/large-ladybugs-breathe.md
+++ b/.changeset/large-ladybugs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+Catch errors thrown by subscription generators, and gracefully clean up the subscription instead of crashing.

--- a/packages/server/src/__tests__/plugin/subscriptionCallback/index.test.ts
+++ b/packages/server/src/__tests__/plugin/subscriptionCallback/index.test.ts
@@ -1108,7 +1108,7 @@ describe('SubscriptionCallbackPlugin', () => {
     mockRouterCheckResponse();
     mockRouterCheckResponse();
     mockRouterCompleteResponse({
-      errors: [{ message: "The subscription generator didn't catch this!" }]
+      errors: [{ message: "The subscription generator didn't catch this!" }],
     });
 
     const result = await server.executeHTTPGraphQLRequest(
@@ -2073,12 +2073,14 @@ async function startSubscriptionServer(
             [Symbol.asyncIterator]() {
               return {
                 next: () => {
-                  throw new Error("The subscription generator didn't catch this!")
-                }
-              }
-            }
-          })
-        }
+                  throw new Error(
+                    "The subscription generator didn't catch this!",
+                  );
+                },
+              };
+            },
+          }),
+        },
       },
     },
     ...opts,
@@ -2237,7 +2239,7 @@ function orderOfOperationsLogger() {
     debug(msg: string) {
       this.orderOfOperations.push(msg);
     },
-    info() { },
+    info() {},
     warn(msg: string) {
       this.orderOfOperations.push(`WARN: ${msg}`);
     },

--- a/packages/server/src/plugin/subscriptionCallback/index.ts
+++ b/packages/server/src/plugin/subscriptionCallback/index.ts
@@ -466,7 +466,8 @@ class SubscriptionManager {
         const err = ensureError(e);
         // The heartbeat request failed.
         this.logger?.error(
-          `Heartbeat request failed (${++consecutiveHeartbeatFailureCount} consecutive): ${err.message
+          `Heartbeat request failed (${++consecutiveHeartbeatFailureCount} consecutive): ${
+            err.message
           }`,
           existingHeartbeat.id,
         );
@@ -596,7 +597,7 @@ class SubscriptionManager {
             `Generator threw an error, terminating subscription: ${error.message}`,
             id,
           );
-          this.completeSubscription([error])
+          this.completeSubscription([error]);
         }
       },
       async completeSubscription(errors?: readonly GraphQLError[]) {

--- a/packages/server/src/plugin/subscriptionCallback/index.ts
+++ b/packages/server/src/plugin/subscriptionCallback/index.ts
@@ -591,12 +591,12 @@ class SubscriptionManager {
           self.logger?.debug(`Subscription completed without errors`, id);
           await this.completeSubscription();
         } catch (e) {
-          const originalError = ensureError(e);
+          const error = ensureGraphQLError(e);
           self.logger?.error(
-            `Generator threw an error, terminating subscription: ${originalError.message}`,
+            `Generator threw an error, terminating subscription: ${error.message}`,
             id,
           );
-          self.terminateSubscription(id, callbackUrl);
+          this.completeSubscription([error])
         }
       },
       async completeSubscription(errors?: readonly GraphQLError[]) {

--- a/packages/server/src/plugin/subscriptionCallback/index.ts
+++ b/packages/server/src/plugin/subscriptionCallback/index.ts
@@ -466,8 +466,7 @@ class SubscriptionManager {
         const err = ensureError(e);
         // The heartbeat request failed.
         this.logger?.error(
-          `Heartbeat request failed (${++consecutiveHeartbeatFailureCount} consecutive): ${
-            err.message
+          `Heartbeat request failed (${++consecutiveHeartbeatFailureCount} consecutive): ${err.message
           }`,
           existingHeartbeat.id,
         );
@@ -557,39 +556,48 @@ class SubscriptionManager {
       cancelled: false,
       async startConsumingSubscription() {
         self.logger?.debug(`Listening to graphql-js subscription`, id);
-        for await (const payload of subscription) {
-          if (this.cancelled) {
-            self.logger?.debug(
-              `Subscription already cancelled, ignoring current and future payloads`,
-              id,
-            );
-            // It's already been cancelled - something else has already handled
-            // sending the `complete` request so we don't want to `break` here
-            // and send it again after the loop.
-            return;
-          }
+        try {
+          for await (const payload of subscription) {
+            if (this.cancelled) {
+              self.logger?.debug(
+                `Subscription already cancelled, ignoring current and future payloads`,
+                id,
+              );
+              // It's already been cancelled - something else has already handled
+              // sending the `complete` request so we don't want to `break` here
+              // and send it again after the loop.
+              return;
+            }
 
-          try {
-            await self.retryFetch({
-              url: callbackUrl,
-              action: 'next',
-              id,
-              verifier,
-              payload,
-            });
-          } catch (e) {
-            const originalError = ensureError(e);
-            self.logger?.error(
-              `\`next\` request failed, terminating subscription: ${originalError.message}`,
-              id,
-            );
-            self.terminateSubscription(id, callbackUrl);
+            try {
+              await self.retryFetch({
+                url: callbackUrl,
+                action: 'next',
+                id,
+                verifier,
+                payload,
+              });
+            } catch (e) {
+              const originalError = ensureError(e);
+              self.logger?.error(
+                `\`next\` request failed, terminating subscription: ${originalError.message}`,
+                id,
+              );
+              self.terminateSubscription(id, callbackUrl);
+            }
           }
+          // The subscription ended without errors, send the `complete` request to
+          // the router
+          self.logger?.debug(`Subscription completed without errors`, id);
+          await this.completeSubscription();
+        } catch (e) {
+          const originalError = ensureError(e);
+          self.logger?.error(
+            `Generator threw an error, terminating subscription: ${originalError.message}`,
+            id,
+          );
+          self.terminateSubscription(id, callbackUrl);
         }
-        // The subscription ended without errors, send the `complete` request to
-        // the router
-        self.logger?.debug(`Subscription completed without errors`, id);
-        await this.completeSubscription();
       },
       async completeSubscription(errors?: readonly GraphQLError[]) {
         if (this.cancelled) return;


### PR DESCRIPTION
Currently, the error handling for subscription events is not well-defined in the GraphQL spec, but that doesn't mean we shouldn't handle them! The existing behavior is that an error thrown from a subscription's generator will go uncaught and crash the whole server.

For a transient failure, it may be preferable for consumers that we simply return an error response and continue waiting for more data from the iterator, in case the producer recovers and resumes producing valid data. However, Node's AsyncGenerator terminates once an error is thrown, even if you manually loop calling `iterator.next()`.

This change wraps the iterator consumption in a `try/catch` and closes the subscription when an error is encountered. Propagating the error up to the subscriber will allow them to decide if they need to resubscribe or not, in the case of a transient error.