### PR TITLE
Missing required import

### DIFF
--- a/docs/source/api/standalone.mdx
+++ b/docs/source/api/standalone.mdx
@@ -168,6 +168,7 @@ import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHt
 import express from 'express';
 import http from 'http';
 import cors from 'cors';
+import bodyParser from 'body-parser';
 import { typeDefs, resolvers } from './schema';
 
 interface MyContext {


### PR DESCRIPTION
In the express middleware it's using a reference to body-parser without importing it first. I added the import to avoid confusion.
