### PR TITLE
[docs] Update docs on where response extensions can be mutated

### DIFF
--- a/docs/source/integrations/plugins-event-reference.mdx
+++ b/docs/source/integrations/plugins-event-reference.mdx
@@ -487,6 +487,8 @@ if the GraphQL operation encounters one or more errors.
 
 (If the operation uses [incremental delivery](../workflow/requests#incremental-delivery-experimental) directives such as `@defer`, `willSendResponse` is called before the *initial* payload is sent; you can use `willSendSubsequentPayload` to find out when more payloads will be sent.)
 
+This is also the place you can mutate the GraphQL response in-place, like adding values to the `extensions` or merging responses from subgraphs with conditional logic.
+
 ```ts
 willSendResponse?(
   requestContext: WithRequired<

--- a/docs/source/integrations/plugins-event-reference.mdx
+++ b/docs/source/integrations/plugins-event-reference.mdx
@@ -487,7 +487,7 @@ if the GraphQL operation encounters one or more errors.
 
 (If the operation uses [incremental delivery](../workflow/requests#incremental-delivery-experimental) directives such as `@defer`, `willSendResponse` is called before the *initial* payload is sent; you can use `willSendSubsequentPayload` to find out when more payloads will be sent.)
 
-This is also the place you can mutate the GraphQL response in-place, like adding values to the `extensions` or redacting information in the `error` blocks.
+The `willSendResponse` event is also where you can mutate the GraphQL response in-place. For example, you can add values to the `extensions` object or redact information in the `error` blocks.
 
 ```ts
 willSendResponse?(

--- a/docs/source/integrations/plugins-event-reference.mdx
+++ b/docs/source/integrations/plugins-event-reference.mdx
@@ -487,7 +487,7 @@ if the GraphQL operation encounters one or more errors.
 
 (If the operation uses [incremental delivery](../workflow/requests#incremental-delivery-experimental) directives such as `@defer`, `willSendResponse` is called before the *initial* payload is sent; you can use `willSendSubsequentPayload` to find out when more payloads will be sent.)
 
-This is also the place you can mutate the GraphQL response in-place, like adding values to the `extensions` or redacting the information in the `error` blocks.
+This is also the place you can mutate the GraphQL response in-place, like adding values to the `extensions` or redacting information in the `error` blocks.
 
 ```ts
 willSendResponse?(

--- a/docs/source/integrations/plugins-event-reference.mdx
+++ b/docs/source/integrations/plugins-event-reference.mdx
@@ -487,7 +487,7 @@ if the GraphQL operation encounters one or more errors.
 
 (If the operation uses [incremental delivery](../workflow/requests#incremental-delivery-experimental) directives such as `@defer`, `willSendResponse` is called before the *initial* payload is sent; you can use `willSendSubsequentPayload` to find out when more payloads will be sent.)
 
-This is also the place you can mutate the GraphQL response in-place, like adding values to the `extensions` or merging responses from subgraphs with conditional logic.
+This is also the place you can mutate the GraphQL response in-place, like adding values to the `extensions` or redacting the information in the `error` blocks.
 
 ```ts
 willSendResponse?(

--- a/docs/source/integrations/plugins-event-reference.mdx
+++ b/docs/source/integrations/plugins-event-reference.mdx
@@ -487,7 +487,7 @@ if the GraphQL operation encounters one or more errors.
 
 (If the operation uses [incremental delivery](../workflow/requests#incremental-delivery-experimental) directives such as `@defer`, `willSendResponse` is called before the *initial* payload is sent; you can use `willSendSubsequentPayload` to find out when more payloads will be sent.)
 
-The `willSendResponse` event is also where you can mutate the GraphQL response in-place. For example, you can add values to the `extensions` object or redact information in the `error` blocks.
+The `willSendResponse` event is also where you can mutate the GraphQL response in-place. For example, you can add values to the `extensions` object or redact information in the `data` block. If you need to mutate the error responses, see the [`formatError` hook](https://www.apollographql.com/docs/apollo-server/data/errors/#for-client-responses).
 
 ```ts
 willSendResponse?(


### PR DESCRIPTION
I couldn't find any articles or docs on how to do this as I was attempting myself to debug an issue for a customer