### PR TITLE
Update custom-scalars.mdx

### DIFF
--- a/docs/source/schema/custom-scalars.mdx
+++ b/docs/source/schema/custom-scalars.mdx
@@ -174,7 +174,7 @@ const typeDefs = `#graphql
 `;
 
 // Validation function for checking "oddness"
-function oddValue(value: number) {
+function oddValue(value: unknown) {
   if (typeof value === 'number' && Number.isInteger(value) && value % 2 !== 0) {
     return value;
   }


### PR DESCRIPTION
`value` should be of type `unknown` instead of `number` with graphql@16.8.1:

```log
Type '(value: number) => number' is not assignable to type 'GraphQLScalarValueParser<number>'.
  Types of parameters 'value' and 'inputValue' are incompatible.
    Type 'unknown' is not assignable to type 'number'.ts(2322)
definition.d.ts(365, 3): The expected type comes from property 'parseValue' which is declared here on type 'Readonly<GraphQLScalarTypeConfig<number, number>>'
```
