### PR TITLE
Add request data to `invalidRequestWasReceived` lifecycle event

### DIFF
--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -1101,7 +1101,10 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
           await Promise.all(
             this.internals.plugins.map(
               async (plugin) =>
-                plugin.invalidRequestWasReceived?.({ error: maybeError }),
+                plugin.invalidRequestWasReceived?.({
+                  request: httpGraphQLRequest,
+                  error: maybeError,
+                }),
             ),
           );
         } catch (pluginError) {

--- a/packages/server/src/externalTypes/plugins.ts
+++ b/packages/server/src/externalTypes/plugins.ts
@@ -23,6 +23,7 @@ import type {
   GraphQLRequestContextWillSendResponse,
   GraphQLRequestContextWillSendSubsequentPayload,
 } from './requestPipeline.js';
+import type { HTTPGraphQLRequest } from './index.js';
 
 export interface GraphQLServerContext {
   readonly logger: Logger;
@@ -76,7 +77,13 @@ export interface ApolloServerPlugin<
    * incorrect headers, invalid JSON body, or invalid search params for GET),
    * but does not include malformed GraphQL.
    */
-  invalidRequestWasReceived?({ error }: { error: Error }): Promise<void>;
+  invalidRequestWasReceived?({
+    request,
+    error,
+  }: {
+    request: HTTPGraphQLRequest;
+    error: Error;
+  }): Promise<void>;
   // Called on startup fail. This can occur if the schema fails to load or if a
   // `serverWillStart` or `renderLandingPage` hook throws.
   startupDidFail?({ error }: { error: Error }): Promise<void>;


### PR DESCRIPTION
Hi,

I want to log all request made to my API and I'm not satisfied by the `didEncounterErrors` because it discards Bad Request event and such.

By adding more the request object to `invalidRequestWasReceived`, I will be able to log information regarding the malformed request such as body and headers that will help me trouble shoot issues.

To give a concrete example, I currently have my API that is consumed by several client but one of them is intermittently spawning a lot of Bad Request issue. By having the ability to log all requests along with their headers and body content, I will be capable of identify the client that's causing the Bad Request.
