### PR TITLE
Hide "did you mean" suggestions when introspection is disabled to avoid leaking schema information

### DIFF
--- a/.changeset/cold-owls-end.md
+++ b/.changeset/cold-owls-end.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': minor
+---
+
+Hide "did you mean" suggestions when introspection is disabled to avoid leaking schema information

--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -175,6 +175,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
 
   rootValue?: ((parsedQuery: DocumentNode) => unknown) | unknown;
   validationRules: Array<ValidationRule>;
+  introspectionEnabled: boolean;
   fieldResolver?: GraphQLFieldResolver<any, TContext>;
   // TODO(AS5): remove OR warn + ignore with this option set, ignore option and
   // flip default behavior.
@@ -298,6 +299,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
         ...(config.validationRules ?? []),
         ...(introspectionEnabled ? [] : [NoIntrospection]),
       ],
+      introspectionEnabled,
       dangerouslyDisableValidation:
         config.dangerouslyDisableValidation ?? false,
       fieldResolver: config.fieldResolver,

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -559,11 +559,13 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
+    // cspell:disable-next-line
     const { body } = await server.executeOperation({ query: '{ hellooo }' });
     const result = singleResult(body);
     expect(result.errors).toEqual([
       {
         message:
+          // cspell:disable-next-line
           'Cannot query field "hellooo" on type "Query". Did you mean "hello"?',
         locations: [{ line: 1, column: 3 }],
         extensions: {
@@ -582,10 +584,12 @@ describe('ApolloServer executeOperation', () => {
     });
     await server.start();
 
+    // cspell:disable-next-line
     const { body } = await server.executeOperation({ query: '{ hellooo }' });
     const result = singleResult(body);
     expect(result.errors).toEqual([
       {
+        // cspell:disable-next-line
         message: 'Cannot query field "hellooo" on type "Query".',
         locations: [{ line: 1, column: 3 }],
         extensions: {

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -249,6 +249,14 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         [...specifiedRules, ...internals.validationRules],
       );
 
+      // Hide "did you mean" suggestions when introspection is disabled to avoid
+      // leaking schema information
+      if (!internals.introspectionEnabled) {
+        validationErrors.forEach((error) => {
+          error.message = error.message.replace(/ ?Did you mean(.+?)\?$/, '');
+        });
+      }
+
       if (validationErrors.length === 0) {
         await validationDidEnd();
       } else {


### PR DESCRIPTION
Hide "did you mean" suggestions when introspection is disabled to avoid leaking schema information.

It was previously discussed (see: https://github.com/apollographql/apollo-server/issues/3919) to wait for https://github.com/graphql/graphql-js/issues/2247 to close, however, that issue has not moved in years and in the mean time libraries and frameworks seem to have opted for implementing their own solutions (E.g. https://github.com/Escape-Technologies/graphql-armor/blob/main/packages/plugins/block-field-suggestions/src/index.ts).

This should be a very low impact change that achieves the goal that would also be easy enough to rip out if this gets properly implemented in graphql-js later.