### PR TITLE
Remove deferSpec=20220824 from the response headers

### DIFF
--- a/packages/integration-testsuite/src/apolloServerTests.ts
+++ b/packages/integration-testsuite/src/apolloServerTests.ts
@@ -1187,9 +1187,7 @@ export function defineIntegrationTestSuiteApolloServerTests(
               expect(response.status).toBe(200);
               expect(
                 response.headers.get('content-type'),
-              ).toMatchInlineSnapshot(
-                `"multipart/mixed; boundary="-"; deferSpec=20220824"`,
-              );
+              ).toMatchInlineSnapshot(`"multipart/mixed; boundary="-"`);
               expect(await response.text()).toMatchInlineSnapshot(`
                 "
                 ---

--- a/packages/integration-testsuite/src/httpServerTests.ts
+++ b/packages/integration-testsuite/src/httpServerTests.ts
@@ -2197,7 +2197,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
               });
             expect(res.status).toEqual(200);
             expect(res.header['content-type']).toMatchInlineSnapshot(
-              `"multipart/mixed; boundary="-"; deferSpec=20220824"`,
+              `"multipart/mixed; boundary="-""`,
             );
             expect(res.text).toMatchInlineSnapshot(`
               "
@@ -2267,7 +2267,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
             const res = await resPromise;
             expect(res.status).toEqual(200);
             expect(res.header['content-type']).toMatchInlineSnapshot(
-              `"multipart/mixed; boundary="-"; deferSpec=20220824"`,
+              `"multipart/mixed; boundary="-""`,
             );
             expect(res.text).toMatchInlineSnapshot(`
               "
@@ -2354,7 +2354,7 @@ export function defineIntegrationTestSuiteHttpServerTests(
               });
             expect(res.status).toEqual(200);
             expect(res.header['content-type']).toMatchInlineSnapshot(
-              `"multipart/mixed; boundary="-"; deferSpec=20220824"`,
+              `"multipart/mixed; boundary="-"`,
             );
             expect(res.text).toEqual(`\r
 ---\r
@@ -2404,7 +2404,7 @@ content-type: application/json; charset=utf-8\r
             const res = await resPromise;
             expect(res.status).toEqual(200);
             expect(res.header['content-type']).toMatchInlineSnapshot(
-              `"multipart/mixed; boundary="-"; deferSpec=20220824"`,
+              `"multipart/mixed; boundary="-"`,
             );
             expect(res.text).toMatchInlineSnapshot(`
               "

--- a/packages/server/src/__tests__/express4/expressSpecific.test.ts
+++ b/packages/server/src/__tests__/express4/expressSpecific.test.ts
@@ -122,7 +122,7 @@ it('incremental delivery works with compression', async () => {
   // Confirm that the response has actually been gzipped.
   expect(res.header['content-encoding']).toMatchInlineSnapshot(`"gzip"`);
   expect(res.header['content-type']).toMatchInlineSnapshot(
-    `"multipart/mixed; boundary="-"; deferSpec=20220824"`,
+    `"multipart/mixed; boundary="-""`,
   );
   expect(res.text).toMatchInlineSnapshot(`
     "

--- a/packages/server/src/runHttpQuery.ts
+++ b/packages/server/src/runHttpQuery.ts
@@ -302,7 +302,7 @@ export async function runHttpQuery<TContext extends BaseContext>({
 
   graphQLResponse.http.headers.set(
     'content-type',
-    'multipart/mixed; boundary="-"; deferSpec=20220824',
+    'multipart/mixed; boundary="-"',
   );
   return {
     ...graphQLResponse.http,

--- a/smoke-test/smoke-test.cjs
+++ b/smoke-test/smoke-test.cjs
@@ -56,7 +56,7 @@ async function smokeTest() {
 
     assert.strictEqual(
       response.headers.get('content-type'),
-      'multipart/mixed; boundary="-"; deferSpec=20220824',
+      'multipart/mixed; boundary="-"',
     );
 
     const body = await response.text();

--- a/smoke-test/smoke-test.mjs
+++ b/smoke-test/smoke-test.mjs
@@ -52,7 +52,7 @@ if (process.env.INCREMENTAL_DELIVERY_TESTS_ENABLED) {
 
   assert.strictEqual(
     response.headers.get('content-type'),
-    'multipart/mixed; boundary="-"; deferSpec=20220824',
+    'multipart/mixed; boundary="-"',
   );
 
   const body = await response.text();


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-server/issues/7909

In the issue I noted

> Is there any reason to add the deferSpec=20220824 to the response header? Without it Apollo Client behaves properly and the devtools are able to preview the response data.

Unfortunately no response on the issue but I couldn't find any information as to why `deferSpec` would need to be in the response headers. If there is a need for it then this PR can be closed.

By removing it the Preview pane in devtools is able to display the deferred data

Before:
![image](https://github.com/user-attachments/assets/c0e8af2e-30bb-4d51-b133-017dcb4ab0a3)

After:
![image](https://github.com/user-attachments/assets/afdf6335-d0a8-438c-b41d-3d3be4cd7e22).

## Tests

I updated the existing tests as this isn't adding anything net new