### PR TITLE
docs: Add Google Cloud Functions integration

### DIFF
--- a/docs/source/shared/integration-table.mdx
+++ b/docs/source/shared/integration-table.mdx
@@ -3,6 +3,7 @@
 | [AWS Lambda](https://aws.amazon.com/lambda/) | [`@as-integrations/aws-lambda`](https://www.npmjs.com/package/@as-integrations/aws-lambda) |
 | [Azure Functions](https://azure.microsoft.com/en-us/services/functions/) | [`@as-integrations/azure-functions`](https://www.npmjs.com/package/@as-integrations/azure-functions) |
 | [Cloudflare Workers](https://workers.cloudflare.com/) | [`@as-integrations/cloudflare-workers`](https://www.npmjs.com/package/@as-integrations/cloudflare-workers) |
+| [Google Functions](https://cloud.google.com/functions) | [`apollo-server-integrations/apollo-server-integration-google-cloud-functions`](https://github.com/apollo-server-integrations/apollo-server-integration-google-cloud-functions) |
 | [Fastify](https://fastify.io/) | [`@as-integrations/fastify`](https://www.npmjs.com/package/@as-integrations/fastify) |
 | [Hapi](https://hapi.dev/) | [`@as-integrations/hapi`](https://www.npmjs.com/package/@as-integrations/hapi) |
 | [Koa](https://koajs.com/) | [`@as-integrations/koa`](https://www.npmjs.com/package/@as-integrations/koa) |

--- a/docs/source/shared/integration-table.mdx
+++ b/docs/source/shared/integration-table.mdx
@@ -3,7 +3,7 @@
 | [AWS Lambda](https://aws.amazon.com/lambda/) | [`@as-integrations/aws-lambda`](https://www.npmjs.com/package/@as-integrations/aws-lambda) |
 | [Azure Functions](https://azure.microsoft.com/en-us/services/functions/) | [`@as-integrations/azure-functions`](https://www.npmjs.com/package/@as-integrations/azure-functions) |
 | [Cloudflare Workers](https://workers.cloudflare.com/) | [`@as-integrations/cloudflare-workers`](https://www.npmjs.com/package/@as-integrations/cloudflare-workers) |
-| [Google Functions](https://cloud.google.com/functions) | [`apollo-server-integrations/apollo-server-integration-google-cloud-functions`](https://github.com/apollo-server-integrations/apollo-server-integration-google-cloud-functions) |
+| [Google Functions](https://cloud.google.com/functions) | [`@as-integrations/google-cloud-functions`](https://www.npmjs.com/package/@as-integrations/google-cloud-functions) |
 | [Fastify](https://fastify.io/) | [`@as-integrations/fastify`](https://www.npmjs.com/package/@as-integrations/fastify) |
 | [Hapi](https://hapi.dev/) | [`@as-integrations/hapi`](https://www.npmjs.com/package/@as-integrations/hapi) |
 | [Koa](https://koajs.com/) | [`@as-integrations/koa`](https://www.npmjs.com/package/@as-integrations/koa) |


### PR DESCRIPTION
Include integration with Google Cloud Functions

This was documented in v3 but disappeared from the list of integrations in v4. Googling for it was, ironically, an exercise in frustration.

Eventually happened on https://github.com/apollo-server-integrations/apollo-server-integration-google-cloud-functions

This package is different from the other supported integrations in that it's not prefixed with `@as/` but instead with `/apollo-server-integrations` which seems surprisingly similar, but different. Not sure if this is truly a supported integration or not.
