### PR TITLE
Update redis connection docs to match latest Keyv API

### DIFF
--- a/docs/source/performance/cache-backends.mdx
+++ b/docs/source/performance/cache-backends.mdx
@@ -96,12 +96,13 @@ npm install keyv @keyv/redis @apollo/utils.keyvadapter
 ### Single instance
 ```ts
 import Keyv from "keyv";
+import KeyvRedis from "@keyv/redis";
 import { KeyvAdapter } from "@apollo/utils.keyvadapter";
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
-  cache: new KeyvAdapter(new Keyv("redis://user:pass@localhost:6379")), // highlight-line
+  cache: new KeyvAdapter(new Keyv(new KeyvRedis("redis://user:pass@localhost:6379"))), // highlight-line
 });
 ```
 
@@ -114,14 +115,14 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   // highlight-start
-  cache: new KeyvAdapter(
-    new Keyv("redis://user:pass@localhost:6379", {
+  cache: new KeyvAdapter(new Keyv(
+    new KeyvRedis("redis://user:pass@localhost:6379", {
       sentinels: [
         { host: "localhost", port: 26379 },
         { host: "localhost", port: 26380 },
       ],
     })
-  ),
+  )),
   // highlight-end
 });
 ```
@@ -208,10 +209,11 @@ To provide error tolerance for cache backends that connect via a client (e.g., R
 
 ```typescript
 import Keyv from "keyv";
+import KeyvRedis from "@keyv/redis";
 import { KeyvAdapter } from "@apollo/utils.keyvadapter";
 import { ErrorsAreMissesCache } from "@apollo/utils.keyvaluecache";
 
-const redisCache = new Keyv("redis://user:pass@localhost:6379");
+const redisCache = new Keyv(new KeyvRedis("redis://user:pass@localhost:6379"));
 const faultTolerantCache = new ErrorsAreMissesCache(
   new KeyvAdapter(redisCache),
 );


### PR DESCRIPTION
The `@apollo/utils.keyvadapter` package was updated in https://github.com/apollographql/apollo-utils/pull/461 to be compatible with Keyv v5. The primary change is that the `Keyv` constructor takes a store instead of a string.

The constructor can be invoked in two ways:
```
// passed as first argument
new Keyv(new KeyvRedis("redis://..."))

// passed as store
new Keyv({ store: new KeyvRedis("redis://...") })
```

This updates the Redis examples in the documentation to match the new API. For simplicity, I've stuck to the first format.
