### PR TITLE
docs: delete preserve-line comments

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -119,7 +119,7 @@ The above `start` script tells TypeScript to compile your code into JavaScript b
 
 #### Set up with JavaScript
 
-> All code examples in this getting started guide are in Typescript. You must transpile them to JavaScript.
+> All code examples in this getting started guide are in TypeScript. You must transpile them to JavaScript.
 
 If you are using JavaScript, create a `index.js` file that will contain **all** of the code for our example application:
 

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -119,6 +119,8 @@ The above `start` script tells TypeScript to compile your code into JavaScript b
 
 #### Set up with JavaScript
 
+> All code examples in this getting started guide are in Typescript. You must transpile them to JavaScript.
+
 If you are using JavaScript, create a `index.js` file that will contain **all** of the code for our example application:
 
 ```bash

--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -153,8 +153,8 @@ Open `index.ts` in your preferred code editor and paste the following into it:
 <MultiCodeBlock>
 
 ```ts title="index.ts"
-import { ApolloServer } from '@apollo/server'; // preserve-line
-import { startStandaloneServer } from '@apollo/server/standalone'; // preserve-line
+import { ApolloServer } from '@apollo/server';
+import { startStandaloneServer } from '@apollo/server/standalone';
 
 // A schema is a collection of type definitions (hence "typeDefs")
 // that together define the "shape" of queries that are executed against

--- a/docs/source/using-federation/apollo-subgraph-setup.mdx
+++ b/docs/source/using-federation/apollo-subgraph-setup.mdx
@@ -69,7 +69,7 @@ We also need to require the `buildSubgraphSchema` function from this package in 
 <MultiCodeBlock>
 
 ```ts title="index.ts"
-import { buildSubgraphSchema } from '@apollo/subgraph'; //preserve-line
+import { buildSubgraphSchema } from '@apollo/subgraph';
 ```
 
 </MultiCodeBlock>


### PR DESCRIPTION
Remove outdated `// preserve-line` comments