### PR TITLE
renovate: pin some packages for Node version reasons

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -95,10 +95,21 @@
       matchPackageNames: ["^@typescript-eslint"],
       allowedVersions: "5.x"
     },
+    // cspell@7 drops support for node v14. We can take this when we drop node v14 support.
+    {
+      matchPackageNames: ["cspell"],
+      allowedVersions: "6.x",
+    },
+    // whatwg-mimetype@4 drops support for node v14. We can take this when we drop node v14 support.
+    {
+      matchPackageNames: ["whatwg-mimetype"],
+      allowedVersions: "3.x",
+    },
     // node-fetch v3 only ships as ESM. We currently build as both CommonJS and
-    // ESM and we're not going to go ESM-only for a while. So let's stay on v2.
-    // (Perhaps we could swap to undici instead if this pin gets to be a
-    // problem.)
+    // ESM, so let's stay on v2.
+    // (Once we drop support for node older than v18, we can switch our default
+    // fetch implementation to be Node's built-in implementation and drop this
+    // very old node-fetch implementation.)
     {
       "matchPackagePatterns": ["node-fetch", "@types/node-fetch"],
       "allowedVersions": "2.x"
@@ -108,6 +119,11 @@
       matchSourceUrlPrefixes: ["https://github.com/rollup/"],
       matchUpdateTypes: ["major"],
       groupName: "rollup",
+    },
+    // rollup@4 drops support for node v14. We can take this when we drop node v14 support.
+    {
+      matchPackageNames: ["rollup"],
+      allowedVersions: "4.x",
     },
     // Only needed until Jest supports prettier@3 for snapshots
     {


### PR DESCRIPTION
Apollo Server 4 claims to support Node v14 and v16 (which are EOL), but many of our dependencies do not in their recent versions. Tell Renovate not to try to upgrade them.

(At some point we'll put out an AS5 which drops support for these old Node versions, which will let us upgrade all our deps again.)