### PR TITLE
tests: drop prettier-2

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -23,5 +23,4 @@ export default {
     // Ignore '.js' at the end of imports; part of ESM support.
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  prettierPath: createRequire(import.meta.url).resolve('prettier-2'),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "nock": "13.5.5",
         "node-fetch": "2.7.0",
         "prettier": "3.3.3",
-        "prettier-2": "npm:prettier@2.8.8",
         "qs-middleware": "1.0.3",
         "requisition": "1.7.0",
         "rollup": "3.29.5",
@@ -11863,22 +11862,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettier-2": {
-      "name": "prettier",
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -23285,12 +23268,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true
-    },
-    "prettier-2": {
-      "version": "npm:prettier@2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "nock": "13.5.5",
     "node-fetch": "2.7.0",
     "prettier": "3.3.3",
-    "prettier-2": "npm:prettier@2.8.8",
     "qs-middleware": "1.0.3",
     "requisition": "1.7.0",
     "rollup": "3.29.5",

--- a/renovate.json5
+++ b/renovate.json5
@@ -125,10 +125,5 @@
       matchPackageNames: ["rollup"],
       allowedVersions: "4.x",
     },
-    // Only needed until Jest supports prettier@3 for snapshots
-    {
-      "matchPackageNames": ["prettier-2"],
-      "allowedVersions": "2.x"
-    },
   ]
 }


### PR DESCRIPTION
At some point the version of Jest we ran didn't support prettier 3, but now it does.
