### PR TITLE
Custom Executor, staticOnly cache control

### DIFF
--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -74,6 +74,7 @@ import { UnreachableCaseError } from './utils/UnreachableCaseError.js';
 import { computeCoreSchemaHash } from './utils/computeCoreSchemaHash.js';
 import { isDefined } from './utils/isDefined.js';
 import { SchemaManager } from './utils/schemaManager.js';
+import { GraphQLExecutor } from './externalTypes/requestPipeline.js';
 
 const NoIntrospection: ValidationRule = (context: ValidationContext) => ({
   Field(node) {
@@ -184,6 +185,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   stringifyResult: (
     value: FormattedExecutionResult,
   ) => string | Promise<string>;
+  customExecutor?: GraphQLExecutor;
 }
 
 function defaultLogger(): Logger {
@@ -330,6 +332,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       stopOnTerminationSignals: config.stopOnTerminationSignals,
 
       gatewayExecutor: null, // set by _start
+      customExecutor: config.customExecutor,
 
       csrfPreventionRequestHeaders:
         config.csrfPrevention === true || config.csrfPrevention === undefined

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -20,6 +20,7 @@ import type { GatewayInterface } from '@apollo/server-gateway-interface';
 import type { ApolloServerPlugin } from './plugins.js';
 import type { BaseContext } from './index.js';
 import type { GraphQLExperimentalIncrementalExecutionResults } from '../incrementalDeliveryPolyfill.js';
+import { GraphQLExecutor } from './requestPipeline.js';
 
 export type DocumentStore = KeyValueCache<DocumentNode>;
 
@@ -118,6 +119,8 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
 
   // For testing only.
   __testing_incrementalExecutionResults?: GraphQLExperimentalIncrementalExecutionResults;
+
+  customExecutor?: GraphQLExecutor;
 }
 
 export interface ApolloServerOptionsWithGateway<TContext extends BaseContext>

--- a/packages/server/src/externalTypes/requestPipeline.ts
+++ b/packages/server/src/externalTypes/requestPipeline.ts
@@ -121,3 +121,15 @@ export type GraphQLRequestContextDidEncounterSubsequentErrors<
 export type GraphQLRequestContextWillSendSubsequentPayload<
   TContext extends BaseContext,
 > = GraphQLRequestContextWillSendResponse<TContext>;
+
+export type GraphQLExecutionResult = {
+  data?: Record<string, any> | null;
+  errors?: ReadonlyArray<GraphQLError>;
+  extensions?: Record<string, any>;
+};
+
+export type GraphQLExecutor<
+  TContext extends BaseContext = Record<string, any>,
+> = (
+  requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
+) => Promise<GraphQLExecutionResult>;

--- a/packages/server/src/plugin/cacheControl/index.ts
+++ b/packages/server/src/plugin/cacheControl/index.ts
@@ -48,6 +48,14 @@ export interface ApolloServerPluginCacheControlOptions {
    * delivery response, and the body contains no errors.
    */
   calculateHttpHeaders?: boolean | 'if-cacheable';
+
+  /**
+   * Disables instrumenting all fields for dynamic cache control hints. This is
+   * a pretty big significant performant boost, especially the larger a response
+   * is.
+   */
+  staticOnly?: boolean;
+
   // For testing only.
   __testing__cacheHints?: Map<string, CacheHint>;
 }
@@ -125,10 +133,15 @@ export function ApolloServerPluginCacheControl(
 
       const defaultMaxAge: number = options.defaultMaxAge ?? 0;
       const calculateHttpHeaders = options.calculateHttpHeaders ?? true;
+      const staticOnly = options.staticOnly ?? false;
       const { __testing__cacheHints } = options;
 
       return {
         async executionDidStart() {
+          if (staticOnly) {
+            return {};
+          }
+
           // Did something set the overall cache policy before we've even
           // started? If so, consider that as an override and don't touch it.
           // Just put set up fake `info.cacheControl` objects and otherwise

--- a/packages/server/src/plugin/subscriptionCallback/index.ts
+++ b/packages/server/src/plugin/subscriptionCallback/index.ts
@@ -199,6 +199,8 @@ function isAsyncIterable<T>(value: any): value is AsyncIterable<T> {
   return value && typeof value[Symbol.asyncIterator] === 'function';
 }
 
+type RetryResponse = Response | Error;
+
 interface SubscriptionObject {
   cancelled: boolean;
   asyncIter: AsyncGenerator<ExecutionResult, void, void>;
@@ -265,7 +267,7 @@ class SubscriptionManager {
         `Sending \`${action}\` request to router` + maybeWithErrors,
         id,
       );
-      return retry<Response, Error>(
+      return retry<RetryResponse>(
         async (bail) => {
           response = fetch(url, {
             method: 'POST',

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -539,6 +539,9 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
         makeGatewayGraphQLRequestContext(requestContext, server, internals),
       );
       return { singleResult: result };
+    } else if (internals.customExecutor) {
+      const result = await internals.customExecutor(requestContext);
+      return { singleResult: result };
     } else {
       const resultOrResults = await executeIncrementally({
         schema: schemaDerivedData.schema,


### PR DESCRIPTION
- Added ability to use a custom executor such as graphql-jit
- Added `staticOnly` to cache control plugin to reduce overhead of willResolveField
- Fix type issue with subscriptions plugin

# Why?

These changes are to optimize general execution time and especially execution time for larger payloads.

Here is a comparison of the response time with a increasing response size. You can see that compared to the Apollo baseline, using Apollo + graphql-jit + staticOnly cache control mode results in a more than twice as fast response time when getting to larger response sizes. Even with smaller response sizes, there is a notable difference in response time.

![Screenshot 2024-11-04 at 2 20 19 PM](https://github.com/user-attachments/assets/72e9461e-9796-4275-a7ce-ce37dc425706)

# How?

## Custom Executor

Version 4 of Apollo Server removed the `executor` argument. This was due to it being a "legacy" option that used to be used for the Gateway. However, in the process of removing it, it also removed the option to drop in something like graphql-JIT.

GraphQL JIT is a drop in replacement for graphql-js when executing. It is pretty significantly faster when looking at benchmarks.

This change introduces an argument called `customExecutor` which allows it to be dropped in. E.g.:

```typescript
const executor = (schema: GraphQLSchema, cacheSize = 2014, compilerOpts = {}) => {
  const cache = lru(cacheSize);
  return async ({ contextValue, document, operationName, request, queryHash }) => {
    const prefix = operationName || 'NotParametrized';
    const cacheKey = `${prefix}-${queryHash}`;
    let compiledQuery = cache.get(cacheKey);
    if (!compiledQuery) {
      const compilationResult = compileQuery(schema, document, operationName || undefined, compilerOpts);
      if (isCompiledQuery(compilationResult)) {
        compiledQuery = compilationResult;
        cache.set(cacheKey, compiledQuery);
      } else {
        // ...is ExecutionResult
        return compilationResult;
      }
    }

    return compiledQuery.query(undefined, contextValue, request.variables || {});
  };
};

const schema = buildSubgraphSchema([{ typeDefs, resolvers }]);

const server = new ApolloServer<BaseContext>({
  schema,
  customExecutor: executor(schema),
});
```

## Static Only Cache Control

The Cache Control plugin plugin currently runs `willResolveField` on every single field. This can cause quite a bit of overhead, especially on larger response sizes. This hook is to allow for dynamic cache control hints to be set in resolvers.

> Note:
> This new "option" was previous suggested/hinted at in a code comment! https://github.com/apollographql/apollo-server/blob/main/packages/server/src/requestPipeline.ts#L422

This change introduces a `staticOnly` argument (default: false) to the `ApolloServerPluginCacheControl` plugin which allows opting out of dynamic cache hints. E.g.:

```typescript
const server = new ApolloServer<BaseContext>({
  cache,
  documentStore: new InMemoryLRUCache<DocumentNode>(),
  plugins: [
    ApolloServerPluginCacheControl({ staticOnly: true }),
  ],
});
```