### PR TITLE
Fixed typescript error with subscription callback plugin

### DIFF
--- a/.changeset/breezy-lies-explode.md
+++ b/.changeset/breezy-lies-explode.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Fixed typescript error with subscription callback plugin

--- a/packages/server/src/plugin/subscriptionCallback/index.ts
+++ b/packages/server/src/plugin/subscriptionCallback/index.ts
@@ -199,6 +199,8 @@ function isAsyncIterable<T>(value: any): value is AsyncIterable<T> {
   return value && typeof value[Symbol.asyncIterator] === 'function';
 }
 
+type RetryResponse = Response | Error;
+
 interface SubscriptionObject {
   cancelled: boolean;
   asyncIter: AsyncGenerator<ExecutionResult, void, void>;
@@ -265,7 +267,7 @@ class SubscriptionManager {
         `Sending \`${action}\` request to router` + maybeWithErrors,
         id,
       );
-      return retry<Response, Error>(
+      return retry<RetryResponse>(
         async (bail) => {
           response = fetch(url, {
             method: 'POST',


### PR DESCRIPTION
Fixed typescript error with subscription callback plugin

This was failing the `compile` command:

![Screenshot 2024-11-05 at 2 31 53 PM](https://github.com/user-attachments/assets/cb92b09a-5d7b-4cac-ba76-70569407d695)
