### PR TITLE
Add a name to the middleware function

### DIFF
--- a/.changeset/nine-chefs-cry.md
+++ b/.changeset/nine-chefs-cry.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Use a named function for express middleware

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -133,6 +133,7 @@ Nuxt
 oneof
 onwarn
 opde
+opentelemetry
 paque
 parseurl
 pbjs

--- a/packages/server/src/__tests__/express4/expressSpecific.test.ts
+++ b/packages/server/src/__tests__/express4/expressSpecific.test.ts
@@ -141,6 +141,13 @@ it('incremental delivery works with compression', async () => {
   await server.stop();
 });
 
+it('express middleware has a name', async () => {
+  const server = new ApolloServer({ typeDefs: 'type Query {f: ID}' });
+  await server.start();
+  expect(expressMiddleware(server).name).toEqual('apolloGraphQL');
+  await server.stop();
+});
+
 it('supporting doubly-encoded variables example from migration guide', async () => {
   const server = new ApolloServer({
     typeDefs: 'type Query {hello(s: String!): String!}',

--- a/packages/server/src/express4/index.ts
+++ b/packages/server/src/express4/index.ts
@@ -43,7 +43,10 @@ export function expressMiddleware<TContext extends BaseContext>(
   const context: ContextFunction<[ExpressContextFunctionArgument], TContext> =
     options?.context ?? defaultContext;
 
-  return (req, res, next) => {
+  // Note that some instrumentation, such as @opentelemetry/instrumentation-express,
+  // relies on middleware functions being named. Returning a named function here
+  // is the difference between seeing `apolloGraphQL` and `anonymous` in traces.
+  return function apolloGraphQL(req, res, next) {
     if (!req.body) {
       // The json body-parser *always* sets req.body to {} if it's unset (even
       // if the Content-Type doesn't match), so if it isn't set, you probably


### PR DESCRIPTION
This is a small quality-of-life improvement. As the code comment says, some observability/instrumentation libraries rely on `Function.name` for the name of express middleware to use in a span. [@opentelemetry/instrumentation-express](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-express/src/utils.ts#L109) is one example.

This PR returns a named function, rather than an anonymous function, and adds a test to ensure that the middleware is named.
