### PR TITLE
docs: add subtitle and meta description to top-level pages

### DIFF
--- a/docs/source/getting-started.mdx
+++ b/docs/source/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 title: Get Started with Apollo Server
-description: ''
+subtitle: Set up a simple GraphQL API with TypeScript or JavaScript
+description: Learn how to create a basic GraphQL server with Apollo Server using TypeScript or JavaScript. This tutorial covers schema definition, data management, and executing queries.
 ---
 
 This tutorial helps you:

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Introduction to Apollo Server
+subtitle: Learn how to build scalable, production-ready GraphQL APIs
+description: Learn how Apollo Server simplifies building GraphQL APIs with its straightforward setup and support for any data source or client.
 ---
 
 > 📣 **Apollo Server 4 is generally available!**


### PR DESCRIPTION
Add meta descriptions and subtitles to help with discoverability