### PR TITLE
Upgrade `@apollo/utils.createhash`

### DIFF
--- a/.changeset/khaki-socks-obey.md
+++ b/.changeset/khaki-socks-obey.md
@@ -1,0 +1,7 @@
+---
+'@apollo/server-integration-testsuite': patch
+'@apollo/server-plugin-response-cache': patch
+'@apollo/server': patch
+---
+
+Compatibility with Next.js Turbopack. Fixes #8004.

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -190,6 +190,7 @@ triaging
 tsbuildinfo
 tsconfig
 tsconfigs
+Turbopack
 typecheck
 typeis
 typenames

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@apollo/client": "3.12.4",
         "@apollo/gateway": "2.9.3",
         "@apollo/subgraph": "2.9.3",
-        "@apollo/utils.createhash": "2.0.1",
+        "@apollo/utils.createhash": "2.0.2",
         "@changesets/changelog-github": "0.5.0",
         "@changesets/cli": "2.27.11",
         "@graphql-codegen/cli": "3.3.1",
@@ -354,9 +354,10 @@
       "link": true
     },
     "node_modules/@apollo/utils.createhash": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz",
-      "integrity": "sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.2.tgz",
+      "integrity": "sha512-UkS3xqnVFLZ3JFpEmU/2cM2iKJotQXMoSTgxXsfQgXLC5gR1WaepoXagmYnPSA7Q/2cmnyTYK5OgAgoC4RULPg==",
+      "license": "MIT",
       "dependencies": {
         "@apollo/utils.isnodelike": "^2.0.1",
         "sha.js": "^2.4.11"
@@ -14226,7 +14227,7 @@
         "@apollo/client": "^3.6.9",
         "@apollo/server": "4.11.2",
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.createhash": "^2.0.2",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "express": "^4.21.1",
         "graphql-http": "1.22.3",
@@ -14293,7 +14294,7 @@
       "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
-        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.createhash": "^2.0.2",
         "@apollo/utils.keyvaluecache": "^2.1.0"
       },
       "engines": {
@@ -14312,7 +14313,7 @@
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^1.1.1",
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.createhash": "^2.0.2",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
@@ -14547,7 +14548,7 @@
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^1.1.1",
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.createhash": "^2.0.2",
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.isnodelike": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
@@ -14598,7 +14599,7 @@
         "@apollo/client": "^3.6.9",
         "@apollo/server": "4.11.2",
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.createhash": "^2.0.2",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "express": "^4.21.1",
         "graphql-http": "1.22.3",
@@ -14645,7 +14646,7 @@
     "@apollo/server-plugin-response-cache": {
       "version": "file:packages/plugin-response-cache",
       "requires": {
-        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.createhash": "^2.0.2",
         "@apollo/utils.keyvaluecache": "^2.1.0"
       }
     },
@@ -14666,9 +14667,9 @@
       }
     },
     "@apollo/utils.createhash": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz",
-      "integrity": "sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.2.tgz",
+      "integrity": "sha512-UkS3xqnVFLZ3JFpEmU/2cM2iKJotQXMoSTgxXsfQgXLC5gR1WaepoXagmYnPSA7Q/2cmnyTYK5OgAgoC4RULPg==",
       "requires": {
         "@apollo/utils.isnodelike": "^2.0.1",
         "sha.js": "^2.4.11"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@apollo/client": "3.12.4",
     "@apollo/gateway": "2.9.3",
     "@apollo/subgraph": "2.9.3",
-    "@apollo/utils.createhash": "2.0.1",
+    "@apollo/utils.createhash": "2.0.2",
     "@changesets/changelog-github": "0.5.0",
     "@changesets/cli": "2.27.11",
     "@graphql-codegen/cli": "3.3.1",

--- a/packages/integration-testsuite/package.json
+++ b/packages/integration-testsuite/package.json
@@ -30,7 +30,7 @@
     "@apollo/client": "^3.6.9",
     "@apollo/server": "4.11.2",
     "@apollo/usage-reporting-protobuf": "^4.1.1",
-    "@apollo/utils.createhash": "^2.0.0",
+    "@apollo/utils.createhash": "^2.0.2",
     "@apollo/utils.keyvaluecache": "^2.1.0",
     "express": "^4.21.1",
     "graphql-http": "1.22.3",

--- a/packages/plugin-response-cache/package.json
+++ b/packages/plugin-response-cache/package.json
@@ -32,7 +32,7 @@
     "node": ">=14.16.0"
   },
   "dependencies": {
-    "@apollo/utils.createhash": "^2.0.0",
+    "@apollo/utils.createhash": "^2.0.2",
     "@apollo/utils.keyvaluecache": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -136,7 +136,7 @@
     "@apollo/cache-control-types": "^1.0.3",
     "@apollo/server-gateway-interface": "^1.1.1",
     "@apollo/usage-reporting-protobuf": "^4.1.1",
-    "@apollo/utils.createhash": "^2.0.0",
+    "@apollo/utils.createhash": "^2.0.2",
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.isnodelike": "^2.0.0",
     "@apollo/utils.keyvaluecache": "^2.1.0",


### PR DESCRIPTION
For compatibility with Next.js Turbopack.

Fixes #8004.
