### PR TITLE
docs(migration): return after sending 400

### DIFF
--- a/.changeset/thick-seals-tan.md
+++ b/.changeset/thick-seals-tan.md
@@ -2,4 +2,4 @@
 '@apollo/server': patch
 ---
 
-Add return after sending 400 response in doubly espaced JSON parser middleware
+Add return after sending 400 response in doubly escaped JSON parser middleware

--- a/.changeset/thick-seals-tan.md
+++ b/.changeset/thick-seals-tan.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Add return after sending 400 response in doubly espaced JSON parser middleware

--- a/docs/source/migration.mdx
+++ b/docs/source/migration.mdx
@@ -1121,6 +1121,7 @@ app.use((req, res, next) => {
     } catch (e) {
       // https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#json-parsing-failure
       res.status(400).send(e instanceof Error ? e.message : e);
+      return;
     }
   }
   next();

--- a/packages/server/src/__tests__/express4/expressSpecific.test.ts
+++ b/packages/server/src/__tests__/express4/expressSpecific.test.ts
@@ -163,6 +163,7 @@ it('supporting doubly-encoded variables example from migration guide', async () 
       } catch (e) {
         // https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#json-parsing-failure
         res.status(400).send(e instanceof Error ? e.message : e);
+        return;
       }
     }
     next();


### PR DESCRIPTION
This is a change to ensure that users that migrate to v4 do not run `next()` when the response was already sent.