### PR TITLE
Update import for useServer for graphql-ws v.6

### DIFF
--- a/docs/source/data/subscriptions.mdx
+++ b/docs/source/data/subscriptions.mdx
@@ -63,7 +63,7 @@ To run both an Express app _and_ a separate WebSocket server for subscriptions, 
    import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
    import { makeExecutableSchema } from '@graphql-tools/schema';
    import { WebSocketServer } from 'ws';
-   import { useServer } from 'graphql-ws/lib/use/ws';
+   import { useServer } from 'graphql-ws/use/ws';
    ```
 
 3. Next, in order to set up both the HTTP and subscription servers, we need to first create an `http.Server`. Do this by passing your Express `app` to the `createServer` function, which we imported from the `http` module:


### PR DESCRIPTION
Updating the import statement to work with v.6 of graphql-ws per their instructions here:
[migrating v5 to v6](https://github.com/enisdenjo/graphql-ws/blob/master/CHANGELOG.md#migrating-from-v5-to-v6-1)
