### PR TITLE
Update `@apollo-server` `README` with 2025 Summit Dates

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -9,7 +9,7 @@
 ---
 
 **Announcement:**
-Join 1000+ engineers at GraphQL Summit for talks, workshops, and office hours, Oct 8-10 in NYC. [Get your pass here ->](https://summit.graphql.com/?utm_campaign=github_federation_readme)
+Join 1000+ engineers at GraphQL Summit 2025 by Apollo for talks, workshops, and office hours. Oct 6-8, 2025 in San Francisco. [Get your pass here ->](https://www.apollographql.com/graphql-summit-2025?utm_campaign=2025-03-04_graphql-summit-github-announcement&utm_medium=github&utm_source=apollo-server)
 
 ---
 


### PR DESCRIPTION
## Summary
Update GraphQL Summit announcement in the `@apollo-server` `README`. This change ensures our `README` reflects the correct information about our upcoming flagship event 🎉 

### What Changed
- Updated the Summit dates from Oct 8-10 in NYC to Oct 6-8, 2025 in San Francisco
- Updated the Summit name to "GraphQL Summit 2025 by Apollo"
- Replaced the link with updated UTM parameters for tracking provided by the marketing team