### PR TITLE
Add official Apollo package for MeteorJS to integration table

### DIFF
--- a/docs/source/shared/integration-table.mdx
+++ b/docs/source/shared/integration-table.mdx
@@ -8,3 +8,4 @@
 | [Koa](https://koajs.com/) | [`@as-integrations/koa`](https://www.npmjs.com/package/@as-integrations/koa) |
 | [Next.js](https://nextjs.org) | [`@as-integrations/next`](https://www.npmjs.com/package/@as-integrations/next) |
 | [Nuxt](https://v3.nuxtjs.org/) / [h3](https://github.com/unjs/h3) | [`@as-integrations/h3`](https://www.npmjs.com/package/@as-integrations/h3) |
+| [MeteorJS](https://www.meteor.com/) / [MeteorJS](https://github.com/meteor/meteor) | [`apollo`](https://atmospherejs.com/meteor/apollo) |


### PR DESCRIPTION
Adding the official MeteorJS Apollo package to the integration table. This package was originally created by the people behind Apollo GraphQL and updated by me (and few others) to use latest Apollo and MeteorJS v3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added MeteorJS and its Apollo integration package to the integration table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->