### PR TITLE
renovate: pin more packages that lack Node v14 support

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -153,6 +153,18 @@
       matchPackageNames: ["npm"],
       allowedVersions: "9.x",
     },
+    // ts-jest@29.3.0 adds a dependency on `type-fest` which drops support for node v14.
+    // We can take this when we drop node v14 support.
+    {
+      matchPackageNames: ["ts-jest"],
+      allowedVersions: "29.2.x",
+    },
+    // nock@14 drops support for node v14 and v16. We can take this when we drop
+    // node v16 support.
+    {
+      matchPackageNames: ["nock"],
+      allowedVersions: "13.x",
+    },
     // We specifically provide a first-party integration (`expressMiddleware`
     // imported from `@apollo/server/express4`) for Express v4 because it is the
     // most common web framework. (Additionally, as an internal implementation


### PR DESCRIPTION
We are starting on AS5 which will drop this old Node requirement (#7515) but are not there yet!
