### PR TITLE
feat: Allow configuration of graphql execution options(maxCoercionErrors)

### DIFF
--- a/packages/server/src/ApolloServer.ts
+++ b/packages/server/src/ApolloServer.ts
@@ -15,6 +15,7 @@ import {
   print,
   printSchema,
   type DocumentNode,
+  type ExecutionArgs,
   type FormattedExecutionResult,
   type GraphQLFieldResolver,
   type GraphQLFormattedError,
@@ -149,6 +150,7 @@ export interface ApolloServerInternals<TContext extends BaseContext> {
   apolloConfig: ApolloConfig;
   plugins: ApolloServerPlugin<TContext>[];
   parseOptions: ParseOptions;
+  executionOptions?: ExecutionArgs['options'];
   // `undefined` means we figure out what to do during _start (because
   // the default depends on whether or not we used the background version
   // of start).
@@ -329,6 +331,7 @@ export class ApolloServer<in out TContext extends BaseContext = BaseContext> {
       // `start()` will call `addDefaultPlugins` to add default plugins.
       plugins: config.plugins ?? [],
       parseOptions: config.parseOptions ?? {},
+      executionOptions: config.executionOptions ?? {},
       state,
       stopOnTerminationSignals: config.stopOnTerminationSignals,
 

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -606,6 +606,34 @@ describe('ApolloServer executeOperation', () => {
     await server.stop();
   });
 
+  it('variable coercion errors, configure max number of errors', async () => {
+    const server = new ApolloServer({
+      typeDefs,
+      resolvers,
+      status400ForVariableCoercionErrors: true,
+      executionOptions: {
+        maxCoercionErrors: 1,
+      },
+    });
+    await server.start();
+    const { body, http } = await server.executeOperation({
+      query: `#graphql
+      query NeedsArg($arg: CompoundInput!) { needsCompoundArg(aCompound: $arg) }
+      `,
+      variables: {
+        arg: { compound: { error1: '1', error2: '2', error3: '3' } },
+      },
+    });
+    const result = singleResult(body);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors?.[0].extensions?.code).toBe('BAD_USER_INPUT');
+    expect(result.errors?.[1].extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(result.errors?.[1].message).toMatch(
+      'Too many errors processing variables, error limit reached. Execution aborted.',
+    );
+    expect(http.status).toBe(400);
+  });
+
   it('passes its second argument as context object', async () => {
     const server = new ApolloServer({
       typeDefs,

--- a/packages/server/src/externalTypes/constructor.ts
+++ b/packages/server/src/externalTypes/constructor.ts
@@ -8,6 +8,7 @@ import type { Logger } from '@apollo/utils.logger';
 import type { IExecutableSchemaDefinition } from '@graphql-tools/schema';
 import type {
   DocumentNode,
+  ExecutionArgs,
   FormattedExecutionResult,
   GraphQLFieldResolver,
   GraphQLFormattedError,
@@ -107,6 +108,8 @@ interface ApolloServerOptionsBase<TContext extends BaseContext> {
   // Used for parsing operations; unlike in AS3, this is not also used for
   // parsing the schema.
   parseOptions?: ParseOptions;
+
+  executionOptions?: ExecutionArgs['options'];
 
   // TODO(AS5): remove OR warn + ignore with this option set, ignore option and
   // flip default behavior. Default false. This opt-in configuration fixes a

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -541,35 +541,36 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
 
     if (internals.__testing_incrementalExecutionResults) {
       return internals.__testing_incrementalExecutionResults;
-    } else if (internals.gatewayExecutor) {
+    }
+    if (internals.gatewayExecutor) {
       const result = await internals.gatewayExecutor(
         makeGatewayGraphQLRequestContext(requestContext, server, internals),
       );
       return { singleResult: result };
-    } else {
-      const resultOrResults = await executeIncrementally({
-        schema: schemaDerivedData.schema,
-        document,
-        rootValue:
-          typeof internals.rootValue === 'function'
-            ? internals.rootValue(document)
-            : internals.rootValue,
-        contextValue: requestContext.contextValue,
-        variableValues: request.variables,
-        operationName: request.operationName,
-        fieldResolver: internals.fieldResolver,
-      });
-      if ('initialResult' in resultOrResults) {
-        return {
-          initialResult: resultOrResults.initialResult,
-          subsequentResults: formatErrorsInSubsequentResults(
-            resultOrResults.subsequentResults,
-          ),
-        };
-      } else {
-        return { singleResult: resultOrResults };
-      }
     }
+
+    const resultOrResults = await executeIncrementally({
+      schema: schemaDerivedData.schema,
+      document,
+      rootValue:
+        typeof internals.rootValue === 'function'
+          ? internals.rootValue(document)
+          : internals.rootValue,
+      contextValue: requestContext.contextValue,
+      variableValues: request.variables,
+      operationName: request.operationName,
+      fieldResolver: internals.fieldResolver,
+      options: internals.executionOptions,
+    });
+    if ('initialResult' in resultOrResults) {
+      return {
+        initialResult: resultOrResults.initialResult,
+        subsequentResults: formatErrorsInSubsequentResults(
+          resultOrResults.subsequentResults,
+        ),
+      };
+    }
+    return { singleResult: resultOrResults };
   }
 
   async function* formatErrorsInSubsequentResults(


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-server/issues/8061

This PR introduces de ability to configure the graphql execution option `maxCoercionErrors` to control how many errors we want to allow in coercion phase. Currently, it defaults to 50 on graphql. 