### PR TITLE
fix(promises): avoid unhandledRejection errors

### DIFF
--- a/.changeset/clear-dryers-eat.md
+++ b/.changeset/clear-dryers-eat.md
@@ -1,0 +1,6 @@
+---
+'@apollo/server-plugin-response-cache': patch
+'@apollo/server': patch
+---
+
+Fix some error logs to properly call `logger.error` or `logger.warn` with `this` set. This fixes errors or crashes from logger implementations that expect `this` to be set properly in their methods.

--- a/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
+++ b/packages/plugin-response-cache/src/ApolloServerPluginResponseCache.ts
@@ -348,7 +348,7 @@ export default function plugin<TContext extends BaseContext>(
             // InMemoryLRUCache synchronously).
             cache
               .set(key, serializedValue, { ttl: policyIfCacheable.maxAge })
-              .catch(logger.warn);
+              .catch(logger.warn.bind(logger));
           };
 
           const isPrivate = policyIfCacheable.scope === 'PRIVATE';

--- a/packages/server/src/plugin/usageReporting/plugin.ts
+++ b/packages/server/src/plugin/usageReporting/plugin.ts
@@ -630,7 +630,7 @@ export function ApolloServerPluginUsageReporting<TContext extends BaseContext>(
           // logger is preferred since this is very much coupled directly to a
           // client-triggered action which might be more granularly tagged by
           // logging implementations.
-          addTrace().catch(logger.error);
+          addTrace().catch(logger.error.bind(logger));
 
           async function addTrace(): Promise<void> {
             // Ignore traces that come in after stop().

--- a/packages/server/src/requestPipeline.ts
+++ b/packages/server/src/requestPipeline.ts
@@ -373,7 +373,7 @@ export async function processGraphQLRequest<TContext extends BaseContext>(
           ? { ttl: internals.persistedQueries?.ttl }
           : undefined,
       ),
-    ).catch(server.logger.warn);
+    ).catch(server.logger.warn.bind(server.logger));
   }
 
   const responseFromPlugin = await invokeHooksUntilDefinedAndNonNull(


### PR DESCRIPTION
when logger needs to access function context
(e.g. like `pino` does need)

to fix we must properly bind logger .warn/.error method reference on promise when passing it into .catch()

---
Hi, this is a small bugfix. We have been seeing a GraphQL Gateway Node process crash with `unhandledRejection` error when server is under heavy load, couple times a quarter maybe.

Originally I pointed the finger to https://github.com/pinojs/pino/issues/1962 , but the solution is not there.

After discussion, we found potential culprit(s) here. Please review?