### PR TITLE
docs: no default TTL value for caches

### DIFF
--- a/docs/source/performance/apq.mdx
+++ b/docs/source/performance/apq.mdx
@@ -195,7 +195,7 @@ To learn how to configure the in-memory cache, set up an external cache, or writ
 
 The cache time-to-live (TTL) value determines how long a registered APQ remains in the cache. If a cached query's TTL elapses and the query is purged, it's re-registered the next time it's sent by a client.
 
-Apollo Server's default in-memory store does not specify a TTL for APQs (an APQ remains cached until it is overwritten by the cache's standard eviction policy). For all other [supported stores](#cache-configuration), the default TTL is 300 seconds. You can override or disable this value by setting the `ttl` attribute of the `persistedQueries` option, in seconds:
+Apollo Server's default in-memory store does not specify a TTL for APQs (an APQ remains cached until it is overwritten by the cache's standard eviction policy). If you are using a different cache backend, you may have specified a TTL when creating your cache. You can override this value by setting the `ttl` attribute of the `persistedQueries` option, in seconds:
 
 ```ts
 const server = new ApolloServer({


### PR DESCRIPTION
This is a very old reference to the old
apollo-server-cache-redis/apollo-server-cache-memcached packages which haven't been recommended since before AS 3.9.

Fixes #8015.
