### PR TITLE
Drop reference to old Codesandbox from issue template

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -8,6 +8,6 @@
     "packages/server",
     "packages/usage-reporting-protobuf"
   ],
-  "sandboxes": ["apollo-server-typescript-3opde","apollo-server"],
+  "sandboxes": ["apollo-server"],
   "node": "20"
 }

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,7 +3,7 @@ description: File a bug report
 body:
   - type: markdown
     attributes:
-      value: "Hello from the Apollo Server team! Hopefully we can help resolve your issue. To increase the chances of us being able to help, please take the time to fill out the form as completely as possible. A minimal, runnable reproduction is the best way to get us to help you quickly and in many cases we simply cannot help without one. Forking our [CodeSandbox](https://codesandbox.io/p/sandbox/apollo-server-typescript-3opde) is a great place to start."
+      value: "Hello from the Apollo Server team! Hopefully we can help resolve your issue. To increase the chances of us being able to help, please take the time to fill out the form as completely as possible. A minimal, runnable reproduction is the best way to get us to help you quickly and in many cases we simply cannot help without one."
   - type: textarea
     attributes:
       label: Issue Description


### PR DESCRIPTION
Having trouble updating it for newer Node versions (not sure how to log in to our org), and the future of the company seems a bit unclear (recent acquisition, CodeSandbox CI seems totally unmaintained). We're on GitHub; people can figure out how to make Git repos.

Fixes #7925.
