### PR TITLE
docs: Update Apollo Server constructor docs for `maxRecursiveSelections`

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -151,6 +151,26 @@ The default value is `true`, **unless** the `NODE_ENV` environment variable is s
 <tr>
 <td>
 
+###### `maxRecursiveSelections`
+
+`boolean` or `number`
+
+</td>
+
+<td>
+
+If `true`, enables a validation rule that computes how many selections would be in the operation if its named fragment definitions were recursively inlined (without actually inlining) and errors if the count exceeds 10,000,000. If `number`, it instead errors if the count exceeds this number.
+
+This rule is executed before any provided `validationRules`, and can be useful to avoid performance issues with those rules or any downstream plugins.
+
+The default value is `false`.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 ###### `hideSchemaDetailsFromClientErrors`
 
 `boolean`


### PR DESCRIPTION
This PR updates the docs for Apollo Server's constructor to explain the `maxRecursiveSelections` argument, which was added in [@apollo/server@4.12.0](https://github.com/apollographql/apollo-server/releases/tag/%40apollo%2Fserver%404.12.0).

Fixes https://github.com/apollographql/apollo-server/issues/8118 .

<!-- FED-731 -->