### PR TITLE
docs: update links for API keys

### DIFF
--- a/docs/source/api/apollo-server.mdx
+++ b/docs/source/api/apollo-server.mdx
@@ -377,7 +377,7 @@ The `formatError` hook receives two arguments: the first is a [`GraphQLFormatted
 
 An object containing configuration options for connecting Apollo Server to [Apollo Studio](https://www.apollographql.com/docs/studio/). Each field of this object can also be set with an environment variable, which is the recommended method of setting these parameters. All fields are optional. The fields are:
 
-- `key`: The [graph API key](https://www.apollographql.com/docs/studio/api-keys/#graph-api-keys) that Apollo Server should use to authenticate with Apollo Studio. You can set this with the `APOLLO_KEY` environment variable.
+- `key`: The [graph API key](/graphos/platform/access-management/api-keys/graph-api-keys) that Apollo Server should use to authenticate with Apollo GraphOS. You can set this with the `APOLLO_KEY` environment variable.
 - `graphRef`: A reference of your graph in Apollo's registry, such as `graph-id@my-variant` or just `graph-id`. You can set this with the `APOLLO_GRAPH_REF` environment variable.
 - `graphId`: The ID of your graph in Apollo's registry. You can set this with the `APOLLO_GRAPH_ID` environment variable. You may not specify this if you specify the graph ref.
 - `graphVariant`: The [variant](https://www.apollographql.com/docs/studio/schema/registry/#managing-environments-with-variants) of your graph to associate this server's schema and metrics with. You can set this with the `APOLLO_GRAPH_VARIANT` environment variable. The default value is `current`. You may not specify this if you specify the graph ref.

--- a/docs/source/deployment/heroku.md
+++ b/docs/source/deployment/heroku.md
@@ -121,7 +121,7 @@ Then from the app's detail page, select the **Deploy** tab. On that tab, you can
 
 To enable the production mode of Apollo Server, you need to set the `NODE_ENV` variable to `production`. To ensure you have visibility into your GraphQL performance in Apollo Studio, you'll want to add the `APOLLO_KEY` environment variable to Heroku. For the API key, log in to [Apollo Studio](https://studio.apollographql.com) and navigate to your graph or create a new one.
 
-Under your Heroku app's Settings tab, click **Reveal Config Vars**. Next, set `NODE_ENV` to `production` and [copy your graph API key](/graphos/api-keys/#graph-api-keys) from Apollo Studio as the value for `APOLLO_KEY`.
+Under your Heroku app's Settings tab, click **Reveal Config Vars**. Next, set `NODE_ENV` to `production` and [copy your graph API key](/graphos/platform/access-management/api-keys/graph-api-keys) from Apollo Studio as the value for `APOLLO_KEY`.
 
 <img class="screenshot" src="../images/deployment/heroku/config-vars.jpg" alt="Adding config vars" />
 

--- a/docs/source/monitoring/metrics.mdx
+++ b/docs/source/monitoring/metrics.mdx
@@ -19,7 +19,7 @@ Apollo Server integrates seamlessly with [Apollo GraphOS](/graphos/) to help you
 
 ### Connecting to GraphOS
 
-To connect Apollo Server to GraphOS, first [obtain a graph API key](/graphos/api-keys#graph-api-keys). To provide this key to Apollo Server, assign it to the `APOLLO_KEY` environment variable in your server's environment.
+To connect Apollo Server to GraphOS, first [obtain a graph API key](/graphos/platform/access-management/api-keys/graph-api-keys). To provide this key to Apollo Server, assign it to the `APOLLO_KEY` environment variable in your server's environment.
 
 Then associate your server instance with a particular graph ID and [graph variant](/graphos/graphs/#variants) by setting the `APOLLO_GRAPH_REF` environment variable.
 


### PR DESCRIPTION
Updates old docs links related to API keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across deployment guides, monitoring configuration, and API reference sections to link to the current Apollo GraphOS documentation for graph API key authentication and configuration. This ensures users can quickly access the latest instructions for obtaining and setting up API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->