### PR TITLE
fix(deps): remove vulnerable dependency `uuid`

### DIFF
--- a/.changeset/strong-bears-fly.md
+++ b/.changeset/strong-bears-fly.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Replace dependency `uuid` with calls to `crypto.randomUUID`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15015,7 +15015,6 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^11.1.0",
         "negotiator": "^1.0.0",
-        "uuid": "^11.1.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -15066,19 +15065,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "packages/server/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/usage-reporting-protobuf": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -144,7 +144,6 @@
     "loglevel": "^1.6.8",
     "lru-cache": "^11.1.0",
     "negotiator": "^1.0.0",
-    "uuid": "^11.1.0",
     "whatwg-mimetype": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -121,7 +121,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
             apolloServerLandingPageVersion,
           );
           async function html() {
-            const nonce = createHash('sha256').update(crypto.randomUUID()).digest('hex');
+            const nonce = createHash('sha256')
+              .update(crypto.randomUUID())
+              .digest('hex');
             const scriptCsp = `script-src 'self' 'nonce-${nonce}' ${scriptSafeList}`;
             const styleCsp = `style-src 'nonce-${nonce}' ${styleSafeList}`;
             const imageCsp = `img-src https://apollo-server-landing-page.cdn.apollographql.com`;

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -14,7 +14,6 @@ import {
 } from './getEmbeddedHTML.js';
 import { packageVersion } from '../../../generated/packageVersion.js';
 import { createHash } from '@apollo/utils.createhash';
-import { v4 as uuidv4 } from 'uuid';
 
 export type {
   ApolloServerPluginLandingPageLocalDefaultOptions,
@@ -122,7 +121,7 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
             apolloServerLandingPageVersion,
           );
           async function html() {
-            const nonce = createHash('sha256').update(uuidv4()).digest('hex');
+            const nonce = createHash('sha256').update(crypto.randomUUID()).digest('hex');
             const scriptCsp = `script-src 'self' 'nonce-${nonce}' ${scriptSafeList}`;
             const styleCsp = `style-src 'nonce-${nonce}' ${styleSafeList}`;
             const imageCsp = `img-src https://apollo-server-landing-page.cdn.apollographql.com`;

--- a/packages/server/src/plugin/schemaReporting/index.ts
+++ b/packages/server/src/plugin/schemaReporting/index.ts
@@ -1,6 +1,5 @@
 import os from 'os';
 import { internalPlugin } from '../../internalPlugin.js';
-import { v4 as uuidv4 } from 'uuid';
 import { printSchema, validateSchema, buildSchema } from 'graphql';
 import { SchemaReporter } from './schemaReporter.js';
 import { schemaIsSubgraph } from '../schemaIsSubgraph.js';
@@ -66,7 +65,7 @@ export function ApolloServerPluginSchemaReporting(
     fetcher,
   }: ApolloServerPluginSchemaReportingOptions = Object.create(null),
 ): ApolloServerPlugin {
-  const bootId = uuidv4();
+  const bootId = crypto.randomUUID();
 
   return internalPlugin({
     __internal_plugin_id__: 'SchemaReporting',


### PR DESCRIPTION
This PR removes vulnerable dependency `uuid` (https://github.com/advisories/GHSA-w5hq-g745-h8pq) in favor of [`crypto.randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), which is available in all supported Node.js versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused external dependency to streamline the install footprint and reduce package surface.

* **Refactor**
  * Migrated internal unique-ID generation to the platform's built-in cryptographic API; no changes to external behavior, user-facing features, or reported identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->