### PR TITLE
Update .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,22 +15,10 @@
 # to create allowlisting functionality.
 
 
-[[ rules ]]
-    id = "high-entropy-base64"
-    [ rules.allowlist ]
-        commits = [
-            # Allowlist https://github.com/apollographql/apollo-server/blob/48aa02fe3bd6bad0a61ef122acef5fda38920df1/docs/source/getting-started.md?plain=1#L175
-            # This is a blob of data from StackEdit
-            "48aa02fe3bd6bad0a61ef122acef5fda38920df1",
-            # Allowlist https://github.com/apollographql/apollo-server/blob/213acbba32829c83f99f12d81ed9e88f3fe1c8cb/docs/_config.yml#L36
-            # This is a segment key that Apollo SecOps was unable to utilize with Segment
-            "213acbba32829c83f99f12d81ed9e88f3fe1c8cb",
-
-        ]
 
 [[ rules ]]
     id = "generic-api-key"
-    [ rules.allowlist ]
+    [[ rules.allowlists ]]
         commits = [
             # Allowlist https://github.com/apollographql/apollo-server/blob/89da132450677ae69aef156ade4c3a11e3885a33/test/testApolloServer.js#L56
             # Code comments indicate the value being identified is not a secret
@@ -50,7 +38,7 @@
 
 [[ rules ]]
     id = "private-key"
-    [ rules.allowlist ]
+    [[ rules.allowlists ]]
         commits = [
             # Allowlist https://github.com/apollographql/apollo-server/blob/aadbeb647485207b408f620a10d8c385ce4ee25f/packages/apollo-server/src/__tests__/stoppable/fixture.key#L1
             # Based on file path, the private key is part of a test and not actually in-use


### PR DESCRIPTION
Apollo's internal Gitleaks scanner got upgraded and these fixes are needed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration by removing an unused rule and updating the configuration format for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->