### PR TITLE
Update dependency `@apollo/protobufjs` to `1.2.8`

### DIFF
--- a/.changeset/fancy-facts-make.md
+++ b/.changeset/fancy-facts-make.md
@@ -1,0 +1,5 @@
+---
+'@apollo/usage-reporting-protobuf': patch
+---
+
+Update dependency `@apollo/protobufjs` to `1.2.8`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ commands:
         type: string
         default: ''
     steps:
-      - checkout
+      - checkout:
+          method: full
       # We can consider using the CircleCI cache to cache Mise and Node, but it tends
       # to be pretty fast to install.
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,7 +241,9 @@
       }
     },
     "node_modules/@apollo/protobufjs": {
-      "version": "1.2.7",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.8.tgz",
+      "integrity": "sha512-r7xNeUqZX+eBBEmyvaPw0/cSz6zgf5jdH8mjUz8ynKpNs/GU7vi2T7sNcZINk2ZID7wwjG91FCgdpCrQuJ8rzA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15086,7 +15088,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@apollo/protobufjs": "1.2.7"
+        "@apollo/protobufjs": "1.2.8"
       }
     }
   }

--- a/packages/usage-reporting-protobuf/package.json
+++ b/packages/usage-reporting-protobuf/package.json
@@ -44,6 +44,6 @@
   "homepage": "https://github.com/apollographql/apollo-server#readme",
   "//": "Don't caret this, we want to be explicit about the version of our fork of protobufjs and update it intentionally if we need to.",
   "dependencies": {
-    "@apollo/protobufjs": "1.2.7"
+    "@apollo/protobufjs": "1.2.8"
   }
 }


### PR DESCRIPTION
Addresses #8198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the protobuf library dependency to a new patch release.
  * Adjusted CI checkout to explicitly fetch the full repository for builds.
  * Added release metadata to trigger a patch release for the usage-reporting protobuf package.
  * No changes to public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->