### PR TITLE
Replace uuid package with native crypto.randomUUID

### DIFF
--- a/.changeset/nice-shrimps-rest.md
+++ b/.changeset/nice-shrimps-rest.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Replaced uuid package with native crypto.randomUUID

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1540,7 +1541,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.18.tgz",
       "integrity": "sha512-EF77RqROHL+4LhMGW5NTeKqfUd/e4OOv6EDFQ/UQQiFyWuqkEKyEz0NDILxOFxWUEVdjT2GQ2cC7t12B6pESwg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.1",
@@ -1680,14 +1682,16 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.12.tgz",
       "integrity": "sha512-JFffQ1dDVEyJq6tCDWv0r/RqkdSnV43P2F/3jJ9rwLgdsOIXwQbXrz6QDlvQLVvNSnORH9KjDtenFTGDyzfCaA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.4.tgz",
       "integrity": "sha512-afea+0rGPDeOV9gdO06UW183Qg6wRhWVkgCFwiO3bDupAoyXRuvupbb5nUyqSTsLXIKL8u8uXQlJ9pkz07oVXw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -1885,7 +1889,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -3404,6 +3409,7 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.0.5.tgz",
       "integrity": "sha512-7oEJT19WW4oe6HR7oLRvHxwlJk2gev0U9px3ufs8sX9PoD1Eza68KF0/tlN7X0dq/WVsBScXQGgCldA1V9Y/jA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.0.5",
         "@jest/expect": "30.0.5",
@@ -3936,6 +3942,7 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4071,9 +4078,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4088,9 +4092,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4105,9 +4106,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4122,9 +4120,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4139,9 +4134,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4156,9 +4148,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4173,9 +4162,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4190,9 +4176,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4207,9 +4190,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4224,9 +4204,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4241,9 +4218,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4258,9 +4232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4275,9 +4246,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4798,6 +4766,7 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -5424,6 +5393,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6020,6 +5990,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -7546,6 +7517,7 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8728,6 +8700,7 @@
     "node_modules/graphql": {
       "version": "16.11.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8824,6 +8797,7 @@
       "version": "5.14.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "website"
       ],
@@ -9892,6 +9866,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.0.5.tgz",
       "integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.5",
         "@jest/types": "30.0.5",
@@ -12943,6 +12918,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -13984,6 +13960,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14313,6 +14290,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14839,6 +14817,7 @@
       "version": "8.13.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15113,7 +15092,6 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^11.1.0",
         "negotiator": "^1.0.0",
-        "uuid": "^11.1.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -15164,19 +15142,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "packages/server/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/usage-reporting-protobuf": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -144,7 +144,6 @@
     "loglevel": "^1.6.8",
     "lru-cache": "^11.1.0",
     "negotiator": "^1.0.0",
-    "uuid": "^11.1.0",
     "whatwg-mimetype": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -121,7 +121,9 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
             apolloServerLandingPageVersion,
           );
           async function html() {
-            const nonce = createHash('sha256').update(crypto.randomUUID()).digest('hex');
+            const nonce = createHash('sha256')
+              .update(crypto.randomUUID())
+              .digest('hex');
             const scriptCsp = `script-src 'self' 'nonce-${nonce}' ${scriptSafeList}`;
             const styleCsp = `style-src 'nonce-${nonce}' ${styleSafeList}`;
             const imageCsp = `img-src https://apollo-server-landing-page.cdn.apollographql.com`;

--- a/packages/server/src/plugin/landingPage/default/index.ts
+++ b/packages/server/src/plugin/landingPage/default/index.ts
@@ -14,7 +14,6 @@ import {
 } from './getEmbeddedHTML.js';
 import { packageVersion } from '../../../generated/packageVersion.js';
 import { createHash } from '@apollo/utils.createhash';
-import { v4 as uuidv4 } from 'uuid';
 
 export type {
   ApolloServerPluginLandingPageLocalDefaultOptions,
@@ -122,7 +121,7 @@ function ApolloServerPluginLandingPageDefault<TContext extends BaseContext>(
             apolloServerLandingPageVersion,
           );
           async function html() {
-            const nonce = createHash('sha256').update(uuidv4()).digest('hex');
+            const nonce = createHash('sha256').update(crypto.randomUUID()).digest('hex');
             const scriptCsp = `script-src 'self' 'nonce-${nonce}' ${scriptSafeList}`;
             const styleCsp = `style-src 'nonce-${nonce}' ${styleSafeList}`;
             const imageCsp = `img-src https://apollo-server-landing-page.cdn.apollographql.com`;

--- a/packages/server/src/plugin/schemaReporting/index.ts
+++ b/packages/server/src/plugin/schemaReporting/index.ts
@@ -1,6 +1,5 @@
 import os from 'os';
 import { internalPlugin } from '../../internalPlugin.js';
-import { v4 as uuidv4 } from 'uuid';
 import { printSchema, validateSchema, buildSchema } from 'graphql';
 import { SchemaReporter } from './schemaReporter.js';
 import { schemaIsSubgraph } from '../schemaIsSubgraph.js';
@@ -66,7 +65,7 @@ export function ApolloServerPluginSchemaReporting(
     fetcher,
   }: ApolloServerPluginSchemaReportingOptions = Object.create(null),
 ): ApolloServerPlugin {
-  const bootId = uuidv4();
+  const bootId = crypto.randomUUID();
 
   return internalPlugin({
     __internal_plugin_id__: 'SchemaReporting',


### PR DESCRIPTION
Hi! First attempt at a contribution here. 

There's currently a [security advisory](https://redirect.github.com/advisories/GHSA-w5hq-g745-h8pq) alert in this repo due to the outdated uuid package. Renovate has attempted to solve this (https://github.com/apollographql/apollo-server/pull/8200) but when i looked at the usage of the package, i figured it'd be better to remove it completely.

`crypto.randomUUID()` gives a v4 uuid and is available in node from v16, and since this project requires 20+ ([since 5.0.0](https://github.com/apollographql/apollo-server/releases/tag/%40apollo%2Fserver%405.0.0)) removal should be safe.

Happy to answer any questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal UUID/nonce generation in landing page and schema reporting plugins to use native Node.js crypto APIs.

* **Chores**
  * Removed the external `uuid` package dependency and recorded a patch version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->