### PR TITLE
feat(types): allow plugin methods to return synchronously

### DIFF
--- a/.changeset/sharp-animals-talk.md
+++ b/.changeset/sharp-animals-talk.md
@@ -1,0 +1,7 @@
+---
+"@apollo/server": minor
+---
+
+Allow plugin methods to return synchronously.
+
+Previously, `ApolloServerPlugin` methods strictly required a `Promise` return type, forcing the use of `async`/`await` even for fully synchronous hooks. This update introduces the `PromiseOrValue` type to strictly widen the plugin types to allow returning either a `Promise` or a synchronous value, improving developer experience.

--- a/packages/server/src/__tests__/ApolloServer.test.ts
+++ b/packages/server/src/__tests__/ApolloServer.test.ts
@@ -818,6 +818,43 @@ describe('ApolloServer executeOperation', () => {
         plugins: [basePlugin],
       });
     });
+
+    it('allows synchronous returns for plugin methods', async () => {
+      let startedCalled = false;
+      let stoppedCalled = false;
+      let willSendResponseCalled = false;
+      const syncPlugin: ApolloServerPlugin<BaseContext> = {
+        serverWillStart() {
+          startedCalled = true;
+          return {
+            serverWillStop() {
+              stoppedCalled = true;
+            },
+          };
+        },
+        requestDidStart() {
+          return {
+            willSendResponse() {
+              willSendResponseCalled = true;
+            },
+          };
+        },
+      };
+
+      const server = new ApolloServer({
+        typeDefs: 'type Query { x: ID }',
+        resolvers: { Query: { x: () => '1' } },
+        plugins: [syncPlugin],
+      });
+
+      await server.start();
+      await server.executeOperation({ query: '{ x }' });
+      await server.stop();
+
+      expect(startedCalled).toBe(true);
+      expect(stoppedCalled).toBe(true);
+      expect(willSendResponseCalled).toBe(true);
+    });
   });
 });
 

--- a/packages/server/src/externalTypes/index.ts
+++ b/packages/server/src/externalTypes/index.ts
@@ -28,6 +28,7 @@ export type {
   GraphQLServerListener,
   GraphQLServerContext,
   LandingPage,
+  PromiseOrValue,
 } from './plugins.js';
 export type {
   GraphQLRequestContext,

--- a/packages/server/src/externalTypes/plugins.ts
+++ b/packages/server/src/externalTypes/plugins.ts
@@ -25,6 +25,8 @@ import type {
 } from './requestPipeline.js';
 import type { GraphQLExperimentalFormattedSubsequentIncrementalExecutionResultAlpha9 } from './incrementalDeliveryPolyfillAlpha9.js';
 
+export type PromiseOrValue<T> = Promise<T> | T;
+
 export interface GraphQLServerContext {
   readonly logger: Logger;
   readonly cache: KeyValueCache<string>;
@@ -45,14 +47,14 @@ export interface ApolloServerPlugin<
   // Called once on server startup, after the schema has been loaded.
   serverWillStart?(
     service: GraphQLServerContext,
-  ): Promise<GraphQLServerListener | void>;
+  ): PromiseOrValue<GraphQLServerListener | void>;
 
   // Called once per request, before parsing or validation of the request has
   // occurred. This hook can return an object of more fine-grained hooks (see
   // `GraphQLRequestListener`) which pertain to the lifecycle of the request.
   requestDidStart?(
     requestContext: GraphQLRequestContext<TContext>,
-  ): Promise<GraphQLRequestListener<TContext> | void>;
+  ): PromiseOrValue<GraphQLRequestListener<TContext> | void>;
 
   /**
    * "Unexpected" errors do not include more common errors like validation,
@@ -67,20 +69,20 @@ export interface ApolloServerPlugin<
   }: {
     requestContext: GraphQLRequestContext<TContext>;
     error: Error;
-  }): Promise<void>;
+  }): PromiseOrValue<void>;
   // Called specifically when the user-provided `context` function throws an
   // error.
-  contextCreationDidFail?({ error }: { error: Error }): Promise<void>;
+  contextCreationDidFail?({ error }: { error: Error }): PromiseOrValue<void>;
   /**
    * This hook is called any time a "Bad Request" error is thrown during request
    * execution. This includes CSRF prevention and malformed requests (e.g.
    * incorrect headers, invalid JSON body, or invalid search params for GET),
    * but does not include malformed GraphQL.
    */
-  invalidRequestWasReceived?({ error }: { error: Error }): Promise<void>;
+  invalidRequestWasReceived?({ error }: { error: Error }): PromiseOrValue<void>;
   // Called on startup fail. This can occur if the schema fails to load or if a
   // `serverWillStart` or `renderLandingPage` hook throws.
-  startupDidFail?({ error }: { error: Error }): Promise<void>;
+  startupDidFail?({ error }: { error: Error }): PromiseOrValue<void>;
 }
 
 export interface GraphQLServerListener {
@@ -94,14 +96,14 @@ export interface GraphQLServerListener {
   // is in progress. A typical use is to stop listening for new connections and
   // wait until all current connections are idle. The built-in
   // ApolloServerPluginDrainHttpServer implements this method.
-  drainServer?(): Promise<void>;
+  drainServer?(): PromiseOrValue<void>;
 
   // When your server is stopped (by calling `stop()` or via the
   // `SIGINT`/`SIGTERM` handlers) then (after the `drainServer` phase finishes)
   // Apollo Server transitions into a state where no new operations will run and
   // then awaits all `drainServer` hooks in parallel. A typical use is to flush
   // outstanding observability data.
-  serverWillStop?(): Promise<void>;
+  serverWillStop?(): PromiseOrValue<void>;
 
   // At most one plugin's serverWillStart may return a GraphQLServerListener
   // with this method. If one does, it is called once on server startup and the
@@ -109,23 +111,23 @@ export interface GraphQLServerListener {
   // is an intentionally simple API; if you want to do something fancy to serve
   // a landing page, you probably should just define a handler in your web
   // framework.
-  renderLandingPage?(): Promise<LandingPage>;
+  renderLandingPage?(): PromiseOrValue<LandingPage>;
 }
 
 // The page served to clients with `accept: text/html` headers.
 export interface LandingPage {
-  html: string | (() => Promise<string>);
+  html: string | (() => PromiseOrValue<string>);
 }
 
 export type GraphQLRequestListenerParsingDidEnd = (
   err?: Error,
-) => Promise<void>;
+) => PromiseOrValue<void>;
 export type GraphQLRequestListenerValidationDidEnd = (
   err?: ReadonlyArray<Error>,
-) => Promise<void>;
+) => PromiseOrValue<void>;
 export type GraphQLRequestListenerExecutionDidEnd = (
   err?: Error,
-) => Promise<void>;
+) => PromiseOrValue<void>;
 export type GraphQLRequestListenerDidResolveField = (
   error: Error | null,
   result?: any,
@@ -134,23 +136,23 @@ export type GraphQLRequestListenerDidResolveField = (
 export interface GraphQLRequestListener<TContext extends BaseContext> {
   didResolveSource?(
     requestContext: GraphQLRequestContextDidResolveSource<TContext>,
-  ): Promise<void>;
+  ): PromiseOrValue<void>;
 
   parsingDidStart?(
     requestContext: GraphQLRequestContextParsingDidStart<TContext>,
-  ): Promise<GraphQLRequestListenerParsingDidEnd | void>;
+  ): PromiseOrValue<GraphQLRequestListenerParsingDidEnd | void>;
 
   validationDidStart?(
     requestContext: GraphQLRequestContextValidationDidStart<TContext>,
-  ): Promise<GraphQLRequestListenerValidationDidEnd | void>;
+  ): PromiseOrValue<GraphQLRequestListenerValidationDidEnd | void>;
 
   didResolveOperation?(
     requestContext: GraphQLRequestContextDidResolveOperation<TContext>,
-  ): Promise<void>;
+  ): PromiseOrValue<void>;
 
   didEncounterErrors?(
     requestContext: GraphQLRequestContextDidEncounterErrors<TContext>,
-  ): Promise<void>;
+  ): PromiseOrValue<void>;
 
   // If this hook is defined, it is invoked immediately before GraphQL execution
   // would take place. If its return value resolves to a non-null
@@ -159,24 +161,24 @@ export interface GraphQLRequestListener<TContext extends BaseContext> {
   // response is used.
   responseForOperation?(
     requestContext: GraphQLRequestContextResponseForOperation<TContext>,
-  ): Promise<GraphQLResponse | null>;
+  ): PromiseOrValue<GraphQLResponse | null>;
 
   // Note that in the case of incremental delivery, the end hook gets called
   // when the initial response is ready to go: further execution can still occur.
   executionDidStart?(
     requestContext: GraphQLRequestContextExecutionDidStart<TContext>,
-  ): Promise<GraphQLRequestExecutionListener<TContext> | void>;
+  ): PromiseOrValue<GraphQLRequestExecutionListener<TContext> | void>;
 
   // Note that in the case of incremental delivery, this is called when the
   // initial response is ready to go.
   willSendResponse?(
     requestContext: GraphQLRequestContextWillSendResponse<TContext>,
-  ): Promise<void>;
+  ): PromiseOrValue<void>;
 
   didEncounterSubsequentErrors?(
     requestContext: GraphQLRequestContextDidEncounterSubsequentErrors<TContext>,
     errors: ReadonlyArray<GraphQLError>,
-  ): Promise<void>;
+  ): PromiseOrValue<void>;
 
   // You can use hasNext to tell if this is the end or not.
   willSendSubsequentPayload?(
@@ -184,7 +186,7 @@ export interface GraphQLRequestListener<TContext extends BaseContext> {
     payload:
       | GraphQLExperimentalFormattedSubsequentIncrementalExecutionResultAlpha2
       | GraphQLExperimentalFormattedSubsequentIncrementalExecutionResultAlpha9,
-  ): Promise<void>;
+  ): PromiseOrValue<void>;
 }
 
 /**

--- a/packages/server/src/utils/invokeHooks.ts
+++ b/packages/server/src/utils/invokeHooks.ts
@@ -1,11 +1,16 @@
 import { isDefined } from './isDefined.js';
+import type { PromiseOrValue } from '../externalTypes/plugins.js';
 
-type AsyncDidEndHook<TArgs extends any[]> = (...args: TArgs) => Promise<void>;
+type AsyncDidEndHook<TArgs extends any[]> = (
+  ...args: TArgs
+) => PromiseOrValue<void>;
 type SyncDidEndHook<TArgs extends any[]> = (...args: TArgs) => void;
 
 export async function invokeDidStartHook<T, TEndHookArgs extends unknown[]>(
   targets: T[],
-  hook: (t: T) => Promise<AsyncDidEndHook<TEndHookArgs> | undefined | void>,
+  hook: (
+    t: T,
+  ) => PromiseOrValue<AsyncDidEndHook<TEndHookArgs> | undefined | void>,
 ): Promise<AsyncDidEndHook<TEndHookArgs>> {
   const didEndHooks = (
     await Promise.all(targets.map((target) => hook(target)))
@@ -41,7 +46,7 @@ export function invokeSyncDidStartHook<T, TEndHookArgs extends unknown[]>(
 
 export async function invokeHooksUntilDefinedAndNonNull<T, TOut>(
   targets: T[],
-  hook: (t: T) => Promise<TOut | null | undefined>,
+  hook: (t: T) => PromiseOrValue<TOut | null | undefined>,
 ): Promise<TOut | null> {
   for (const target of targets) {
     const value = await hook(target);


### PR DESCRIPTION
Fixes #8146

## Description

This PR updates the `ApolloServerPlugin` and various listener method types to allow synchronous returns by introducing and using a `PromiseOrValue<T>` helper instead of strictly requiring `Promise<T>`.

Previously, plugin authors were forced to define their methods as `async` or explicitly return a resolved `Promise`, even when their implementation performed no asynchronous operations (e.g., simple logging or stat collection). This created friction, especially when porting existing JavaScript plugins to TypeScript.

This change strictly widens the types, making it purely backward compatible. All internal utilities, such as the `invokeHooks` methods, already await or cleanly handle non-promise values seamlessly through `Promise.all` and standard asynchronous loops, so the runtime behavior remains completely unaffected.

## Changes Made
- Introduced `export type PromiseOrValue<T> = Promise<T> | T;` in `packages/server/src/externalTypes/plugins.ts`.
- Replaced `Promise<T>` with `PromiseOrValue<T>` on plugin hooks (`requestDidStart`, `serverWillStart`, etc.) and event listener methods.
- Updated `invokeHooks.ts` internals to correctly type the hooked functions using `PromiseOrValue`.
- Added a test in `packages/server/src/__tests__/ApolloServer.test.ts` to ensure that fully synchronous plugin methods compile and execute correctly.

## Testing
- [x] Ran `npm run compile` to verify there are no TypeScript errors.
- [x] Ran `npm run test` and confirmed all tests pass locally.
- [x] Added an explicit test suite verifying synchronous plugin execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin lifecycle hooks now accept either synchronous or Promise-based returns across server, request, and response lifecycles.

* **Tests**
  * Added coverage verifying plugins with synchronous hook implementations run correctly through startup, request handling, and shutdown.

* **Documentation**
  * Added a changeset entry documenting the plugin hook return-type support for synchronous returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->