### PR TITLE
switch over to npm staged publishing

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,6 +5,7 @@
 [tools]
 node = "24.13.0"
 "github:codecov/codecov-cli" = { version = "10.4.0", bin = "codecov-cli" }
+npm = "11.15"
 
 [env]
 # Put binaries from npm-installed packages on PATH (eg `changeset`).

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -70,3 +70,7 @@ url = "https://nodejs.org/dist/v24.13.0/node-v24.13.0-darwin-x64.tar.gz"
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:ca2742695be8de44027d71b3f53a4bdb36009b95575fe1ae6f7f0b5ce091cb88"
 url = "https://nodejs.org/dist/v24.13.0/node-v24.13.0-win-x64.zip"
+
+[[tools.npm]]
+version = "11.15.0"
+backend = "npm:npm"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      # shim around npm to convert `npm publish` to `npm stage publish` for staged publishing until changesets adds direct support for staged publishing.
+      - run: echo "${{ github.workspace }}/scripts/changesets-wrapper" >> "$GITHUB_PATH"
+
       - name: Create Release Pull Request / NPM Publish
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -137,6 +137,7 @@ paque
 parseurl
 pbjs
 pbts
+pipefail
 pook
 Pook
 pooks

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -5,14 +5,15 @@
 #
 set -euo pipefail
 
-# we assume that this binary was called because it's the first matching `npm` in PATH,
-# so we remove this directory from PATH and find the real npm binary that way
+# Find the real npm by temporarily excluding this directory from PATH,
+# but do NOT export the modified PATH — child processes (e.g. changeset publish)
+# must still see this wrapper so their own `npm publish` calls get rewritten too.
 SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-export PATH="${PATH//$SELF_DIR:/}"
+REAL_NPM="$(PATH="${PATH//$SELF_DIR:/}" command -v npm)"
 
 if [ "${1:-}" = "publish" ]; then
 	shift
-	exec npm stage publish "$@"
+	exec "$REAL_NPM" stage publish "$@"
 fi
 
-exec npm "$@"
+exec "$REAL_NPM" "$@"

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Shim that rewrites `npm publish ...` to `npm stage publish ...`
+# (https://docs.npmjs.com/staged-publishing) and forwards every other
+# invocation to the real npm unchanged.
+#
+set -euo pipefail
+
+# we assume that this binary was called because it's the first matching `npm` in PATH,
+# so we remove this directory from PATH and find the real npm binary that way
+SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+export PATH="${PATH//$SELF_DIR:/}"
+
+if [ "${1:-}" = "publish" ]; then
+	shift
+	exec npm stage publish "$@"
+fi
+
+exec npm "$@"

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -2,6 +2,7 @@
 # Shim that rewrites `npm publish ...` to `npm stage publish ...`
 # (https://docs.npmjs.com/staged-publishing) and forwards every other
 # invocation to the real npm unchanged.
+# Temporary workaround while waiting for https://github.com/changesets/changesets/issues/2025
 #
 set -euo pipefail
 


### PR DESCRIPTION
I've already applied the necessary changes over at `npm`:

```json
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/server"
}
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/server-integration-testsuite"
}
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/cache-control-types"
}
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/server-gateway-interface"
}
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/server-integration-testsuite"
}
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/server-plugin-response-cache"
}
{
  "type": "github",
  "file": "release-pr.yml",
  "repository": "apollographql/apollo-server",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/usage-reporting-protobuf"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned npm tooling to version 11.15.
  * Updated the release workflow to ensure publishing runs through a dedicated shim for consistent npm publish behavior.
  * Added a lightweight publish shim that routes `npm publish` through the staged publish flow.
  * Updated spell-check terms to include “pipefail”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->