### PR TITLE
fix(drainHttpServer): do not re-insert sockets after close-before-finish

### DIFF
--- a/.changeset/drain-close-before-finish.md
+++ b/.changeset/drain-close-before-finish.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server": patch
+---
+
+Fix `ApolloServerPluginDrainHttpServer` retaining closed sockets when a socket's `close` event runs before the response `finish` callback. The finish handler now skips updating the map if the close listener already removed the entry.

--- a/packages/server/src/__tests__/plugin/drainHttpServer/stoppable.test.ts
+++ b/packages/server/src/__tests__/plugin/drainHttpServer/stoppable.test.ts
@@ -382,3 +382,48 @@ Object.keys(schemes).forEach((schemeName) => {
     }
   });
 });
+
+describe('Stopper requestCountPerSocket cleanup', () => {
+  it('does not re-insert a socket when finish runs after close', () => {
+    // Simulate Node's connection/request/close/finish event order without a
+    // real TCP connection so we can force close-before-finish deterministically.
+    const { EventEmitter } = require('events');
+    const server = new EventEmitter();
+    const stopper = new Stopper(server as any);
+    const socket = new EventEmitter();
+    const req = { socket };
+    const res = new EventEmitter();
+
+    server.emit('connection', socket);
+    expect((stopper as any).requestCountPerSocket.has(socket)).toBe(true);
+
+    server.emit('request', req, res);
+    expect((stopper as any).requestCountPerSocket.get(socket)).toBe(1);
+
+    // close before finish (the leaky ordering)
+    socket.emit('close');
+    expect((stopper as any).requestCountPerSocket.has(socket)).toBe(false);
+
+    res.emit('finish');
+    expect((stopper as any).requestCountPerSocket.has(socket)).toBe(false);
+  });
+
+  it('still decrements the pending count when finish runs before close', () => {
+    const { EventEmitter } = require('events');
+    const server = new EventEmitter();
+    const stopper = new Stopper(server as any);
+    const socket = new EventEmitter();
+    const req = { socket };
+    const res = new EventEmitter();
+
+    server.emit('connection', socket);
+    server.emit('request', req, res);
+    expect((stopper as any).requestCountPerSocket.get(socket)).toBe(1);
+
+    res.emit('finish');
+    expect((stopper as any).requestCountPerSocket.get(socket)).toBe(0);
+
+    socket.emit('close');
+    expect((stopper as any).requestCountPerSocket.has(socket)).toBe(false);
+  });
+});

--- a/packages/server/src/plugin/drainHttpServer/stoppable.ts
+++ b/packages/server/src/plugin/drainHttpServer/stoppable.ts
@@ -53,7 +53,13 @@ export class Stopper {
           (this.requestCountPerSocket.get(req.socket) ?? 0) + 1,
         );
         res.once('finish', () => {
-          const pending = (this.requestCountPerSocket.get(req.socket) ?? 0) - 1;
+          // If the socket already closed, its map entry was removed by the
+          // 'close' listener. Do not re-insert it — otherwise the closed socket
+          // is retained for the lifetime of the process (close-before-finish).
+          if (!this.requestCountPerSocket.has(req.socket)) {
+            return;
+          }
+          const pending = this.requestCountPerSocket.get(req.socket)! - 1;
           this.requestCountPerSocket.set(req.socket, pending);
           // If we're in the process of stopping and it's gone idle, close the
           // socket.


### PR DESCRIPTION
## Summary

Closes #8222.

`Stopper` (used by `ApolloServerPluginDrainHttpServer`) deletes a socket from `requestCountPerSocket` on `socket` `'close'`, but the response `'finish'` handler always called `set()`. When `'close'` is processed before `'finish'`:

1. the `once('close')` listener deletes the entry and is consumed
2. `'finish'` re-inserts the same closed socket
3. nothing removes it again, so the Map retains the socket for the process lifetime

This was observed in production (thousands of leaked sockets) and reproduced with forced GC in the linked issue.

The finish handler now returns early when the socket is no longer in the map, matching the invariant that only sockets still tracked by the close listener should be updated.

## Test plan

- [x] Added unit tests that force close-before-finish and finish-before-close event order via EventEmitters
- [x] `npm test -- --testPathPatterns='drainHttpServer/stoppable' --no-coverage` — 17/17 passing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP server draining to prevent closed sockets from being retained when connection closure occurs before response completion.
  * Improved cleanup of in-flight request tracking during shutdown.

* **Tests**
  * Added coverage for socket cleanup across different close and response-finish event orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->