### PR TITLE
fix(drainHttpServer): don't resurrect sockets removed by the close handler

### DIFF
--- a/.changeset/plenty-pugs-shave.md
+++ b/.changeset/plenty-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@apollo/server': patch
+---
+
+Fix a socket leak in `ApolloServerPluginDrainHttpServer`. When a socket's `'close'` event was processed before the response's queued `'finish'` callback, the `'finish'` callback re-inserted the socket into the plugin's tracking `Map` after the (single-use) close listener had already removed it, so the socket and everything it referenced were retained for the lifetime of the process.

--- a/packages/server/src/__tests__/plugin/drainHttpServer/stoppable.test.ts
+++ b/packages/server/src/__tests__/plugin/drainHttpServer/stoppable.test.ts
@@ -26,6 +26,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import { EventEmitter } from 'events';
 import http from 'http';
 import https from 'https';
 const a: any = require('awaiting');
@@ -380,5 +381,62 @@ Object.keys(schemes).forEach((schemeName) => {
         await a.event(server, 'close');
       });
     }
+  });
+});
+
+describe('Stopper socket tracking', () => {
+  // Regression test: the 'finish' callback must not re-insert a socket that the
+  // 'close' handler already removed. The close listener is registered with
+  // `once`, so once it has fired nothing remains to remove a re-inserted entry
+  // and the Map grows for the lifetime of the process.
+  it('does not retain a socket whose close was processed before finish', () => {
+    const server = new http.Server();
+    const stopper = new Stopper(server);
+    // Reach into the private field the same way the leak would manifest.
+    const tracked = (
+      stopper as unknown as {
+        requestCountPerSocket: Map<unknown, number>;
+      }
+    ).requestCountPerSocket;
+
+    const socket = new EventEmitter();
+    const res = new EventEmitter();
+
+    // Node emits 'connection' for an accepted socket before any request on it.
+    server.emit('connection', socket);
+    expect(tracked.size).toBe(1);
+
+    server.emit('request', { socket }, res);
+    expect(tracked.size).toBe(1);
+
+    // 'close' is processed before the queued 'finish' callback runs.
+    socket.emit('close');
+    expect(tracked.size).toBe(0);
+
+    res.emit('finish');
+    expect(tracked.size).toBe(0);
+  });
+
+  it('still decrements the count when finish precedes close', () => {
+    const server = new http.Server();
+    const stopper = new Stopper(server);
+    const tracked = (
+      stopper as unknown as {
+        requestCountPerSocket: Map<unknown, number>;
+      }
+    ).requestCountPerSocket;
+
+    const socket = new EventEmitter();
+    const res = new EventEmitter();
+
+    server.emit('connection', socket);
+    server.emit('request', { socket }, res);
+    expect(tracked.get(socket)).toBe(1);
+
+    res.emit('finish');
+    expect(tracked.get(socket)).toBe(0);
+
+    socket.emit('close');
+    expect(tracked.size).toBe(0);
   });
 });

--- a/packages/server/src/plugin/drainHttpServer/stoppable.ts
+++ b/packages/server/src/plugin/drainHttpServer/stoppable.ts
@@ -53,7 +53,16 @@ export class Stopper {
           (this.requestCountPerSocket.get(req.socket) ?? 0) + 1,
         );
         res.once('finish', () => {
-          const pending = (this.requestCountPerSocket.get(req.socket) ?? 0) - 1;
+          // The socket's 'close' handler may already have run, which both
+          // deleted this entry and consumed its `once` listener. Re-inserting
+          // the socket here would keep it (and everything it references) in the
+          // Map for the lifetime of the process, because no close listener
+          // remains to remove it. A closed socket has no pending requests worth
+          // tracking, so skip instead.
+          if (!this.requestCountPerSocket.has(req.socket)) {
+            return;
+          }
+          const pending = this.requestCountPerSocket.get(req.socket)! - 1;
           this.requestCountPerSocket.set(req.socket, pending);
           // If we're in the process of stopping and it's gone idle, close the
           // socket.


### PR DESCRIPTION
Fixes #8222.

### Problem

`Stopper`, used by `ApolloServerPluginDrainHttpServer`, tracks in-flight requests in a
`Map<Socket, number>`. The only code that removes an entry is the `socket.once('close', ...)`
listener registered when the connection is opened:

```ts
socket.once('close', () => this.requestCountPerSocket.delete(socket));   // the only removal
...
res.once('finish', () => {
  const pending = (this.requestCountPerSocket.get(req.socket) ?? 0) - 1;
  this.requestCountPerSocket.set(req.socket, pending);                   // unconditional
  ...
});
```

If a socket's `'close'` event is processed **before** its queued `'finish'` callback runs:

1. the close listener deletes the entry — and is consumed, because it is registered with `once()`;
2. the `'finish'` callback re-inserts the same socket via `set()`;
3. no close listener remains, so nothing will ever remove it again.

The Map then holds a closed `Socket` — and everything it references — for the lifetime of the
process. In our production gateway a heap snapshot showed 18,299 closed sockets retained by this
Map (an earlier snapshot showed 48,706); every one of them had already had its close listener fire
and be consumed. Full evidence is in #8222.

This is not opt-in for NestJS users: `@nestjs/apollo` appends this plugin automatically for
Express integrations.

### Fix

Never create an entry that the close handler already removed:

```ts
if (!this.requestCountPerSocket.has(req.socket)) {
  return;
}
const pending = this.requestCountPerSocket.get(req.socket)! - 1;
```

Behaviour is unchanged for the normal (`finish` before `close`) ordering, and skipping
`socket.end()` for an already-closed socket is correct.

I used `has()` rather than checking `socket.closed`/`socket.destroyed` because `has()` states the
actual invariant — only track sockets the close handler hasn't already reclaimed — and does not
depend on `net.Socket#closed`, which is not available on every Node version this package has
supported.

### Tests

Two regression tests in `stoppable.test.ts` drive the two orderings directly, since the reversed
ordering is a rare I/O race that we could not reproduce over loopback (see #8222 for the
reproduction repo and the details of that investigation):

- `does not retain a socket whose close was processed before finish` — fails on `main`
  (`Expected: 0, Received: 1`), passes with this change.
- `still decrements the count when finish precedes close` — guards the normal ordering so the fix
  cannot silently skip the decrement.

`packages/server` suite: 570 passed, 0 failed.
